### PR TITLE
Use const instead of let on never reassigned var

### DIFF
--- a/awx/ui/client/lib/components/layout/side-nav.directive.js
+++ b/awx/ui/client/lib/components/layout/side-nav.directive.js
@@ -11,7 +11,7 @@ function atSideNavLink (scope, element, attrs, ctrl) {
 }
 
 function AtSideNavController ($scope, $window) {
-    let vm = this || {};
+    const vm = this || {};
     const breakpoint = 700;
 
     vm.isExpanded = false;


### PR DESCRIPTION
Signed-off-by: Julen Landa Alustiza <julen@zokormazo.info>

##### SUMMARY

Fix linting error.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.0.547
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
`npm run watch` is broken due to using let for a never reassigned var:

```
npm run watch

> awx@1.0.0 watch /home/julen/projects/awx/awx/ui
> webpack-dev-server --config build/webpack.watch.js --progress


Project is running at http://127.0.0.1:3000/
webpack output is served from /static/
Content not from webpack is served from /home/julen/projects/awx/awx/ui/static
[hard-source:core] HardSourceWebpackPlugin is writing to a new confighash path for the first time: /home/julen/projects/awx/awx/ui/static/node_modules/.cache/hard-source/5ab4486fb41a699df3f31eaea0ea63aca9572715debddf0f78c15bd146f432e1
  0% compiling[hard-source:util] A child compiler (html-webpack-plugin for "../templates/ui/index.html") has a
memory cache but its cache name is unknown.
HardSourceWebpackPlugin will be disabled for this child
compiler.
   913 modules                                                                          

ERROR in ./client/lib/components/layout/side-nav.directive.js

/home/julen/projects/awx/awx/ui/client/lib/components/layout/side-nav.directive.js
  14:9  error  'vm' is never reassigned. Use 'const' instead  prefer-const

✖ 1 problem (1 error, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.

webpack: Failed to compile.
```
