### PR TITLE
Fixed most lists so that name links can be opened in a new tab

### DIFF
--- a/awx/ui/client/src/access/add-rbac-user-team/rbac-selected-list.directive.js
+++ b/awx/ui/client/src/access/add-rbac-user-team/rbac-selected-list.directive.js
@@ -42,7 +42,8 @@ export default ['$compile', 'i18n', 'generateList',
                             name: list.fields.name,
                             scm_type: list.fields.scm_type
                         };
-                        list.fields.name.ngClick = 'linkoutResource("project", project)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = "#/projects/{{project.id}}";
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
                         list.fields.scm_type.columnClass = 'col-md-5 col-sm-5 hidden-xs';
                         break;
@@ -51,7 +52,8 @@ export default ['$compile', 'i18n', 'generateList',
                             name: list.fields.name,
                             organization: list.fields.organization
                         };
-                        list.fields.name.ngClick = 'linkoutResource("inventory", inventory)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = '{{inventory.linkToDetails}}';
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
                         list.fields.organization.columnClass = 'col-md-5 col-sm-5 hidden-xs';
                         break;
@@ -62,7 +64,8 @@ export default ['$compile', 'i18n', 'generateList',
                             name: list.fields.name
                         };
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
-                        list.fields.name.ngClick = 'linkoutResource("job_template", job_template)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = "#/templates/job_template/{{job_template.id}}";
                         break;
                     case 'workflow_templates':
                         list.name = 'workflow_job_templates';
@@ -71,20 +74,23 @@ export default ['$compile', 'i18n', 'generateList',
                             name: list.fields.name
                         };
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
-                        list.fields.name.ngClick = 'linkoutResource("workflow_job_template", workflow_job_template)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = "#/templates/workflow_job_template/{{workflow_template.id}}";
                         break;
                     case 'credentials':
                         list.fields = {
                             name: list.fields.name
                         };
-                        list.fields.name.ngClick = 'linkoutResource("credential", credential)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = "#/credentials/{{credential.id}}";
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
                         break;
                     case 'organizations':
                         list.fields = {
                             name: list.fields.name
                         };
-                        list.fields.name.ngClick = 'linkoutResource("organization", organization)';
+                        delete list.fields.name.ngClick;
+                        list.fields.name.ngHref = "#/organizations/{{organization.id}}";
                         list.fields.name.columnClass = 'col-md-5 col-sm-5 col-xs-10';
                         break;
                 }
@@ -116,6 +122,24 @@ export default ['$compile', 'i18n', 'generateList',
                 scope.$watchCollection('collection', function(selected){
                     scope[`${list.iterator}_dataset`] = scope.collection;
                     scope[list.name] = _.values(scope.collection);
+                });
+
+                scope.$watch(list.name, function(){
+                    if(scope.list.name === 'inventories') {
+                        if (scope[list.name] !== undefined) {
+                            scope[list.name].forEach(function(item, item_idx) {
+                                var itm = scope[list.name][item_idx];
+
+                                if(itm.kind && itm.kind === "smart") {
+                                    itm.linkToDetails = `#/inventories/smart/${itm.id}`;
+                                }
+                                else {
+                                    itm.linkToDetails = `#/inventories/inventory/${itm.id}`;
+                                }
+
+                            });
+                        }
+                    }
                 });
 
                 scope.removeSelection = function(resource, type){

--- a/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
+++ b/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
@@ -46,7 +46,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         name: list.fields.name,
                         scm_type: list.fields.scm_type
                     };
-                    list.fields.name.ngClick = 'linkoutResource("project", project)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/projects/{{project.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     list.fields.scm_type.columnClass = 'col-md-5 col-sm-5 hidden-xs';
                     break;
@@ -56,7 +57,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         name: list.fields.name,
                         organization: list.fields.organization
                     };
-                    list.fields.name.ngClick = 'linkoutResource("inventory", inventory)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = '{{inventory.linkToDetails}}';
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     list.fields.organization.columnClass = 'col-md-5 col-sm-5 hidden-xs';
                     delete list.disableRow;
@@ -69,7 +71,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                     list.fields = {
                         name: list.fields.name
                     };
