### PR TITLE
fix a bug in credential parsing at Job Template launch time

### DIFF
--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -2874,9 +2874,9 @@ class JobTemplateLaunch(RetrieveAPIView):
                     if not isinstance(prompted_value, Iterable) or isinstance(prompted_value, basestring):
                         prompted_value = [prompted_value]
 
-                    # If user gave extra_credentials, special case to use exactly
+                    # If user gave legacy credentials, special case to use exactly
                     # the given list without merging with JT credentials
-                    if key == 'extra_credentials' and prompted_value:
+                    if key in ('credential', 'vault_credential', 'extra_credentials') and prompted_value:
                         obj._deprecated_credential_launch = True  # signal to not merge credentials
                     new_credentials.extend(prompted_value)
 

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -378,7 +378,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, Notificatio
         unified_job.save()
 
         # Labels and credentials copied here
-        if kwargs.get('credentials'):
+        if kwargs.get('credentials') and unified_job.spawned_by_workflow:
             Credential = UnifiedJob._meta.get_field('credentials').related_model
             cred_dict = Credential.unique_dict(self.credentials.all())
             prompted_dict = Credential.unique_dict(kwargs['credentials'])


### PR DESCRIPTION
the "merge launch credentials with what's on the JT" behavior should
_only_ be applied to jobs launched from a workflow; explicit credentials
provided in a vanilla Job Template launch payload should be used
explictly

see: https://github.com/ansible/awx/issues/932
related: https://github.com/ansible/awx/pull/740