### PR TITLE
The link to the AWX project FAQ added

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To install AWX, please view the [Install guide](./INSTALL.md).
 
 To learn more about using AWX, and Tower, view the [Tower docs site](http://docs.ansible.com/ansible-tower/index.html).
 
+The AWX Project Frequently Asked Questions can be found [here](https://www.ansible.com/awx-project-faq).
+
 Contributing
 ------------
 


### PR DESCRIPTION
The FAQ about the AWX project is not linked in any obvious place on the Ansible web page - or Am I just blind (?) - so I think that adding a link to the project README is justifiable.

I've found that FAQ in the @maxamillion [tweet](https://twitter.com/TheMaxamillion/status/906404748328296449).