### PR TITLE
Use $document instead of document for on fn

### DIFF
--- a/awx/ui/client/lib/components/layout/side-nav.directive.js
+++ b/awx/ui/client/lib/components/layout/side-nav.directive.js
@@ -1,9 +1,11 @@
 const templateUrl = require('~components/layout/side-nav.partial.html');
 
+let $document;
+
 function atSideNavLink (scope, element, attrs, ctrl) {
     scope.layoutVm = ctrl;
 
-    document.on('click', (e) => {
+    $document.on('click', (e) => {
         if ($(e.target).parents('.at-Layout-side').length === 0) {
             scope.$emit('clickOutsideSideNav');
         }
@@ -35,7 +37,9 @@ function AtSideNavController ($scope, $window) {
 
 AtSideNavController.$inject = ['$scope', '$window'];
 
-function atSideNav () {
+function atSideNav (_$document_) {
+    $document = _$document_;
+
     return {
         restrict: 'E',
         replace: true,
@@ -49,5 +53,7 @@ function atSideNav () {
         }
     };
 }
+
+atSideNav.$inject = ['$document'];
 
 export default atSideNav;


### PR DESCRIPTION
##### SUMMARY
`document.on` was used in a directive on instead of `$document.on` -- `document.on` is not a function. Since `$document` is a jQuery-wrapped `document`, it does have `on` available.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.0.578
```
