### PR TITLE
Set bigger dropping zone after last item on survey drag and drop list

### DIFF
--- a/awx/ui/client/src/templates/survey-maker/survey-maker.block.less
+++ b/awx/ui/client/src/templates/survey-maker/survey-maker.block.less
@@ -165,6 +165,8 @@
     position: relative;
     min-height: 42px;
     padding-left: 0px;
+    margin-bottom: 0px;
+    padding-bottom: 10px;
 
     /* These classes are dynamically added via the angular-drag-and-drop-lists directive */
     .dndPlaceholder {


### PR DESCRIPTION
Signed-off-by: Julen Landa Alustiza <julen@zokormazo.info>

##### SUMMARY
The drop zone after the last row is so small that it's difficult to drop the moving row to the last position.

This expands it a bit for a better UX

Related #131

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

 - UI

##### AWX VERSION
```
awx: 1.0.0.520

```