### PR TITLE
auto restart containers created by the installer

### DIFF
--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -99,7 +99,7 @@
   docker_container:
     name: postgres
     state: started
-    restart_policy: always
+    restart_policy: unless-stopped
     image: postgres:9.6
     volumes:
       - "{{ postgres_data_dir }}:/var/lib/postgresql/data:Z"
@@ -114,7 +114,7 @@
   docker_container:
     name: rabbitmq
     state: started
-    restart_policy: always
+    restart_policy: unless-stopped
     image: rabbitmq:3
     env:
       RABBITMQ_DEFAULT_VHOST: "awx"
@@ -124,7 +124,7 @@
   docker_container:
     name: memcached
     state: started
-    restart_policy: always
+    restart_policy: unless-stopped
     image: memcached:alpine
 
 - name: Wait for postgres and rabbitmq to activate
@@ -172,7 +172,7 @@
   docker_container:
     name: awx_web
     state: started
-    restart_policy: always
+    restart_policy: unless-stopped
     image: "{{ awx_web_docker_actual_image }}:{{ awx_version }}"
     user: root
     ports:
@@ -198,7 +198,7 @@
   docker_container:
     name: awx_task
     state: started
-    restart_policy: always
+    restart_policy: unless-stopped
     image: "{{ awx_task_docker_actual_image }}:{{ awx_version }}"
     links: "{{ awx_task_container_links|list }}"
     user: root

--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -99,6 +99,7 @@
   docker_container:
     name: postgres
     state: started
+    restart_policy: always
     image: postgres:9.6
     volumes:
       - "{{ postgres_data_dir }}:/var/lib/postgresql/data:Z"
@@ -113,6 +114,7 @@
   docker_container:
     name: rabbitmq
     state: started
+    restart_policy: always
     image: rabbitmq:3
     env:
       RABBITMQ_DEFAULT_VHOST: "awx"
@@ -122,6 +124,7 @@
   docker_container:
     name: memcached
     state: started
+    restart_policy: always
     image: memcached:alpine
 
 - name: Wait for postgres and rabbitmq to activate
@@ -169,6 +172,7 @@
   docker_container:
     name: awx_web
     state: started
+    restart_policy: always
     image: "{{ awx_web_docker_actual_image }}:{{ awx_version }}"
     user: root
     ports:
@@ -194,6 +198,7 @@
   docker_container:
     name: awx_task
     state: started
+    restart_policy: always
     image: "{{ awx_task_docker_actual_image }}:{{ awx_version }}"
     links: "{{ awx_task_container_links|list }}"
     user: root


### PR DESCRIPTION
##### SUMMARY
Related to #210 
This commit changes restart policy of containers created by the installer. Without it, AWX will not start automatically when the docker daemon comes up (e.g. after a reboot of the host)


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.0.520
```


##### ADDITIONAL INFORMATION

it was sufficient to set the restart_policy flag in in the installer playbook: http://docs.ansible.com/ansible/latest/docker_container_module.html 
