### PR TITLE
Ui/fix/input replace revert

### DIFF
--- a/awx/ui/client/features/credentials/edit-credentials.controller.js
+++ b/awx/ui/client/features/credentials/edit-credentials.controller.js
@@ -23,7 +23,7 @@ function EditCredentialsController (models, $state, $scope, strings, componentsS
     };
 
     $scope.$watch('$state.current.name', (value) => {
-        if (/credentials.edit($|\.organization$)/.test(value)) {
+        if (/credentials.edit($|\.organization$|\.credentialType$)/.test(value)) {
             vm.tab.details._active = true;
             vm.tab.permissions._active = false;
         } else {

--- a/awx/ui/client/lib/components/input/secret.directive.js
+++ b/awx/ui/client/lib/components/input/secret.directive.js
@@ -37,6 +37,12 @@ function AtInputSecretController (baseInputController) {
         vm.check();
     };
 
+    vm.toggleRevertReplace = () => {
+        scope.state._isBeingReplaced = !scope.state._isBeingReplaced;
+
+        vm.onRevertReplaceToggle();
+    };
+
     vm.toggleShowHide = () => {
         if (scope.type === 'password') {
             scope.type = 'text';

--- a/awx/ui/test/e2e/tests/test-credentials-add-edit-machine.js
+++ b/awx/ui/test/e2e/tests/test-credentials-add-edit-machine.js
@@ -177,6 +177,30 @@ module.exports = {
 
         credentials.waitForElementNotPresent(`${row}:nth-of-type(2)`);
         credentials.expect.element(row).text.contain(store.credential.name);
+    },
+    'change the password after saving': client => {
+        const credentials = client.page.credentials();
+        const { edit } = credentials.section;
+        const { machine } = edit.section.details.section;
+
+        machine.section.password.expect.element('@replace').visible;
+        machine.section.password.expect.element('@replace').enabled;
+        machine.section.password.expect.element('@revert').not.present;
+
+        machine.expect.element('@password').not.enabled;
+
+        machine.section.password.click('@replace');
+        machine.section.password.expect.element('@replace').not.present;
+        machine.section.password.expect.element('@revert').visible;
+
+        machine.expect.element('@password').enabled;
+        machine.setValue('@password', 'newpassword');
+
+        edit.section.details.click('@save');
+
+        credentials
+            .waitForElementVisible('div.spinny')
+            .waitForElementNotVisible('div.spinny');
 
         client.end();
     }


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/awx/issues/770

Adds a fix and a test case for the secret input component's replace/revert.

(...And fixed a tab that was incorrectly changing behavior in the background when performing a credential type lookup).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.1.285
```
Thanks for filing the issue, @AlanCoding 