### PR TITLE
The keyword 'cloud' has been deprecated in favor of the 'profile' key…

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -840,7 +840,7 @@ def rackspace(cls):
                 'type': 'string',
                 'help_text': ('A comma separated list of regions for the servers. If omitted then all regions are searched.')
             }],
-            'required': ['username', 'password', project']
+            'required': ['username', 'password', 'project']
         }
     )
 

--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -60,6 +60,7 @@ class V1Credential(object):
         ('azure', 'Microsoft Azure Classic (deprecated)'),
         ('azure_rm', 'Microsoft Azure Resource Manager'),
         ('openstack', 'OpenStack'),
+        ('rackspace', 'Rackspace'),
         ('insights', 'Insights'),
     ]
     FIELDS = {
@@ -809,6 +810,37 @@ def openstack(cls):
                               'common scenarios.')
             }],
             'required': ['username', 'password', 'host', 'project']
+        }
+    )
+
+
+@CredentialType.default
+def rackspace(cls):
+    return cls(
+        kind='cloud',
+        name='Rackspace',
+        managed_by_tower=True,
+        inputs={
+            'fields': [{
+                'id': 'username',
+                'label': 'Username',
+                'type': 'string'
+            }, {
+                'id': 'password',
+                'label': 'Password',
+                'type': 'string',
+                'secret': True,
+            }, {
+                'id': 'project',
+                'label': 'Account number',
+                'type': 'string',
+            }, {
+                'id': 'regions',
+                'label': 'Regions',
+                'type': 'string',
+                'help_text': ('A comma separated list of regions for the servers. If omitted then all regions are searched.')
+            }],
+            'required': ['username', 'password', project']
         }
     )
 

--- a/awx/plugins/inventory/openstack.yml
+++ b/awx/plugins/inventory/openstack.yml
@@ -1,20 +1,20 @@
 clouds:
   mordred:
-    cloud: hp
+    profile: hp
     auth:
       username: mordred@example.com
       password: my-wonderful-password
       project_name: mordred-tenant
     region_name: region-b.geo-1
   monty:
-    cloud: hp
+    profile: hp
     auth:
       username: monty.taylor@example.com
       password: another-wonderful-password
       project_name: monty.taylor@example.com-default-tenant
     region_name: region-b.geo-1
   rax:
-    cloud: rackspace
+    profile: rackspace
     auth:
       username: example
       password: spectacular-password


### PR DESCRIPTION
…word in os_client_config.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For openstack inventories the 'cloud' has been deprecated in favor of the 'profile' keyword. This changes the sample openstack.yml file.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.0.589
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
