### PR TITLE
Changing the color option for hipchat to always be lowercase

### DIFF
--- a/awx/main/notifications/hipchat_backend.py
+++ b/awx/main/notifications/hipchat_backend.py
@@ -26,10 +26,13 @@ class HipChatBackend(AWXBaseEmailBackend):
     def __init__(self, token, color, api_url, notify, fail_silently=False, **kwargs):
         super(HipChatBackend, self).__init__(fail_silently=fail_silently)
         self.token = token
-        self.color = color
+	if color == 'None':
+        	self.color = color
+	else:
+		self.color = color.lower()
         self.api_url = api_url
         self.notify = notify
-        
+
     def send_messages(self, messages):
         sent_messages = 0
 
@@ -38,7 +41,7 @@ class HipChatBackend(AWXBaseEmailBackend):
                 r = requests.post("{}/v2/room/{}/notification".format(self.api_url, rcp),
                                   params={"auth_token": self.token},
                                   verify=False,
-                                  json={"color": self.color.lower(),
+                                  json={"color": self.color,
                                         "message": m.subject,
                                         "notify": self.notify,
                                         "from": m.from_email,

--- a/awx/main/notifications/hipchat_backend.py
+++ b/awx/main/notifications/hipchat_backend.py
@@ -26,11 +26,11 @@ class HipChatBackend(AWXBaseEmailBackend):
     def __init__(self, token, color, api_url, notify, fail_silently=False, **kwargs):
         super(HipChatBackend, self).__init__(fail_silently=fail_silently)
         self.token = token
-	if color is not None:
-		self.color = color.lower()
+        if color is not None:
+            self.color = color.lower()
         self.api_url = api_url
         self.notify = notify
-
+        
     def send_messages(self, messages):
         sent_messages = 0
 

--- a/awx/main/notifications/hipchat_backend.py
+++ b/awx/main/notifications/hipchat_backend.py
@@ -26,9 +26,7 @@ class HipChatBackend(AWXBaseEmailBackend):
     def __init__(self, token, color, api_url, notify, fail_silently=False, **kwargs):
         super(HipChatBackend, self).__init__(fail_silently=fail_silently)
         self.token = token
-	if color == 'None':
-        	self.color = color
-	else:
+	if color is not None:
 		self.color = color.lower()
         self.api_url = api_url
         self.notify = notify

--- a/awx/main/notifications/hipchat_backend.py
+++ b/awx/main/notifications/hipchat_backend.py
@@ -38,7 +38,7 @@ class HipChatBackend(AWXBaseEmailBackend):
                 r = requests.post("{}/v2/room/{}/notification".format(self.api_url, rcp),
                                   params={"auth_token": self.token},
                                   verify=False,
-                                  json={"color": self.color,
+                                  json={"color": self.color.lower(),
                                         "message": m.subject,
                                         "notify": self.notify,
                                         "from": m.from_email,


### PR DESCRIPTION


Signed-off-by: Romain Brucker <romain.brucker@amalto.com>

##### SUMMARY
Changing the color value send to the Hipchat API to lowercase (right now we are sending a value with an uppercase first letter, which is not accepted by the API, resulting in an error)

##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME
 - UI

##### SUMMARY
When creating an Hipchat notification template, we have to pick a color.
The color is sent with an uppercase first later (Red, Yellow), the Hipchat API expects a lowercase (red, yellow)

##### ENVIRONMENT
* AWX version: 1.0.0.288
* Ansible version:  2.3.0.0
* Operating System: Debian 9
* Web Browser: Chrome 61

##### STEPS TO REPRODUCE

Notification > Add > Select Hipchat and enter the details (room name, token, etc ...)

##### EXPECTED RESULTS

The step above send a REST request to the Hipchat API. It should send it with the color name formated all lowercase.

##### ACTUAL RESULTS

The color name is sent with a starting uppercase (see additional details)

##### ADDITIONAL INFORMATION

```
2017-09-26 15:52:15,232 ERROR    awx.main.tasks Send Notification Failed Error sending message to hipchat: {
  "error": {
    "code": 400,
    "field": "color",
    "message": "Value u'Red' for field 'color' is not in the enumeration: ['yellow', 'green', 'red', 'purple', 'gray', 'random']",
    "options": [
      "yellow",
      "green",
      "red",
      "purple",
      "gray",
      "random"
    ],
    "type": "Bad Request",
    "validation": "enum",
    "value": "Red"
  }
}
```
