### PR TITLE
Implement workflow job failure

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -468,9 +468,6 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
     def _get_unified_job_template_class(cls):
         return WorkflowJobTemplate
 
-    def _has_failed(self):
-        return False
-
     def socketio_emit_data(self):
         return {}
 

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -218,12 +218,12 @@ class TaskManager():
                 workflow_job.save()
                 dag.cancel_node_jobs()
                 connection.on_commit(lambda: workflow_job.websocket_emit_status(workflow_job.status))
-            elif dag.is_workflow_done():
+            else:
+                is_done, has_failed = dag.is_workflow_done()
+                if not is_done:
+                    continue
                 result.append(workflow_job.id)
-                if workflow_job._has_failed():
-                    workflow_job.status = 'failed'
-                else:
-                    workflow_job.status = 'successful'
+                workflow_job.status = 'failed' if has_failed else 'successful'
                 workflow_job.save()
                 connection.on_commit(lambda: workflow_job.websocket_emit_status(workflow_job.status))
         return result
@@ -362,7 +362,7 @@ class TaskManager():
             return False
 
         '''
-        If the latest project update has a created time == job_created_time-1 
+        If the latest project update has a created time == job_created_time-1
         then consider the project update found. This is so we don't enter an infinite loop
         of updating the project when cache timeout is 0.
         '''
@@ -514,7 +514,7 @@ class TaskManager():
             return None
 
         '''
-        Only consider failing tasks on instances for which we obtained a task 
+        Only consider failing tasks on instances for which we obtained a task
         list from celery for.
         '''
         running_tasks, waiting_tasks = self.get_running_tasks()

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -48,6 +48,10 @@ Workflow job summary:
 
 Starting from Tower 3.2, Workflow jobs support simultaneous job runs just like that of ordinary jobs. It is controlled by `allow_simultaneous` field of underlying workflow job template. By default, simultaneous workflow job runs are disabled and users should be prudent in enabling this functionality. Because the performance boost of simultaneous workflow runs will only manifest when a large portion of jobs contained by a workflow allow simultaneous runs. Otherwise it is expected to have some long-running workflow jobs since its spawned jobs can be in pending state for a long time.
 
+Before Tower 3.3, the 'failed' status of workflow job is not defined. Starting from 3.3 we define a finished workflow job to fail, if at least one of the conditions below satisfies:
+* At least one node runs into states `canceled` or `error`.
+* At least one leaf node runs into states `failed`, but no child node is spawned to run (no error handler).
+
 ### Workflow Copy and Relaunch
 Other than the normal way of creating workflow job templates, it is also possible to copy existing workflow job templates. The resulting new workflow job template will be mostly identical to the original, except for `name` field which will be appended a text to indicate it's a copy.
 


### PR DESCRIPTION
##### SUMMARY
Relates #264.

This PR proposed and implemented a way of defining workflow failure
state:

A workflow job fails if one of the conditions below satisfies.
* At least one node runs into states `canceled` or `error`.
* At least one node runs into states `failed`, but no child node is
  spawned to run (no error handler).

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 1.0.0.589
```