### PR TITLE
Fix 404 link to django auth ldap documentation

### DIFF
--- a/awx/locale/django.pot
+++ b/awx/locale/django.pot
@@ -3748,7 +3748,7 @@ msgstr ""
 #: awx/sso/conf.py:287
 msgid ""
 "The group type may need to be changed based on the type of the LDAP server.  "
-"Values are listed at: http://pythonhosted.org/django-auth-ldap/groups."
+"Values are listed at: https://django-auth-ldap.readthedocs.io/en/latest/groups.html."
 "html#types-of-groups"
 msgstr ""
 


### PR DESCRIPTION
Signed-off-by: liquidat <liquidat@bayz.de>

##### SUMMARY
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`awx/locale/django.pot`

##### AWX VERSION
```
awx: 1.0.2.286
```


##### ADDITIONAL INFORMATION
The link was pointing to a no longer reachable documentation page. The new link points to the official Django documentation.