### PR TITLE
Updates INSTALL.md to reflect Ansible 2.4 requirement

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ To install the assets, clone the `awx-logos` repo so that it is next to your `aw
 
 Before you can run a deployment, you'll need the following installed in your local environment:
 
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.3+
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.4+
 - [Docker](https://docs.docker.com/engine/installation/)
 - [docker-py](https://github.com/docker/docker-py) Python module
 - [GNU Make](https://www.gnu.org/software/make/)


### PR DESCRIPTION
##### SUMMARY

Updates INSTALL.md to indicate that Ansible 2.4+ is required.

related #532 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.1.121
```


##### ADDITIONAL INFORMATION
Simple documentation change. Playbook uses 2.4 features