### PR TITLE
Add REMOTE_HOST_HEADERS override to OpenShift template

### DIFF
--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -17,6 +17,11 @@ data:
     CLUSTER_HOST_ID = socket.gethostname()
     SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
     
+    # Token-based authentication performs a hash check on HTTP headers expected to be consistent, including the remote host IP.
+    # The default OpenShift router exposes the remote host IP via the X-Forwarded-For header.
+    # You might have to change this setting if you use an additional reverse proxy in front of OpenShift.
+    REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR']
+
     CELERY_TASK_QUEUES += (Queue(CLUSTER_HOST_ID, Exchange(CLUSTER_HOST_ID), routing_key=CLUSTER_HOST_ID),)
     CELERY_TASK_ROUTES['awx.main.tasks.cluster_node_heartbeat'] = {'queue': CLUSTER_HOST_ID, 'routing_key': CLUSTER_HOST_ID}
     CELERY_TASK_ROUTES['awx.main.tasks.purge_old_stdout_files'] = {'queue': CLUSTER_HOST_ID, 'routing_key': CLUSTER_HOST_ID}


### PR DESCRIPTION
Signed-off-by: Scott Percival <scott.percival@dbca.wa.gov.au>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
AWX's token auth performs a hash check on some headers every request that are expected to be consistent. By default it will use REMOTE_ADDR as the client IP address, which in most OpenShift environments will be the IP of one of the routers. This can lead to the maddening situation where logins will work roughly 90% of the time with a direct hostname (as routing is usually sticky) and maybe 5% of the time through a load-balanced reverse proxy (not sticky).

Fix is to add a sensible default (X-Forwarded-For) and a hint to the OpenShift settings.py template.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.2.286
```
