### PR TITLE
Build sdist inside of a container

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,6 @@ This document provides a guide for installing AWX.
   - [Clone the repo](#clone-the-repo)
   - [AWX branding](#awx-branding)
   - [Prerequisites](#prerequisites)
-    - [Installing gettext](#installing-gettext)
   - [AWX Tunables](#awx-tunables)
   - [Choose a deployment platform](#choose-a-deployment-platform)
 - [OpenShift](#openshift)
@@ -49,28 +48,10 @@ To install the assets, clone the awx-logos repo into the root of your local AWX 
 Before you can run a deployment, you'll need the following installed in your local environment:
 
 - [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html)
-- gettext package for your platform (See [Installing gettext](#installing-gettext))
 - [Docker](https://docs.docker.com/engine/installation/)
 - [docker-py](https://github.com/docker/docker-py) Python module
-- [Node 6.x LTS version](https://nodejs.org/en/download/)
-- [NPM 3.x LTS](https://docs.npmjs.com/)
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Git](https://git-scm.com/)
-
-#### Installing gettext
-
-On Fedora / CentOS / RHEL:
-
-```bash
-$ yum install gettext
-```
-
-On macOS:
-
-```bash
-$ brew install gettext
-$ brew link gettext --force
-```
 
 ### AWX Tunables
 

--- a/installer/image_build/files/Dockerfile.sdist
+++ b/installer/image_build/files/Dockerfile.sdist
@@ -1,0 +1,20 @@
+FROM centos:7
+
+RUN yum install -y epel-release
+
+RUN yum install -y bzip2 \
+    gcc-c++ \
+    gettext \
+    git \
+    make \
+    python \
+    python-pip
+
+RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+RUN yum install -y nodejs
+RUN npm set progress=false
+
+WORKDIR "/awx"
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["make sdist"]

--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -47,12 +47,22 @@
   when: not sdist.stat.exists
   delegate_to: localhost
 
+- name: Build sdist builder image
+  docker_image:
+    path: "image_build/files"
+    dockerfile: Dockerfile.sdist
+    name: awx_sdist_builder
+    tag: "{{ awx_version }}"
+    force: true
+
 - name: Build AWX distribution
-  shell: make sdist
-  args:
-    chdir: ..
-    creates: "./dist/{{ awx_sdist_file }}"
-  delegate_to: localhost
+  docker_container:
+    image: "awx_sdist_builder:{{ awx_version }}"
+    name: awx_sdist_builder
+    state: started
+    detach: false
+    volumes:
+      - ../:/awx
 
 - name: Set docker build base path
   set_fact:


### PR DESCRIPTION
A lot of people have experienced issues with the system-level dependencies that are required in order to build the source distribution that is handed off to the image builds. This makes it unnecessary to install any additional software on the host machine aside from Ansible and Docker.

I've successfully tested this with native Docker on Fedora 26 and Docker For Mac.

While this eliminates the need for installing any additional tooling, there are some downsides:

- While native Docker on Linux does not incur the overhead of copying files to / from a VM,  I/O with Docker For Mac is ***slow***. This substantially increases the amount of time it takes to create the source distribution on macOS.
- We incur the cost of building this image. On a fast connection and decent hardware the time added is negligible, but it is something worth noting.

I personally think these tradeoffs are worth the benefits, but I'll let others weigh in as to whether or not we want to go this route.

Link #83