### PR TITLE
remove raw SQL in visible_roles

### DIFF
--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -378,7 +378,7 @@ def admin(user):
 
 @pytest.fixture
 def system_auditor(user):
-    u = user(False)
+    u = user('an-auditor', False)
     Role.singleton('system_auditor').members.add(u)
     return u
 

--- a/awx/main/tests/functional/test_rbac_role.py
+++ b/awx/main/tests/functional/test_rbac_role.py
@@ -4,6 +4,7 @@ from awx.main.access import (
     RoleAccess,
     UserAccess,
     TeamAccess)
+from awx.main.models import Role
 
 
 @pytest.mark.django_db
@@ -32,3 +33,20 @@ def test_role_access_attach(rando, inventory):
     inventory.read_role.members.add(rando)
     access = RoleAccess(rando)
     assert not access.can_attach(inventory.admin_role, rando, 'members', None)
+
+
+@pytest.mark.django_db
+def test_visible_roles(admin_user, system_auditor, rando, organization, project):
+    '''
+    system admin & system auditor fixtures needed to create system roles
+    '''
+    organization.auditor_role.members.add(rando)
+    access = RoleAccess(rando)
+
+    assert rando not in organization.admin_role
+    assert access.can_read(organization.admin_role)
+    assert organization.admin_role in Role.visible_roles(rando)
+
+    assert rando not in project.admin_role
+    assert access.can_read(project.admin_role)
+    assert project.admin_role in Role.visible_roles(rando)


### PR DESCRIPTION
Viewing as org admin, looking at the query to return the results for the `/api/v2/roles/` list:

before:

```sql
SELECT "main_rbac_roles"."id", 
       "main_rbac_roles"."role_field", 
       "main_rbac_roles"."singleton_name", 
       "main_rbac_roles"."implicit_parents", 
       "main_rbac_roles"."content_type_id", 
       "main_rbac_roles"."object_id" 
FROM   "main_rbac_roles" 
WHERE  ( main_rbac_roles.id IN (SELECT DISTINCT visible_roles_t2.ancestor_id 
                                FROM 
         main_rbac_role_ancestors AS visible_roles_t1 
         LEFT JOIN main_rbac_role_ancestors AS 
                   visible_roles_t2 
                ON ( visible_roles_t1.descendent_id = 
                     visible_roles_t2.descendent_id ) 
                                WHERE  visible_roles_t1.ancestor_id IN ( 4, 206 
                                       )) ) 
LIMIT  25 
```

After

```sql
SELECT "main_rbac_roles"."id", 
       "main_rbac_roles"."role_field", 
       "main_rbac_roles"."singleton_name", 
       "main_rbac_roles"."implicit_parents", 
       "main_rbac_roles"."content_type_id", 
       "main_rbac_roles"."object_id" 
FROM   "main_rbac_roles" 
WHERE  "main_rbac_roles"."id" IN (SELECT DISTINCT V0."ancestor_id" AS Col1 
                                  FROM   "main_rbac_role_ancestors" V0 
                                  WHERE  V0."descendent_id" IN 
                                         (SELECT U0."descendent_id" AS Col1 
                                          FROM   "main_rbac_role_ancestors" U0 
                                          WHERE  U0."ancestor_id" IN ( 4, 206 )) 
                                 ) 
LIMIT  25 
```

The org admin in this case has role 4, which is to admin the org, and role 206, which is their personal user role.

We do "lose" something here, although slight. IIRC, it's valid in Django it's valid to do `select_related` and then filter by the result of the extra field. The SQL in this method was doing one-level-more than this because the LEFT JOIN was doing something extremely non-obvious, in such a way that it could be put in terms of simple columns, which could be used in a `select_related`. Because of that, the JOIN is replaced with a special WHERE.

Keep in mind, we're still outright _listing_ the roles that the user has, which has scaling problems on the face of it. I'm just seeking to change as little as possible.

My reason for doing this is because I feel confident that using `visible_roles` inside of other queryset is hiding some hidden server errors, which was first surfaced by the test failure we fixed in my last PR.