### PR TITLE
allow WFJT admins to cancel scheduled jobs

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1841,7 +1841,9 @@ class WorkflowJobAccess(BaseAccess):
     def can_cancel(self, obj):
         if not obj.can_cancel:
             return False
-        return self.can_delete(obj) or self.user == obj.created_by
+        if self.user == obj.created_by or self.can_delete(obj):
+            return True
+        return obj.workflow_job_template is not None and self.user in obj.workflow_job_template.admin_role
 
 
 class AdHocCommandAccess(BaseAccess):

--- a/awx/main/tests/functional/test_rbac_workflow.py
+++ b/awx/main/tests/functional/test_rbac_workflow.py
@@ -104,6 +104,11 @@ class TestWorkflowJobAccess:
         access = WorkflowJobAccess(rando)
         assert access.can_cancel(workflow_job)
 
+    def test_admin_cancel_access(self, wfjt, workflow_job, rando):
+        wfjt.admin_role.members.add(rando)
+        access = WorkflowJobAccess(rando)
+        assert access.can_cancel(workflow_job)
+
 
 @pytest.mark.django_db
 class TestWFJTCopyAccess:


### PR DESCRIPTION
Scenario:

I am given admin access to a WFJT, so then I modify things, create nodes, and do other stuff. I create a schedule that runs this WFJT, which runs, but then I discover a mistake.

This PR allows the user in that scenario to cancel that job, and brings workflow job cancel ability in-line with the established behavior for canceling jobs.

Connect https://github.com/ansible/awx/issues/336