### PR TITLE
Add protection against credential getattr

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -249,10 +249,11 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
     ])
 
     def __getattr__(self, item):
-        if item in V1Credential.FIELDS:
-            return self.inputs.get(item, V1Credential.FIELDS[item].default)
-        elif item in self.inputs:
-            return self.inputs[item]
+        if item != 'inputs':
+            if item in V1Credential.FIELDS:
+                return self.inputs.get(item, V1Credential.FIELDS[item].default)
+            elif item in self.inputs:
+                return self.inputs[item]
         raise AttributeError(item)
 
     def __setattr__(self, item, value):


### PR DESCRIPTION
##### SUMMARY
Relates #474.

Add protection in `__getattr__` method to prevent possible infinite
recursion loop.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 1.0.1.94
```