### PR TITLE
Add mobile menu

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -2328,11 +2328,3 @@ body {
 .btn {
     text-transform: uppercase;
 }
-
-@breakpoint-sm: 700px;
-
-@media screen and (max-width: @breakpoint-sm) {
-    #content-container {
-        padding-top: 100px;
-    }
-}

--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -2328,3 +2328,11 @@ body {
 .btn {
     text-transform: uppercase;
 }
+
+@breakpoint-sm: 700px;
+
+@media screen and (max-width: @breakpoint-sm) {
+    #content-container {
+        padding-top: 100px;
+    }
+}

--- a/awx/ui/client/lib/components/layout/_index.less
+++ b/awx/ui/client/lib/components/layout/_index.less
@@ -83,6 +83,7 @@
     }
 
     &-side {
+        background: @at-color-side-nav-background;
         position: fixed;
         bottom: 0;
         top: @at-height-top-side-nav-makeup;
@@ -92,7 +93,7 @@
         z-index: @at-z-index-side-nav;
 
         .at-Layout-sideNavItem {
-            background: @at-color-side-nav-background;
+            background: inherit;
             color: @at-color-side-nav-content;
             display: flex;
             cursor: pointer;
@@ -122,8 +123,8 @@
         }
 
         .at-Layout-sideNavSpacer {
+            background: inherit;
             height: @at-height-side-nav-spacer;
-            background: @at-color-side-nav-background;
         }
 
         &--expanded {
@@ -174,13 +175,13 @@
     }
 }
 
