### PR TITLE
cascade cancel proj update when job canceled

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -279,6 +279,9 @@ class TaskManagerJobMixin(TaskManagerUnifiedJobMixin):
     class Meta:
         abstract = True
 
+    def get_jobs_fail_chain(self):
+        return [self.project_update] if self.project_update else []
+
     def dependent_jobs_finished(self):
         for j in self.dependent_jobs.all():
             if j.status in ['pending', 'waiting', 'running']:


### PR DESCRIPTION
related to https://github.com/ansible/ansible-tower/issues/7766

* Implicit project update, launch_type='sync', get "associated" with a
job via project_update. When a job is canceled, so should this implicit
project update. This change enforces that logic.