### PR TITLE
Prove that Shippable CI is not testing anything

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -8,11 +8,6 @@ env:
   - AWX_BUILD_TARGET=ui-test-ci
   - AWX_BUILD_TARGET="flake8 jshint"
 
-branches:
-  only:
-    - devel
-    - release_*
-
 build:
   pre_ci:
     - docker build -t ansible/awx_devel -f tools/docker-compose/Dockerfile .

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - 2.7
+    - 3.6
 
 env:
   - AWX_BUILD_TARGET=test


### PR DESCRIPTION
This repo's current code contains Python 3 Syntax Errors ([E999](http://flake8.readthedocs.io/en/latest/user/error-codes.html)) that should halt the Shippable CI process if flake8 is being run against the repo's code.