### PR TITLE
Add autocomplete attr to component form

### DIFF
--- a/awx/ui/client/features/credentials/add-edit-credentials.view.html
+++ b/awx/ui/client/features/credentials/add-edit-credentials.view.html
@@ -7,7 +7,7 @@
     </at-tab-group>
 
     <at-panel-body>
-        <at-form state="vm.form">
+        <at-form state="vm.form" autocomplete="off">
             <at-input-text col="4" tab="1" state="vm.form.name"></at-input-text>
             <at-input-text col="4" tab="2" state="vm.form.description"></at-input-text>
             <at-input-lookup col="4" tab="3" state="vm.form.organization"></at-input-lookup>

--- a/awx/ui/client/lib/components/form/form.directive.js
+++ b/awx/ui/client/lib/components/form/form.directive.js
@@ -209,7 +209,8 @@ function atForm () {
         controllerAs: 'vm',
         link: atFormLink,
         scope: {
-            state: '='
+            state: '=',
+            autocomplete: '@'
         }
     };
 }

--- a/awx/ui/client/lib/components/form/form.partial.html
+++ b/awx/ui/client/lib/components/form/form.partial.html
@@ -1,7 +1,7 @@
 <div>
-    <form>
+    <form ng-attr-autocomplete="{{::autocomplete || undefined }}">
         <div class="row">
-            <ng-transclude></ng-transclude> 
+            <ng-transclude></ng-transclude>
         </div>
     </form>
 


### PR DESCRIPTION
##### SUMMARY
Gives the option of setting `autocomplete` on forms to (attempt) to stop browsers and password managers from suggesting/inserting input that isn't relevant.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.0.587
```