### PR TITLE
Consolidation of variables parsing throughout codebase

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -11,9 +11,6 @@ import urllib
 from collections import OrderedDict
 from dateutil import rrule
 
-# PyYAML
-import yaml
-
 # Django
 from django.conf import settings
 from django.contrib.auth import authenticate
@@ -1312,6 +1309,9 @@ class HostSerializer(BaseSerializerWithVariables):
             raise serializers.ValidationError({"detail": _("Cannot create Host for Smart Inventory")})
         return value
 
+    def validate_variables(self, value):
+        return vars_validate_or_raise(value)
+
     def validate(self, attrs):
         name = force_text(attrs.get('name', self.instance and self.instance.name or ''))
         host, port = self._get_host_port_from_name(name)
@@ -1319,19 +1319,9 @@ class HostSerializer(BaseSerializerWithVariables):
         if port:
             attrs['name'] = host
             variables = force_text(attrs.get('variables', self.instance and self.instance.variables or ''))
-            try:
-                vars_dict = json.loads(variables.strip() or '{}')
-                vars_dict['ansible_ssh_port'] = port
-                attrs['variables'] = json.dumps(vars_dict)
-            except (ValueError, TypeError):
-                try:
-                    vars_dict = yaml.safe_load(variables)
-                    if vars_dict is None:
-                        vars_dict = {}
-                    vars_dict['ansible_ssh_port'] = port
-                    attrs['variables'] = yaml.dump(vars_dict)
-                except (yaml.YAMLError, TypeError):
-                    raise serializers.ValidationError({'variables': _('Must be valid JSON or YAML.')})
+            vars_dict = parse_yaml_or_json(variables)
+            vars_dict['ansible_ssh_port'] = port
+            attrs['variables'] = json.dumps(vars_dict)
 
         return super(HostSerializer, self).validate(attrs)
 
@@ -3286,18 +3276,12 @@ class JobLaunchSerializer(BaseSerializer):
 
         extra_vars = attrs.get('extra_vars', {})
 
-        if isinstance(extra_vars, basestring):
-            try:
-                extra_vars = json.loads(extra_vars)
-            except (ValueError, TypeError):
-                try:
-                    extra_vars = yaml.safe_load(extra_vars)
-                    assert isinstance(extra_vars, dict)
-                except (yaml.YAMLError, TypeError, AttributeError, AssertionError):
-                    errors['extra_vars'] = _('Must be valid JSON or YAML.')
-
-        if not isinstance(extra_vars, dict):
-            extra_vars = {}
+        try:
+            extra_vars = parse_yaml_or_json(extra_vars, silent_failure=False)
+        except:
+            # Log exception, in case of yet-unknown parsing failures
+            logger.exception('extra_vars parsing error on Job Template launch.')
+            errors['extra_vars'] = _('Must be valid JSON or YAML.')
 
         if self.get_survey_enabled(obj):
             validation_errors = obj.survey_variable_validation(extra_vars)
@@ -3371,18 +3355,12 @@ class WorkflowJobLaunchSerializer(BaseSerializer):
 
         extra_vars = attrs.get('extra_vars', {})
 
-        if isinstance(extra_vars, basestring):
-            try:
-                extra_vars = json.loads(extra_vars)
-            except (ValueError, TypeError):
-                try:
-                    extra_vars = yaml.safe_load(extra_vars)
-                    assert isinstance(extra_vars, dict)
-                except (yaml.YAMLError, TypeError, AttributeError, AssertionError):
-                    errors['extra_vars'] = _('Must be valid JSON or YAML.')
-
-        if not isinstance(extra_vars, dict):
-            extra_vars = {}
+        try:
+            extra_vars = parse_yaml_or_json(extra_vars, silent_failure=False)
+        except:
+            # Log exception, in case of yet-unknown parsing failures
+            logger.exception('extra_vars parsing error on Workflow JT launch.')
+            errors['extra_vars'] = _('Must be valid JSON or YAML.')
 
         if self.get_survey_enabled(obj):
             validation_errors = obj.survey_variable_validation(extra_vars)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -25,7 +25,7 @@ from django.utils.timezone import now
 from django.utils.functional import cached_property
 
 # Django REST Framework
-from rest_framework.exceptions import ValidationError, PermissionDenied
+from rest_framework.exceptions import ValidationError, PermissionDenied, ParseError
 from rest_framework import fields
 from rest_framework import serializers
 from rest_framework import validators
@@ -3278,10 +3278,9 @@ class JobLaunchSerializer(BaseSerializer):
 
         try:
             extra_vars = parse_yaml_or_json(extra_vars, silent_failure=False)
