### PR TITLE
extends JT xtra var error msg

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -300,7 +300,8 @@ class SurveyJobTemplateMixin(models.Model):
             rejected.update(extra_vars)
             # ignored variables does not block manual launch
             if 'prompts' not in _exclude_errors:
-                errors['extra_vars'] = [_('Variables {list_of_keys} are not allowed on launch.').format(
+                errors['extra_vars'] = [_('Variables {list_of_keys} are not allowed on launch. Check the Prompt on Launch setting '+
+                                        'on the Job Template to include Extra Variables.').format(
                     list_of_keys=', '.join(extra_vars.keys()))]
 
         return (accepted, rejected, errors)


### PR DESCRIPTION
##### SUMMARY
This extends the error message to better inform the user why xtra vars aren't accepted for Schedules.  The extra vars are only accepted if the `ask_variables_on_launch` flag is True, a setting that can be toggled in the UI on the JT.  

In response to #983
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


