### PR TITLE
Fix JS syntax error

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.service.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.service.js
@@ -149,17 +149,6 @@ export default
                     .error(this.error.bind(this))
                     .finally();
             }
-            if(source === 'vmware'){
-                group_by = _.map(group_by, (i) => {return i.value;});
-                $("#inventory_source_group_by").siblings(".select2").first().find(".select2-selection__choice").each(function(optionIndex, option){
-                    group_by.push(option.title);
-                });
-                group_by = (Array.isArray(group_by)) ?  _.uniq(group_by).join() : "";
-                return group_by;
-            }
-            else {
-                return;
-            }
         }
     };
 }];


### PR DESCRIPTION
This is fallout from the Tower 3.2.2 merge conflict. These lines are actually up above:

https://github.com/ansible/awx/blob/devel/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.service.js#L124-L134