-        except:
-            # Log exception, in case of yet-unknown parsing failures
-            logger.exception('extra_vars parsing error on Job Template launch.')
-            errors['extra_vars'] = _('Must be valid JSON or YAML.')
+        except ParseError as e:
+            # Catch known user variable formatting errors
+            errors['extra_vars'] = str(e)
 
         if self.get_survey_enabled(obj):
             validation_errors = obj.survey_variable_validation(extra_vars)
@@ -3357,10 +3356,9 @@ class WorkflowJobLaunchSerializer(BaseSerializer):
 
         try:
             extra_vars = parse_yaml_or_json(extra_vars, silent_failure=False)
-        except:
-            # Log exception, in case of yet-unknown parsing failures
-            logger.exception('extra_vars parsing error on Workflow JT launch.')
-            errors['extra_vars'] = _('Must be valid JSON or YAML.')
+        except ParseError as e:
+            # Catch known user variable formatting errors
+            errors['extra_vars'] = str(e)
 
         if self.get_survey_enabled(obj):
             validation_errors = obj.survey_variable_validation(extra_vars)

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -199,7 +199,7 @@ def test_job_reject_invalid_prompted_extra_vars(runtime_data, job_template_promp
         dict(extra_vars='{"unbalanced brackets":'), admin_user, expect=400)
 
     assert 'extra_vars' in response.data
-    assert 'valid JSON or YAML' in str(response.data['extra_vars'][0])
+    assert 'Cannot parse as' in str(response.data['extra_vars'][0])
 
 
 @pytest.mark.django_db

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -582,12 +582,25 @@ def cache_list_capabilities(page, prefetch_list, model, user):
                 obj.capabilities_cache[display_method] = True
 
 
+def validate_vars_type(vars_obj):
+    if not isinstance(vars_obj, dict):
+        vars_type = type(vars_obj)
+        if hasattr(vars_type, '__name__'):
+            data_type = vars_type.__name__
+        else:
+            data_type = str(vars_type)
+        raise AssertionError(
+            _('Input type `{data_type}` is not a dictionary').format(
+                data_type=data_type)
+        )
+
+
 def parse_yaml_or_json(vars_str, silent_failure=True):
     '''
     Attempt to parse a string of variables.
     First, with JSON parser, if that fails, then with PyYAML.
     If both attempts fail, return an empty dictionary if `silent_failure`
-    is True, re-raise the last error if `silent_failure` if False.
+    is True, re-raise combination error if `silent_failure` if False.
     '''
     if isinstance(vars_str, dict):
         return vars_str
@@ -596,18 +609,21 @@ def parse_yaml_or_json(vars_str, silent_failure=True):
 
     try:
         vars_dict = json.loads(vars_str)
-        assert isinstance(vars_dict, dict)
-    except (ValueError, TypeError, AssertionError):
+        validate_vars_type(vars_dict)
+    except (ValueError, TypeError, AssertionError) as json_err:
         try:
             vars_dict = yaml.safe_load(vars_str)
             # Can be None if '---'
             if vars_dict is None:
                 return {}
-            assert isinstance(vars_dict, dict)
-        except (yaml.YAMLError, TypeError, AttributeError, AssertionError):
+            validate_vars_type(vars_dict)
+        except (yaml.YAMLError, TypeError, AttributeError, AssertionError) as yaml_err:
             if silent_failure:
                 return {}
-            raise
+            raise ParseError(_(
+                'Cannot parse as JSON (error: {json_error}) or '
+                'YAML (error: {yaml_error}).').format(
+                    json_error=str(json_err), yaml_error=str(yaml_err)))
     return vars_dict
 
 

--- a/awx/main/validators.py
+++ b/awx/main/validators.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 
 # REST framework
 from rest_framework.serializers import ValidationError as RestValidationError
+from rest_framework.exceptions import ParseError
 
 # AWX
 from awx.main.utils import parse_yaml_or_json
@@ -183,6 +184,6 @@ def vars_validate_or_raise(vars_str):
     try:
         parse_yaml_or_json(vars_str, silent_failure=False)
         return vars_str
-    except:
-        raise RestValidationError(_('Must be valid JSON or YAML.'))
+    except ParseError as e:
+        raise RestValidationError(str(e))
 


### PR DESCRIPTION
* Remove attempted support of key=value pattern, because
  it is not actually allowed in practice
* Have variables validator defer to the utils variables parser
* Prune serializers of a handful of cases that previous
  attempts at cleanup have missed

The thing about the `key=value` parsing should probably go in the changelog, just so we officially announce its death, but you haven't been able to use this format anyway for a long time AFAIK. I think we could consider re-adding someday it with a bonafide python library, if such a thing were to exist.

Main thing here is to remove hand-crafted handling of variables parsing errors.