### PR TITLE
Remove nodeport customization

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,10 +133,6 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 > Name of the OpenShift project that will be created, and used as the namespace for the AWX app. Defaults to *awx*.
 
-*awx_node_port*
-
-> The web server port running inside the AWX pod. Defaults to *30083*.
-
 *openshift_user*
 
 > Username of the OpenShift user that will create the project, and deploy the application. Defaults to *developer*.

--- a/installer/check_vars/tasks/check_openshift.yml
+++ b/installer/check_vars/tasks/check_openshift.yml
@@ -18,12 +18,6 @@
     - openshift_password is defined and openshift_password != ''
     msg: "Set the value of 'openshift_password' in the inventory file."
 
-- name: awx_node_port should be defined
-  assert:
-    that:
-    - awx_node_port is defined and awx_node_port != ''
-    msg: "Set the value of 'awx_node_port' in the inventory file."
-
 - name: docker_registry should be defined if not using dockerhub
   assert:
     that:

--- a/installer/openshift/templates/deployment.yml.j2
+++ b/installer/openshift/templates/deployment.yml.j2
@@ -77,7 +77,6 @@ spec:
   ports:
     - name: http
       port: 8052
-      nodePort: {{ awx_node_port }}
   selector:
     name: awx-web-deploy
 ---


### PR DESCRIPTION
This isn't strictly necessary for the Openshift routes and can
sometimes cause problems when the resource is already defined in openshift
