### PR TITLE
add email option to registry login

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -25,6 +25,8 @@ host_port=80
 # docker_registry=172.30.1.1:5000
 # docker_registry_repository=awx
 # docker_registry_username=developer
+# docker_registry_password=developerpass
+# docker_registry_email=dev@example.org
 
 # Set pg_hostname if you have an external postgres server, otherwise
 # a new ephemeral postgres service will be created

--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -20,6 +20,7 @@
     registry: "{{ docker_registry }}"
     username: "{{ docker_registry_username }}"
     password: "{{ docker_registry_password }}"
+    email: "{{ docker_registry_email | default(omit) }}"
     reauthorize: yes
   when: docker_registry is defined and docker_registry_password is defined
   delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This feature will allow to push images to registries which need email option, like hub.docker.com.
I have already tried this to push images to [docker hub](https://hub.docker.com/r/paulfantom/awx_web)
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.0.391
```
