### PR TITLE
Allow non-FQDN for AUTH_LDAP_SERVER_URI.

### DIFF
--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -109,6 +109,7 @@ class LDAPServerURIField(fields.URLField):
 
     def __init__(self, **kwargs):
         kwargs.setdefault('schemes', ('ldap', 'ldaps'))
+        kwargs.setdefault('allow_plain_hostname', True)
         super(LDAPServerURIField, self).__init__(**kwargs)
 
     def run_validators(self, value):


### PR DESCRIPTION
##### SUMMARY

Allow a plain hostname to be specified for the LDAP server.

Related #537.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - API

##### AWX VERSION

```
awx: 1.0.1.138
```
