### PR TITLE
Add dnspython dependency for ansible in order to make the dig filter work

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -17,6 +17,7 @@ backports.ssl-match-hostname==3.5.0.1
 kombu==3.0.37
 boto==2.46.1
 boto3==1.4.4
+dnspython==1.15.0
 python-memcached==1.58
 psphere==0.5.2
 psutil==5.2.2

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -42,6 +42,7 @@ cryptography==2.0.3       # via adal, azure-storage, paramiko, pyopenssl, secret
 debtcollector==1.15.0     # via oslo.config, oslo.utils, python-designateclient, python-keystoneclient, python-neutronclient
 decorator==4.0.11         # via shade
 deprecation==1.0.1        # via openstacksdk
+dnspython==1.15.0
 #docutils==0.12            # via botocore
 dogpile.cache==0.6.3      # via python-ironicclient, shade
 enum34==1.1.6             # via cryptography, msrest


### PR DESCRIPTION
##### SUMMARY

This adds dnspython (1.15.0) to the requirements_ansible.(txt|in), which is required for the dig filter module in Ansible. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 1.0.0.573