### PR TITLE
Make is easier to deploy AWX to a remote host

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -1,3 +1,7 @@
+# This is where the AWX will be deployed to
+# To deploy to a remote host instead of localhost, comment out the localhost line and
+# uncomment the following line and replace it with an appopriate hostname
+# awx-remote-server
 localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
 
 [all:vars]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This make it more obvious how to configure the inventory file to run on a remote host instead of localhost

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.82
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```