### PR TITLE
Modify wrong virtualenv path for sosreport plugin

### DIFF
--- a/tools/sosreport/tower.py
+++ b/tools/sosreport/tower.py
@@ -8,8 +8,8 @@ SOSREPORT_TOWER_COMMANDS = [
     "ansible --version",      # ansible core version
     "awx-manage --version", # tower version
     "supervisorctl status",   # tower process status
-    "/var/lib/awx/venv/tower/bin/pip freeze",             # pip package list
-    "/var/lib/awx/venv/ansible/bin/pip freeze",             # pip package list
+    "/var/lib/awx/venv/awx/bin/pip freeze",               # pip package list
+    "/var/lib/awx/venv/ansible/bin/pip freeze",           # pip package list
     "tree -d /var/lib/awx",   # show me the dirs
     "ls -ll /var/lib/awx",    # check permissions
     "ls -ll /etc/tower",


### PR DESCRIPTION
##### SUMMARY

sosreport command should collect pip freeze list using /var/lib/awx/venv/awx/bin/pip command instead of /var/lib/awx/venv/tower/bin/pip

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- tools/sosreport/tower.py

##### AWX VERSION

- AWX: devel
- Tower: v3.2.x or later

##### ADDITIONAL INFORMATION

AWX/Tower(v3.2.x or later) uses /var/lib/awx/venv/awx as the virtualenv directory.
