### PR TITLE
Cache the global settings list, cProfile speedup

### DIFF
--- a/awx/main/tests/unit/conftest.py
+++ b/awx/main/tests/unit/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
+from mock import PropertyMock
+
 
 @pytest.fixture(autouse=True)
 def _disable_database_settings(mocker):
-    mocker.patch('awx.conf.settings.SettingsWrapper._get_supported_settings', return_value=[])
+    m = mocker.patch('awx.conf.settings.SettingsWrapper.all_supported_settings', new_callable=PropertyMock)
+    m.return_value = []


### PR DESCRIPTION
See the cProfile output from

https://github.com/ansible/awx/pull/837#issue-282107545

to see what motivated this.

But this still doesn't get rid of the DB calls, and the time remains at 3.3s or so.

Nonetheless, I would estimate a speedup of roughly 0.000278949737549*1193= .33 seconds. That's not nothing.

I also _think_ this is safe, because the registry is defined in code, so this can't possibly change from one call to another.