### PR TITLE
Make sure sdist builder image and AWX distribution are built locally

### DIFF
--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -54,6 +54,7 @@
     name: awx_sdist_builder
     tag: "{{ awx_version }}"
     force: true
+  delegate_to: localhost
 
 - name: Build AWX distribution
   docker_container:
@@ -63,6 +64,7 @@
     detach: false
     volumes:
       - ../:/awx:Z
+  delegate_to: localhost
 
 - name: Set docker build base path
   set_fact:


### PR DESCRIPTION
Even when deploying the final image remotely. #104 made it impossible to build locally and deploy remotely according to the documentation, this fixes that. 

Signed-off-by: Eike Frost <ei@kefro.st>

##### SUMMARY

Adds delegate_to: localhost to the dockerized build instructions added in #104 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 1.0.0.342
