### PR TITLE
Add zabbix-api dependency to ansible requirements for docker image for zabbix_*-Modules

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -26,3 +26,4 @@ secretstorage==2.3.1
 shade==1.20.0
 setuptools==36.0.1
 pip==9.0.1
+zabbix-api==0.5.3

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -122,6 +122,7 @@ unicodecsv==0.14.1        # via cliff
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.11.0         # via pywinrm
+zabbix-api==0.5.3
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==9.0.1


### PR DESCRIPTION
##### SUMMARY

This adds zabbix-api (0.5.3) to the requirements_ansible.(txt|in), which is required for all the zabbix_* modules in Ansible. zabbix-api does not pull in any more dependencies and should be safe to include.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 1.0.0.573