### PR TITLE
Move install.template.ejs to be built for prod only

### DIFF
--- a/awx/ui/build/webpack.base.js
+++ b/awx/ui/build/webpack.base.js
@@ -25,8 +25,6 @@ const APP_ENTRY = path.join(SOURCE_PATH, 'app.js');
 const VENDOR_ENTRY = path.join(SOURCE_PATH, 'vendor.js');
 const INDEX_ENTRY = path.join(CLIENT_PATH, 'index.template.ejs');
 const INDEX_OUTPUT = path.join(UI_PATH, 'templates/ui/index.html');
-const INSTALL_RUNNING_ENTRY = path.join(CLIENT_PATH, 'installing.template.ejs')
-const INSTALL_RUNNING_OUTPUT = path.join(UI_PATH, 'templates/ui/installing.html');
 const THEME_ENTRY = path.join(LIB_PATH, 'theme', 'index.less');
 const OUTPUT = 'js/[name].[hash].js';
 const CHUNKS = ['vendor', 'app'];
@@ -164,19 +162,6 @@ let base = {
             alwaysWriteToDisk: true,
             template: INDEX_ENTRY,
             filename: INDEX_OUTPUT,
-            inject: false,
-            chunks: CHUNKS,
-            chunksSortMode: (moduleA, moduleB) => {
-                moduleA.files.sort((fileA, fileB) => fileA.includes('js') ? -1 : 1)
-                moduleB.files.sort((fileA, fileB) => fileA.includes('js') ? -1 : 1)
-
-                return moduleA.names[0] === 'vendor' ? -1 : 1
-            }
-        }),
-        new HtmlWebpackPlugin({
-            alwaysWriteToDisk: true,
-            template: INSTALL_RUNNING_ENTRY,
-            filename: INSTALL_RUNNING_OUTPUT,
             inject: false,
             chunks: CHUNKS,
             chunksSortMode: (moduleA, moduleB) => {

--- a/awx/ui/build/webpack.production.js
+++ b/awx/ui/build/webpack.production.js
@@ -1,15 +1,36 @@
-const _ = require('lodash');
+const path = require('path');
 
+const _ = require('lodash');
 const webpack = require('webpack');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 let base = require('./webpack.base');
+
+const CLIENT_PATH = path.resolve(__dirname, '../client');
+const UI_PATH = path.resolve(__dirname, '..');
+const INSTALL_RUNNING_ENTRY = path.join(CLIENT_PATH, 'installing.template.ejs')
+const INSTALL_RUNNING_OUTPUT = path.join(UI_PATH, 'templates/ui/installing.html');
+const CHUNKS = ['vendor', 'app'];
 
 let production = {
     plugins: [
         new UglifyJSPlugin({
             compress: true,
             mangle: false
+        }),
+        new HtmlWebpackPlugin({
+            alwaysWriteToDisk: true,
+            template: INSTALL_RUNNING_ENTRY,
+            filename: INSTALL_RUNNING_OUTPUT,
+            inject: false,
+            chunks: CHUNKS,
+            chunksSortMode: (moduleA, moduleB) => {
+                moduleA.files.sort((fileA, fileB) => fileA.includes('js') ? -1 : 1);
+                moduleB.files.sort((fileA, fileB) => fileA.includes('js') ? -1 : 1);
+
+                return moduleA.names[0] === 'vendor' ? -1 : 1;
+            }
         })
     ]
 };


### PR DESCRIPTION
Small change shifting the `installing.html` generation from the base config to the production config since it's only intended for production environments.