### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/awx/api/parsers.py
+++ b/awx/api/parsers.py
@@ -33,7 +33,7 @@ class OrderedDictLoader(yaml.SafeLoader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise yaml.constructor.ConstructorError(
                     "while constructing a mapping", node.start_mark,
                     "found unacceptable key (%s)" % exc, key_node.start_mark

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1175,7 +1175,7 @@ class InventorySerializer(BaseSerializerWithVariables):
         if host_filter:
             try:
                 SmartFilter().query_from_string(host_filter)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 raise models.base.ValidationError(e)
         return host_filter
 

--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
@@ -1859,7 +1860,7 @@ class InventoryDetail(ControlledByScmMixin, RetrieveUpdateDestroyAPIView):
         try:
             obj.schedule_deletion(getattr(request.user, 'id', None))
             return Response(status=status.HTTP_202_ACCEPTED)
-        except RuntimeError, e:
+        except RuntimeError as e:
             return Response(dict(error=_("{0}".format(e))), status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -186,7 +186,7 @@ def get_cache_value(value):
         value = SETTING_CACHE_NONE
     elif isinstance(value, (list, tuple)) and len(value) == 0:
         value = SETTING_CACHE_EMPTY_LIST
-    elif isinstance(value, (dict,)) and len(value) == 0:
+    elif isinstance(value, dict) and len(value) == 0:
         value = SETTING_CACHE_EMPTY_DICT
     return value
 
@@ -272,7 +272,7 @@ class SettingsWrapper(UserSettingsHolder):
                 setting_ids[setting.key] = setting.id
                 try:
                     value = decrypt_field(setting, 'value')
-                except ValueError, e:
+                except ValueError as e:
                     #TODO: Remove in Tower 3.3
                     logger.debug('encountered error decrypting field: %s - attempting fallback to old', e)
                     value = old_decrypt_field(setting, 'value')

--- a/awx/conf/utils.py
+++ b/awx/conf/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Python
+from __future__ import print_function
 import difflib
 import glob
 import os

--- a/awx/main/expect/run.py
+++ b/awx/main/expect/run.py
@@ -47,7 +47,7 @@ def open_fifo_write(path, data):
     This blocks the thread until an external process (such as ssh-agent)
     reads data from the pipe.
     '''
-    os.mkfifo(path, 0600)
+    os.mkfifo(path, 0o600)
     thread.start_new_thread(lambda p, d: open(p, 'w').write(d), (path, data))
 
 

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -354,7 +354,7 @@ class SmartFilterField(models.TextField):
             return None
         try:
             SmartFilter().query_from_string(value)
-        except RuntimeError, e:
+        except RuntimeError as e:
             raise models.base.ValidationError(e)
         return super(SmartFilterField, self).get_prep_value(value)
 

--- a/awx/main/management/commands/cleanup_facts.py
+++ b/awx/main/management/commands/cleanup_facts.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/management/commands/deprovision_instance.py
+++ b/awx/main/management/commands/deprovision_instance.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/management/commands/generate_isolated_key.py
+++ b/awx/main/management/commands/generate_isolated_key.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 import datetime
@@ -17,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         if getattr(settings, 'AWX_ISOLATED_PRIVATE_KEY', False):
-            print settings.AWX_ISOLATED_PUBLIC_KEY
+            print(settings.AWX_ISOLATED_PUBLIC_KEY)
             return
 
         key = rsa.generate_private_key(
@@ -41,4 +42,4 @@ class Command(BaseCommand):
             ) + " generated-by-awx@%s" % datetime.datetime.utcnow().isoformat()
         )
         pemfile.save()
-        print pemfile.value
+        print(pemfile.value)

--- a/awx/main/management/commands/list_instances.py
+++ b/awx/main/management/commands/list_instances.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/management/commands/provision_instance.py
+++ b/awx/main/management/commands/provision_instance.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/management/commands/register_queue.py
+++ b/awx/main/management/commands/register_queue.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2017 Ansible Tower by Red Hat
 # All Rights Reserved.
 import sys

--- a/awx/main/management/commands/remove_from_queue.py
+++ b/awx/main/management/commands/remove_from_queue.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2017 Ansible Tower by Red Hat
 # All Rights Reserved.
 import sys

--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 

--- a/awx/main/management/commands/unregister_queue.py
+++ b/awx/main/management/commands/unregister_queue.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2017 Ansible Tower by Red Hat
 # All Rights Reserved.
 import sys

--- a/awx/main/management/commands/user_info.py
+++ b/awx/main/management/commands/user_info.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 

--- a/awx/main/queue.py
+++ b/awx/main/queue.py
@@ -46,6 +46,6 @@ class CallbackQueueDispatcher(object):
                                  delivery_mode="persistent" if settings.PERSISTENT_CALLBACK_MESSAGES else "transient",
                                  routing_key=self.connection_queue)
                 return
-            except Exception, e:
+            except Exception as e:
                 self.logger.info('Publish Job Event Exception: %r, retry=%d', e,
                                  retry_count, exc_info=True)

--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -7,7 +7,7 @@ REPLACE_STR = '$encrypted$'
 class UriCleaner(object):
     REPLACE_STR = REPLACE_STR
     # https://regex101.com/r/sV2dO2/2
-    SENSITIVE_URI_PATTERN = re.compile(ur'(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))', re.MULTILINE)
+    SENSITIVE_URI_PATTERN = re.compile(r'(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))', re.MULTILINE)
 
     @staticmethod
     def remove_sensitive(cleartext):

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -541,5 +541,5 @@ def delete_inventory_for_org(sender, instance, **kwargs):
     for inventory in inventories:
         try:
             inventory.schedule_deletion(user_id=getattr(user, 'id', None))
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.debug(e)

--- a/awx/main/south_migrations/0031_v145_changes.py
+++ b/awx/main/south_migrations/0031_v145_changes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
@@ -17,7 +18,7 @@ class Migration(DataMigration):
                 obj1 = eval(obj_type + ".objects.get(id=" + str(activity_stream_object.object1_id) + ")")
                 if hasattr(activity_stream_object, activity_stream_object.object1):
                     getattr(activity_stream_object, activity_stream_object.object1).add(obj1)
-            except ObjectDoesNotExist, e:
+            except ObjectDoesNotExist as e:
                 print("Object 1 for AS id=%s does not exist. (Object Type: %s, id: %s" % (str(activity_stream_object.id),
                                                                                           activity_stream_object.object1_type,
                                                                                           str(activity_stream_object.object1_id)))
@@ -29,7 +30,7 @@ class Migration(DataMigration):
                         obj_type = 'orm["auth.User"]'
                     obj2 = eval(obj_type + ".objects.get(id=" + str(activity_stream_object.object2_id) + ")")
                     getattr(activity_stream_object, activity_stream_object.object2).add(obj2)
-                except ObjectDoesNotExist, e:
+                except ObjectDoesNotExist as e:
                     print("Object 2 for AS id=%s does not exist. (Object Type: %s, id: %s" % (str(activity_stream_object.id),
                                                                                               activity_stream_object.object2_type,
                                                                                               str(activity_stream_object.object2_id)))

--- a/awx/main/south_migrations/0042_v200_changes.py
+++ b/awx/main/south_migrations/0042_v200_changes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/awx/main/south_migrations/0044_v1411_changes.py
+++ b/awx/main/south_migrations/0044_v1411_changes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/awx/main/south_migrations/0047_v200_changes.py
+++ b/awx/main/south_migrations/0047_v200_changes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1032,7 +1032,7 @@ class RunJob(BaseTask):
         # job and visible inside the proot environment (when enabled).
         cp_dir = os.path.join(kwargs['private_data_dir'], 'cp')
         if not os.path.exists(cp_dir):
-            os.mkdir(cp_dir, 0700)
+            os.mkdir(cp_dir, 0o700)
         env['ANSIBLE_SSH_CONTROL_PATH'] = os.path.join(cp_dir, '%%h%%p%%r')
 
         # Allow the inventory script to include host variables inline via ['_meta']['hostvars'].

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 from awx.api.versioning import reverse

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 # Python
 import pytest

--- a/awx/main/tests/functional/test_projects.py
+++ b/awx/main/tests/functional/test_projects.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import mock # noqa
 import pytest
 

--- a/awx/main/tests/functional/test_python_requirements.py
+++ b/awx/main/tests/functional/test_python_requirements.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import os
 import re

--- a/awx/main/tests/manual/workflows/linear.py
+++ b/awx/main/tests/manual/workflows/linear.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # AWX
 from awx.main.models import (
     WorkflowJobTemplateNode,

--- a/awx/main/tests/manual/workflows/parallel.py
+++ b/awx/main/tests/manual/workflows/parallel.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # AWX
 from awx.main.models import (
     WorkflowJobTemplateNode,

--- a/awx/main/tests/old/inventory.py
+++ b/awx/main/tests/old/inventory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
@@ -758,9 +759,9 @@ class InventoryUpdatesTest(BaseTransactionTest):
             self.get(inv_up_url, expect=404)
 
     def print_group_tree(self, group, depth=0):
-        print ('  ' * depth) + '+ ' + group.name
+        print(('  ' * depth) + '+ ' + group.name)
         for host in group.hosts.order_by('name'):
-            print ('  ' * depth) + '  - ' + host.name
+            print(('  ' * depth) + '  - ' + host.name)
         for child in group.children.order_by('name'):
             self.print_group_tree(child, depth + 1)
 

--- a/awx/main/tests/old/tasks.py
+++ b/awx/main/tests/old/tasks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
@@ -336,11 +337,11 @@ class RunJobTest(BaseJobExecutionTest):
                          has_roles=False):
         job_events = job.job_events.all()
         if False and async:
-            print
+            print()
             qs = self.super_django_user.get_queryset(JobEvent)
             for je in qs.filter(job=job):
                 print(je.get_event_display2())
-                print(je.event, je, je.failed)
+                print((je.event, je, je.failed))
                 print(je.event_data)
         for job_event in job_events:
             unicode(job_event)  # For test coverage.

--- a/awx/main/tests/unit/api/test_filters.py
+++ b/awx/main/tests/unit/api/test_filters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import pytest
 
 from rest_framework.exceptions import PermissionDenied, ParseError

--- a/awx/main/tests/unit/utils/test_filters.py
+++ b/awx/main/tests/unit/utils/test_filters.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 # Python
 import pytest

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -32,6 +32,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 from django.utils.encoding import smart_str
 from django.utils.text import slugify
 from django.apps import apps
+from functools import reduce
 
 logger = logging.getLogger('awx.main.utils')
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -12,6 +12,7 @@ from pyparsing import (
 import django
 
 from awx.main.utils.common import get_search_fields
+from functools import reduce
 
 __all__ = ['SmartFilter']
 

--- a/awx/plugins/inventory/awxrest.py
+++ b/awx/plugins/inventory/awxrest.py
@@ -126,7 +126,7 @@ class InventoryScript(object):
                 self.get_data(output)
             else:
                 raise RuntimeError('Either --list or --host must be specified')
-        except Exception, e:
+        except Exception as e:
             output.write('%s\n' % json.dumps(dict(failed=True)))
             if self.options.get('traceback', False):
                 sys.stderr.write(traceback.format_exc())

--- a/awx/plugins/inventory/azure_rm.py
+++ b/awx/plugins/inventory/azure_rm.py
@@ -183,6 +183,7 @@ Company: Ansible by Red Hat
 
 Version: 1.0.0
 '''
+from __future__ import print_function
 
 import argparse
 import ConfigParser

--- a/awx/plugins/inventory/ec2.py
+++ b/awx/plugins/inventory/ec2.py
@@ -102,6 +102,7 @@ variable named:
 Security groups are comma-separated in 'ec2_security_group_ids' and
 'ec2_security_group_names'.
 '''
+from __future__ import print_function
 
 # (c) 2012, Peter Sankauskas
 #

--- a/awx/plugins/inventory/gce.py
+++ b/awx/plugins/inventory/gce.py
@@ -72,6 +72,7 @@ Author: Eric Johnson <erjohnso@google.com>
 Contributors: Matt Hite <mhite@hotmail.com>, Tom Melendez <supertom@google.com>
 Version: 0.0.3
 '''
+from __future__ import print_function
 
 __requires__ = ['pycrypto>=2.6']
 try:

--- a/awx/plugins/inventory/openstack.py
+++ b/awx/plugins/inventory/openstack.py
@@ -45,6 +45,7 @@
 #                When set to False, the inventory will return hosts from
 #                whichever other clouds it can contact. (Default: True)
 
+from __future__ import print_function
 import argparse
 import collections
 import os

--- a/awx/plugins/inventory/windows_azure.py
+++ b/awx/plugins/inventory/windows_azure.py
@@ -14,6 +14,7 @@ installed.
 
 Adapted from the ansible Linode plugin by Dan Slimmon.
 '''
+from __future__ import print_function
 
 # (c) 2013, John Whitbeck
 #

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
@@ -17,7 +18,7 @@ import mimetypes
 from split_settings.tools import optional, include
 
 # Load default settings.
-from defaults import *  # NOQA
+from .defaults import *  # NOQA
 
 # show colored logs in the dev environment
 # to disable this, set `COLOR_LOGS = False` in awx/settings/local_settings.py

--- a/awx/settings/development_quiet.py
+++ b/awx/settings/development_quiet.py
@@ -1,13 +1,14 @@
+from __future__ import absolute_import
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
 # Development settings for AWX project, but with DEBUG disabled
 
 # Load development settings.
-from defaults import *  # NOQA
+from .defaults import *  # NOQA
 
 # Load development settings.
-from development import *  # NOQA
+from .development import *  # NOQA
 
 # Disable capturing DEBUG
 DEBUG = False

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
@@ -13,7 +14,7 @@ import traceback
 from split_settings.tools import optional, include
 
 # Load default settings.
-from defaults import *  # NOQA
+from .defaults import *  # NOQA
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,12 +1,17 @@
 language: python
 
 python:
-    - 2.7
+    - "2.7"
+    - "3.6"
 
 env:
   - AWX_BUILD_TARGET=test
   - AWX_BUILD_TARGET=ui-test-ci
   - AWX_BUILD_TARGET="flake8 jshint"
+
+matrix:
+  allow_failures:
+    - python "3.6"
 
 branches:
   only:

--- a/tools/data_generators/rbac_dummy_data_generator.py
+++ b/tools/data_generators/rbac_dummy_data_generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved
+from __future__ import print_function
 import os
 import sys
 
@@ -89,7 +90,7 @@ options = vars(options)
 
 
 if options['preset']:
-    print ' Using preset data numbers set ' + str(options['preset'])
+    print(' Using preset data numbers set ' + str(options['preset']))
     # Read the numbers of resources from presets file, if provided
     presets_filename = os.path.abspath(os.path.join(
         os.path.dirname(os.path.abspath(__file__)), 'presets.tsv'))

--- a/tools/rdb.py
+++ b/tools/rdb.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import rlcompleter
 try:
     import readline
@@ -183,7 +184,7 @@ def listen():
     def _consume(queue):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.bind(('0.0.0.0', 6899))
-        print 'listening for rdb notifications on :6899...'
+        print('listening for rdb notifications on :6899...')
         while True:
             r, w, x = select.select([sock], [], [])
             for i in r:
@@ -201,13 +202,13 @@ def listen():
                 if port == 'q':
                     break
                 port = int(port)
-                print 'opening telnet session at localhost:%d...' % port
+                print('opening telnet session at localhost:%d...' % port)
                 telnet(port)
-                print 'listening for rdb notifications on :6899...'
+                print('listening for rdb notifications on :6899...')
             except Empty:
                 pass
     except KeyboardInterrupt:
-        print 'got Ctrl-C'
+        print('got Ctrl-C')
         queue.put('q')
 
 
@@ -218,9 +219,9 @@ def telnet(port):
     try:
         s.connect(('0.0.0.0', port))
     except:
-        print 'unable to connect'
+        print('unable to connect')
         return
-    print 'connected to 0.0.0.0:%d' % port
+    print('connected to 0.0.0.0:%d' % port)
 
     while True:
         socket_list = [sys.stdin, s]
@@ -229,7 +230,7 @@ def telnet(port):
             if sock == s:
                 data = sock.recv(4096)
                 if not data:
-                    print 'connection closed'
+                    print('connection closed')
                     return
                 else:
                     sys.stdout.write(data)

--- a/tools/scripts/compilemessages.py
+++ b/tools/scripts/compilemessages.py
@@ -5,6 +5,7 @@
 # is not available when `make languages` is invoked.
 #
 
+from __future__ import print_function
 import codecs
 import datetime
 import locale
@@ -31,7 +32,7 @@ def has_bom(fn):
     return sample.startswith((codecs.BOM_UTF8, codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE))
 
 
-def popen_wrapper(args, os_err_exc_type=StandardError, stdout_encoding='utf-8'):
+def popen_wrapper(args, os_err_exc_type=Exception, stdout_encoding='utf-8'):
     """
     Friendly wrapper around Popen.
     Returns stdout output, stderr output and OS status code.

--- a/tools/scripts/manage_translations.py
+++ b/tools/scripts/manage_translations.py
@@ -37,6 +37,7 @@
 #  $ python tools/scripts/manage_translations.py pull --both --lang ja
 
 # python
+from __future__ import print_function
 import os
 from argparse import ArgumentParser
 from subprocess import PIPE, Popen

--- a/tools/scripts/pk_to_named_url.py
+++ b/tools/scripts/pk_to_named_url.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import argparse
 import six
 


### PR DESCRIPTION
This PR replaces #98 which in turn replaced #50 

Make the minimal, safe changes required to convert the code to be syntax compatible with both Python 2 and Python 3. There would definitely be __more work required__ to complete the port of the code to Python 3 but this is a minimal, safe first step.

1. Run: `futurize --stage1 -w **/*.py`

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`

2. Replace a ur'string' with an r'string' in `awx/main/redact.py`
3. Start testing on Python 3 in allow_failures mode in `shippable.yml`