-                    list.fields.name.ngClick = 'linkoutResource("job_template", job_template)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/templates/job_template/{{job_template.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     break;
 
@@ -80,7 +83,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                     list.fields = {
                         name: list.fields.name
                     };
-                    list.fields.name.ngClick = 'linkoutResource("workflow_job_template", workflow_template)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/templates/workflow_job_template/{{workflow_template.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     break;
                 case 'Users':
@@ -89,7 +93,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         first_name: list.fields.first_name,
                         last_name: list.fields.last_name
                     };
-                    list.fields.username.ngClick = 'linkoutResource("user", user)';
+                    delete list.fields.username.ngClick;
+                    list.fields.username.ngHref = "#/users/{{user.id}}";
                     list.fields.username.columnClass = 'col-md-5 col-sm-5 col-xs-11';
                     list.fields.first_name.columnClass = 'col-md-3 col-sm-3 hidden-xs';
                     list.fields.last_name.columnClass = 'col-md-3 col-sm-3 hidden-xs';
@@ -99,7 +104,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         name: list.fields.name,
                         organization: list.fields.organization,
                     };
-                    list.fields.name.ngClick = 'linkoutResource("team", team)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/teams/{{team.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     list.fields.organization.columnClass = 'col-md-5 col-sm-5 hidden-xs';
                     break;
@@ -107,14 +113,16 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                     list.fields = {
                         name: list.fields.name
                     };
-                    list.fields.name.ngClick = 'linkoutResource("organization", organization)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/organizations/{{organization.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     break;
                 case 'Credentials':
                     list.fields = {
                         name: list.fields.name
                     };
-                    list.fields.name.ngClick = 'linkoutResource("credential", credential)';
+                    delete list.fields.name.ngClick;
+                    list.fields.name.ngHref = "#/credentials/{{credential.id}}";
                     list.fields.name.columnClass = 'col-md-6 col-sm-6 col-xs-11';
                     break;
                 default:
@@ -173,6 +181,20 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         });
                     }
                 }
+                else if(scope.list.name === 'inventories') {
+                    if (scope[list.name] !== undefined) {
+                        scope[list.name].forEach(function(item, item_idx) {
+                            var itm = scope[list.name][item_idx];
+
+                            if(itm.kind && itm.kind === "smart") {
+                                itm.linkToDetails = `#/inventories/smart/${itm.id}`;
+                            }
+                            else {
+                                itm.linkToDetails = `#/inventories/inventory/${itm.id}`;
+                            }
+                        });
+                    }
+                }
             }
 
             function isSelected(item){
@@ -184,6 +206,7 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                 });
                 return item;
             }
+
             element.append(list_html);
             $compile(element.contents())(scope);
 

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -64,12 +64,12 @@
                             </td>
                             <td class="List-tableCell name-column InventoryManage-breakWord col-lg-6 col-md-8 col-sm-8 col-xs-7">
                                 <div class="host-name">
-                                    <a href="" ng-click="editHost(host.id)">{{host.name }}</a>
+                                    <a ui-sref="hosts.edit({host_id:host.id})">{{host.name }}</a>
                                 </div>
                             </td>
                             <td class="List-tableCell inventory_name-column col-lg-5 col-md-4 col-sm-4 hidden-xs elllipsis">
                                 <div class="host-name">
-                                    <a href="" ng-click="editInventory(host)">{{host.inventory_name }}</a>
+                                    <a href="#/inventories/inventory/{{host.inventory}}">{{host.inventory_name}}</a>
                                 </div>
                             </td>
                             <td class="List-actionsContainer">

