### PR TITLE
Fix height of side navigation panel 

### DIFF
--- a/awx/ui/client/lib/components/layout/_index.less
+++ b/awx/ui/client/lib/components/layout/_index.less
@@ -89,7 +89,7 @@
         bottom: 0;
         top: @at-height-top-side-nav-makeup;
         overflow-y: auto;
-        min-height: 100vh;
+        max-height: 100vh;
         min-width: @at-width-collapsed-side-nav;
 
         .at-Layout-sideNavItem {


### PR DESCRIPTION
Issue: https://github.com/ansible/awx/issues/27

This fixes the issue where the Settings icon in the side navigation panel is not visible at 100% zoom in Chrome and Firefox.

### Chrome
<img width="1440" alt="screen shot 2017-09-08 at 12 03 31 pm" src="https://user-images.githubusercontent.com/15881645/30222763-fb9bef56-9495-11e7-8068-a6a6e5677a2b.png">

### Firefox
<img width="1432" alt="screen shot 2017-09-08 at 12 06 51 pm" src="https://user-images.githubusercontent.com/15881645/30222760-f85c095c-9495-11e7-8081-1b8929d4f0f1.png">
