### PR TITLE
do not use parent_model with GenericAPIView

### DIFF
--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -2835,7 +2835,6 @@ class JobTemplateSchedulesList(SubListCreateAPIView):
 class JobTemplateSurveySpec(GenericAPIView):
 
     model = JobTemplate
-    parent_model = JobTemplate
     serializer_class = EmptySerializer
     new_in_210 = True
 
@@ -3365,7 +3364,6 @@ class WorkflowJobTemplateDetail(WorkflowsEnforcementMixin, RetrieveUpdateDestroy
 class WorkflowJobTemplateCopy(WorkflowsEnforcementMixin, GenericAPIView):
 
     model = WorkflowJobTemplate
-    parent_model = WorkflowJobTemplate
     serializer_class = EmptySerializer
     new_in_310 = True
 


### PR DESCRIPTION
Resolution to #157

These views don't use the parent model for anything that can be identified. Many other object-based action views (like launch, relaunch, etc) do it exactly like this, where the model is defined but the parent_model is not.