### PR TITLE
Fix typo: Failed to get credential tpyes

### DIFF
--- a/awx/ui/client/src/projects/main.js
+++ b/awx/ui/client/src/projects/main.js
@@ -42,7 +42,7 @@ angular.module('Projects', [])
                             }).catch(function(response) {
                                 ProcessErrors(null, response.data, response.status, null, {
                                     hdr: 'Error!',
-                                    msg: 'Failed to get credential tpyes. GET returned status: ' +
+                                    msg: 'Failed to get credential types. GET returned status: ' +
                                         response.status
                                 });
                             });


### PR DESCRIPTION
Changed "credential tpyes" to "credential types"

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 1.0.1.231
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
