### PR TITLE
Add support for defining AWS API credentials

### DIFF
--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -234,3 +234,5 @@
       MEMCACHED_PORT: "11211"
       AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
       AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+      AWS_ACCESS_KEY_ID: "{{ aws_access_key_id|default('') }}"
+      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key|default('') }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There's no easy way in this current implementation to define AWS API credentials to use Ansible AWS modules in Tower when you are not running AWX in AWS. IAM roles work for AWS, but otherwise you're kinda screwed.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.82
```


##### ADDITIONAL INFORMATION
<!---
You can define AWS access credentials each time you call the module, however this bloats your playbook massively.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
With the following test playbook:
```
---

- hosts: localhost
  tasks:
    - ec2_ami_find:
        region: 'eu-west-1'
        owner: amazon
        name: 'Windows_Server-2012-R2_RTM-English-64Bit-Base*'
        platform: windows
        sort: name
        sort_order: descending
        sort_end: 1
        state: available
        no_result_action: fail
```
Before:
```
task path: /var/lib/awx/projects/_11__tower_test/playbook.yml:511:12:58
21
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV4Handler'] Check your credentials"}
```
After:
```
task path: /var/lib/awx/projects/_11__tower_test/playbook.yml:511:20:14
21
ok: [localhost] => {"changed": false, "failed": false, "results": [{"ami_id": "ami-1ecc1e67", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": true, "encrypted": false, "size": 30, "snapshot_id": "snap-0177137eb44aad54d", "volume_type": "gp2"}, 
.....
```

