### PR TITLE
raise error for invalid type lookup

### DIFF
--- a/awx/main/tests/functional/utils/test_common.py
+++ b/awx/main/tests/functional/utils/test_common.py
@@ -3,10 +3,14 @@ import pytest
 import copy
 import json
 
+from django.db import DatabaseError
+
 from awx.main.utils.common import (
     model_instance_diff,
     model_to_dict,
+    get_model_for_type
 )
+from awx.main import models
 
 
 @pytest.mark.django_db
@@ -58,3 +62,20 @@ def test_model_instance_diff(alice, bob):
     assert hasattr(alice, 'is_superuser')
     assert hasattr(bob, 'is_superuser')
     assert 'is_superuser' not in output_dict
+
+
+@pytest.mark.django_db
+def test_get_model_for_invalid_type():
+    with pytest.raises(DatabaseError) as exc:
+        get_model_for_type('foobar')
+    assert 'not a valid AWX model' in str(exc)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("model_type,model_class", [
+    ('inventory', models.Inventory),
+    ('job_template', models.JobTemplate),
+    ('unified_job_template', models.UnifiedJobTemplate)
+])
+def test_get_model_for_valid_type(model_type, model_class):
+    assert get_model_for_type(model_type) == model_class

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -24,6 +24,7 @@ from decorator import decorator
 
 # Django
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import DatabaseError
 from django.utils.translation import ugettext_lazy as _
 from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
 
@@ -506,6 +507,8 @@ def get_model_for_type(type):
         ct_type = get_type_for_model(ct_model)
         if type == ct_type:
             return ct_model
+    else:
+        raise DatabaseError('"{}" is not a valid AWX model.'.format(type))
 
 
 def cache_list_capabilities(page, prefetch_list, model, user):


### PR DESCRIPTION
Just some error handling and getting test coverage where we didn't have it before.

I had hit this issue within the churn of development.

```
awx_1        | 2017-10-26 14:40:50,677 ERROR    django.request Internal Server Error: /api/v1/credentials/
awx_1        | Traceback (most recent call last):
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
awx_1        |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
awx_1        |     return func(*args, **kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
awx_1        |     return view_func(*args, **kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/views/generic/base.py", line 71, in view
awx_1        |     return self.dispatch(request, *args, **kwargs)
awx_1        |   File "./awx/api/generics.py", line 246, in dispatch
awx_1        |     return super(APIView, self).dispatch(request, *args, **kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 466, in dispatch
awx_1        |     response = self.handle_exception(exc)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 463, in dispatch
awx_1        |     response = handler(request, *args, **kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 477, in options
awx_1        |     data = self.metadata_class().determine_metadata(request, self)
awx_1        |   File "./awx/api/metadata.py", line 189, in determine_metadata
awx_1        |     metadata = super(Metadata, self).determine_metadata(request, view)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/metadata.py", line 69, in determine_metadata
awx_1        |     actions = self.determine_actions(request, view)
awx_1        |   File "./awx/api/metadata.py", line 157, in determine_actions
awx_1        |     meta['choices'] = serializer.get_type_choices()
awx_1        |   File "./awx/api/serializers.py", line 278, in get_type_choices
awx_1        |     name = type_name_map.get(t, force_text(get_model_for_type(t)._meta.verbose_name).title())
awx_1        | AttributeError: 'NoneType' object has no attribute '_meta'
```

Exactly what value was passed in for type was never deduced, but by raising this error, we will surface up those errors before it moves on and produces secondary errors like that seen above.