### PR TITLE
Added In Ansible Version Requirement Into Installation Doc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ To install the assets, clone the awx-logos repo into the root of your local AWX 
 
 Before you can run a deployment, you'll need the following installed in your local environment:
 
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html)
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.3+
 - [Docker](https://docs.docker.com/engine/installation/)
 - [docker-py](https://github.com/docker/docker-py) Python module
 - [GNU Make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
##### SUMMARY
As per the issue reported in https://github.com/ansible/awx/issues/234 if you are running an Ansible version below 2.3 you will fail when trying to install using the provided playbook. This add's some extra text to the installation document to highlight that you need Ansible version 2.3 or above and hopefully avoid some confusion.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.0.519
```

##### ADDITIONAL INFORMATION
```
No additional information required
```
