### PR TITLE
fix builds on Mac OS X

### DIFF
--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -144,6 +144,12 @@
   service:
     name: docker
     state: started
+  when: not (ansible_distribution == "MacOSX")
+
+- name: Docker should be running For Mac
+  shell: '[ $(launchctl list | grep com.docker.docker | cut -f 1) != "-" ]'
+  delegate_to: localhost
+  when: ansible_distribution == "MacOSX"
 
 - name: Build base web image
   docker_image:

--- a/installer/install.yml
+++ b/installer/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Build and deploy AWX
   hosts: all
-  gather_facts: false
+  gather_facts: true
   roles:
     - { role: check_vars }
     - { role: image_build }


### PR DESCRIPTION
Building a Docker image on Mac OS X fails because the 'service' module in Ansible is not implemented for Mac OS X.