### PR TITLE
Adding Project Based Navigation of Job Templates

### DIFF
--- a/awx/ui/client/src/projects/projects-templates.route.js
+++ b/awx/ui/client/src/projects/projects-templates.route.js
@@ -33,6 +33,7 @@ export default {
         ListDefinition: ['TemplateList', '$transition$', (TemplateList, $transition$) => {
             let id = $transition$.params().project_id;
             TemplateList.actions.add.ngClick = `$state.go('templates.addJobTemplate', {project_id: ${id}})`;
+            TemplateList.basePath = 'job_templates';
             return TemplateList;
         }],
         Dataset: ['ListDefinition', 'QuerySet', '$stateParams', 'GetBasePath', '$interpolate', '$rootScope',

--- a/awx/ui/client/src/projects/projects-templates.route.js
+++ b/awx/ui/client/src/projects/projects-templates.route.js
@@ -1,0 +1,55 @@
+import { N_ } from '../i18n';
+
+export default {
+    url: "/templates",
+    name: 'projects.edit.templates',
+    params: {
+        template_search: {
+            value: {
+                page_size: '20',
+                project: '',
+                order_by: "-id"
+            }
+        }
+    },
+    ncyBreadcrumb: {
+        label: N_("JOB TEMPLATES")
+    },
+    views: {
+        'related': {
+            templateProvider: function(FormDefinition, GenerateForm) {
+                let html = GenerateForm.buildCollection({
+                    mode: 'edit',
+                    related: 'templates',
+                    form: typeof(FormDefinition) === 'function' ?
+                        FormDefinition() : FormDefinition
+                });
+                return html;
+            },
+            controller: 'TemplatesListController'
+        }
+    },
+    resolve: {
+        ListDefinition: ['TemplateList', '$transition$', (TemplateList, $transition$) => {
+            let id = $transition$.params().project_id;
+            TemplateList.actions.add.ngClick = `$state.go('templates.addJobTemplate', {project_id: ${id}})`;
+            return TemplateList;
+        }],
+        Dataset: ['ListDefinition', 'QuerySet', '$stateParams', 'GetBasePath', '$interpolate', '$rootScope',
+            (list, qs, $stateParams, GetBasePath, $interpolate, $rootScope) => {
+                // allow related list definitions to use interpolated $rootScope / $stateParams in basePath field
+                let path, interpolator;
+                if (GetBasePath(list.basePath)) {
+                    path = GetBasePath(list.basePath);
+                } else {
+                    interpolator = $interpolate(list.basePath);
+                    path = interpolator({ $rootScope: $rootScope, $stateParams: $stateParams });
+                }
+                let project_id = $stateParams.project_id;
+                $stateParams[`${list.iterator}_search`].project = project_id;
+                path = GetBasePath('job_templates');
+                return qs.search(path, $stateParams[`${list.iterator}_search`]);
+            }
+        ]
+    }
+};

--- a/awx/ui/client/src/projects/projects.form.js
+++ b/awx/ui/client/src/projects/projects.form.js
@@ -10,7 +10,8 @@
  * @description This form is for adding/editing projects
 */
 
-export default ['i18n', 'NotificationsList', function(i18n, NotificationsList) {
+export default ['i18n', 'NotificationsList', 'TemplateList',
+ function(i18n, NotificationsList, TemplateList) {
     return function() {
     var projectsFormObj = {
         addTitle: i18n._('NEW PROJECT'),
@@ -220,6 +221,9 @@ export default ['i18n', 'NotificationsList', function(i18n, NotificationsList) {
         },
 
         related: {
+            templates: {
+                include: "TemplateList",
+            },
             permissions: {
                 name: 'permissions',
                 awToolTip: i18n._('Please save before assigning permissions.'),
@@ -275,6 +279,11 @@ export default ['i18n', 'NotificationsList', function(i18n, NotificationsList) {
     var itm;
 
     for (itm in projectsFormObj.related) {
+        if (projectsFormObj.related[itm].include === "TemplateList") {
+            projectsFormObj.related[itm] = _.clone(TemplateList);
+            projectsFormObj.related[itm].title = i18n._('Job Templates');
+            projectsFormObj.related[itm].skipGenerator = true;
+        }
         if (projectsFormObj.related[itm].include === "NotificationsList") {
             projectsFormObj.related[itm] = NotificationsList;
             projectsFormObj.related[itm].generateList = true;   // tell form generator to call list generator and inject a list

--- a/awx/ui/client/src/projects/projects.form.js
+++ b/awx/ui/client/src/projects/projects.form.js
@@ -221,9 +221,6 @@ export default ['i18n', 'NotificationsList', 'TemplateList',
         },
 
         related: {
-            templates: {
-                include: "TemplateList",
-            },
             permissions: {
                 name: 'permissions',
                 awToolTip: i18n._('Please save before assigning permissions.'),
@@ -271,7 +268,10 @@ export default ['i18n', 'NotificationsList', 'TemplateList',
             },
             notifications: {
                 include: "NotificationsList",
-            }
+            },
+            templates: {
+                include: "TemplateList",
+            },
         }
 
     };

--- a/awx/ui/client/src/shared/form-generator.js
+++ b/awx/ui/client/src/shared/form-generator.js
@@ -1950,29 +1950,31 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                 if (collection.fieldActions) {
                     html += "<td class=\"List-actionsContainer\"><div class=\"List-tableCell List-actionButtonCell actions\">";
                     for (act in collection.fieldActions) {
-                        fAction = collection.fieldActions[act];
-                        html += "<button id=\"" + ((fAction.id) ? fAction.id : act + "-action") + "\" ";
-                        html += (fAction.awToolTip) ? 'aw-tool-tip="' + fAction.awToolTip + '"' : '';
-                        html += (fAction.dataPlacement) ? 'data-placement="' + fAction.dataPlacement + '"' : '';
-                        html += (fAction.href) ? "href=\"" + fAction.href + "\" " : "";
-                        html += (fAction.ngClick) ? this.attr(fAction, 'ngClick') : "";
-                        html += (fAction.ngHref) ? this.attr(fAction, 'ngHref') : "";
-                        html += (fAction.ngShow) ? this.attr(fAction, 'ngShow') : "";
-                        html += " class=\"List-actionButton ";
-                        html += (act === 'delete') ? "List-actionButton--delete" : "";
-                        html += "\"";
+                        if (act !== 'columnClass') {
+                            fAction = collection.fieldActions[act];
+                            html += "<button id=\"" + ((fAction.id) ? fAction.id : act + "-action") + "\" ";
+                            html += (fAction.awToolTip) ? 'aw-tool-tip="' + fAction.awToolTip + '"' : '';
+                            html += (fAction.dataPlacement) ? 'data-placement="' + fAction.dataPlacement + '"' : '';
+                            html += (fAction.href) ? "href=\"" + fAction.href + "\" " : "";
+                            html += (fAction.ngClick) ? this.attr(fAction, 'ngClick') : "";
+                            html += (fAction.ngHref) ? this.attr(fAction, 'ngHref') : "";
+                            html += (fAction.ngShow) ? this.attr(fAction, 'ngShow') : "";
+                            html += " class=\"List-actionButton ";
+                            html += (act === 'delete') ? "List-actionButton--delete" : "";
+                            html += "\"";
 
-                        html += ">";
-                        if (fAction.iconClass) {
-                            html += "<i class=\"" + fAction.iconClass + "\"></i>";
-                        } else {
-                            html += SelectIcon({
-                                action: act
-                            });
+                            html += ">";
+                            if (fAction.iconClass) {
+                                html += "<i class=\"" + fAction.iconClass + "\"></i>";
+                            } else {
+                                html += SelectIcon({
+                                    action: act
+                                });
+                            }
+                            // html += SelectIcon({ action: act });
+                            //html += (fAction.label) ? "<span class=\"list-action-label\"> " + fAction.label + "</span>": "";
+                            html += "</button>";
                         }
-                        // html += SelectIcon({ action: act });
-                        //html += (fAction.label) ? "<span class=\"list-action-label\"> " + fAction.label + "</span>": "";
-                        html += "</button>";
                     }
                     html += "</div></td>";
                     html += "</tr>\n";

--- a/awx/ui/client/src/shared/socket/socket.service.js
+++ b/awx/ui/client/src/shared/socket/socket.service.js
@@ -34,7 +34,6 @@ export default
                     self.socket.onopen = function () {
                         $log.debug("Websocket connection opened. Socket readyState: " + self.socket.readyState);
                         socketPromise.resolve();
-                        console.log('promise resolved, and readyState: '+ self.readyState);
                         self.checkStatus();
                         if(needsResubscribing){
                             self.subscribe(self.getLast());

--- a/awx/ui/client/src/templates/main.js
+++ b/awx/ui/client/src/templates/main.js
@@ -44,7 +44,7 @@ angular.module('templates', [surveyMaker.name, templatesList.name, jobTemplates.
 
                 addJobTemplate = stateDefinitions.generateTree({
                     name: 'templates.addJobTemplate',
-                    url: '/add_job_template?inventory_id&credential_id',
+                    url: '/add_job_template?inventory_id&credential_id&project_id',
                     modes: ['add'],
                     form: 'JobTemplateForm',
                     controllers: {
@@ -69,14 +69,28 @@ angular.module('templates', [surveyMaker.name, templatesList.name, jobTemplates.
                                             });
                                     }
                             }],
-                            Project: ['$stateParams', 'Rest', 'GetBasePath', 'ProcessErrors',
-                                function($stateParams, Rest, GetBasePath, ProcessErrors){
-                                    if($stateParams.credential_id){
-                                        let path = `${GetBasePath('projects')}?credential__id=${Number($stateParams.credential_id)}`;
+                            Project: ['Rest', 'GetBasePath', 'ProcessErrors', '$transition$',
+                                function(Rest, GetBasePath, ProcessErrors, $transition$){
+                                    if($transition$.params().credential_id){
+                                        let path = `${GetBasePath('projects')}?credential__id=${Number($transition$.params().credential_id)}`;
                                         Rest.setUrl(path);
                                         return Rest.get().
                                             then(function(data){
                                                 return data.data.results[0];
+                                            }).catch(function(response) {
+                                                ProcessErrors(null, response.data, response.status, null, {
+                                                    hdr: 'Error!',
+                                                    msg: 'Failed to get project info. GET returned status: ' +
+                                                        response.status
+                                                });
+                                            });
+                                    }
+                                    else if($transition$.params().project_id){
+                                        let path = `${GetBasePath('projects')}${$transition$.params().project_id}`;
+                                        Rest.setUrl(path);
+                                        return Rest.get().
+                                            then(function(data){
+                                                return data.data;
                                             }).catch(function(response) {
                                                 ProcessErrors(null, response.data, response.status, null, {
                                                     hdr: 'Error!',


### PR DESCRIPTION
##### SUMMARY
This adds a Job Templates tab onto the Project form that gives
the user the ability to see all the job templates using a project.
Clicking the add button on this list will take the user to the job
template form with the project field auto-filled with the project.

relates to https://github.com/ansible/awx/issues/72

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.1.94
```


##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/7010629/31972404-6fb9d5ca-b8d5-11e7-9311-c40d5fab0e46.png)


![image](https://user-images.githubusercontent.com/7010629/31972406-73489046-b8d5-11e7-9e31-d587d41b1d2c.png)


