### PR TITLE
Fix an issue where we ignored the secret key during install

### DIFF
--- a/installer/image_build/files/settings.py
+++ b/installer/image_build/files/settings.py
@@ -6,7 +6,7 @@ import os
 def get_secret():
     if os.path.exists("/etc/tower/SECRET_KEY"):
         return file('/etc/tower/SECRET_KEY', 'rb').read().strip()
-    return os.getenv("SECRET_KEY", "privateawx"),
+    return os.getenv("SECRET_KEY", "privateawx")
 
 
 ADMINS = ()

--- a/installer/image_build/templates/Dockerfile.j2
+++ b/installer/image_build/templates/Dockerfile.j2
@@ -40,7 +40,6 @@ RUN yum -y install epel-release && \
 
 RUN mkdir -p /var/log/tower
 RUN mkdir -p /etc/tower
-RUN echo "awxsecret" > /etc/tower/SECRET_KEY
 COPY {{ awx_sdist_file }} /tmp/{{ awx_sdist_file }}
 RUN OFFICIAL=yes pip install /tmp/{{ awx_sdist_file }}
 

--- a/installer/inventory
+++ b/installer/inventory
@@ -44,8 +44,10 @@ pg_password=awxpass
 pg_database=awx
 pg_port=5432
 
-# AWX Tunables
-awx_secret_key=aabbcc
+# AWX Secret key
+# It's *very* important that this stay the same between upgrades or you will use the ability to decrypt
+# your credentials
+awx_secret_key=awxsecret
 
 # Proxy
 #http_proxy=http://proxy:3128

--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -212,3 +212,4 @@
       RABBITMQ_VHOST: "awx"
       MEMCACHED_HOST: "memcached"
       MEMCACHED_PORT: "11211"
+      SECRET_KEY: "{{ awx_secret_key }}"


### PR DESCRIPTION
I'm also trying to make sure we have a good upgrade path for those using standalone docker containers so I've pulled the original default value from the container and updated the base inventory file with it

ref: #99 