### PR TITLE
Enable image stream lookups in AWX OpenShift Project

### DIFF
--- a/installer/openshift/tasks/main.yml
+++ b/installer/openshift/tasks/main.yml
@@ -68,14 +68,17 @@
       when: docker_registry is defined
       delegate_to: localhost
 
+    - name: Enable image stream lookups for awx images
+      shell: "oc set image-lookup --all -n {{ awx_openshift_project }}"
+
     - name: Set full web image path
       set_fact:
-        awx_web_openshift_image: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_web_image }}:{{ awx_version }}"
+        awx_web_openshift_image: "{{ awx_web_image }}:{{ awx_version }}"
       when: awx_web_openshift_image is not defined
 
     - name: Set full task image path
       set_fact:
-        awx_task_openshift_image: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_task_image }}:{{ awx_version }}"
+        awx_task_openshift_image: "{{ awx_task_image }}:{{ awx_version }}"
       when: awx_task_openshift_image is not defined
   when: dockerhub_base is not defined
 


### PR DESCRIPTION
This resolves an issue where the AWX pod would not be authorized to pull the AWX images from the internal OpenShift registry.

See the OpenShift docs on this for more info: https://docs.openshift.com/container-platform/3.6/dev_guide/managing_images.html#using-is-with-k8s

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.207
```