### PR TITLE
Fixed display of host facts

### DIFF
--- a/awx/ui/client/src/inventories-hosts/shared/ansible-facts/ansible-facts.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/ansible-facts/ansible-facts.controller.js
@@ -7,8 +7,8 @@
 function AnsibleFacts($scope, Facts, ParseTypeChange, ParseVariableString) {
 
     function init() {
-        $scope.facts = ParseVariableString(Facts.data);
-        let rows = (_.isEmpty(Facts.data)) ? 6 : 20;
+        $scope.facts = ParseVariableString(Facts);
+        let rows = (_.isEmpty(Facts)) ? 6 : 20;
         $("#host_facts").attr("rows", rows);
         $scope.parseType = 'yaml';
         ParseTypeChange({


### PR DESCRIPTION
##### SUMMARY
With this pull request users should again be able to view host facts after launching a job template with Use Fact Cache enabled against the inventory to which a host belongs.  The bug here was that we were getting the fact data correctly but were attempting to parse the wrong thing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
link https://github.com/ansible/awx/issues/860
