### PR TITLE
support free and serial strategy

### DIFF
--- a/awx/lib/awx_display_callback/module.py
+++ b/awx/lib/awx_display_callback/module.py
@@ -220,12 +220,8 @@ class BaseCallbackModule(CallbackBase):
     def v2_playbook_on_task_start(self, task, is_conditional):
         # FIXME: Flag task path output as vv.
         task_uuid = str(task._uuid)
-        if task_uuid in self.task_uuids:
-            # FIXME: When this task UUID repeats, it means the play is using the
-            # free strategy, so different hosts may be running different tasks
-            # within a play.
-            return
-        self.task_uuids.add(task_uuid)
+        if task_uuid not in self.task_uuids:
+            self.task_uuids.add(task_uuid)
         self.set_task(task)
         event_data = dict(
             task=task,

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -882,7 +882,7 @@ class JobEvent(CreatedModifiedModel):
     #     - playbook_on_include (only v2 - only used for handlers?)
     #     - playbook_on_setup (not used for v2)
     #       - runner_on*
-    #     - playbook_on_task_start (once for each task within a play)
+    #     - playbook_on_task_start (once for each task within a play, except when using free or serial strategy, then maybe many)
     #       - runner_on_failed
     #       - runner_on_ok
     #       - runner_on_error (not used for v2)


### PR DESCRIPTION
* Allow duplicate (same uuid) playbook_on_task_start events

or we could not accept this PR and we would still, effectively, support free and serial strategy in the API.

fixes #288 