### PR TITLE
Fix extra whitespace in callback URL.

### DIFF
--- a/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
+++ b/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
@@ -508,8 +508,7 @@ export default
 `Host callbacks are enabled for this template. The callback URL is:
 <p style=\"padding: 10px 0;\">
     <strong>
-        ${$scope.callback_server_path}
-        ${data.related.callback}
+        ${$scope.callback_server_path}${data.related.callback}
     </strong>
 </p>
 <p>The host configuration key is:


### PR DESCRIPTION
The newline causes an extra space to show between the Tower host and the callback API endpoint... which makes it an invalid URL for cutting and pasting.

