### PR TITLE
Fix using SAML NameID

### DIFF
--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -241,7 +241,9 @@ class TowerSAMLIdentityProvider(BaseSAMLIdentityProvider):
         another attribute to use.
         """
         key = self.conf.get(conf_key, default_attribute)
-        value = attributes[key][0] if key in attributes else None
+        value = attributes[key] if key in attributes else None
+        if isinstance(value, list):
+            value = value[0]
         if conf_key in ('attr_first_name', 'attr_last_name', 'attr_username', 'attr_email') and value is None:
             logger.warn("Could not map user detail '%s' from SAML attribute '%s'; "
                         "update SOCIAL_AUTH_SAML_ENABLED_IDPS['%s']['%s'] with the correct SAML attribute.",


### PR DESCRIPTION
Without this patch, SAML backend will only use the first letter of the NameID as attribute value.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>