### PR TITLE
Use Options models to consolidate field_names list

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1364,9 +1364,9 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions):
 
     @classmethod
     def _get_unified_job_field_names(cls):
-        return ['name', 'description', 'source', 'source_path', 'source_script', 'source_vars', 'schedule',
-                'credential', 'source_regions', 'instance_filters', 'group_by', 'overwrite', 'overwrite_vars',
-                'timeout', 'verbosity', 'source_project_update',]
+        return set(f.name for f in InventorySourceOptions._meta.fields) | set(
+            ['name', 'description', 'schedule']
+        )
 
     def save(self, *args, **kwargs):
         # If update_fields has been specified, add our field names to it,

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -289,13 +289,9 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
 
     @classmethod
     def _get_unified_job_field_names(cls):
-        return ['name', 'description', 'job_type', 'inventory', 'project',
-                'playbook', 'credentials', 'forks', 'schedule', 'limit',
-                'verbosity', 'job_tags', 'extra_vars',
-                'force_handlers', 'skip_tags', 'start_at_task',
-                'become_enabled', 'labels', 'survey_passwords',
-                'allow_simultaneous', 'timeout', 'use_fact_cache',
-                'diff_mode',]
+        return set(f.name for f in JobOptions._meta.fields) | set(
+            ['name', 'description', 'schedule', 'survey_passwords', 'labels', 'credentials']
+        )
 
     @property
     def validation_errors(self):

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -306,9 +306,9 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin):
 
     @classmethod
     def _get_unified_job_field_names(cls):
-        return ['name', 'description', 'local_path', 'scm_type', 'scm_url',
-                'scm_branch', 'scm_clean', 'scm_delete_on_update',
-                'credential', 'schedule', 'timeout',]
+        return set(f.name for f in ProjectOptions._meta.fields) | set(
+            ['name', 'description', 'schedule']
+        )
 
     def save(self, *args, **kwargs):
         new_instance = not bool(self.pk)

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -838,7 +838,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
         unified_job_class = self.__class__
         unified_jt_class = self._get_unified_job_template_class()
         parent_field_name = unified_job_class._get_parent_field_name()
-        fields = unified_jt_class._get_unified_job_field_names() + [parent_field_name]
+        fields = unified_jt_class._get_unified_job_field_names() | set([parent_field_name])
 
         create_data = {"launch_type": "relaunch"}
         if limit:

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -316,15 +316,16 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
 
     @classmethod
     def _get_unified_job_field_names(cls):
-        return ['name', 'description', 'extra_vars', 'labels', 'survey_passwords',
-                'schedule', 'launch_type', 'allow_simultaneous']
+        return set(f.name for f in WorkflowJobOptions._meta.fields) | set(
+            ['name', 'description', 'schedule', 'survey_passwords', 'labels']
+        )
 
     @classmethod
     def _get_unified_jt_copy_names(cls):
         base_list = super(WorkflowJobTemplate, cls)._get_unified_jt_copy_names()
         base_list.remove('labels')
-        return (base_list +
-                ['survey_spec', 'survey_enabled', 'ask_variables_on_launch', 'organization'])
+        return (base_list |
+                set(['survey_spec', 'survey_enabled', 'ask_variables_on_launch', 'organization']))
 
     def get_absolute_url(self, request=None):
         return reverse('api:workflow_job_template_detail', kwargs={'pk': self.pk}, request=request)


### PR DESCRIPTION
The real core purpose of these sets is to determine which fields to copy over from the Unified Job Template to its corresponding Unified Job.

I'm skeptical, but there might be some critical manual over-rides we need to this list.

Anyway, since the `Options` model is a shared abstract model, it's very existence indicates that fields should be common to both the template and the job. So there's no value, whatsoever, in manually listing them. It also makes for a piece of code that's just plain unreadable.

How do I know I didn't miss any fields?

How do I know there aren't any "Options" model field that we _shouldn't_ copy?

```
In [6]: from awx.main.models.jobs import JobOptions
   ...: from awx.main.models.workflow import WorkflowJobOptions
   ...: from awx.main.models.inventory import InventorySourceOptions
   ...: from awx.main.models.projects import ProjectOptions
   ...: for cls, options in ((JobTemplate, JobOptions), (WorkflowJobTemplate, WorkflowJobOptions), (InventorySource, InventorySourceOptions), (Project, ProjectOptions)):
   ...:   s1 = set(f.name for f in options._meta.fields)
   ...:   s2 = set(cls._get_unified_job_field_names())
   ...:   print ''
   ...:   print str(cls)
   ...:   print s2
   ...:   print s1 - s2
   ...:   print s2 - s1
   ...:   

<class 'awx.main.models.jobs.JobTemplate'>
set(['labels', 'job_type', 'skip_tags', 'playbook', 'force_handlers', 'job_tags', 'diff_mode', 'inventory', 'forks', 'become_enabled', 'description', 'schedule', 'survey_passwords', 'start_at_task', 'credentials', 'name', 'use_fact_cache', 'extra_vars', 'verbosity', 'allow_simultaneous', 'project', 'limit', 'timeout'])
set([])
set(['name', 'schedule', 'survey_passwords', 'labels', 'credentials', 'description'])

<class 'awx.main.models.workflow.WorkflowJobTemplate'>
set(['name', 'schedule', 'extra_vars', 'labels', 'allow_simultaneous', 'survey_passwords', 'launch_type', 'description'])
set([])
set(['description', 'schedule', 'survey_passwords', 'labels', 'launch_type', 'name'])

<class 'awx.main.models.inventory.InventorySource'>
set(['credential', 'source_vars', 'name', 'overwrite_vars', 'schedule', 'verbosity', 'source_regions', 'source_path', 'instance_filters', 'source_project_update', 'source', 'source_script', 'group_by', 'timeout', 'overwrite', 'description'])
set([])
set(['description', 'name', 'source_project_update', 'schedule'])

<class 'awx.main.models.projects.Project'>
set(['credential', 'scm_branch', 'name', 'schedule', 'scm_clean', 'scm_url', 'scm_delete_on_update', 'local_path', 'scm_type', 'timeout', 'description'])
set([])
set(['description', 'name', 'schedule'])
```

No "Options" model _anywhere_ has _any_ fields that are not also in these listing.

That means we should abstract that away!