### PR TITLE
Fix typo in AWXDjangoStrategy constructor

### DIFF
--- a/awx/sso/strategies/django_strategy.py
+++ b/awx/sso/strategies/django_strategy.py
@@ -13,9 +13,6 @@ class AWXDjangoStrategy(DjangoStrategy):
        want to ensure we update the SOCIAL_AUTH_STRATEGY setting.
     """
 
-    def __init__(self, storage, request=None, tpl=None):
-        super(AWXDjangoStrategy, self).__init__(storage, tpl)
-
     def request_port(self):
         """Port in use for this request
            https://github.com/python-social-auth/social-app-django/blob/master/social_django/strategy.py#L76


### PR DESCRIPTION
Signed-off-by: Matvey Kruglov <kubuzzzz@gmail.com>

##### SUMMARY

Fix typo in AWXDjangoStrategy, which leads to broken social logins. Request object doesn't pass to the strategy, so redirect_uri for google auth2 (and other authentication methods)  was created without hostname in it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
1.0.0.504
```
