### PR TITLE
Make get_system_task_capacity portable

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -584,9 +584,9 @@ def get_system_task_capacity():
         return settings.SYSTEM_TASK_CAPACITY
     mem = psutil.virtual_memory()
     total_mem_value = mem.total / 1024 / 1024
-    if int(total_mem_value) <= 2048:
+    if total_mem_value <= 2048:
         return 50
-    return 50 + ((int(total_mem_value) / 1024) - 2) * 75
+    return 50 + ((total_mem_value / 1024) - 2) * 75
 
 
 _inventory_updates = threading.local()

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -583,7 +583,7 @@ def get_system_task_capacity():
     if hasattr(settings, 'SYSTEM_TASK_CAPACITY'):
         return settings.SYSTEM_TASK_CAPACITY
     mem = psutil.virtual_memory()
-    total_mem_value = mem.total/1024/1024
+    total_mem_value = mem.total / 1024 / 1024
     if int(total_mem_value) <= 2048:
         return 50
     return 50 + ((int(total_mem_value) / 1024) - 2) * 75

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -17,6 +17,7 @@ import threading
 import contextlib
 import tempfile
 import six
+import psutil
 
 # Decorator
 from decorator import decorator
@@ -581,12 +582,8 @@ def get_system_task_capacity():
     from django.conf import settings
     if hasattr(settings, 'SYSTEM_TASK_CAPACITY'):
         return settings.SYSTEM_TASK_CAPACITY
-    try:
-        out = subprocess.check_output(['free', '-m'])
-    except subprocess.CalledProcessError:
-        logger.exception('Problem obtaining capacity from system.')
-        return 0
-    total_mem_value = out.split()[7]
+    mem = psutil.virtual_memory()
+    total_mem_value = mem.total/1024/1024
     if int(total_mem_value) <= 2048:
         return 50
     return 50 + ((int(total_mem_value) / 1024) - 2) * 75


### PR DESCRIPTION
Call to free(1) is not portable

Switch to using psutil which can get the same info in a portable way. Values should be the same.
