### PR TITLE
consolidate management of lists of prompts

### DIFF
--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -80,6 +80,7 @@ from awx.api.serializers import * # noqa
 from awx.api.metadata import RoleMetadata, JobTypeMetadata
 from awx.main.consumers import emit_channel_notification
 from awx.main.models.unified_jobs import ACTIVE_STATES
+from awx.main.models.prompts import ask_mapping
 from awx.main.scheduler.tasks import run_job_complete
 
 logger = logging.getLogger('awx.api.views')
@@ -2708,12 +2709,12 @@ class JobTemplateLaunch(RetrieveAPIView):
                 extra_vars.setdefault(v, u'')
             if extra_vars:
                 data['extra_vars'] = extra_vars
-            ask_for_vars_dict = obj._ask_for_vars_dict()
-            ask_for_vars_dict.pop('extra_vars')
+            modified_ask_mapping = ask_mapping.copy()
+            modified_ask_mapping.pop('extra_vars')
             if get_request_version(self.request) == 1:  # TODO: remove in 3.3
-                ask_for_vars_dict.pop('extra_credentials')
-            for field in ask_for_vars_dict:
-                if not ask_for_vars_dict[field]:
+                modified_ask_mapping.pop('extra_credentials')
+            for field in modified_ask_mapping.keys():
+                if not getattr(obj, modified_ask_mapping[field]):
                     data.pop(field, None)
                 elif field == 'inventory' or field == 'credential':
                     data[field] = getattrd(obj, "%s.%s" % (field, 'id'), None)

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -25,6 +25,7 @@ from awx.main.utils import (
 )
 from awx.main.models import * # noqa
 from awx.main.models.unified_jobs import ACTIVE_STATES
+from awx.main.models.prompts import ask_mapping
 from awx.main.models.mixins import ResourceMixin
 
 from awx.conf.license import LicenseForbids, feature_enabled
@@ -1416,7 +1417,7 @@ class JobAccess(BaseAccess):
             prompts_access = True
             job_fields = {}
             jt_extra_credentials = set(obj.job_template.extra_credentials.all())
-            for fd in obj.job_template._ask_for_vars_dict():
+            for fd in ask_mapping.keys():
                 if fd == 'extra_credentials':
                     job_fields[fd] = job_extra_credentials
                 job_fields[fd] = getattr(obj, fd)

