### PR TITLE
Address discrepancy in POST response between jobs launches and project / inventory source updates

### DIFF
--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -126,9 +126,14 @@ class TestInventoryInventorySourcesUpdate:
         mock_request.user.can_access.return_value = can_access
 
         with mocker.patch.object(InventoryInventorySourcesUpdate, 'get_object', return_value=obj):
-            view = InventoryInventorySourcesUpdate()
-            response = view.post(mock_request)
-            assert response.data == expected
+            with mocker.patch.object(InventoryInventorySourcesUpdate, 'get_serializer_context', return_value=None):
+                with mocker.patch('awx.api.views.InventoryUpdateSerializer') as serializer_class:
+                    serializer = serializer_class.return_value
+                    serializer.to_representation.return_value = {}
+
+                    view = InventoryInventorySourcesUpdate()
+                    response = view.post(mock_request)
+                    assert response.data == expected
 
 
 class TestHostInsights():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #365

Updates project updates and inventory source(s) update endpoints, so that POST-ing to the endpoint (i.e. launching an update) returns a full serialization of the object being updated. This adds consistency between job, project, and inventory updates.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
1.0.0-591-ge0c0013

##### ADDITIONAL INFORMATION

