### PR TITLE
Pass existing object references within access methods

### DIFF
--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -34,7 +34,7 @@ class ModelAccessPermission(permissions.BasePermission):
 
     def check_get_permissions(self, request, view, obj=None):
         if hasattr(view, 'parent_model'):
-            parent_obj = get_object_or_400(view.parent_model, pk=view.kwargs['pk'])
+            parent_obj = view.get_parent_object()
             if not check_user_access(request.user, view.parent_model, 'read',
                                      parent_obj):
                 return False
@@ -44,12 +44,12 @@ class ModelAccessPermission(permissions.BasePermission):
 
     def check_post_permissions(self, request, view, obj=None):
         if hasattr(view, 'parent_model'):
-            parent_obj = get_object_or_400(view.parent_model, pk=view.kwargs['pk'])
+            parent_obj = view.get_parent_object()
             if not check_user_access(request.user, view.parent_model, 'read',
                                      parent_obj):
                 return False
             if hasattr(view, 'parent_key'):
-                if not check_user_access(request.user, view.model, 'add', {view.parent_key: parent_obj.pk}):
+                if not check_user_access(request.user, view.model, 'add', {view.parent_key: parent_obj}):
                     return False
             return True
         elif getattr(view, 'is_job_start', False):

--- a/awx/api/renderers.py
+++ b/awx/api/renderers.py
@@ -48,7 +48,8 @@ class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
         obj = getattr(view, 'object', None)
         if obj is None and hasattr(view, 'get_object') and hasattr(view, 'retrieve'):
             try:
-                obj = view.get_object()
+                view.object = view.get_object()
+                obj = view.object
             except Exception:
                 obj = None
         with override_method(view, request, method) as request:

--- a/awx/main/tests/unit/api/test_generics.py
+++ b/awx/main/tests/unit/api/test_generics.py
@@ -242,28 +242,28 @@ class TestResourceAccessList:
             ), method='GET')
 
 
-    def mock_view(self):
+    def mock_view(self, parent=None):
         view = ResourceAccessList()
         view.parent_model = Organization
         view.kwargs = {'pk': 4}
+        if parent:
+            view.get_parent_object = lambda: parent
         return view
 
 
     def test_parent_access_check_failed(self, mocker, mock_organization):
-        with mocker.patch('awx.api.permissions.get_object_or_400', return_value=mock_organization):
-            mock_access = mocker.MagicMock(__name__='for logger', return_value=False)
-            with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
-                with pytest.raises(PermissionDenied):
-                    self.mock_view().check_permissions(self.mock_request())
-                mock_access.assert_called_once_with(mock_organization)
+        mock_access = mocker.MagicMock(__name__='for logger', return_value=False)
+        with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
+            with pytest.raises(PermissionDenied):
+                self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
+            mock_access.assert_called_once_with(mock_organization)
 
 
     def test_parent_access_check_worked(self, mocker, mock_organization):
-        with mocker.patch('awx.api.permissions.get_object_or_400', return_value=mock_organization):
-            mock_access = mocker.MagicMock(__name__='for logger', return_value=True)
-            with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
-                self.mock_view().check_permissions(self.mock_request())
-                mock_access.assert_called_once_with(mock_organization)
+        mock_access = mocker.MagicMock(__name__='for logger', return_value=True)
+        with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
+            self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
+            mock_access.assert_called_once_with(mock_organization)
 
 
 def test_related_search_reverse_FK_field():

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -724,7 +724,10 @@ def get_pk_from_dict(_dict, key):
     Helper for obtaining a pk from user data dict or None if not present.
     '''
     try:
-        return int(_dict[key])
+        val = _dict[key]
+        if isinstance(val, object) and hasattr(val, 'id'):
+            return val.id  # return id if given model object
+        return int(val)
     except (TypeError, KeyError, ValueError):
         return None
 


### PR DESCRIPTION
Just looking at `/inventories/N/hosts/`, we retrieve the inventory (pk=N) *6* distinct times. This is because we had a habit of passing the pk from one piece of code to another, at which point the 2nd piece of code would go turn the pk into a python object. With this change, the method is called *0* for a GET to that endpoint, because the view constructs its own lookup.

I argue that this revision actually leaves us with _fewer_ moving parts and better modularization.

Signed-off-by: Alan Rominger arominge@redhat.com