### PR TITLE
Add m2r to setup requirements file

### DIFF
--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -4,3 +4,4 @@ vcversioner>=2.16.0.0
 pytest-runner
 isort
 virtualenv
+m2r


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

We `pip download` this file for offline installs. Automat lists this package as a setup_requires, but `pip download` doesn’t resolve these dependencies (distutils will attempt to install them via easy_install when setup.py is invoked).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.1.286
```
