### PR TITLE
Fixed spinners after jquery-ui upgrade

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -2335,3 +2335,8 @@ body {
 .btn {
     text-transform: uppercase;
 }
+
+.ui-spinner-input {
+    margin-top: .3em;
+    margin-bottom: .3em;
+}

--- a/awx/ui/client/legacy/styles/forms.less
+++ b/awx/ui/client/legacy/styles/forms.less
@@ -355,7 +355,7 @@
 .Form-numberInputButton {
     color: @default-icon!important;
     font-size: 14px;
-
+    display: block;
 }
 
 .Form-dropDown {

--- a/awx/ui/client/src/vendor.js
+++ b/awx/ui/client/src/vendor.js
@@ -18,8 +18,16 @@ global.$ = global.jQuery;
 
 require('jquery-resize');
 require('jquery-ui');
+require('jquery-ui/ui/widgets/button');
+require('jquery-ui/ui/widgets/spinner');
 require('bootstrap');
 require('bootstrap-datepicker');
+
+// jquery-ui and bootstrap both define $.fn.button
+// the code below resolves that namespace clash
+const btn = $.fn.button.noConflict();
+$.fn.btn = btn;
+
 require('select2');
 
 // Standalone libs


### PR DESCRIPTION
##### SUMMARY
Due to directory structure changes with the jquery-ui project we now need to explicitly the widgets that we want to use.

related #865 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

<img width="453" alt="screen shot 2017-12-20 at 4 05 08 pm" src="https://user-images.githubusercontent.com/9889020/34228704-9414f2a0-e59f-11e7-86a5-b0a54e55e371.png">
<img width="438" alt="screen shot 2017-12-20 at 4 04 55 pm" src="https://user-images.githubusercontent.com/9889020/34228705-9422f878-e59f-11e7-8793-0b4c2962804c.png">
