### PR TITLE
Deprecate user-specific settings

### DIFF
--- a/awx/conf/access.py
+++ b/awx/conf/access.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-# Django
-from django.db.models import Q
-
 # Tower
 from awx.main.access import BaseAccess, register_access
 from awx.conf.models import Setting
@@ -14,7 +11,6 @@ class SettingAccess(BaseAccess):
     - I can see settings when I am a super user or system auditor.
     - I can edit settings when I am a super user.
     - I can clear settings when I am a super user.
-    - I can always see/edit/clear my own user settings.
     '''
 
     model = Setting
@@ -23,23 +19,11 @@ class SettingAccess(BaseAccess):
     # an attribute for each setting and a "user" attribute (set to None unless
     # it is a user setting).
 
-    def get_queryset(self):
-        if self.user.is_superuser or self.user.is_system_auditor:
-            return self.model.objects.filter(Q(user__isnull=True) | Q(user=self.user))
-        else:
-            return self.model.objects.filter(user=self.user)
-
     def can_read(self, obj):
-        return bool(self.user.is_superuser or self.user.is_system_auditor or (obj and obj.user == self.user))
+        return bool(self.user.is_superuser or self.user.is_system_auditor)
 
     def can_add(self, data):
         return False  # There is no API endpoint to POST new settings.
-
-    def can_change(self, obj, data):
-        return bool(self.user.is_superuser or (obj and obj.user == self.user))
-
-    def can_delete(self, obj):
-        return bool(self.user.is_superuser or (obj and obj.user == self.user))
 
 
 register_access(Setting, SettingAccess)

--- a/awx/conf/management/commands/migrate_to_database_settings.py
+++ b/awx/conf/management/commands/migrate_to_database_settings.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
     def _get_settings_file_patterns(self):
         if MODE == 'development':
             return [
-                '/etc/tower/settings.py', 
+                '/etc/tower/settings.py',
                 '/etc/tower/conf.d/*.py',
                 os.path.join(os.path.dirname(__file__), '..', '..', '..', 'settings', 'local_*.py')
             ]
@@ -409,12 +409,12 @@ class Command(BaseCommand):
                 self.stdout.write('  No settings to migrate!')
         for name, db_value in to_migrate.items():
             display_value = json.dumps(db_value, indent=4)
-            setting = Setting.objects.filter(key=name, user__isnull=True).order_by('pk').first()
+            setting = Setting.objects.filter(key=name).order_by('pk').first()
             action = 'No Change'
             if not setting:
                 action = 'Migrated'
                 if not self.dry_run:
-                    Setting.objects.create(key=name, user=None, value=db_value)
+                    Setting.objects.create(key=name, value=db_value)
             elif setting.value != db_value or type(setting.value) != type(db_value):
                 action = 'Updated'
                 if not self.dry_run:

--- a/awx/conf/migrations/0005_v330_remove_user.py
+++ b/awx/conf/migrations/0005_v330_remove_user.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+from django.db import migrations
+
+
+def remove_user_defined_configurations(apps, schema_editor):
+    Setting = apps.get_model('conf', 'Setting')
+    for setting_to_del in Setting.objects.filter(user__isnull=False):
+        setting_to_del.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('conf', '0004_v320_reencrypt'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_user_defined_configurations
+        ),
+        migrations.RemoveField(
+            model_name='setting',
+            name='user',
+        ),
+    ]

--- a/awx/conf/models.py
+++ b/awx/conf/models.py
@@ -8,7 +8,7 @@ import json
 from django.db import models
 
 # Tower
-from awx.main.models.base import CreatedModifiedModel, prevent_search
+from awx.main.models.base import CreatedModifiedModel
 from awx.main.fields import JSONField
 from awx.main.utils import encrypt_field
 from awx.conf import settings_registry
@@ -24,14 +24,6 @@ class Setting(CreatedModifiedModel):
     value = JSONField(
         null=True,
     )
-    user = prevent_search(models.ForeignKey(
-        'auth.User',
-        related_name='settings',
-        default=None,
-        null=True,
-        editable=False,
-        on_delete=models.CASCADE,
-    ))
 
     def __unicode__(self):
         try:
@@ -39,10 +31,7 @@ class Setting(CreatedModifiedModel):
         except ValueError:
             # In the rare case the DB value is invalid JSON.
             json_value = u'<Invalid JSON>'
-        if self.user:
-            return u'{} ({}) = {}'.format(self.key, self.user, json_value)
-        else:
-            return u'{} = {}'.format(self.key, json_value)
+        return u'{} = {}'.format(self.key, json_value)
 
     def save(self, *args, **kwargs):
         encrypted = settings_registry.is_setting_encrypted(self.key)

--- a/awx/conf/serializers.py
+++ b/awx/conf/serializers.py
@@ -90,6 +90,6 @@ class SettingSingletonSerializer(serializers.Serializer):
             # Make LICENSE read-only here; update via /api/v1/config/ only.
             if key == 'LICENSE':
                 extra_kwargs['read_only'] = True
-            field = settings_registry.get_setting_field(key, mixin_class=SettingFieldMixin, for_user=bool(category_slug == 'user'), **extra_kwargs)
+            field = settings_registry.get_setting_field(key, mixin_class=SettingFieldMixin, **extra_kwargs)
             fields[key] = field
         return fields

--- a/awx/conf/signals.py
+++ b/awx/conf/signals.py
@@ -45,18 +45,12 @@ def handle_setting_change(key, for_delete=False):
 @receiver(post_save, sender=Setting)
 def on_post_save_setting(sender, **kwargs):
     instance = kwargs['instance']
-    # Skip for user-specific settings.
-    if instance.user:
-        return
     handle_setting_change(instance.key)
 
 
 @receiver(pre_delete, sender=Setting)
 def on_pre_delete_setting(sender, **kwargs):
     instance = kwargs['instance']
-    # Skip for user-specific settings.
-    if instance.user:
-        return
     # Save instance key (setting name) for post_delete.
     instance._saved_key_ = instance.key
 

--- a/awx/conf/tests/unit/test_settings.py
+++ b/awx/conf/tests/unit/test_settings.py
@@ -308,11 +308,7 @@ def test_db_setting_create(settings, mocker):
     ]):
         settings.AWX_SOME_SETTING = 'NEW-VALUE'
 
-    models.Setting.objects.create.assert_called_with(
-        key='AWX_SOME_SETTING',
-        user=None,
-        value='NEW-VALUE'
-    )
+    models.Setting.objects.create.assert_called_with(key='AWX_SOME_SETTING', value='NEW-VALUE')
 
 
 def test_db_setting_update(settings, mocker):
@@ -384,11 +380,7 @@ def test_charfield_properly_sets_none(settings, mocker):
     ]):
         settings.AWX_SOME_SETTING = None
 
-    models.Setting.objects.create.assert_called_with(
-        key='AWX_SOME_SETTING',
-        user=None,
-        value=None
-    )
+    models.Setting.objects.create.assert_called_with(key='AWX_SOME_SETTING', value=None)
 
 
 def test_settings_use_cache(settings, mocker):


### PR DESCRIPTION
##### SUMMARY
The setting category 'user' was designed to give normal user the ability
to specify their own version of some settings. Problem is:

1. Code in `awx/conf/settings.py` shows user-defined settings will never
be actually used.
2. We do not currently have any setting under user category.

Therefore we deprecate the special 'user' category in general, as well
as the `user` field defined in Setting model.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.0.500
```


##### ADDITIONAL INFORMATION
Inspired by #193 but probably not a direct fix for it.