### PR TITLE
fix test fallout from 321 merge

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -678,19 +678,11 @@ class BaseTask(LogErrorsTask):
 
     def build_inventory(self, instance, **kwargs):
         path = os.path.join(kwargs['private_data_dir'], 'inventory')
-        if not os.path.exists(path):
-            with open(path, 'w') as f:
-                json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
-                f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint """%s"""\n' % json_data)
-                os.chmod(path, stat.S_IRUSR | stat.S_IXUSR)
-            return path
-        else:
-            # work around an inventory caching bug in Ansible 2.4.0
-            # see: https://github.com/ansible/ansible/pull/30817
-            # see: https://github.com/ansible/awx/issues/246
-            inventory_script = tempfile.mktemp(suffix='.awxrest.py', dir=kwargs['private_data_dir'])
-            shutil.copy(plugin, inventory_script)
-            return inventory_script
+        with open(path, 'w') as f:
+            json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
+            f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint """%s"""\n' % json_data)
+            os.chmod(path, stat.S_IRUSR | stat.S_IXUSR)
+        return path
 
     def build_args(self, instance, **kwargs):
         raise NotImplementedError

--- a/awx/main/tests/unit/models/test_survey_models.py
+++ b/awx/main/tests/unit/models/test_survey_models.py
@@ -1,7 +1,5 @@
 import tempfile
-import pytest
 import json
-import tempfile
 
 import pytest
 

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -268,7 +268,7 @@ class TestGenericRun(TestJobExecution):
             self.task.run(self.pk)
         for c in [
             mock.call(self.pk, execution_node=settings.CLUSTER_HOST_ID, status='running'),
-            mock.call(self.pk, output_replacements=[], result_traceback=mock.ANY, status='canceled')
+            mock.call(self.pk, status='canceled')
         ]:
             assert c in self.task.update_model.call_args_list
 


### PR DESCRIPTION
changes:

 - fix obvious flake8 due to imports being used in 1 branch, but not the other
 - tweak the kwargs used for the cancel callback (believed to be ditched in the exceptions refactor, because not needed)
 - remove fix for Ansible fact caching workaround, because it's no longer relevant with the dynamically-generated inventory file