### PR TITLE
Use $http_host in trailing slash redirect

### DIFF
--- a/installer/image_build/files/nginx.conf
+++ b/installer/image_build/files/nginx.conf
@@ -76,7 +76,7 @@ http {
 
         location / {
             # Add trailing / if missing
-            rewrite ^(.*[^/])$ $1/ permanent;
+            rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
             uwsgi_read_timeout 120s;
             uwsgi_pass uwsgi;
             include /etc/nginx/uwsgi_params;


### PR DESCRIPTION

Fixes #420 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This allows the port from the request header to be used rather than having the request redirected to the port being used inside the container which may not be accessible.

I'm sure this isn't the most elegant way to accomplish this, but it seems to work ...

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
$ make VERSION
/bin/sh: VERSION: Permission denied
Makefile:606: recipe for target 'VERSION' failed
make: *** [VERSION] Error 1
```

Not sure if that :point_up: was intended ... how about:

```bash
$ cat VERSION
1.0.0.341
```

Signed-off-by: Nick Carboni <ncarboni@redhat.com>