### PR TITLE
Add extra encoding to ldap_dn verification

### DIFF
--- a/awx/main/tests/functional/api/test_settings.py
+++ b/awx/main/tests/functional/api/test_settings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
@@ -96,6 +97,8 @@ def test_ldap_settings(get, put, patch, delete, admin):
     patch(url, user=admin, data={'AUTH_LDAP_SERVER_URI': 'ldap://ldap.example.com ldap://ldap2.example.com'}, expect=200)
     patch(url, user=admin, data={'AUTH_LDAP_SERVER_URI': 'ldap://ldap.example.com,ldap://ldap2.example.com'}, expect=200)
     patch(url, user=admin, data={'AUTH_LDAP_SERVER_URI': 'ldap://ldap.example.com, ldap://ldap2.example.com'}, expect=200)
+    patch(url, user=admin, data={'AUTH_LDAP_BIND_DN': 'cn=Manager,dc=example,dc=com'}, expect=200)
+    patch(url, user=admin, data={'AUTH_LDAP_BIND_DN': u'cn=暴力膜,dc=大新闻,dc=真的粉丝'}, expect=200)
 
 
 @pytest.mark.parametrize('setting', [

--- a/awx/sso/tests/unit/test_ldap.py
+++ b/awx/sso/tests/unit/test_ldap.py
@@ -15,7 +15,4 @@ def test_ldap_default_network_timeout(mocker):
     from_db = mocker.Mock(**{'order_by.return_value': []})
     with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=from_db):
         settings = LDAPSettings()
-        assert settings.CONNECTION_OPTIONS == {
-            ldap.OPT_REFERRALS: 0,
-            ldap.OPT_NETWORK_TIMEOUT: 30
-        }
+        assert settings.CONNECTION_OPTIONS[ldap.OPT_NETWORK_TIMEOUT] == 30

--- a/awx/sso/validators.py
+++ b/awx/sso/validators.py
@@ -22,7 +22,7 @@ def validate_ldap_dn(value, with_user=False):
     else:
         dn_value = value
     try:
-        ldap.dn.str2dn(dn_value)
+        ldap.dn.str2dn(dn_value.encode('utf-8'))
     except ldap.DECODING_ERROR:
         raise ValidationError(_('Invalid DN: %s') % value)
 


### PR DESCRIPTION
##### SUMMARY
Relates #391.

Upstream `python-ldap` (surprisingly) does not support utf-8 DN. So
explicit encoding is needed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 1.0.0.708
```