### PR TITLE
Rework installer to support local minishift environment

### DIFF
--- a/installer/image_build/tasks/main.yml
+++ b/installer/image_build/tasks/main.yml
@@ -59,8 +59,9 @@
     tag: "{{ awx_version }}"
     force: true
   delegate_to: localhost
+  when: use_container_for_build|bool
 
-- name: Build AWX distribution
+- name: Build AWX distribution using container
   docker_container:
     env:
       http_proxy: "{{ http_proxy | default('') }}"
@@ -73,6 +74,14 @@
     volumes:
       - ../:/awx:Z
   delegate_to: localhost
+  when: use_container_for_build|bool
+
+- name: Build AWX distribution locally
+  shell: make sdist
+  args:
+    chdir: ..
+  delegate_to: localhost
+  when: not use_container_for_build|bool
 
 - name: Set docker build base path
   set_fact:

--- a/installer/inventory
+++ b/installer/inventory
@@ -2,6 +2,17 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 
 [all:vars]
 
+# Use a local distribution build container image for building the AWX package
+# This is helpful if you don't want to bother installing the build-time dependencies as
+# it is taken care of already.
+# NOTE: IMPORTANT: If you are running a mininshift install, using this container might not work
+#                  if you are using certain drivers like KVM where the source tree can't be mapped
+#                  into the build container.
+#                  Thus this setting must be set to False which will trigger a local build. To view the
+#                  typical dependencies that you might need to install see:
+#                  installer/image_build/files/Dockerfile.sdist
+use_container_for_build=true
+
 # Build AWX with official logos
 # Requires cloning awx-logos repo into the project root.
 # Review the trademark guidelines at https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md
@@ -9,7 +20,6 @@ awx_official=false
 
 # Openshift Install
 # Will need to set -e openshift_password=developer -e docker_registry_password=$(oc whoami -t)
-#
 # openshift_host=127.0.0.1:8443
 # awx_openshift_project=awx
 # openshift_user=developer
@@ -19,7 +29,7 @@ awx_official=false
 postgres_data_dir=/tmp/pgdocker
 host_port=80
 
-# Required for Openshift, Optional for Standalone Docker install
+# Required for Openshift (unless you use an external registry), Optional for Standalone Docker install
 # Define if you want the image pushed to a registry. The container definition
 # will also use these images
 # docker_registry=172.30.1.1:5000


### PR DESCRIPTION
This also adds an option to *not* use the local container for building
the software distribution which is required for a local minishift
environment based install

connect #124 