### PR TITLE
initializing i18nInit module

### DIFF
--- a/awx/ui/client/src/app.js
+++ b/awx/ui/client/src/app.js
@@ -171,12 +171,13 @@ angular.module('awApp', [
         'CheckLicense', '$location', 'Authorization', 'LoadBasePaths', 'Timer',
         'LoadConfig', 'Store', 'pendoService', 'Prompt', 'Rest',
         'Wait', 'ProcessErrors', '$state', 'GetBasePath', 'ConfigService',
-        'FeaturesService', '$filter', 'SocketService', 'AppStrings',
+        'FeaturesService', '$filter', 'SocketService', 'AppStrings', 'I18NInit',
         function($stateExtender, $q, $compile, $cookies, $rootScope, $log, $stateParams,
             CheckLicense, $location, Authorization, LoadBasePaths, Timer,
             LoadConfig, Store, pendoService, Prompt, Rest, Wait,
             ProcessErrors, $state, GetBasePath, ConfigService, FeaturesService,
-            $filter, SocketService, AppStrings) {
+            $filter, SocketService, AppStrings, I18NInit) {
+            I18NInit();
             $rootScope.$state = $state;
             $rootScope.$state.matches = function(stateName) {
                 return $state.current.name.search(stateName) > 0;


### PR DESCRIPTION
##### SUMMARY
The i18nInit module was not getting initialized at all in AWX. The call to initialize this was lost in translation from the old navigation to the new nav bar. 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.0.488
```


##### ADDITIONAL INFORMATION
I realized that translations were not working in AWX. To test this you should be able to run 

```
make pot
make languages 
```
outside the container and restart the UI 
