### PR TITLE
Enable saving button on disabled Auth providers

### DIFF
--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-ldap.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-ldap.form.js
@@ -100,7 +100,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' || form.$invalid || form.$pending"
+                ngDisabled: "!ldap_auth || form.$invalid || form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-radius.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-radius.form.js
@@ -39,7 +39,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' || form.$invalid || form.$pending"
+                ngDisabled: "!enterprise_auth || form.$invalid || form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-saml.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-saml.form.js
@@ -92,7 +92,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' || form.$invalid || form.$pending"
+                ngDisabled: "!enterprise_auth || form.$invalid || form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-tacacs.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-tacacs.form.js
@@ -52,7 +52,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' || form.$invalid || form.$pending"
+                ngDisabled: "!enterprise_auth || form.$invalid || form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/configuration.controller.js
+++ b/awx/ui/client/src/configuration/configuration.controller.js
@@ -7,7 +7,7 @@
 export default [
     '$scope', '$rootScope', '$state', '$stateParams', '$timeout', '$q', 'Alert',
     'ConfigurationService', 'ConfigurationUtils', 'CreateDialog', 'CreateSelect2', 'i18n', 'ParseTypeChange', 'ProcessErrors', 'Store',
-    'Wait', 'configDataResolve', 'ToJSON',
+    'Wait', 'configDataResolve', 'ToJSON', 'ConfigService',
     //Form definitions
     'configurationAzureForm',
     'configurationGithubForm',
@@ -26,7 +26,7 @@ export default [
     function(
         $scope, $rootScope, $state, $stateParams, $timeout, $q, Alert,
         ConfigurationService, ConfigurationUtils, CreateDialog, CreateSelect2, i18n, ParseTypeChange, ProcessErrors, Store,
-        Wait, configDataResolve, ToJSON,
+        Wait, configDataResolve, ToJSON, ConfigService,
         //Form definitions
         configurationAzureForm,
         configurationGithubForm,
@@ -94,9 +94,6 @@ export default [
                                 }
 
                             } else {
-                                if (key === "LICENSE") {
-                                    $scope.license_type = data[key].license_type;
-                                }
                                 //handle nested objects
                                 if(ConfigurationUtils.isEmpty(data[key])) {
                                     $scope[key] = '{}';
@@ -109,6 +106,11 @@ export default [
                         }
                     });
                     $scope.$broadcast('populated', data);
+                });
+            ConfigService.getConfig()
+                .then(function(data) {
+                    $scope.ldap_auth = data.license_info.features.ldap;
+                    $scope.enterprise_auth = data.license_info.features.enterprise_auth;
                 });
         };
 


### PR DESCRIPTION
Enables saving button on LDAP, RADIUS, SAML and TACACS+ Auth proviers

Signed-off-by: Julen Landa Alustiza <julen@zokormazo.info>

##### SUMMARY
The enterprise license check has no sense here so I replaced it with enable like in the rest of the auth providers.

Fixes #88

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
awx: 1.0.0.386