--- a/awx/main/models/prompts.py
+++ b/awx/main/models/prompts.py
@@ -1,0 +1,138 @@
+# Django
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+# AWX
+from awx.main.models.base import (
+    BaseModel,
+    JOB_TYPE_CHOICES, VERBOSITY_CHOICES,
+    prevent_search
+)
+from awx.main.fields import JSONField
+
+
+__all__ = [
+    'PromptedFields', 'AskPromptedFields', 'LaunchTimeConfig',
+    'ask_mapping'
+]
+
+
+promptable_fields = dict(
+    extra_vars = prevent_search(models.TextField(
+        blank=True,
+        default='',
+    )),
+    diff_mode = models.BooleanField(
+        default=False,
+        help_text=_("If enabled, textual changes made to any templated files on the host are shown in the standard output"),
+    ),
+    job_type = models.CharField(
+        max_length=64,
+        choices=JOB_TYPE_CHOICES,
+        default='run',
+    ),
+    inventory = models.ForeignKey(
+        'Inventory',
+        related_name='%(class)ss',
+        blank=True,
+        null=True,
+        default=None,
+        on_delete=models.SET_NULL,
+    ),
+    credential = models.ForeignKey(
+        'Credential',
+        related_name='%(class)ss',
+        blank=True,
+        null=True,
+        default=None,
+        on_delete=models.SET_NULL,
+    ),
+    limit = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+    ),
+    verbosity = models.PositiveIntegerField(
+        choices=VERBOSITY_CHOICES,
+        blank=True,
+        default=0,
+    ),
+    job_tags = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+    ),
+    skip_tags = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+    )
+)
+
+
+ask_mapping = {}
+
+for field_name, field in promptable_fields.items():
+    ask_mapping[field_name] = 'ask_{}_on_launch'.format(field_name)
+
+# Special cases
+ask_mapping['job_tags'] = 'ask_tags_on_launch'
+ask_mapping['extra_vars'] = 'ask_variables_on_launch'
+ask_mapping['vault_credential'] = 'ask_credential_on_launch'
+ask_mapping['extra_credentials'] = 'ask_credential_on_launch'
+
+
+# Derive fields for templates that configure prompting with `ask_` fields
+ask_fields = {}
+for field_name in set(ask_mapping.values()):
+    ask_fields[field_name] = models.BooleanField(
+        blank=True,
+        default=False,
+    )
+
+
+# Derive fields for saved launch configurations
+class extracted_field(object):
+    """
+    Interface for psuedo-property stored in `char_prompts` dict
+    """
+    def __init__(self, field_name):
+        self.field_name = field_name
+
+    def __get__(self, instance, type=None):
+        return instance.char_prompts.get(self.field_name, None)
+
+    def __set__(self, instance, value):
+        instance.char_prompts[self.field_name] = value
+
+
+config_fields = {}
+for field_name, field in promptable_fields.items():
+    if isinstance(field, models.ForeignKey):
+        config_fields[field_name] = field
+    else:
+        config_fields[field_name] = extracted_field(field_name)
+
+config_fields['char_prompts'] = JSONField(
+    blank=True,
+    default={}
+)
+
+
+def apply_meta_fields(data):
+    data['Meta'] = type('Meta', (), {'abstract': True})
+    data['__module__'] = __name__
+
+
+apply_meta_fields(promptable_fields)
+apply_meta_fields(ask_fields)
+apply_meta_fields(config_fields)
+
+
+PromptedFields = type('PromptedFields', (BaseModel,), promptable_fields)
+
+
+AskPromptedFields = type('AskPromptedFields', (BaseModel,), ask_fields)
+
+
+LaunchTimeConfig = type('LaunchTimeConfig', (BaseModel,), config_fields)

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -23,6 +23,7 @@ from awx.main.models.rbac import (
 )
 from awx.main.fields import ImplicitRoleField
 from awx.main.models.mixins import ResourceMixin, SurveyJobTemplateMixin, SurveyJobMixin
+from awx.main.models.prompts import AskPromptedFields, LaunchTimeConfig, ask_mapping
 from awx.main.redact import REPLACE_STR
 from awx.main.utils import parse_yaml_or_json
 from awx.main.fields import JSONField
@@ -32,10 +33,8 @@ from urlparse import urljoin
 
 __all__ = ['WorkflowJobTemplate', 'WorkflowJob', 'WorkflowJobOptions', 'WorkflowJobNode', 'WorkflowJobTemplateNode',]
 
-CHAR_PROMPTS_LIST = ['job_type', 'job_tags', 'skip_tags', 'limit']
 
-
-class WorkflowNodeBase(CreatedModifiedModel):
+class WorkflowNodeBase(CreatedModifiedModel, LaunchTimeConfig):
     class Meta:
         abstract = True
         app_label = 'main'
@@ -66,61 +65,26 @@ class WorkflowNodeBase(CreatedModifiedModel):
         default=None,
         on_delete=models.SET_NULL,
     )
-    # Prompting-related fields
-    inventory = models.ForeignKey(
-        'Inventory',
-        related_name='%(class)ss',
-        blank=True,
-        null=True,
-        default=None,
-        on_delete=models.SET_NULL,
-    )
-    credential = models.ForeignKey(
-        'Credential',
-        related_name='%(class)ss',
-        blank=True,
-        null=True,
-        default=None,
-        on_delete=models.SET_NULL,
-    )
-    char_prompts = JSONField(
-        blank=True,
-        default={}
-    )
 
     def prompts_dict(self):
         data = {}
