### PR TITLE
allow use of custom inventory plugins

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1523,7 +1523,7 @@ class CustomInventoryScriptSerializer(BaseSerializer):
 class InventorySourceOptionsSerializer(BaseSerializer):
 
     class Meta:
-        fields = ('*', 'source', 'source_path', 'source_script', 'source_vars', 'credential',
+        fields = ('*', 'source', 'source_path', 'plugin_path', 'source_script', 'source_vars', 'credential',
                   'source_regions', 'instance_filters', 'group_by', 'overwrite', 'overwrite_vars',
                   'timeout', 'verbosity')
 

--- a/awx/main/migrations/0009_scm_inventory_plugins.py
+++ b/awx/main/migrations/0009_scm_inventory_plugins.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0008_v320_drop_v1_credential_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='inventorysource',
+            name='plugin_path',
+            field=models.CharField(default=b'', help_text='Inventory plugin to use for import, use leading @ to get from relative path in source control.', max_length=1024, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='inventorysource',
+            name='source_path',
+            field=models.CharField(default=b'', help_text='Relative path of inventory in source control.', max_length=1024, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='inventoryupdate',
+            name='plugin_path',
+            field=models.CharField(default=b'', help_text='Inventory plugin to use for import, use leading @ to get from relative path in source control.', max_length=1024, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='inventoryupdate',
+            name='source_path',
+            field=models.CharField(default=b'', help_text='Relative path of inventory in source control.', max_length=1024, blank=True),
+        ),
+    ]

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1043,6 +1043,14 @@ class InventorySourceOptions(BaseModel):
         max_length=1024,
         blank=True,
         default='',
+        help_text=_('Relative path of inventory in source control.'),
+    )
+    plugin_path = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+        help_text=_('Inventory plugin to use for import, use leading @ to get '
+                    'from relative path in source control.'),
     )
     source_script = models.ForeignKey(
         'CustomInventoryScript',
@@ -1337,7 +1345,7 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions):
 
     @classmethod
     def _get_unified_job_field_names(cls):
-        return ['name', 'description', 'source', 'source_path', 'source_script', 'source_vars', 'schedule',
+        return ['name', 'description', 'source', 'source_path', 'plugin_path', 'source_script', 'source_vars', 'schedule',
                 'credential', 'source_regions', 'instance_filters', 'group_by', 'overwrite', 'overwrite_vars',
                 'timeout', 'verbosity', 'launch_type', 'source_project_update',]
 


### PR DESCRIPTION
This allows 2 different use cases, and my examples follow my writeup here:

https://github.com/AlanCoding/Ansible-inventory-file-examples/tree/master/plugins

The two scenarios, how to use given you already have an SCM inventory from that repo:

 - set `"plugin_path": "@plugins/user_plugins/alan.py"`
 - set `"plugin_path": "alan"`

I know some people probably won't be a fan of the "@" notation, and if that's the case, we may just have to introduce another field (although I'm not a fan of that). Doing otherwise may involve conversations with Ansible core.

Connect https://github.com/ansible/awx/issues/171