### PR TITLE
Related: 245 263  Bypass canGetInventory when ask_inventory_on_launch

### DIFF
--- a/awx/ui/client/src/templates/main.js
+++ b/awx/ui/client/src/templates/main.js
@@ -173,6 +173,9 @@ angular.module('templates', [surveyMaker.name, templatesList.name, jobTemplates.
                             }],
                             canGetInventory: ['Rest', 'ProcessErrors', 'jobTemplateData',
                                 function(Rest, ProcessErrors, jobTemplateData) {
+                                    if (jobTemplateData.ask_inventory_on_launch){
+                                          return true;
+                                    }
                                     Rest.setUrl(jobTemplateData.related.inventory);
                                     return Rest.get()
                                         .then(() => {


### PR DESCRIPTION
##### SUMMARY

The canGetInventory in check awx/awx/ui/client/src/templates/main.js doen't work properly when the api returns null inventory due to ask_inventory_on_launch being set in templates.
 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.0.539
```


