### PR TITLE
Fixing Host Event Modal Selecting

### DIFF
--- a/awx/ui/client/src/job-results/host-event/host-event.controller.js
+++ b/awx/ui/client/src/job-results/host-event/host-event.controller.js
@@ -112,7 +112,7 @@
                 minWidth: 600
             });
             $('.modal-dialog').draggable({
-                cancel: '.CodeMirror'
+                cancel: '.HostEvent-view--container'
             });
 
             function resize(){


### PR DESCRIPTION
##### SUMMARY
When on the host event modal, the user was only able to select/copy/paste on the JSON tab was not able to select the text on the stdout or stderr tabs. 
 
relates to https://github.com/ansible/awx/issues/441

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.1.36
```

