### PR TITLE
Move license checking logic to /api/v2/config

### DIFF
--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-ldap.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-ldap.form.js
@@ -100,7 +100,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' && license_type !== 'open' || configuration_ldap_template_form.$invalid || configuration_ldap_template_form.$pending"
+                ngDisabled: "!ldap_auth || configuration_ldap_template_form.$invalid || configuration_ldap_template_form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-radius.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-radius.form.js
@@ -39,7 +39,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' && license_type !== 'open' || configuration_radius_template_form.$invalid || configuration_radius_template_form.$pending"
+                ngDisabled: "!enterprise_auth || configuration_radius_template_form.$invalid || configuration_radius_template_form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-saml.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-saml.form.js
@@ -92,7 +92,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' && license_type !== 'open' || configuration_saml_template_form.$invalid || configuration_saml_template_form.$pending"
+                ngDisabled: "!enterprise_auth || configuration_saml_template_form.$invalid || configuration_saml_template_form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/auth-form/sub-forms/auth-tacacs.form.js
+++ b/awx/ui/client/src/configuration/auth-form/sub-forms/auth-tacacs.form.js
@@ -52,7 +52,7 @@ export default ['i18n', function(i18n) {
             },
             save: {
                 ngClick: 'vm.formSave()',
-                ngDisabled: "license_type !== 'enterprise' && license_type !== 'open' || configuration_tacacs_template_form.$invalid || configuration_tacacs_template_form.$pending"
+                ngDisabled: "!enterprise_auth || configuration_tacacs_template_form.$invalid || configuration_tacacs_template_form.$pending"
             }
         }
     };

--- a/awx/ui/client/src/configuration/configuration.controller.js
+++ b/awx/ui/client/src/configuration/configuration.controller.js
@@ -7,7 +7,7 @@
 export default [
     '$scope', '$rootScope', '$state', '$stateParams', '$timeout', '$q', 'Alert',
     'ConfigurationService', 'ConfigurationUtils', 'CreateDialog', 'CreateSelect2', 'i18n', 'ParseTypeChange', 'ProcessErrors', 'Store',
-    'Wait', 'configDataResolve', 'ToJSON',
+    'Wait', 'configDataResolve', 'ToJSON', 'ConfigService',
     //Form definitions
     'configurationAzureForm',
     'configurationGithubForm',
@@ -26,7 +26,7 @@ export default [
     function(
         $scope, $rootScope, $state, $stateParams, $timeout, $q, Alert,
         ConfigurationService, ConfigurationUtils, CreateDialog, CreateSelect2, i18n, ParseTypeChange, ProcessErrors, Store,
-        Wait, configDataResolve, ToJSON,
+        Wait, configDataResolve, ToJSON, ConfigService,
         //Form definitions
         configurationAzureForm,
         configurationGithubForm,
@@ -94,13 +94,6 @@ export default [
                                 }
 
                             } else {
-                                if (key === "LICENSE") {
-                                    if (_.isEmpty(data[key])) {
-                                        $scope.license_type = "open";
-                                    } else {
-                                        $scope.license_type = data[key].license_type;
-                                    }
-                                }
                                 //handle nested objects
                                 if(ConfigurationUtils.isEmpty(data[key])) {
                                     $scope[key] = '{}';
@@ -114,6 +107,19 @@ export default [
                     });
                     $scope.$broadcast('populated', data);
                 });
+                ConfigService.getConfig()
+                    .then(function(data) {
+                        $scope.ldap_auth = data.license_info.features.ldap;
+                        $scope.enterprise_auth = data.license_info.features.enterprise_auth;
+                    })
+                    .catch(function(data, status) {
+                        ProcessErrors($scope, data, status, null,
+                            {
+                                hdr: i18n._('Error'),
+                                msg: i18n._('There was an error getting config values: ') + status
+                            }
+                        );
+                    });
         };
 
         populateFromApi();


### PR DESCRIPTION
Use license_info.features.ldap & license_info.feature.enterprise_auth from /api/v2/config for
auth providers button enabling instead of using info from /api/v2/settings/all

Signed-off-by: Julen Landa Alustiza <julen@zokormazo.info>

##### SUMMARY

Info from `/api/v2/config` should be used for license feature checking.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
awx: 1.0.0.500
