### PR TITLE
Update custom credential document for mult-file injection

### DIFF
--- a/docs/custom_credential_types.md
+++ b/docs/custom_credential_types.md
@@ -181,6 +181,20 @@ certificate/key data:
         }
     }
 
+3.3 adds the ability for a single ``Credential Type`` to inject multiple files:
+
+    "injectors": {
+        "file": {
+            "template.cert": "{{cert}}",
+            "template.key": "{{key}}"
+        },
+        "env": {
+            "MY_CERT": "{{tower.filename.cert}",
+            "MY_KEY": "{{tower.filename.key}}"
+        }
+    }
+
+
 
 Job and Job Template Credential Assignment
 ------------------------------------------
@@ -309,6 +323,9 @@ When verifying acceptance we should ensure the following statements are true:
 * Superusers (and only superusers) should be able to define custom `Credential
   Types`.  They should properly inject environment variables, extra vars, and
   files for playbook runs, SCM updates, inventory updates, and ad-hoc runs.
+* Custom `Credential Types` should support injecting both single and
+  multiple files. (Furthermore, the new syntax for injecting multiple files
+  should work properly even if only a single file is injected).
 * The default `Credential Types` included with Tower in 3.2 should be
   non-editable/readonly and cannot be deleted by any user.
 * Stored `Credential` values for _all_ types should be consistent before and


### PR DESCRIPTION
##### SUMMARY

Updates the existing Custom Credential documentation to include a description of injecting multiple files using a single custom credential.

##### ISSUE TYPE
 - Feature Pull Request (Doc update)

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION

For background, see https://github.com/ansible/awx/issues/349