### PR TITLE
Fix import of social_core.exceptions in sso/pipeline.py

### DIFF
--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -5,7 +5,7 @@
 import re
 
 # Python Social Auth
-from social.exceptions import AuthException
+from social_core.exceptions import AuthException
 
 # Django
 from django.utils.translation import ugettext_lazy as _

--- a/awx/sso/tests/unit/test_pipeline.py
+++ b/awx/sso/tests/unit/test_pipeline.py
@@ -1,0 +1,2 @@
+def test_module_loads():
+    from awx.sso import pipeline  # noqa


### PR DESCRIPTION
Signed-off-by: Joachim Jablon <ewjoachim@gmail.com>

##### SUMMARY

Currently, when trying to log in using GitHub (or any social auth), we have an error saying "No module named social.exceptions". This bug was introduced by https://github.com/ansible/awx/commit/8faf5887754addeb4940f73a6e02a380f7623541 which changed the social auth modules, and didn't update the import line.

Note : there is nothing in all the test suite that actually loads the social auth pipeline, so I added a test that does just this, and it seems like it's enough for a regression test (it fails before the fix and passes after the fix)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.241
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Reproduction:
- Configure the AWX instance with GitHub
- Login with Github
- It fails with "No module named social.exceptions" in the form errors (but the exception is properly catched)

After the fix:
- it works