### PR TITLE
Adding jupyter notebook support to the AWX development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,17 +334,17 @@ receiver:
 	fi; \
 	$(PYTHON) manage.py run_callback_receiver
 
-socketservice:
-	@if [ "$(VENV_BASE)" ]; then \
-		. $(VENV_BASE)/awx/bin/activate; \
-	fi; \
-	$(PYTHON) manage.py run_socketio_service
-
 nginx:
 	nginx -g "daemon off;"
 
 rdb:
 	$(PYTHON) tools/rdb.py
+
+jupyter:
+	@if [ "$(VENV_BASE)" ]; then \
+		. $(VENV_BASE)/awx/bin/activate; \
+	fi; \
+	$(MANAGEMENT_COMMAND) shell_plus --notebook
 
 reports:
 	mkdir -p $@

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -19,6 +19,18 @@ from split_settings.tools import optional, include
 # Load default settings.
 from defaults import *  # NOQA
 
+# awx-manage shell_plus --notebook
+NOTEBOOK_ARGUMENTS = [
+    '--NotebookApp.token=',
+    '--ip', '0.0.0.0',
+    '--port', '8888',
+    '--allow-root',
+    '--no-browser',
+]
+
+# print SQL queries in shell_plus
+SHELL_PLUS_PRINT_SQL = False
+
 # show colored logs in the dev environment
 # to disable this, set `COLOR_LOGS = False` in awx/settings/local_settings.py
 LOGGING['handlers']['console']['()'] = 'awx.main.utils.handlers.ColorHandler'

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -13,3 +13,5 @@ pytest-mock
 logutils
 flower
 uwsgitop
+jupyter
+matplotlib

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       CELERY_RDB_HOST: 0.0.0.0
       AWX_GROUP_QUEUES: tower
     ports:
+      - "8888:8888"
       - "8080:8080"
       - "5555:5555"
       - "8013:8013"

--- a/tools/docker-compose/Procfile
+++ b/tools/docker-compose/Procfile
@@ -5,3 +5,4 @@ celeryd:        make celeryd
 receiver:       make receiver
 flower:         make flower
 uwsgi:          make uwsgi
+jupyter:        make jupyter

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -59,6 +59,14 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
+[program:jupyter]
+command = make jupyter
+autostart = true
+autorestart = true
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+
 [group:awx-processes]
 programs=celeryd,receiver,runworker,uwsgi,daphne,nginx,flower
 priority=5


### PR DESCRIPTION
* Jupyter starts alongside the other awx services and is available on
  0.0.0.0:8888
* make target: make jupyter
* default settings in settings/development.py
* Added jupyter, matplotlib, numpy to dev dependencies

Having this available alongside the development environment would make things *much* better.

After launching the dev services jupyter will be available on port `8888` with no credentials. The shell_plus kernel will instantly have the same access as the normal `shell_plus`.

As far as sharing goes, github automatically parses the files:

https://gist.github.com/matburt/93fac0613fe5f43e6930e0c6105a93b7

Some running screen shots:
<img width="1504" alt="screen shot 2017-12-05 at 9 19 34 pm" src="https://user-images.githubusercontent.com/89544/33645087-0d17c9d2-da17-11e7-87c0-747decaa574a.png">

<img width="1465" alt="screen shot 2017-12-05 at 10 36 44 pm" src="https://user-images.githubusercontent.com/89544/33645090-0faa6182-da17-11e7-9c5a-9aa769b9cebd.png">
