### PR TITLE
Whitespace cleanup for installer.

### DIFF
--- a/installer/check_vars/tasks/check_docker.yml
+++ b/installer/check_vars/tasks/check_docker.yml
@@ -1,5 +1,5 @@
 # check_docker.yml
---- 
+---
 - name: postgres_data_dir should be defined
   assert:
     that:
@@ -12,4 +12,3 @@
     that:
     - host_port is defined and host_port != ''
     msg: "Set the value of 'host_port' in the inventory file."
-

--- a/installer/check_vars/tasks/check_openshift.yml
+++ b/installer/check_vars/tasks/check_openshift.yml
@@ -1,48 +1,48 @@
 # check_openshift.yml
 ---
-- name: awx_openshift_project should be defined 
+- name: awx_openshift_project should be defined
   assert:
     that:
     - awx_openshift_project is defined and awx_openshift_project != ''
     msg: "Set the value of 'awx_openshift_project' in the inventory file."
 
-- name: openshift_user should be defined 
+- name: openshift_user should be defined
   assert:
     that:
     - openshift_user is defined and openshift_user != ''
     msg: "Set the value of 'openshift_user' in the inventory file."
 
-- name: openshift_password should be defined 
+- name: openshift_password should be defined
   assert:
     that:
     - openshift_password is defined and openshift_password != ''
     msg: "Set the value of 'openshift_password' in the inventory file."
 
-- name: awx_node_port should be defined 
+- name: awx_node_port should be defined
   assert:
     that:
     - awx_node_port is defined and awx_node_port != ''
     msg: "Set the value of 'awx_node_port' in the inventory file."
 
-- name: docker_registry should be defined 
+- name: docker_registry should be defined
   assert:
     that:
     - docker_registry is defined and docker_registry != ''
     msg: "Set the value of 'docker_registry' in the inventory file."
 
-- name: docker_registry_repository should be defined 
+- name: docker_registry_repository should be defined
   assert:
     that:
     - docker_registry_repository is defined and docker_registry_repository != ''
     msg: "Set the value of 'docker_registry_repository' in the inventory file."
 
-- name: docker_registry_username should be defined 
+- name: docker_registry_username should be defined
   assert:
     that:
     - docker_registry_username is defined and docker_registry_username != ''
     msg: "Set the value of 'docker_registry_username' in the inventory file."
 
-- name: docker_registry_password should be defined 
+- name: docker_registry_password should be defined
   assert:
     that:
     - docker_registry_password is defined and docker_registry_password != ''

--- a/installer/check_vars/tasks/main.yml
+++ b/installer/check_vars/tasks/main.yml
@@ -1,9 +1,7 @@
 # main.yml
 ---
-
-- include: check_openshift.yml 
+- include: check_openshift.yml
   when: openshift_host is defined and openshift_host != ''
 
-- include: check_docker.yml 
+- include: check_docker.yml
   when: openshift_host is not defined or openshift_host == ''
-

--- a/installer/image_build/files/nginx.conf
+++ b/installer/image_build/files/nginx.conf
@@ -28,7 +28,6 @@ http {
     #tcp_nopush     on;
     #gzip  on;
 
-    
     upstream uwsgi {
         server localhost:8050;
         }

--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Get Version from checkout if not provided
   shell: "git describe --long | sed 's/\\-g.*//' | sed 's/\\-/\\./'"
   delegate_to: localhost
@@ -157,7 +156,7 @@
     tag: "{{ awx_version }}"
     pull: no
   delegate_to: localhost
-    
+
 - name: Clean docker base directory
   file:
     path: "{{ docker_base_path }}"

--- a/installer/inventory
+++ b/installer/inventory
@@ -26,7 +26,7 @@ host_port=80
 # docker_registry_repository=awx
 # docker_registry_username=developer
 
-# Set pg_hostname if you have an external postgres server, otherwise 
+# Set pg_hostname if you have an external postgres server, otherwise
 # a new ephemeral postgres service will be created
 # pg_hostname=postgresql
 pg_username=awx

--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -9,7 +9,7 @@ data:
     import os
     import socket
     ADMINS = ()
-
+    
     # Container environments don't like chroots
     AWX_PROOT_ENABLED = False
     
@@ -35,13 +35,13 @@ data:
     EMAIL_HOST_USER = ''
     EMAIL_HOST_PASSWORD = ''
     EMAIL_USE_TLS = False
-
+    
     LOGGING['handlers']['console'] = {
         '()': 'logging.StreamHandler',
         'level': 'DEBUG',
         'formatter': 'simple',
     }
-
+    
     LOGGING['loggers']['django.request']['handlers'] = ['console']
     LOGGING['loggers']['rest_framework.request']['handlers'] = ['console']
     LOGGING['loggers']['awx']['handlers'] = ['console']


### PR DESCRIPTION
I was running through the installer and my OCD tendencies were annoyed by a few whitespace errors here and there. This PR only adjusts whitespace inside the playbooks and included files inside `installer/`.`