### PR TITLE
Include JSON string in temporary inventory script with %r

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -680,7 +680,7 @@ class BaseTask(LogErrorsTask):
         path = os.path.join(kwargs['private_data_dir'], 'inventory')
         with open(path, 'w') as f:
             json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
-            f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint """%s"""\n' % json_data)
+            f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint %r\n' % json_data)
             os.chmod(path, stat.S_IRUSR | stat.S_IXUSR)
         return path
 


### PR DESCRIPTION
##### SUMMARY

Output repr() of JSON in temporary inventory script to prevent Python from devouring escape sequences.

Including a JSONified string in Python source via `%s` doesn't account for any escape sequences in the JSON data, so they are interpreted by Python instead of being output as-is. `%r` should properly quote any escape sequences for use in a Python source file.

Related #546.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - API

##### AWX VERSION

```
awx: 1.0.1.138
```

##### ADDITIONAL INFORMATION

:bacon: for @theasp!