### PR TITLE
fix test functionality to avoid using wrong role

### DIFF
--- a/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
+++ b/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
@@ -352,9 +352,11 @@ def test_rbac_default_credential_usage(get, post, job_template, alice, machine_c
     post(url, {'credential': machine_credential.pk}, alice, expect=201)
 
     # make (copy) a _new_ SSH cred
-    new_cred = machine_credential
-    new_cred.pk = None
-    new_cred.save()
+    new_cred = Credential.objects.create(
+        name=machine_credential.name,
+        credential_type=machine_credential.credential_type,
+        inputs=machine_credential.inputs
+    )
 
     # alice is attempting to launch with a *different* SSH cred, but
     # she does not have access to it, so she cannot launch


### PR DESCRIPTION
I'm awfully buried in the saved launch-time configuration feature, but I thought this was sensible to port into devel before the fact.

Problem:

Creation using the method here doesn't work completely. Try:

```python
    # make (copy) a _new_ SSH cred
    print ' role pk ' + str(machine_credential.use_role.pk)
    new_cred = machine_credential
    new_cred.pk = None
    new_cred.save()
    print ' role pk ' + str(new_cred.use_role.pk)
```

You get

```
 role pk 22
 new role pk 22
```

Apparently nulling the pk of a resource and saving it does not re-assign it to the its new (correct) roles.