### PR TITLE
Fix bug when creating system job schedule

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -19,6 +19,7 @@ from awx.main.models.jobs import LaunchTimeConfig
 from awx.main.utils import ignore_inventory_computed_fields
 from awx.main.consumers import emit_channel_notification
 
+
 logger = logging.getLogger('awx.main.models.schedule')
 
 __all__ = ['Schedule']
@@ -90,40 +91,6 @@ class Schedule(CommonModel, LaunchTimeConfig):
         editable=False,
         help_text=_("The next time that the scheduled action will run.")
     )
-
-    # extra_data is actually a string with a JSON payload in it. This
-    # is technically OK because a string is a valid JSON. One day we will
-    # enforce non-string JSON.
-    def _clean_extra_data_system_jobs(self):
-        extra_data = self.extra_data
-        if not isinstance(extra_data, dict):
-            try:
-                extra_data = json.loads(self.extra_data)
-            except Exception:
-                raise ValidationError(_("Expected JSON"))
-
-        if extra_data and 'days' in extra_data:
-            try:
-                if type(extra_data['days']) is bool:
-                    raise ValueError
-                if float(extra_data['days']) != int(extra_data['days']):
-                    raise ValueError
-                days = int(extra_data['days'])
-                if days < 0:
-                    raise ValueError
-            except ValueError:
-                raise ValidationError(_("days must be a positive integer."))
-        return self.extra_data
-
-    def clean_extra_data(self):
-        if not self.unified_job_template:
-            return self.extra_data
-
-        # Compare class by string name because it's hard to import SystemJobTemplate
-        if type(self.unified_job_template).__name__ is not 'SystemJobTemplate':
-            return self.extra_data
-
-        return self._clean_extra_data_system_jobs()
 
     def __unicode__(self):
         return u'%s_t%s_%s_%s' % (self.name, self.unified_job_template.id, self.id, self.next_run)


### PR DESCRIPTION
the bug was

```
2017-12-19 19:30:24,764 ERROR    django.request Internal Server Error: /api/v1/system_job_templates/1/schedules/
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/lib/python2.7/site-packages/awx/api/generics.py", line 253, in dispatch
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 489, in dispatch
    response = self.handle_exception(exc)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 449, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 486, in dispatch
    response = handler(request, *args, **kwargs)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/generics.py", line 244, in post
    return self.create(request, *args, **kwargs)
  File "/lib/python2.7/site-packages/awx/api/generics.py", line 526, in create
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/serializers.py", line 236, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/lib/python2.7/site-packages/awx/api/serializers.py", line 479, in run_validation
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/rest_framework/serializers.py", line 434, in run_validation
    value = self.validate(value)
  File "/lib/python2.7/site-packages/awx/api/serializers.py", line 3121, in validate
  File "/lib/python2.7/site-packages/awx/api/serializers.py", line 513, in validate
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/db/models/base.py", line 1228, in full_clean
    self.clean_fields(exclude=exclude)
  File "/lib/python2.7/site-packages/awx/main/models/base.py", line 117, in clean_fields
  File "/lib/python2.7/site-packages/awx/main/models/schedules.py", line 126, in clean_extra_data
  File "/lib/python2.7/site-packages/awx/main/models/schedules.py", line 115, in _clean_extra_data_system_jobs
NameError: global name 'ValidationError' is not defined
```

expected results

```json
{
    "extra_data": [
        "days must be a positive integer."
    ]
}
```

this is still accomplished by the logic that now lives in the SystemJob model.