### PR TITLE
Specify a PGDATA directory to prevent container re-create issues

### DIFF
--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -94,6 +94,7 @@
       POSTGRES_USER: "{{ pg_username }}"
       POSTGRES_PASSWORD: "{{ pg_password }}"
       POSTGRES_DB: "{{ pg_database }}"
+      PGDATA: "/var/lib/postgresql/data/pgdata"
   when: pg_hostname is not defined or pg_hostname == ''
   register: postgres_container_activate
 


### PR DESCRIPTION
This fixes issue #438 on a basic level but has a caveat:

If you recreate your container and use the installer then your data will be in the wrong place. This might necessitate a dump and restore:

`docker exec postgres pg_dump -U postgres -F t awx > awx_backup.sql`

Then recreate the pg container in standalone fashion, move  the backup to a directory under the volume (by default the volume is mapped to `/tmp/pgdocker` then do something like this:

`docker exec postgres sh -c "pg_restore -U awx -C -d awx /var/lib/postgresql/data/awx_backup.sql"`

New installs will have this work out of the box without issue.