### PR TITLE
Fix CloudForms enabled & id variable names - relates to #705

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -834,12 +834,12 @@ SATELLITE6_GROUP_PATTERNS = ["{app}-{tier}-{color}", "{app}-{color}", "{app}", "
 # ---------------------
 # ----- CloudForms -----
 # ---------------------
-CLOUDFORMS_ENABLED_VAR = 'power_state'
+CLOUDFORMS_ENABLED_VAR = 'cloudforms.power_state'
 CLOUDFORMS_ENABLED_VALUE = 'on'
 CLOUDFORMS_GROUP_FILTER = r'^.+$'
 CLOUDFORMS_HOST_FILTER = r'^.+$'
 CLOUDFORMS_EXCLUDE_EMPTY_GROUPS = True
-CLOUDFORMS_INSTANCE_ID_VAR = 'id'
+CLOUDFORMS_INSTANCE_ID_VAR = 'cloudforms.id'
 
 # ---------------------
 # ----- Custom -----


### PR DESCRIPTION
On Cloudforms (Version 2.0 at least), the dictionary that gets passed to
the inventory_import has a top-level 'cloudforms' dictionary element
that contains the 'id' and 'power_state' rather than those elements
being at the top-level of the dictionary.

This change adds in the 'cloudforms' into the expected name.

This incorrect variable name highlighted the issue that was part of issue #705 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix the CLOUDFORMS_ENABLED_VAR and CLOUDFORMS_INSTANCE_ID_VAR values to match what is in the dictionary when importing inventory

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.257
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