-        if self.inventory:
-            data['inventory'] = self.inventory.pk
-        if self.credential:
-            data['credential'] = self.credential.pk
-        for fd in CHAR_PROMPTS_LIST:
-            if fd in self.char_prompts:
+        field_names = [field.name for field in self._meta.fields]
+        for fd in ask_mapping.keys():
+            if fd in field_names:
+                # ForeignKey fields are maintained directly on model
+                fd_val = getattr(self, '{}_id'.format(fd))
+                if fd_val is not None:
+                    data[fd] = fd_val
+            elif fd in self.char_prompts:
                 data[fd] = self.char_prompts[fd]
         return data
-
-    @property
-    def job_type(self):
-        return self.char_prompts.get('job_type', None)
-
-    @property
-    def job_tags(self):
-        return self.char_prompts.get('job_tags', None)
-
-    @property
-    def skip_tags(self):
-        return self.char_prompts.get('skip_tags', None)
-
-    @property
-    def limit(self):
-        return self.char_prompts.get('limit', None)
 
     def get_prompts_warnings(self):
         ujt_obj = self.unified_job_template
         if ujt_obj is None:
             return {}
         prompts_dict = self.prompts_dict()
-        if not hasattr(ujt_obj, '_ask_for_vars_dict'):
+        if not isinstance(ujt_obj, AskPromptedFields):
             if prompts_dict:
                 return {'ignored': {'all': 'Cannot use prompts on unified_job_template that is not type of job template'}}
             else:
@@ -237,7 +201,7 @@ class WorkflowJobNode(WorkflowNodeBase):
         # reject/accept prompted fields
         data = {}
         ujt_obj = self.unified_job_template
-        if ujt_obj and hasattr(ujt_obj, '_ask_for_vars_dict'):
+        if ujt_obj and isinstance(ujt_obj, AskPromptedFields):
             accepted_fields, ignored_fields = ujt_obj._accept_or_ignore_job_kwargs(**self.prompts_dict())
             for fd in ujt_obj._extra_job_type_errors(accepted_fields):
                 accepted_fields.pop(fd)

--- a/awx/main/tests/unit/models/test_workflow_unit.py
+++ b/awx/main/tests/unit/models/test_workflow_unit.py
@@ -125,13 +125,16 @@ def job_node_no_prompts(workflow_job_unit, jt_ask):
 @pytest.fixture
 def job_node_with_prompts(job_node_no_prompts):
     job_node_no_prompts.char_prompts = example_prompts
-    job_node_no_prompts.inventory = Inventory(name='example-inv')
+    job_node_no_prompts.inventory = Inventory(name='example-inv', id=45)
+    job_node_no_prompts.inventory_id = 45
     ssh_type = CredentialType.defaults['ssh']()
     job_node_no_prompts.credential = Credential(
+        id=43,
         name='example-inv',
         credential_type=ssh_type,
         inputs={'username': 'asdf', 'password': 'asdf'}
     )
+    job_node_with_prompts.credential_id = 43
     return job_node_no_prompts
 
 
@@ -151,6 +154,13 @@ def wfjt_node_with_prompts(wfjt_node_no_prompts):
         inputs={'username': 'asdf', 'password': 'asdf'}
     )
     return wfjt_node_no_prompts
+
+
+def test_node_getter_and_setters():
+    node = WorkflowJobTemplateNode()
+    node.job_type = 'check'
+    assert node.char_prompts['job_type'] == 'check'
+    assert node.job_type == 'check'
 
 
 class TestWorkflowJobCreate:


### PR DESCRIPTION
Pre-work, getting ready to tackle https://github.com/ansible/awx/issues/169

This approach could be controversial - that's why I'm putting out a WIP pull request for it now, early in the development cycle for the feature. Looking for feedback @matburt @ryanpetrello 

I've tried to avoid being fancy. No hacking into the Django Model metaclass, just some minor overhead to make sure that I play nice with it.

Motivation is #555, which is proof-positive that if we maintain these fields in different places for the different types of instantiations of them, that it will break, and fast. This is the only way I can see to keep DRY, and avoid that pain.

Tested `awx-manage makemigrations`, and this diff triggers no migrations. I realize I might have some work with the unit tests to do.