### PR TITLE
Revert "Ensure Docker is running fixes #59"

### DIFF
--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -140,11 +140,6 @@
     dest: "{{ docker_base_path }}/Makefile"
   delegate_to: localhost
 
-- name: Docker should be running
-  service:
-    name: docker
-    state: started
-
 - name: Build base web image
   docker_image:
     path: "{{ docker_base_path }}"


### PR DESCRIPTION
Reverts ansible/awx#61

This breaks several other operating systems. User should ensure service is running prior to starting the installer.