### PR TITLE
Add dependencies to documentation to build NPM packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,6 +54,7 @@ Before you can run a deployment, you'll need the following installed in your loc
 - [docker-py](https://github.com/docker/docker-py) Python module
 - [Node 6.x LTS version](https://nodejs.org/en/download/)
 - [NPM 3.x LTS](https://docs.npmjs.com/)
+- other packages required to build npm packages (See [Installing other](#installing-other))
 
 #### Installing gettext
 
@@ -68,6 +69,14 @@ On macOS:
 ```bash
 $ brew install gettext
 $ brew link gettext --force
+```
+
+#### Installing other
+
+On Fedora / CentOS / RHEL:
+
+```bash
+$ yum install gcc-g++ bzip2
 ```
 
 ### AWX Tunables

--- a/awx/ui/npm-shrinkwrap.json
+++ b/awx/ui/npm-shrinkwrap.json
@@ -89,12 +89,12 @@
     "angular-breadcrumb": {
       "version": "0.4.1",
       "from": "ansible/angular-breadcrumb#0.4.1",
-      "resolved": "git://github.com/ansible/angular-breadcrumb.git#6c2b1ad45ad5fbe7adf39af1ef3b294ca8e207a9"
+      "resolved": "https://github.com/ansible/angular-breadcrumb.git#6c2b1ad45ad5fbe7adf39af1ef3b294ca8e207a9"
     },
     "angular-codemirror": {
       "version": "1.0.4",
       "from": "ansible/angular-codemirror#1.0.4",
-      "resolved": "git://github.com/ansible/angular-codemirror.git#75c3a2d0ccdf2e4c836fab7d7617d5db6c585c1b",
+      "resolved": "https://github.com/ansible/angular-codemirror.git#75c3a2d0ccdf2e4c836fab7d7617d5db6c585c1b",
       "dependencies": {
         "angular": {
           "version": "1.4.7",
@@ -111,7 +111,7 @@
     "angular-drag-and-drop-lists": {
       "version": "1.4.0",
       "from": "ansible/angular-drag-and-drop-lists#1.4.0",
-      "resolved": "git://github.com/ansible/angular-drag-and-drop-lists.git#4d32654ab7159689a7767b9be8fc85f9812ca5a8"
+      "resolved": "https://github.com/ansible/angular-drag-and-drop-lists.git#4d32654ab7159689a7767b9be8fc85f9812ca5a8"
     },
     "angular-duration-format": {
       "version": "1.0.1",
@@ -171,12 +171,12 @@
     "angular-scheduler": {
       "version": "0.1.0",
       "from": "ansible/angular-scheduler#0.1.1",
-      "resolved": "git://github.com/ansible/angular-scheduler.git#9f2893a54c758b05bd6afce897488c01a6e8959d",
+      "resolved": "https://github.com/ansible/angular-scheduler.git#9f2893a54c758b05bd6afce897488c01a6e8959d",
       "dependencies": {
         "angular-tz-extensions": {
           "version": "0.3.11",
           "from": "ansible/angular-tz-extensions",
-          "resolved": "git://github.com/ansible/angular-tz-extensions.git#33caaa9ccf5dfe29a95962c17c3c9e6b9775be35",
+          "resolved": "https://github.com/ansible/angular-tz-extensions.git#33caaa9ccf5dfe29a95962c17c3c9e6b9775be35",
           "dependencies": {
             "angular": {
               "version": "1.4.7",
@@ -195,7 +195,7 @@
     "angular-tz-extensions": {
       "version": "0.3.11",
       "from": "ansible/angular-tz-extensions#0.3.13",
-      "resolved": "git://github.com/ansible/angular-tz-extensions.git#33caaa9ccf5dfe29a95962c17c3c9e6b9775be35",
+      "resolved": "https://github.com/ansible/angular-tz-extensions.git#33caaa9ccf5dfe29a95962c17c3c9e6b9775be35",
       "dependencies": {
         "angular": {
           "version": "1.4.7",
@@ -3962,7 +3962,7 @@
     "lr-infinite-scroll": {
       "version": "1.0.0",
       "from": "lorenzofox3/lrInfiniteScroll",
-      "resolved": "git://github.com/lorenzofox3/lrInfiniteScroll.git#59d348bc5c18f164438d2a30f1fd79b333c3b649"
+      "resolved": "https://github.com/lorenzofox3/lrInfiniteScroll.git#59d348bc5c18f164438d2a30f1fd79b333c3b649"
     },
     "lru-cache": {
       "version": "2.2.4",
@@ -4093,7 +4093,7 @@
     "ng-toast": {
       "version": "2.0.0",
       "from": "ansible/ngToast#2.0.1",
-      "resolved": "git://github.com/ansible/ngToast.git#fea95bb34d27687e414619b4f72c11735d909f93"
+      "resolved": "https://github.com/ansible/ngToast.git#fea95bb34d27687e414619b4f72c11735d909f93"
     },
     "node-libs-browser": {
       "version": "0.7.0",
@@ -4161,7 +4161,7 @@
     "nvd3": {
       "version": "1.7.1",
       "from": "ansible/nvd3#1.7.1",
-      "resolved": "git://github.com/ansible/nvd3.git#a28bcd494a1df0677be7cf2ebc0578f44eb21102"
+      "resolved": "https://github.com/ansible/nvd3.git#a28bcd494a1df0677be7cf2ebc0578f44eb21102"
     },
     "nwmatcher": {
       "version": "1.3.9",
@@ -4910,7 +4910,7 @@
     "rrule": {
       "version": "2.2.0-dev",
       "from": "jkbrzt/rrule#4ff63b2f8524fd6d5ba6e80db770953b5cd08a0c",
-      "resolved": "git://github.com/jkbrzt/rrule.git#4ff63b2f8524fd6d5ba6e80db770953b5cd08a0c"
+      "resolved": "https://github.com/jkbrzt/rrule.git#4ff63b2f8524fd6d5ba6e80db770953b5cd08a0c"
     },
     "run-async": {
       "version": "0.1.0",
@@ -5460,7 +5460,7 @@
     "timezone-js": {
       "version": "0.4.14",
       "from": "ansible/timezone-js#0.4.14",
-      "resolved": "git://github.com/ansible/timezone-js.git#6937de14ce0c193961538bb5b3b12b7ef62a358f"
+      "resolved": "https://github.com/ansible/timezone-js.git#6937de14ce0c193961538bb5b3b12b7ef62a358f"
     },
     "tiny-lr": {
       "version": "0.2.1",


### PR DESCRIPTION
Replace git:// links with https:// links for people who can't access Github repositories using SSH protocol