### PR TITLE
Feature - Retry failed hosts

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -1047,6 +1047,8 @@ input[type="checkbox"].checkbox-no-label {
       color: @green;
   }
 
+  .icon-host-all:before,
+  .icon-host-failed:before,
   .icon-job-active:before,
   .icon-job-running:before,
   .icon-job-success:before,
@@ -1098,12 +1100,17 @@ input[type="checkbox"].checkbox-no-label {
       color: @changed;
   }
 
+  .icon-host-failed,
   .icon-job-stopped,
   .icon-job-error,
   .icon-job-failed,
   .icon-job-stdout-download-tooltip,
   .icon-job-canceled {
       color: @red;
+  }
+
+  .icon-host-all {
+      color: @at-blue;
   }
 
   .icon-job-unreachable {

--- a/awx/ui/client/legacy/styles/lists.less
+++ b/awx/ui/client/legacy/styles/lists.less
@@ -19,7 +19,6 @@ table, tbody {
     width: 100%;
     margin-top: 20px;
     table-layout: fixed;
-    overflow: hidden;
 }
 
 .List-tableHeader{
@@ -70,7 +69,7 @@ table, tbody {
 }
 
 .List-tableRow--selected {
-    border-left: 10px solid @list-row-select-bord;
+    border-left: 5px solid @list-row-select-bord;
 }
 
 .List-tableRow--selected > :first-child {
@@ -124,7 +123,8 @@ table, tbody {
     color: @list-action-icon;
     background-color: @list-actn-bg;
     border: none;
-    border-radius: 50%;
+    border-radius: 4px;
+    margin-left: 15px;
 }
 
 .List-actionButton:hover {
@@ -134,10 +134,6 @@ table, tbody {
 
 .List-actionButton--delete:hover {
     background-color: @list-actn-del-bg-hov !important;
-}
-
-.List-actionButton + .List-actionButton {
-    margin-left: 15px;
 }
 
 .List-header {

--- a/awx/ui/client/lib/components/_index.less
+++ b/awx/ui/client/lib/components/_index.less
@@ -7,3 +7,4 @@
 @import 'tabs/_index';
 @import 'utility/_index';
 @import 'truncate/_index';
+@import 'relaunchButton/_index';

--- a/awx/ui/client/lib/components/components.strings.js
+++ b/awx/ui/client/lib/components/components.strings.js
@@ -76,6 +76,11 @@ function ComponentsStrings (BaseString) {
     ns.capacityBar = {
         IS_OFFLINE: t.s('Unavailable to run jobs.')
     };
+
+    ns.relaunch = {
+        DEFAULT: t.s('Relaunch using the same parameters'),
+        HOSTS: t.s('Relaunch using host parameters')
+    };
 }
 
 ComponentsStrings.$inject = ['BaseStringService'];

--- a/awx/ui/client/lib/components/components.strings.js
+++ b/awx/ui/client/lib/components/components.strings.js
@@ -79,7 +79,10 @@ function ComponentsStrings (BaseString) {
 
     ns.relaunch = {
         DEFAULT: t.s('Relaunch using the same parameters'),
-        HOSTS: t.s('Relaunch using host parameters')
+        HOSTS: t.s('Relaunch using host parameters'),
+        DROPDOWN_TITLE: t.s('Relaunch On'),
+        ALL: t.s('All'),
+        FAILED: t.s('Failed')
     };
 }
 

--- a/awx/ui/client/lib/components/index.js
+++ b/awx/ui/client/lib/components/index.js
@@ -26,6 +26,7 @@ import tab from '~components/tabs/tab.directive';
 import tabGroup from '~components/tabs/group.directive';
 import topNavItem from '~components/layout/top-nav-item.directive';
 import truncate from '~components/truncate/truncate.directive';
+import relaunch from '~components/relaunchButton/relaunchButton.directive';
 
 import BaseInputController from '~components/input/base.controller';
 import ComponentsStrings from '~components/components.strings';
@@ -62,6 +63,7 @@ angular
     .directive('atTabGroup', tabGroup)
     .directive('atTopNavItem', topNavItem)
     .directive('atTruncate', truncate)
+    .component('atRelaunch', relaunch)
     .service('BaseInputController', BaseInputController)
     .service('ComponentsStrings', ComponentsStrings);
 

--- a/awx/ui/client/lib/components/index.js
+++ b/awx/ui/client/lib/components/index.js
@@ -26,7 +26,7 @@ import tab from '~components/tabs/tab.directive';
 import tabGroup from '~components/tabs/group.directive';
 import topNavItem from '~components/layout/top-nav-item.directive';
 import truncate from '~components/truncate/truncate.directive';
-import relaunch from '~components/relaunchButton/relaunchButton.directive';
+import relaunch from '~components/relaunchButton/relaunchButton.component';
 
 import BaseInputController from '~components/input/base.controller';
 import ComponentsStrings from '~components/components.strings';

--- a/awx/ui/client/lib/components/relaunchButton/_index.less
+++ b/awx/ui/client/lib/components/relaunchButton/_index.less
@@ -1,0 +1,39 @@
+.at-Relaunch {
+    margin-left: 15px;
+
+    &--button {
+        font-size: 16px;
+        height: 30px;
+        min-width: 30px;
+        color: #848992;
+        background-color: inherit;
+        border: none;
+        border-radius: 4px;
+    }
+    &--button:hover {
+        background-color: @at-blue;
+        color: white;
+    }
+    &--dropdownTitle {
+        color: #707070;
+        font-size: 12px;
+        font-weight: bold;
+        text-transform: uppercase;
+        padding: 3px 10px;
+    }
+    &--dropdownOptions {
+        i {
+            padding-right: 5px;
+        }
+        a:hover {
+            cursor: pointer;
+        }
+    }
+}
+
+.open {
+    .at-Relaunch--button {
+        background-color: @at-blue;
+        color: white;
+    }
+}

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
@@ -12,7 +12,7 @@ const atRelaunch = {
 function atRelaunchCtrl (RelaunchJob, InitiatePlaybookRun, strings, $scope) {
     const vm = this;
     const scope = $scope.$parent;
-    const { job } = $scope.$parent;
+    const job = _.get(scope, 'job') || _.get(scope, 'completed_job');
 
     vm.$onInit = () => {
         vm.showRelaunch = !(job.type === 'system_job') && job.summary_fields.user_capabilities.start;

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
@@ -6,8 +6,7 @@ const atRelaunch = {
         state: '<'
     },
     controller: ['RelaunchJob', 'InitiatePlaybookRun', 'ComponentsStrings', '$scope', atRelaunchCtrl],
-    controllerAs: 'vm',
-    replace: true
+    controllerAs: 'vm'
 };
 
 function atRelaunchCtrl (RelaunchJob, InitiatePlaybookRun, strings, $scope) {
@@ -19,6 +18,26 @@ function atRelaunchCtrl (RelaunchJob, InitiatePlaybookRun, strings, $scope) {
         vm.showRelaunch = !(job.type === 'system_job') && job.summary_fields.user_capabilities.start;
         vm.showDropdown = job.type === 'job' && job.failed === true;
 
+        vm.createDropdown();
+        vm.createTooltips();
+    };
+
+    vm.createDropdown = () => {
+        vm.icon = 'icon-launch';
+        vm.dropdownTitle = strings.get('relaunch.DROPDOWN_TITLE');
+        vm.dropdownOptions = [
+            {
+                name: strings.get('relaunch.ALL'),
+                icon: 'icon-host-all'
+            },
+            {
+                name: strings.get('relaunch.FAILED'),
+                icon: 'icon-host-failed'
+            }
+        ];
+    };
+
+    vm.createTooltips = () => {
         if (vm.showDropdown) {
             vm.tooltip = strings.get('relaunch.HOSTS');
         } else {

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.directive.js
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.directive.js
@@ -1,0 +1,55 @@
+import templateUrl from './relaunchButton.partial.html';
+
+const atRelaunch = {
+    templateUrl,
+    bindings: {
+        state: '<'
+    },
+    controller: ['RelaunchJob', 'InitiatePlaybookRun', 'ComponentsStrings', '$scope', atRelaunchCtrl],
+    controllerAs: 'vm',
+    replace: true
+};
+
+function atRelaunchCtrl (RelaunchJob, InitiatePlaybookRun, strings, $scope) {
+    const vm = this;
+    const scope = $scope.$parent;
+    const { job } = $scope.$parent;
+
+    vm.$onInit = () => {
+        vm.showRelaunch = !(job.type === 'system_job') && job.summary_fields.user_capabilities.start;
+        vm.showDropdown = job.type === 'job' && job.failed === true;
+
+        if (vm.showDropdown) {
+            vm.tooltip = strings.get('relaunch.HOSTS');
+        } else {
+            vm.tooltip = strings.get('relaunch.DEFAULT');
+        }
+    };
+
+    vm.relaunchJob = () => {
+        let typeId;
+
+        if (job.type === 'inventory_update') {
+            typeId = job.inventory_source;
+        } else if (job.type === 'project_update') {
+            typeId = job.project;
+        } else if (job.type === 'job' || job.type === 'system_job'
+         || job.type === 'ad_hoc_command' || job.type === 'workflow_job') {
+            typeId = job.id;
+        }
+
+        RelaunchJob({ scope, id: typeId, type: job.type, name: job.name });
+    };
+
+    vm.relaunchOn = (option) => {
+        InitiatePlaybookRun({
+            scope,
+            id: job.id,
+            relaunch: true,
+            job_type: job.type,
+            host_type: (option.name).toLowerCase()
+        });
+    };
+}
+
+export default atRelaunch;

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
@@ -8,14 +8,14 @@
             data-toggle="dropdown"
             aria-expanded="false"
             id="relaunchDropdown">
-            <i class="{{ vm.state.icon }}"></i>
+            <i class="{{ vm.icon }}"></i>
         </button>
 
         <ul class="dropdown-menu pull-right" aria-labelledby="relaunchDropdown">
             <li class="at-Relaunch--dropdownTitle">
-                <span>{{ vm.state.dropdownTitle }}</span>
+                <span>{{ vm.dropdownTitle }}</span>
             </li>
-            <li ng-repeat="option in vm.state.dropdownOptions"
+            <li ng-repeat="option in vm.dropdownOptions"
                 class="at-Relaunch--dropdownOptions">
                 <a ng-click="vm.relaunchOn(option)">
                     <i class="fa {{ option.icon }}"></i>
@@ -28,6 +28,6 @@
     <button class="at-Relaunch--button"
             ng-click="vm.relaunchJob()"
             ng-if="!vm.showDropdown">
-            <i class="{{ vm.state.icon }}"></i>
+            <i class="{{ vm.icon }}"></i>
     </button>
 </div>

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
@@ -1,0 +1,33 @@
+<div ng-if="vm.showRelaunch"
+    class="at-Relaunch"
+    aw-tool-tip="{{ vm.tooltip }}"
+    data-placement="top">
+
+    <div class="btn-group" role="group" ng-if="vm.showDropdown">
+        <button class="at-Relaunch--button"
+            data-toggle="dropdown"
+            aria-expanded="false"
+            id="relaunchDropdown">
+            <i class="{{ vm.state.icon }}"></i>
+        </button>
+
+        <ul class="dropdown-menu pull-right" aria-labelledby="relaunchDropdown">
+            <li class="at-Relaunch--dropdownTitle">
+                <span>{{ vm.state.dropdownTitle }}</span>
+            </li>
+            <li ng-repeat="option in vm.state.dropdownOptions"
+                class="at-Relaunch--dropdownOptions">
+                <a ng-click="vm.relaunchOn(option)">
+                    <i class="fa {{ option.icon }}"></i>
+                    {{ option.name }}
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <button class="at-Relaunch--button"
+            ng-click="vm.relaunchJob()"
+            ng-if="!vm.showDropdown">
+            <i class="{{ vm.state.icon }}"></i>
+    </button>
+</div>

--- a/awx/ui/client/src/inventories-hosts/inventories/related/completed-jobs/completed-jobs.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/completed-jobs/completed-jobs.list.js
@@ -76,7 +76,8 @@ export default ['i18n', function(i18n) {
                 ngClick: 'relaunchJob($event, completed_job.id)',
                 awToolTip: i18n._('Relaunch using the same parameters'),
                 dataPlacement: 'top',
-                ngShow: "!completed_job.type == 'system_job' || completed_job.summary_fields.user_capabilities.start"
+                ngShow: "!completed_job.type == 'system_job' || completed_job.summary_fields.user_capabilities.start",
+                relaunch: true
             },
             "delete": {
                 mode: 'all',

--- a/awx/ui/client/src/job-results/job-results.block.less
+++ b/awx/ui/client/src/job-results/job-results.block.less
@@ -55,6 +55,10 @@
     text-transform: uppercase;
 }
 
+.JobResults-panelHeaderButtonActions {
+    display: flex;
+}
+
 .JobResults-resultRow {
     width: 100%;
     display: flex;

--- a/awx/ui/client/src/job-results/job-results.partial.html
+++ b/awx/ui/client/src/job-results/job-results.partial.html
@@ -19,18 +19,10 @@
                     </div>
 
                     <!-- LEFT PANE HEADER ACTIONS -->
-                    <div>
+                    <div class="JobResults-panelHeaderButtonActions">
 
                         <!-- RELAUNCH ACTION -->
-                        <button class="List-actionButton"
-                            data-placement="top"
-                            mode="all"
-                            ng-click="relaunchJob()"
-                            aw-tool-tip="{{'Relaunch using the same parameters' | translate}}"
-                            data-original-title=""
-                            title="">
-                            <i class="icon-launch"></i>
-                        </button>
+                        <at-relaunch state="job"></at-relaunch>
 
                         <!-- CANCEL ACTION -->
                         <button class="List-actionButton

--- a/awx/ui/client/src/job-submission/job-submission-factories/initiateplaybookrun.factory.js
+++ b/awx/ui/client/src/job-submission/job-submission-factories/initiateplaybookrun.factory.js
@@ -10,10 +10,13 @@ export default
                 var scope = params.scope.$new(),
                 id = params.id,
                 relaunch = params.relaunch || false,
-                job_type = params.job_type;
+                job_type = params.job_type,
+                host_type = params.host_type || "";
                 scope.job_template_id = id;
 
-                var el = $compile( "<submit-job data-submit-job-id=" + id + " submit-job-type=" + job_type + " data-submit-job-relaunch=" + relaunch + "></submit-job>" )( scope );
+                var el = $compile( "<submit-job data-submit-job-id=" + id + " submit-job-type=" + job_type + " data-submit-job-relaunch=" + relaunch +
+                " relaunch-host-type=" + host_type +
+                "></submit-job>" )( scope );
                 $('#content-container').remove('submit-job').append( el );
             };
         }

--- a/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
+++ b/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
@@ -133,13 +133,9 @@ export default
                         job_launch_data.diff_mode = scope.other_prompt_data.diff_mode;
                     }
 
-                    if(scope.relaunchHostType) {
+                    if(!Empty(scope.relaunchHostType)) {
                         job_launch_data.hosts = scope.relaunchHostType;
                     }
-                    console.log(job_launch_data);
-                    // if(_.get(scope, 'retry_counts.failed') === true) {
-                    //     job_launch_data.hosts = "failed";
-                    // }
 
                     // If the extra_vars dict is empty, we don't want to include it if we didn't prompt for anything.
                     if(jQuery.isEmptyObject(job_launch_data.extra_vars)===true && scope.prompt_for_vars===false){

--- a/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
+++ b/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
@@ -11,6 +11,7 @@ export default
                 job_launch_data = {},
                 url = params.url,
                 submitJobType = params.submitJobType,
+                relaunchHostType = params.relaunchHostType,
                 vars_url = GetBasePath('job_templates')+scope.job_template_id + '/',
                 base = $location.path().replace(/^\//, '').split('/')[0],
                 extra_vars;
@@ -131,6 +132,14 @@ export default
                     if(scope.ask_diff_mode_on_launch && _.has(scope, 'other_prompt_data.diff_mode')){
                         job_launch_data.diff_mode = scope.other_prompt_data.diff_mode;
                     }
+
+                    if(scope.relaunchHostType) {
+                        job_launch_data.hosts = scope.relaunchHostType;
+                    }
+                    console.log(job_launch_data);
+                    // if(_.get(scope, 'retry_counts.failed') === true) {
+                    //     job_launch_data.hosts = "failed";
+                    // }
 
                     // If the extra_vars dict is empty, we don't want to include it if we didn't prompt for anything.
                     if(jQuery.isEmptyObject(job_launch_data.extra_vars)===true && scope.prompt_for_vars===false){

--- a/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
+++ b/awx/ui/client/src/job-submission/job-submission-factories/launchjob.factory.js
@@ -11,7 +11,6 @@ export default
                 job_launch_data = {},
                 url = params.url,
                 submitJobType = params.submitJobType,
-                relaunchHostType = params.relaunchHostType,
                 vars_url = GetBasePath('job_templates')+scope.job_template_id + '/',
                 base = $location.path().replace(/^\//, '').split('/')[0],
                 extra_vars;

--- a/awx/ui/client/src/job-submission/job-submission.controller.js
+++ b/awx/ui/client/src/job-submission/job-submission.controller.js
@@ -83,7 +83,8 @@ export default
                 LaunchJob({
                     scope: $scope,
                     url: launch_url,
-                    submitJobType: $scope.submitJobType
+                    submitJobType: $scope.submitJobType,
+                    relaunchHostType: $scope.relaunchHostType
                 });
             };
 

--- a/awx/ui/client/src/job-submission/job-submission.directive.js
+++ b/awx/ui/client/src/job-submission/job-submission.directive.js
@@ -12,7 +12,8 @@ export default [ 'templateUrl', 'CreateDialog', 'Wait', 'CreateSelect2', 'ParseT
         scope: {
             submitJobId: '=',
             submitJobType: '@',
-            submitJobRelaunch: '='
+            submitJobRelaunch: '=',
+            relaunchHostType: '@'
         },
         templateUrl: templateUrl('job-submission/job-submission'),
         controller: jobSubmissionController,

--- a/awx/ui/client/src/jobs/all-jobs.list.js
+++ b/awx/ui/client/src/jobs/all-jobs.list.js
@@ -92,7 +92,7 @@ export default ['i18n', function(i18n) {
                 dataPlacement: "top"
             },
             submit: {
-                icon: 'icon-launch',
+                icon: 'icon-rocket',
                 mode: 'all',
                 ngClick: 'relaunchJob($event, job.id)',
                 awToolTip: i18n._('Relaunch using the same parameters'),

--- a/awx/ui/client/src/jobs/all-jobs.list.js
+++ b/awx/ui/client/src/jobs/all-jobs.list.js
@@ -92,12 +92,24 @@ export default ['i18n', function(i18n) {
                 dataPlacement: "top"
             },
             submit: {
-                icon: 'icon-rocket',
+                icon: 'icon-launch',
                 mode: 'all',
                 ngClick: 'relaunchJob($event, job.id)',
                 awToolTip: i18n._('Relaunch using the same parameters'),
                 dataPlacement: 'top',
-                ngShow: "!(job.type == 'system_job') && job.summary_fields.user_capabilities.start"
+                ngShow: "!(job.type == 'system_job') && job.summary_fields.user_capabilities.start",
+                relaunch: true,
+                dropdownTitle: 'Relaunch On',
+                dropdownOptions: [
+                    {
+                        name: 'All',
+                        icon: 'icon-host-all'
+                    },
+                    {
+                        name: 'Failed',
+                        icon: 'icon-host-failed'
+                    }
+                ],
             },
             cancel: {
                 mode: 'all',

--- a/awx/ui/client/src/jobs/all-jobs.list.js
+++ b/awx/ui/client/src/jobs/all-jobs.list.js
@@ -99,17 +99,6 @@ export default ['i18n', function(i18n) {
                 dataPlacement: 'top',
                 ngShow: "!(job.type == 'system_job') && job.summary_fields.user_capabilities.start",
                 relaunch: true,
-                dropdownTitle: 'Relaunch On',
-                dropdownOptions: [
-                    {
-                        name: 'All',
-                        icon: 'icon-host-all'
-                    },
-                    {
-                        name: 'Failed',
-                        icon: 'icon-host-failed'
-                    }
-                ],
             },
             cancel: {
                 mode: 'all',

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -398,7 +398,7 @@ export default ['$compile', 'Attr', 'Icon',
                             }
                             // Plug in Dropdown Component
                             if (field_action === 'submit' && list.fieldActions[field_action].relaunch === true) {
-                                innerTable += `<at-relaunch scope='$scope' state='list.fieldActions.submit'></at-relaunch>`
+                                innerTable += `<at-relaunch></at-relaunch>`
                             } else {
                                 fAction = list.fieldActions[field_action];
                                 innerTable += "<button id=\"";

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -396,7 +396,10 @@ export default ['$compile', 'Attr', 'Icon',
                             if (field_action === 'pending_deletion') {
                                 innerTable += `<a ng-if='${list.iterator}.pending_deletion'>Pending Delete</a>`;
                             }
-                            else {
+                            // Plug in Dropdown Component
+                            if (field_action === 'submit' && list.fieldActions[field_action].relaunch === true) {
+                                innerTable += `<at-relaunch scope='$scope' state='list.fieldActions.submit'></at-relaunch>`
+                            } else {
                                 fAction = list.fieldActions[field_action];
                                 innerTable += "<button id=\"";
                                 innerTable += (fAction.id) ? fAction.id : field_action + "-action";

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -398,7 +398,7 @@ export default ['$compile', 'Attr', 'Icon',
                             }
                             // Plug in Dropdown Component
                             if (field_action === 'submit' && list.fieldActions[field_action].relaunch === true) {
-                                innerTable += `<at-relaunch></at-relaunch>`
+                                innerTable += `<at-relaunch></at-relaunch>`;
                             } else {
                                 fAction = list.fieldActions[field_action];
                                 innerTable += "<button id=\"";


### PR DESCRIPTION
##### SUMMARY
This PR should allow AWX jobs to be relaunched on only the hosts that failed. In the UI, if a job run had _failed_ hosts, the relaunch button should display a dropdown that denotes whether to launch the job on `All` or `Failed` hosts. On the other hand, if the job had no _failed_ hosts, then the relaunch button should launch the job with the current default relaunch.

##### ISSUE TYPE
 - Feature Pull Request https://github.com/ansible/awx/issues/219

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
The relaunch button is a component, and is implemented in the following locations: 
* All Jobs List
* Completed Jobs List
* Job Results Panel

In future iterations, the goal is to explicitly pass the job property to the component's isolate scope instead of relying on inheriting from the parent $scope. This component will also need to be revised and polished due to continuing development on https://github.com/ansible/awx/issues/279. There was also discussion related to creating a more  generic dropdown component in AWX.  

###### JOBS LIST
![retry](https://user-images.githubusercontent.com/15881645/32795418-94fac53c-c939-11e7-8a81-5c26cc226462.gif)

###### JOB RESULTS
![retry job details](https://user-images.githubusercontent.com/15881645/32796122-c2643a10-c93b-11e7-9d28-bb8e2484ffce.gif)