### PR TITLE
support specifying multiple vault IDs for a playbook run

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -415,6 +415,13 @@ class JSONSchemaField(JSONBField):
         return value
 
 
+@JSONSchemaField.format_checker.checks('vault_id')
+def format_vault_id(value):
+    if '@' in value:
+        raise jsonschema.exceptions.FormatError('@ is not an allowed character')
+    return True
+
+
 @JSONSchemaField.format_checker.checks('ssh_private_key')
 def format_ssh_private_key(value):
     # Sanity check: GCE, in particular, provides JSON-encoded private

--- a/awx/main/migrations/0009_v330_multi_credential.py
+++ b/awx/main/migrations/0009_v330_multi_credential.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 from awx.main.migrations import _migration_utils as migration_utils
+from awx.main.migrations import _credentialtypes as credentialtypes
 from awx.main.migrations._multi_cred import migrate_to_multi_cred
 
 
@@ -50,4 +51,5 @@ class Migration(migrations.Migration):
             model_name='jobtemplate',
             name='vault_credential',
         ),
+        migrations.RunPython(credentialtypes.add_vault_id_field)
     ]

--- a/awx/main/migrations/_credentialtypes.py
+++ b/awx/main/migrations/_credentialtypes.py
@@ -173,3 +173,8 @@ def migrate_job_credentials(apps, schema_editor):
     finally:
         utils.get_current_apps = orig_current_apps
 
+
+def add_vault_id_field(apps, schema_editor):
+    vault_credtype = CredentialType.objects.get(kind='vault')
+    vault_credtype.inputs = CredentialType.defaults.get('vault')().inputs
+    vault_credtype.save()

--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -689,6 +689,16 @@ def vault(cls):
                 'type': 'string',
                 'secret': True,
                 'ask_at_runtime': True
+            }, {
+                'id': 'vault_id',
+                'label': 'Vault Identifier',
+                'type': 'string',
+                'format': 'vault_id',
+                'help_text': ('Specify an (optional) Vault ID. This is '
+                              'equivalent to specifying the --vault-id '
+                              'Ansible parameter for providing multiple Vault '
+                              'passwords.  Note: this feature only works in '
+                              'Ansible 2.4+.')
             }],
             'required': ['vault_password'],
         }

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -173,6 +173,10 @@ class JobOptions(BaseModel):
         return list(self.credentials.filter(credential_type__kind='cloud'))
 
     @property
+    def vault_credentials(self):
+        return list(self.credentials.filter(credential_type__kind='vault'))
+
+    @property
     def credential(self):
         cred = self.get_deprecated_credential('ssh')
         if cred is not None:


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/352

this is the _first half_ of support, but represents the bulk of the work; after @AlanCoding's https://github.com/ansible/awx/pull/740 PR merges, I'll also need to add some additional code to support `ASK` in `passwords_needed_to_start` for multivault so you can specify them at launch time (so that the UI knows which vault ID passwords to prompt for).

The goal is for the UI to provide `ASK` multi vault as described here:

https://github.com/ansible/awx/issues/352#issuecomment-337995178