### PR TITLE
fix credentials form title selector

### DIFF
--- a/awx/ui/test/e2e/objects/credentials.js
+++ b/awx/ui/test/e2e/objects/credentials.js
@@ -225,7 +225,7 @@ module.exports = {
                 details
             },
             elements: {
-                title: 'h3[class="at-Panel-headingTitle"] span'
+                title: 'h3[class="at-Panel-headingTitle"]'
             }
         },
         edit: {
@@ -235,7 +235,7 @@ module.exports = {
                 permissions
             },
             elements: {
-                title: 'h3[class="at-Panel-headingTitle"] span'
+                title: 'h3[class="at-Panel-headingTitle"]'
             }
         },
         list: {


### PR DESCRIPTION
this selector was a little flaky when using the docker chrome container image