### PR TITLE
consolidate management of lists of prompts (try #2)

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -38,6 +38,7 @@ from polymorphic.models import PolymorphicModel
 from awx.main.constants import SCHEDULEABLE_PROVIDERS, ANSI_SGR_PATTERN
 from awx.main.models import * # noqa
 from awx.main.models.unified_jobs import ACTIVE_STATES
+from awx.main.models.jobs import ask_mapping
 from awx.main.access import get_user_capabilities
 from awx.main.fields import ImplicitRoleField
 from awx.main.utils import (
@@ -3289,10 +3290,8 @@ class JobLaunchSerializer(BaseSerializer):
         return False
 
     def get_defaults(self, obj):
-        ask_for_vars_dict = obj._ask_for_vars_dict()
-        ask_for_vars_dict['vault_credential'] = False
         defaults_dict = {}
-        for field in ask_for_vars_dict:
+        for field in ask_mapping.keys():
             if field in ('inventory', 'credential', 'vault_credential'):
                 defaults_dict[field] = dict(
                     name=getattrd(obj, '%s.name' % field, None),
@@ -3320,7 +3319,7 @@ class JobLaunchSerializer(BaseSerializer):
         data = self.context.get('data')
 
         for field in obj.resources_needed_to_start:
-            if not (attrs.get(field, False) and obj._ask_for_vars_dict().get(field, False)):
+            if not (attrs.get(field, False) and getattr(obj, ask_mapping[field], False)):
                 errors[field] = _("Job Template '%s' is missing or undefined.") % field
 
         if obj.inventory and obj.inventory.pending_deletion is True:

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -444,10 +444,6 @@ class BaseSerializer(serializers.ModelSerializer):
             else:
                 field_class = CharNullField
 
-        # Update verbosity choices from settings (for job templates, jobs, ad hoc commands).
-        if field_name == 'verbosity' and 'choices' in field_kwargs:
-            field_kwargs['choices'] = getattr(settings, 'VERBOSITY_CHOICES', field_kwargs['choices'])
-
         # Update the message used for the unique validator to use capitalized
         # verbose name; keeps unique message the same as with DRF 2.x.
         opts = self.Meta.model._meta.concrete_model._meta
@@ -2926,10 +2922,14 @@ class WorkflowJobCancelSerializer(WorkflowJobSerializer):
 
 
 class WorkflowNodeBaseSerializer(BaseSerializer):
-    job_type = serializers.CharField(allow_blank=True, allow_null=True, required=False, default=None)
+    job_type = serializers.ChoiceField(allow_blank=True, allow_null=True, required=False, default=None,
+                                       choices=JOB_TYPE_CHOICES)
     job_tags = serializers.CharField(allow_blank=True, allow_null=True, required=False, default=None)
     limit = serializers.CharField(allow_blank=True, allow_null=True, required=False, default=None)
     skip_tags = serializers.CharField(allow_blank=True, allow_null=True, required=False, default=None)
+    diff_mode = serializers.NullBooleanField(required=False, default=None)
+    verbosity = serializers.ChoiceField(allow_null=True, required=False, default=None,
+                                        choices=VERBOSITY_CHOICES)
     success_nodes = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     failure_nodes = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     always_nodes = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
@@ -2937,20 +2937,14 @@ class WorkflowNodeBaseSerializer(BaseSerializer):
     class Meta:
         fields = ('*', '-name', '-description', 'id', 'url', 'related',
                   'unified_job_template', 'success_nodes', 'failure_nodes', 'always_nodes',
-                  'inventory', 'credential', 'job_type', 'job_tags', 'skip_tags', 'limit', 'skip_tags')
+                  'inventory', 'credential',
+                  'job_type', 'job_tags', 'skip_tags', 'limit', 'skip_tags', 'diff_mode', 'verbosity')
 
     def get_related(self, obj):
         res = super(WorkflowNodeBaseSerializer, self).get_related(obj)
         if obj.unified_job_template:
             res['unified_job_template'] = obj.unified_job_template.get_absolute_url(self.context.get('request'))
         return res
-
-    def validate(self, attrs):
-        # char_prompts go through different validation, so remove them here
-        for fd in ['job_type', 'job_tags', 'skip_tags', 'limit']:
-            if fd in attrs:
-                attrs.pop(fd)
-        return super(WorkflowNodeBaseSerializer, self).validate(attrs)
 
 
 class WorkflowJobTemplateNodeSerializer(WorkflowNodeBaseSerializer):
@@ -2967,40 +2961,7 @@ class WorkflowJobTemplateNodeSerializer(WorkflowNodeBaseSerializer):
             res['workflow_job_template'] = self.reverse('api:workflow_job_template_detail', kwargs={'pk': obj.workflow_job_template.pk})
         return res
 
-    def to_internal_value(self, data):
-        internal_value = super(WorkflowNodeBaseSerializer, self).to_internal_value(data)
-        view = self.context.get('view', None)
-        request_method = None
-        if view and view.request:
-            request_method = view.request.method
-        if request_method in ['PATCH']:
-            obj = self.instance
-            char_prompts = copy.copy(obj.char_prompts)
-            char_prompts.update(self.extract_char_prompts(data))
-        else:
-            char_prompts = self.extract_char_prompts(data)
-        for fd in copy.copy(char_prompts):
-            if char_prompts[fd] is None:
-                char_prompts.pop(fd)
-        internal_value['char_prompts'] = char_prompts
-        return internal_value
-
-    def extract_char_prompts(self, data):
-        char_prompts = {}
-        for fd in ['job_type', 'job_tags', 'skip_tags', 'limit']:
-            # Accept null values, if given
-            if fd in data:
-                char_prompts[fd] = data[fd]
-        return char_prompts
-
     def validate(self, attrs):
-        if 'char_prompts' in attrs:
-            if 'job_type' in attrs['char_prompts']:
-                job_types = [t for t, v in JOB_TYPE_CHOICES]
-                if attrs['char_prompts']['job_type'] not in job_types:
-                    raise serializers.ValidationError({
-                        "job_type": _("%(job_type)s is not a valid job type. The choices are %(choices)s.") % {
-                            'job_type': attrs['char_prompts']['job_type'], 'choices': job_types}})
         if self.instance is None and ('workflow_job_template' not in attrs or
                                       attrs['workflow_job_template'] is None):
             raise serializers.ValidationError({
@@ -3052,10 +3013,6 @@ class WorkflowJobTemplateNodeDetailSerializer(WorkflowJobTemplateNodeSerializer)
             field_kwargs['read_only'] = True
             field_kwargs.pop('queryset', None)
         return field_class, field_kwargs
-
-
-class WorkflowJobTemplateNodeListSerializer(WorkflowJobTemplateNodeSerializer):
-    pass
 
 
 class JobListSerializer(JobSerializer, UnifiedJobListSerializer):

--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -3184,7 +3184,7 @@ class WorkflowJobNodeDetail(WorkflowsEnforcementMixin, RetrieveAPIView):
 class WorkflowJobTemplateNodeList(WorkflowsEnforcementMixin, ListCreateAPIView):
 
     model = WorkflowJobTemplateNode
-    serializer_class = WorkflowJobTemplateNodeListSerializer
+    serializer_class = WorkflowJobTemplateNodeSerializer
     new_in_310 = True
 
 
@@ -3194,21 +3194,11 @@ class WorkflowJobTemplateNodeDetail(WorkflowsEnforcementMixin, RetrieveUpdateDes
     serializer_class = WorkflowJobTemplateNodeDetailSerializer
     new_in_310 = True
 
-    def update_raw_data(self, data):
-        for fd in ['job_type', 'job_tags', 'skip_tags', 'limit', 'skip_tags']:
-            data[fd] = None
-        try:
-            obj = self.get_object()
-            data.update(obj.char_prompts)
-        except Exception:
-            pass
-        return super(WorkflowJobTemplateNodeDetail, self).update_raw_data(data)
-
 
 class WorkflowJobTemplateNodeChildrenBaseList(WorkflowsEnforcementMixin, EnforceParentRelationshipMixin, SubListCreateAttachDetachAPIView):
 
     model = WorkflowJobTemplateNode
-    serializer_class = WorkflowJobTemplateNodeListSerializer
+    serializer_class = WorkflowJobTemplateNodeSerializer
     always_allow_superuser = True
     parent_model = WorkflowJobTemplateNode
     relationship = ''
@@ -3432,16 +3422,11 @@ class WorkflowJobRelaunch(WorkflowsEnforcementMixin, GenericAPIView):
 class WorkflowJobTemplateWorkflowNodesList(WorkflowsEnforcementMixin, SubListCreateAPIView):
 
     model = WorkflowJobTemplateNode
-    serializer_class = WorkflowJobTemplateNodeListSerializer
+    serializer_class = WorkflowJobTemplateNodeSerializer
     parent_model = WorkflowJobTemplate
     relationship = 'workflow_job_template_nodes'
     parent_key = 'workflow_job_template'
     new_in_310 = True
-
-    def update_raw_data(self, data):
-        for fd in ['job_type', 'job_tags', 'skip_tags', 'limit', 'skip_tags']:
-            data[fd] = None
-        return super(WorkflowJobTemplateWorkflowNodesList, self).update_raw_data(data)
 
     def get_queryset(self):
         return super(WorkflowJobTemplateWorkflowNodesList, self).get_queryset().order_by('id')

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -25,6 +25,7 @@ from awx.main.utils import (
 )
 from awx.main.models import * # noqa
 from awx.main.models.unified_jobs import ACTIVE_STATES
+from awx.main.models.jobs import ask_mapping
 from awx.main.models.mixins import ResourceMixin
 
 from awx.conf.license import LicenseForbids, feature_enabled
@@ -1416,7 +1417,7 @@ class JobAccess(BaseAccess):
             prompts_access = True
             job_fields = {}
             jt_extra_credentials = set(obj.job_template.extra_credentials.all())
-            for fd in obj.job_template._ask_for_vars_dict():
+            for fd in ask_mapping.keys():
                 if fd == 'extra_credentials':
                     job_fields[fd] = job_extra_credentials
                 job_fields[fd] = getattr(obj, fd)

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -142,6 +142,10 @@ ask_mapping['extra_credentials'] = 'ask_credential_on_launch'
 
 
 class LaunchTimeConfig(BaseModel):
+    '''
+    Common model for all objects that save details of a saved launch config
+    WFJT / WJ nodes, schedules, and job launch configs (not all implemented yet)
+    '''
     class Meta:
         abstract = True
 
@@ -176,7 +180,10 @@ class extracted_field(object):
         return instance.char_prompts.get(self.field_name, None)
 
     def __set__(self, instance, value):
-        instance.char_prompts[self.field_name] = value
+        if value is None:
+            instance.char_prompts.pop(self.field_name, None)
+        else:
+            instance.char_prompts[self.field_name] = value
 
 
 for field in JobPromptsOptions._meta.fields:

--- a/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
@@ -135,14 +135,16 @@ class TestWorkflowJobTemplateNodeSerializerCharPrompts():
     def test_change_single_field(self, WFJT_serializer):
         "Test that a single prompt field can be changed without affecting other fields"
         internal_value = WFJT_serializer.to_internal_value({'job_type': 'check'})
-        assert internal_value['char_prompts']['job_type'] == 'check'
-        assert internal_value['char_prompts']['limit'] == 'webservers'
+        assert internal_value['job_type'] == 'check'
+        WFJT_serializer.instance.job_type = 'check'
+        assert WFJT_serializer.instance.limit == 'webservers'
 
     def test_null_single_field(self, WFJT_serializer):
         "Test that a single prompt field can be removed without affecting other fields"
         internal_value = WFJT_serializer.to_internal_value({'job_type': None})
-        assert 'job_type' not in internal_value['char_prompts']
-        assert internal_value['char_prompts']['limit'] == 'webservers'
+        assert internal_value['job_type'] is None
+        WFJT_serializer.instance.job_type = None
+        assert WFJT_serializer.instance.limit == 'webservers'
 
 
 @mock.patch('awx.api.serializers.WorkflowNodeBaseSerializer.get_related', lambda x,y: {})

--- a/awx/main/tests/unit/models/test_job_template_unit.py
+++ b/awx/main/tests/unit/models/test_job_template_unit.py
@@ -1,6 +1,12 @@
 import pytest
 import json
 
+# Django
+from django.db import models
+
+# AWX
+from awx.main.models.jobs import JobTemplate, ask_mapping
+
 
 def test_missing_project_error(job_template_factory):
     objects = job_template_factory(
@@ -143,3 +149,16 @@ def test_job_template_can_start_with_callback_extra_vars_provided(job_template_f
     obj = objects.job_template
     obj.ask_variables_on_launch = True
     assert obj.can_start_without_user_input(callback_extra_vars='{"foo": "bar"}') is True
+
+
+def test_ask_mapping_integrity():
+    error_text = (
+        'Programming Error: field {} is marked as a promptable field, '
+        'but JobTemplate model lacks expected corresponding Boolean {} field '
+        'to enable its prompting.'
+    )
+    field_names = [field.name for field in JobTemplate._meta.fields]
+    for field_name, ask_field_name in ask_mapping.items():
+        assert ask_field_name in field_names, error_text.format(field_name, ask_field_name)
+        field = JobTemplate._meta.get_field(ask_field_name)
+        assert isinstance(field, models.BooleanField), error_text.format(field_name, ask_field_name)

--- a/awx/main/tests/unit/models/test_workflow_unit.py
+++ b/awx/main/tests/unit/models/test_workflow_unit.py
@@ -125,13 +125,16 @@ def job_node_no_prompts(workflow_job_unit, jt_ask):
 @pytest.fixture
 def job_node_with_prompts(job_node_no_prompts):
     job_node_no_prompts.char_prompts = example_prompts
-    job_node_no_prompts.inventory = Inventory(name='example-inv')
+    job_node_no_prompts.inventory = Inventory(name='example-inv', id=45)
+    job_node_no_prompts.inventory_id = 45
     ssh_type = CredentialType.defaults['ssh']()
     job_node_no_prompts.credential = Credential(
+        id=43,
         name='example-inv',
         credential_type=ssh_type,
         inputs={'username': 'asdf', 'password': 'asdf'}
     )
+    job_node_with_prompts.credential_id = 43
     return job_node_no_prompts
 
 
@@ -151,6 +154,13 @@ def wfjt_node_with_prompts(wfjt_node_no_prompts):
         inputs={'username': 'asdf', 'password': 'asdf'}
     )
     return wfjt_node_no_prompts
+
+
+def test_node_getter_and_setters():
+    node = WorkflowJobTemplateNode()
+    node.job_type = 'check'
+    assert node.char_prompts['job_type'] == 'check'
+    assert node.job_type == 'check'
 
 
 class TestWorkflowJobCreate:


### PR DESCRIPTION
This uses a flatter model structure to accomplish a good deal of what https://github.com/ansible/awx/pull/561 did, this is a restructuring intended to address @matburt's comments.

This is a direct addressing of #555, but it's really a part of the lead-up to a solution to #169

@ryanpetrello if you have a look at the TODO markers, this is what I would like to become the contract for the collision point between both of our current pieces of work.

tests pass locally

`makemigrations` detected no changes