--- a/awx/ui/client/src/inventories-hosts/inventories/inventory.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/inventory.list.js
@@ -49,7 +49,7 @@ export default ['i18n', function(i18n) {
                 modalColumnClass: 'col-md-12',
                 awToolTip: "{{ inventory.description | sanitize }}",
                 awTipPlacement: "top",
-                ngClick: 'editInventory(inventory)'
+                uiSref: '{{inventory.linkToDetails}}'
             },
             kind: {
                 label: i18n._('Type'),

--- a/awx/ui/client/src/inventories-hosts/inventories/list/inventory-list.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/inventory-list.controller.js
@@ -67,6 +67,8 @@ function InventoriesList($scope,
         }
 
         inventory.kind_label = inventory.kind === '' ? 'Inventory' : (inventory.kind === 'smart' ? i18n._('Smart Inventory'): i18n._('Inventory'));
+
+        inventory.linkToDetails = (inventory.kind && inventory.kind === 'smart') ? `inventories.editSmartInventory({smartinventory_id:${inventory.id}})` : `inventories.edit({inventory_id:${inventory.id}})`;
     }
 
     $scope.editInventory = function (inventory) {

--- a/awx/ui/client/src/inventories-hosts/inventories/related/completed-jobs/completed-jobs.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/completed-jobs/completed-jobs.list.js
@@ -31,12 +31,12 @@ export default ['i18n', function(i18n) {
                 dataTitle: "{{ completed_job.status_popover_title }}",
                 icon: 'icon-job-{{ completed_job.status }}',
                 iconOnly: true,
-                ngClick:"viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 nosort: true
             },
             id: {
                 label: i18n._('ID'),
-                ngClick:"viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 columnClass: 'col-lg-1 col-md-1 col-sm-2 col-xs-2 List-staticColumnAdjacent',
                 awToolTip: "{{ completed_job.status_tip }}",
                 dataPlacement: 'top'
@@ -44,7 +44,7 @@ export default ['i18n', function(i18n) {
             name: {
                 label: i18n._('Name'),
                 columnClass: 'col-lg-4 col-md-4 col-sm-4 col-xs-6',
-                ngClick: "viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 awToolTip: "{{ completed_job.name | sanitize }}",
                 dataPlacement: 'top'
             },

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
@@ -31,7 +31,7 @@
             name: {
                 label: i18n._('Groups'),
                 key: true,
-                ngClick: "goToGroupGroups(group.id)",
+                uiSref: "inventories.edit.groups.edit({group_id:group.id})",
                 columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
                 class: 'InventoryManage-breakWord',
             }

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups.list.js
@@ -31,7 +31,7 @@
             name: {
                 label: i18n._('Groups'),
                 key: true,
-                ngClick: "goToGroupGroups(nested_group.id)",
+                uiSref: "inventories.edit.groups.edit.nested_groups({group_id:nested_group.id)}",
                 columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
                 class: 'InventoryManage-breakWord',
             }

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
@@ -55,7 +55,7 @@ export default ['i18n', function(i18n) {
             name: {
                 key: true,
                 label: i18n._('Hosts'),
-                ngClick: "editHost(nested_host.id)",
+                uiSref: "inventories.edit.hosts.edit({host_id: nested_host.id})",
                 ngClass: "{ 'host-disabled-label': !nested_host.enabled }",
                 columnClass: 'col-lg-6 col-md-8 col-sm-8 col-xs-7',
                 dataHostId: "{{ nested_host.id }}",

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -54,7 +54,7 @@ export default ['i18n', function(i18n) {
             name: {
                 key: true,
                 label: i18n._('Hosts'),
-                ngClick: "editHost(host)",
+                uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
                 ngClass: "{ 'host-disabled-label': !host.enabled }",
                 columnClass: 'col-lg-6 col-md-8 col-sm-8 col-xs-7',
                 dataHostId: "{{ host.id }}",

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.list.js
@@ -33,7 +33,7 @@
             name: {
                 label: i18n._('Sources'),
                 key: true,
-                ngClick: "editSource(inventory_source.id)",
+                uiSref: "inventories.edit.inventory_sources.edit({inventory_source_id:inventory_source.id})",
                 columnClass: 'col-lg-4 col-md-4 col-sm-4 col-xs-4',
                 class: 'InventoryManage-breakWord',
             },

--- a/awx/ui/client/src/jobs/all-jobs.list.js
+++ b/awx/ui/client/src/jobs/all-jobs.list.js
@@ -28,12 +28,11 @@ export default ['i18n', function(i18n) {
                 dataTitle: "{{ job.status_popover_title }}",
                 icon: 'icon-job-{{ job.status }}',
                 iconOnly: true,
-                ngClick:"viewjobResults(job)",
+                uiSref: '{{job.linkToDetails}}',
                 nosort: true
             },
             id: {
                 label: 'ID',
-                ngClick:"viewjobResults(job)",
                 columnClass: 'col-lg-1 col-md-1 col-sm-2 col-xs-2 List-staticColumnAdjacent',
                 awToolTip: "{{ job.status_tip }}",
                 dataPlacement: 'top',
@@ -42,7 +41,7 @@ export default ['i18n', function(i18n) {
             name: {
                 label: i18n._('Name'),
                 columnClass: 'col-lg-2 col-md-3 col-sm-4 col-xs-6',
-                ngClick: "viewjobResults(job)",
+                uiSref: '{{job.linkToDetails}}',
                 badgePlacement: 'right',
                 badgeCustom: true,
                 badgeIcon: `<a href="{{ job.workflow_result_link }}"

--- a/awx/ui/client/src/jobs/jobs-list.controller.js
+++ b/awx/ui/client/src/jobs/jobs-list.controller.js
@@ -48,6 +48,27 @@
             $scope[list.name].forEach(function(item, item_idx) {
                 var itm = $scope[list.name][item_idx];
 
+                switch (item.type) {
+                    case 'job':
+                        item.linkToDetails = `jobResult({id: ${item.id}})`;
+                        break;
+                    case 'ad_hoc_command':
+                        item.linkToDetails = `adHocJobStdout({id: ${item.id}})`;
+                        break;
+                    case 'system_job':
+                        item.linkToDetails = `managementJobStdout({id: ${item.id}})`;
+                        break;
+                    case 'project_update':
+                        item.linkToDetails = `scmUpdateStdout({id: ${item.id}})`;
+                        break;
+                    case 'inventory_update':
+                        item.linkToDetails = `inventorySyncStdout({id: ${item.id}})`;
+                        break;
+                    case 'workflow_job':
+                        item.linkToDetails = `workflowResults({id: ${item.id}})`;
+                        break;
+                }
+
                 if(item.summary_fields && item.summary_fields.source_workflow_job &&
                     item.summary_fields.source_workflow_job.id){
                         item.workflow_result_link = `/#/workflows/${item.summary_fields.source_workflow_job.id}`;

--- a/awx/ui/client/src/organizations/list/organizations-list.partial.html
+++ b/awx/ui/client/src/organizations/list/organizations-list.partial.html
@@ -52,10 +52,11 @@
                     ng-repeat="card in orgCards track by card.id">
                     <div class="OrgCards-header">
                         <h3 class="OrgCards-label"
-                            ng-click="editOrganization(card.id)"
                             aw-tool-tip="{{ (card.description || '') | sanitize }}"
                             aw-tip-placement="top">
-                            {{ card.name }}
+                            <a ui-sref="organizations.edit({organization_id:card.id})">
+                                {{ card.name }}
+                            </a>
                         </h3>
                         <div class="OrgCards-actionItems">
                             <button class="OrgCards-actionItem

--- a/awx/ui/client/src/scheduler/schedulerList.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerList.controller.js
@@ -75,6 +75,18 @@ export default [
                 }
                 buildTooltips(itm);
 
+                if (!$state.is('jobs.schedules')){
+                    if($state.current.name.endsWith('.add')) {
+                        itm.linkToDetails = `^.edit({schedule_id:schedule.id})`;
+                    }
+                    else if($state.current.name.endsWith('.edit')) {
+                        itm.linkToDetails = `.({schedule_id:schedule.id})`;
+                    }
+                    else {
+                        itm.linkToDetails = `.edit({schedule_id:schedule.id})`;
+                    }
+                }
+
             });
         }
 

--- a/awx/ui/client/src/scheduler/schedules.list.js
+++ b/awx/ui/client/src/scheduler/schedules.list.js
@@ -31,7 +31,8 @@ export default ['i18n', function(i18n) {
             name: {
                 key: true,
                 label: i18n._('Name'),
-                ngClick: "editSchedule(schedule)",
+                uiSref: "{{schedule.linkToDetails}}",
+                // ngClick: "editSchedule(schedule)",
                 columnClass: "col-md-3 col-sm-3 col-xs-6"
             },
             dtstart: {

--- a/awx/ui/client/src/scheduler/schedules.list.js
+++ b/awx/ui/client/src/scheduler/schedules.list.js
@@ -32,7 +32,6 @@ export default ['i18n', function(i18n) {
                 key: true,
                 label: i18n._('Name'),
                 uiSref: "{{schedule.linkToDetails}}",
-                // ngClick: "editSchedule(schedule)",
                 columnClass: "col-md-3 col-sm-3 col-xs-6"
             },
             dtstart: {

--- a/awx/ui/client/src/shared/generator-helpers.js
+++ b/awx/ui/client/src/shared/generator-helpers.js
@@ -598,7 +598,7 @@ angular.module('GeneratorHelpers', [systemStatus.name])
                     }
 
                     // Start the Link
-                    if ((field.key || field.link || field.linkTo || field.ngClick || field.ngHref || field.awToolTip || field.awPopOver) &&
+                    if ((field.key || field.link || field.linkTo || field.ngClick || field.ngHref || field.uiSref || field.awToolTip || field.awPopOver) &&
                         options.mode !== 'lookup' && options.mode !== 'select' && !field.noLink && !field.ngBindHtml) {
                         if(field.noLink === true){
                             // provide an override here in case we want key=true for sorting purposes but don't want links -- see: portal mode,

--- a/awx/ui/client/src/templates/completed-jobs.list.js
+++ b/awx/ui/client/src/templates/completed-jobs.list.js
@@ -32,12 +32,12 @@ export default ['i18n', function(i18n) {
                 dataTitle: "{{ completed_job.status_popover_title }}",
                 icon: 'icon-job-{{ completed_job.status }}',
                 iconOnly: true,
-                ngClick:"viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 nosort: true
             },
             id: {
                 label: 'ID',
-                ngClick:"viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 columnClass: 'col-lg-1 col-md-1 col-sm-2 col-xs-2 List-staticColumnAdjacent',
                 awToolTip: "{{ completed_job.status_tip }}",
                 dataPlacement: 'top'
@@ -45,7 +45,7 @@ export default ['i18n', function(i18n) {
             name: {
                 label: i18n._('Name'),
                 columnClass: 'col-lg-4 col-md-4 col-sm-4 col-xs-6',
-                ngClick: "viewjobResults(completed_job)",
+                uiSref: '{{completed_job.linkToDetails}}',
                 awToolTip: "{{ completed_job.name | sanitize }}",
                 dataPlacement: 'top'
             },


### PR DESCRIPTION
##### SUMMARY
related #274

This PR should make the name link in the following lists right click->open in a new tab compliant.  In order to achieve this we needed to remove the ngClick events from these links and provide an href instead.

Jobs (#/jobs)
Inventories (#/inventories)
Hosts (#/hosts)
Organization name (#/organizations)
User/Team/Job Template/WFJT/Project/Inventory/Credential/Org in permissions modals throughout app
Inventory Groups (#/inventories/inventory/:id/groups)
Inventory Hosts (#/inventories/inventory/:id/hosts)
Inventory Sources (#/inventories/inventory/:id/inventory_sources)
Inventory Completed Jobs (#/inventories/inventory/:id/completed_jobs) ID/Name both don't work
Template Completed Jobs (#/templates/job_template/:id/completed_jobs) ID/Name both don't work
All Schedule lists except `#/jobs/schedules`

@wenottingham I didn't make these changes to the schedules list (#/jobs/schedules) because inventory sync schedules require the UI to make an extra GET to obtain the inventory ID before we can navigate the user to the correct schedule form.  I spoke with @AlanCoding and this step will be necessary as long as Inventory is not a field on the unified job template model.  If Inventory was on the unified job template model then the API could provide the inventory ID via the schedules summary fields.  If the Schedules list is important then we should discuss our options for getting around this problem.  Otherwise, I'll make a note of that in the original issue and move forward.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.1.138
```
