### PR TITLE
Update error handling on host service after angular upgrade

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/add/host-add.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/add/host-add.controller.js
@@ -45,7 +45,8 @@ export default ['$state', '$stateParams', '$scope', 'RelatedHostsFormDefinition'
             };
             HostsService.post(params).then(function(res) {
                 $state.go('^.edit', { host_id: res.data.id }, { reload: true });
-            });
+            })
+            .catch(function(){});
         };
     }
 ];

--- a/awx/ui/client/src/inventories-hosts/shared/hosts.service.js
+++ b/awx/ui/client/src/inventories-hosts/shared/hosts.service.js
@@ -18,7 +18,7 @@
                 return '';
             },
             error: function(data, status) {
-                ProcessErrors($rootScope, data, status, null, { hdr: 'Error!',
+                ProcessErrors($rootScope, data.data, status, null, { hdr: 'Error!',
                 msg: 'Call to ' + this.url + '. GET returned: ' + status });
             },
             success: function(data){


### PR DESCRIPTION
##### SUMMARY
The error handling in the host service needed to be updated after the angular upgrade to v.1.6. Relates to https://github.com/ansible/awx/issues/764. To reproduce, you should see the correct error message when attempting to add a duplicate host to an inventory. 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

```
awx: 1.0.1.280
```

