### PR TITLE
add awx install type to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,6 +16,7 @@
 ##### ENVIRONMENT
 <!--
 * AWX version: X.Y.Z
+* AWX install method: openshift, minishift, docker on linux, docker for mac, boot2docker
 * Ansible version:  X.Y.Z
 * Operating System:
 * Web Browser:


### PR DESCRIPTION
* Recreation of user-issues increasing depends on the chosen install
path used. Thus, we need this information when recreating the issue
locally. Ask the user to include this information in the issue template.