### PR TITLE
store cloudforms inventory cache files in the proper location on disk

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1780,6 +1780,11 @@ class RunInventoryUpdate(BaseTask):
             section = 'cache'
             cp.add_section(section)
             cp.set(section, 'max_age', "0")
+            cache_path = tempfile.mkdtemp(
+                prefix='cloudforms_cache',
+                dir=kwargs.get('private_data_dir', None)
+            )
+            cp.set(section, 'path', cache_path)
 
         elif inventory_update.source == 'azure_rm':
             section = 'azure'

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1375,6 +1375,10 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             assert config.get('cloudforms', 'username') == 'bob'
             assert config.get('cloudforms', 'password') == 'secret'
             assert config.get('cloudforms', 'ssl_verify') == 'false'
+
+            cache_path = config.get('cache', 'path')
+            assert cache_path.startswith(env['AWX_PRIVATE_DATA_DIR'])
+            assert os.path.isdir(cache_path)
             return ['successful', 0]
 
         self.run_pexpect.side_effect = run_pexpect_side_effect


### PR DESCRIPTION
with process isolation enabled (which is the awx default), cloudforms
caches inventory script results on disk; awx should direct cloudforms to
store these cache files in a location that's exposed to the isolated
environment

see: https://github.com/ansible/ansible/pull/31760