-
 @breakpoint-sm: 700px;
 
 @media screen and (max-width: @breakpoint-sm) {
     .at-Layout {
         &-side {
             top: 60px;
+            background-color: transparent;
 
             .at-Layout-sideNavItem.at-Layout-sideNavToggle {
                 display: flex;
@@ -192,6 +193,7 @@
             .at-Layout-sideNavItem,
             .at-Layout-sideNavSpacer {
                 display: none;
+                background-color: @at-color-side-nav-background;
             }
 
             &--expanded {
@@ -207,6 +209,10 @@
 
         .at-Layout-main {
             padding-left: 0;
+
+            #content-container {
+                padding-top: 100px;
+            }
         }
     }
 }

--- a/awx/ui/client/lib/components/layout/_index.less
+++ b/awx/ui/client/lib/components/layout/_index.less
@@ -83,8 +83,6 @@
     }
 
     &-side {
-        background: @at-color-side-nav-background;
-        color: @at-color-side-nav-content;
         position: fixed;
         bottom: 0;
         top: @at-height-top-side-nav-makeup;
@@ -94,10 +92,11 @@
         z-index: @at-z-index-side-nav;
 
         .at-Layout-sideNavItem {
+            background: @at-color-side-nav-background;
+            color: @at-color-side-nav-content;
             display: flex;
             cursor: pointer;
             text-transform: uppercase;
-
 
                 > i.fa {
                     padding-left: 20px;
@@ -124,6 +123,7 @@
 
         .at-Layout-sideNavSpacer {
             height: @at-height-side-nav-spacer;
+            background: @at-color-side-nav-background;
         }
 
         &--expanded {
@@ -170,6 +170,43 @@
         a {
             cursor: pointer;
             margin-right: @at-margin-after-footer-link;
+        }
+    }
+}
+
+
+@breakpoint-sm: 700px;
+
+@media screen and (max-width: @breakpoint-sm) {
+    .at-Layout {
+        &-side {
+            top: 60px;
+
+            .at-Layout-sideNavItem.at-Layout-sideNavToggle {
+                display: flex;
+                height: 40px;
+                align-items: center;
+                width: 55px;
+            }
+
+            .at-Layout-sideNavItem,
+            .at-Layout-sideNavSpacer {
+                display: none;
+            }
+
+            &--expanded {
+                width: 100vw;
+                z-index: @at-z-index-side-nav;
+
+                .at-Layout-sideNavItem,
+                .at-Layout-sideNavSpacer {
+                    display: flex;
+                }
+            }
+        }
+
+        .at-Layout-main {
+            padding-left: 0;
         }
     }
 }

--- a/awx/ui/client/lib/components/layout/side-nav.directive.js
+++ b/awx/ui/client/lib/components/layout/side-nav.directive.js
@@ -2,27 +2,38 @@ const templateUrl = require('~components/layout/side-nav.partial.html');
 
 function atSideNavLink (scope, element, attrs, ctrl) {
     scope.layoutVm = ctrl;
+
+    document.on('click', (e) => {
+        if ($(e.target).parents('.at-Layout-side').length === 0) {
+            scope.$emit('clickOutsideSideNav');
+        }
+    });
 }
 
-function AtSideNavController ($scope) {
+function AtSideNavController ($scope, $window) {
     let vm = this || {};
+    const breakpoint = 700;
 
     vm.isExpanded = false;
 
     vm.toggleExpansion = () => {
         vm.isExpanded = !vm.isExpanded;
-    }
+    };
 
-    document.body.onclick = (e) => {
-        if ($(e.target).parents(".at-Layout-side").length === 0) {
+    $scope.$watch('layoutVm.currentState', () => {
+        if ($window.innerWidth <= breakpoint) {
             vm.isExpanded = false;
         }
-    }
+    });
 
-    $scope.$on('$locationChangeStart', function(event) {
-        vm.isExpanded = false;
+    $scope.$on('clickOutsideSideNav', () => {
+        if ($window.innerWidth <= breakpoint) {
+            vm.isExpanded = false;
+        }
     });
 }
+
+AtSideNavController.$inject = ['$scope', '$window'];
 
 function atSideNav () {
     return {

--- a/awx/ui/client/lib/components/layout/side-nav.directive.js
+++ b/awx/ui/client/lib/components/layout/side-nav.directive.js
@@ -4,14 +4,24 @@ function atSideNavLink (scope, element, attrs, ctrl) {
     scope.layoutVm = ctrl;
 }
 
-function AtSideNavController () {
-    const vm = this || {};
+function AtSideNavController ($scope) {
+    let vm = this || {};
 
     vm.isExpanded = false;
 
     vm.toggleExpansion = () => {
         vm.isExpanded = !vm.isExpanded;
-    };
+    }
+
+    document.body.onclick = (e) => {
+        if ($(e.target).parents(".at-Layout-side").length === 0) {
+            vm.isExpanded = false;
+        }
+    }
+
+    $scope.$on('$locationChangeStart', function(event) {
+        vm.isExpanded = false;
+    });
 }
 
 function atSideNav () {

--- a/awx/ui/client/lib/components/layout/side-nav.partial.html
+++ b/awx/ui/client/lib/components/layout/side-nav.partial.html
@@ -1,6 +1,6 @@
 <div class="at-Layout-side"
-    ng-class="{'at-Layout-side--expanded': vm.isExpanded && layoutVm.isLoggedIn}">
-        <div class="at-Layout-sideNavItem" ng-click="vm.toggleExpansion()"
+    ng-class="{'at-Layout-side--expanded': vm.isExpanded && layoutVm.isLoggedIn}" ng-show="layoutVm.isLoggedIn && !layoutVm.licenseIsMissing">
+        <div class="at-Layout-sideNavItem at-Layout-sideNavToggle" ng-click="vm.toggleExpansion()"
             ng-show="layoutVm.isLoggedIn && !layoutVm.licenseIsMissing">
                 <i class="fa fa-bars"></i>
         </div>

--- a/awx/ui/client/src/bread-crumb/bread-crumb.block.less
+++ b/awx/ui/client/src/bread-crumb/bread-crumb.block.less
@@ -85,6 +85,7 @@
 }
 
 @breadcrumb-breakpoint: 900px;
+@breakpoint-sm: 700px;
 
 @media screen and (max-width: @breadcrumb-breakpoint) {
     .BreadCrumb-menuLinkImage {
@@ -93,5 +94,13 @@
     .BreadCrumb-menuLink {
         width: 67px;
         padding: 0 21px;
+    }
+}
+
+@media screen and (max-width: @breakpoint-sm) {
+    .BreadCrumb {
+        padding-left: 50px;
+        position: fixed;
+        z-index: 2;
     }
 }

--- a/awx/ui/client/test/unit/karma.conf.js
+++ b/awx/ui/client/test/unit/karma.conf.js
@@ -1,4 +1,5 @@
 let path = require('path');
+const webpackConfig = require('../../../build/webpack.test.js');
 
 module.exports = config => {
     config.set({
@@ -30,22 +31,7 @@ module.exports = config => {
                 return '/static/partials' + filepath;
             }
         },
-        webpack: {
-            module: {
-                loaders: [
-                    {
-                        test: /\.js$/,
-                        loader: 'babel',
-                        exclude: /node_modules/
-                    },
-                    {
-                        test: /\.json$/,
-                        loader: 'json',
-                        exclude: /node_modules/
-                    },
-                ]
-            }
-        },
+        webpack: webpackConfig,
         webpackMiddleware: {
             noInfo: 'errors-only'
         }


### PR DESCRIPTION
#### SUMMARY
This pull request contains the new mobile navigation menu. 
* Breakpoint is set to 700px (subject to change).
* The click handler will collapse the navigation menu if the user clicks outside of the sidebar nav, or when $locationChangeStart is triggered.


#### Collapsed
<img width="601" alt="screen shot 2017-09-19 at 11 58 01 am" src="https://user-images.githubusercontent.com/15881645/30602505-b33a2fe8-9d32-11e7-971c-23481cfc2375.png">

#### Expanded
<img width="399" alt="screen shot 2017-09-19 at 11 58 23 am" src="https://user-images.githubusercontent.com/15881645/30602508-b47227e4-9d32-11e7-858a-f97ac5652f9b.png">
