### PR TITLE
Force awxweb hostname

### DIFF
--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -149,7 +149,7 @@
     awx_task_container_links:
       - rabbitmq
       - memcached
-      - awx_web
+      - awx_web:awxweb
   when: pg_hostname is defined
 
 - name: Set properties with postgres for awx_task
@@ -158,7 +158,7 @@
     awx_task_container_links:
       - rabbitmq
       - memcached
-      - awx_web
+      - awx_web:awxweb
       - postgres
   when: pg_hostname is not defined or pg_hostname == ''
 


### PR DESCRIPTION
For some reason some docker deployments seem not to be able to resolve
the awxweb host from the awx task host at least when started from the
playbook. This hopefully provides a resolution for that

ref #135 