### PR TITLE
fixes ansible callback import json warning

### DIFF
--- a/awx/lib/tests/test_display_callback.py
+++ b/awx/lib/tests/test_display_callback.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2017 Ansible by Red Hat
+# All Rights Reserved
+
+from __future__ import absolute_import
+
 from collections import OrderedDict
 import json
 import mock


### PR DESCRIPTION
[WARNING]: Failure using method (v2_runner_on_ok) in callback plugin
(<awx_display_callback.module.AWXDefaultCallbackModule object at
0x47f6090>):
'module' object has no attribute 'dumps'

The above error is thrown by ansible if callback plugins don't respect
the same import precedence configuration as Ansible. ansible callback/*
dir includes a json.py file. This is imported by ansible
callback/__init__.py when a callback plugin implementation imports from
Ansible callback base without setting the correct import precedence.