### PR TITLE
only pause when containers are launched

### DIFF
--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -107,7 +107,7 @@
       POSTGRES_PASSWORD: "{{ pg_password }}"
       POSTGRES_DB: "{{ pg_database }}"
   when: pg_hostname is not defined or pg_hostname == ''
-  register: postgres_container_started
+  register: postgres_container_activate
 
 - name: Activate rabbitmq container
   docker_container:
@@ -116,7 +116,7 @@
     image: rabbitmq:3
     env:
       RABBITMQ_DEFAULT_VHOST: "awx"
-  register: rabbitmq_container_started
+  register: rabbitmq_container_activate
 
 - name: Activate memcached container
   docker_container:
@@ -127,7 +127,7 @@
 - name: Wait for postgres and rabbitmq to activate
   pause:
     seconds: 15
-  when: postgres_container_started.changed or rabbitmq_container_started.changed
+  when: postgres_container_activate.changed or rabbitmq_container_activate.changed
 
 - name: Set properties without postgres for awx_web
   set_fact:

--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -107,6 +107,7 @@
       POSTGRES_PASSWORD: "{{ pg_password }}"
       POSTGRES_DB: "{{ pg_database }}"
   when: pg_hostname is not defined or pg_hostname == ''
+  register: postgres_container_started
 
 - name: Activate rabbitmq container
   docker_container:
@@ -115,6 +116,7 @@
     image: rabbitmq:3
     env:
       RABBITMQ_DEFAULT_VHOST: "awx"
+  register: rabbitmq_container_started
 
 - name: Activate memcached container
   docker_container:
@@ -125,6 +127,7 @@
 - name: Wait for postgres and rabbitmq to activate
   pause:
     seconds: 15
+  when: postgres_container_started.changed or rabbitmq_container_started.changed
 
 - name: Set properties without postgres for awx_web
   set_fact:


### PR DESCRIPTION
##### SUMMARY
The local_docker deployment pauses whether or not there are changes to running containers.  This commit checks for changes before pausing.  No sense in waiting for containers to launch if they're already running.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
AWX: 1.0.0.378

##### ADDITIONAL INFORMATION
Before:
```
TASK [local_docker : Activate postgres container] *******************************************************
skipping: [localhost]

TASK [local_docker : Activate rabbitmq container] *******************************************************
ok: [localhost]

TASK [local_docker : Activate memcached container] ******************************************************
ok: [localhost]

TASK [local_docker : Wait for postgres and rabbitmq to activate] ****************************************
Pausing for 15 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [localhost]
```
After:
```
TASK [local_docker : Activate postgres container] *******************************************************
skipping: [localhost]

TASK [local_docker : Activate rabbitmq container] *******************************************************
ok: [localhost]

TASK [local_docker : Activate memcached container] ******************************************************
ok: [localhost]

TASK [local_docker : Wait for postgres and rabbitmq to activate] ****************************************
skipping: [localhost]

```
