### PR TITLE
do not use expensive visible_roles for Activity Stream filter

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2243,7 +2243,7 @@ class ActivityStreamAccess(BaseAccess):
             Q(notification_template__organization__in=auditing_orgs) |
             Q(notification__notification_template__organization__in=auditing_orgs) |
             Q(label__organization__in=auditing_orgs) |
-            Q(role__in=Role.visible_roles(self.user) if auditing_orgs else [])
+            Q(role__in=Role.objects.filter(ancestors__in=self.user.roles.all()) if auditing_orgs else [])
         ).distinct()
 
     def can_add(self, data):


### PR DESCRIPTION
Trying to get the Shippable tests more green.

This might change the functionality of what results are returned in the activity stream list. However, what we had seemed a little heavy-handed to begin with. It's an arbitrary switch to say that an org admin can see all activity related to roles they can see, because many of those roles have nothing to do with the organization.