### PR TITLE
Avoid looping over all unicode chars on startup

### DIFF
--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -15,9 +15,6 @@ from awx.main.utils.common import get_search_fields
 
 __all__ = ['SmartFilter']
 
-unicode_spaces = [unichr(c) for c in xrange(sys.maxunicode) if unichr(c).isspace()]
-unicode_spaces_other = unicode_spaces + [u'(', u')', u'=', u'"']
-
 
 def string_to_type(t):
     if t == u'true':
@@ -213,6 +210,8 @@ class SmartFilter(object):
         filter_string_raw = filter_string
         filter_string = unicode(filter_string)
 
+        unicode_spaces = [unichr(c) for c in xrange(sys.maxunicode) if unichr(c).isspace()]
+        unicode_spaces_other = unicode_spaces + [u'(', u')', u'=', u'"']
         atom = CharsNotIn(unicode_spaces_other)
         atom_inside_quotes = CharsNotIn(u'"')
         atom_quoted = Literal('"') + Optional(atom_inside_quotes) + Literal('"')


### PR DESCRIPTION
I'm doing this as a means of reducing the speed of startup, which is approaching 4 seconds (very slow).

I got here from cprofile:

```
>>> pstats.Stats('djangoprofile').sort_stats('time').print_stats(20)
Thu Dec 14 13:34:50 2017    djangoprofile

         5871224 function calls (5768621 primitive calls) in 35.162 seconds

   Ordered by: internal time
   List reduced from 10803 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    6.022    6.022   11.971   11.971 awx/main/utils/filters.py:1(<module>)
  1114353    2.936    0.000    2.936    0.000 {unichr}
  1114111    2.835    0.000    2.835    0.000 {method 'isspace' of 'unicode' objects}
     1933    1.915    0.001    4.925    0.003 awx/conf/registry.py:91(get_registered_settings)
   521715    1.334    0.000    1.337    0.000 {method 'get' of 'dict' objects}
   481354    1.226    0.000    1.226    0.000 {method 'append' of 'list' objects}
313633/312671    0.869    0.000    0.953    0.000 {isinstance}
49139/1038    0.759    0.000    3.321    0.003 /venv/awx/lib/python2.7/site-packages/pkg_resources/_vendor/pyparsing.py:1347(_parseNoCache)
     2101    0.665    0.000    1.285    0.001 /usr/lib64/python2.7/collections.py:108(items)
   235696    0.634    0.000    0.634    0.000 /usr/lib64/python2.7/collections.py:73(__iter__)
186686/184520    0.488    0.000    0.500    0.000 {len}
   158601    0.419    0.000    0.420    0.000 {hasattr}
     2338    0.416    0.000    1.653    0.001 /venv/awx/lib/python2.7/site-packages/django/utils/regex_helper.py:53(normalize)
     1585    0.412    0.000    0.820    0.001 /venv/awx/lib/python2.7/site-packages/django/utils/functional.py:81(__prepare_class__)
    46635    0.390    0.000    0.653    0.000 /venv/awx/lib/python2.7/site-packages/pkg_resources/_vendor/packaging/version.py:65(_compare)
    69834    0.358    0.000    0.599    0.000 {next}
    42178    0.346    0.000    0.557    0.000 /venv/awx/lib64/python2.7/sre_parse.py:183(__next)
31830/29786    0.318    0.000    0.737    0.000 /venv/awx/lib/python2.7/site-packages/pkg_resources/_vendor/pyparsing.py:349(__init__)
 2475/757    0.295    0.000    1.431    0.002 /venv/awx/lib64/python2.7/sre_parse.py:380(_parse)
    20035    0.251    0.000    0.426    0.000 /venv/awx/lib/python2.7/site-packages/rply/grammar.py:119(_first)
```

Wait, what is this `isspace` thing? It's used in the utils method at the start of the file... but why would the list it builds be a problem?

```
>>> sys.maxunicode
1114111
```

Oh that's not good.

```
(awx) [root@awx awx_devel]# time python -c "import sys; [unichr(c) for c in xrange(sys.maxunicode) if unichr(c).isspace()]"

real	0m0.250s
user	0m0.240s
sys	0m0.000s
```