### PR TITLE
optimize OutputEventFilter for large stdout streams

### DIFF
--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -147,7 +147,7 @@ class CallbackBrokerWorker(ConsumerMixin):
                     from pprint import pformat
                     logger.info('Body: {}'.format(
                         highlight(pformat(body, width=160), PythonLexer(), Terminal256Formatter(style='friendly'))
-                    ))
+                    )[:1024 * 4])
 
                 def _save_event_data():
                     for key, cls in event_map.items():

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,6 +10,7 @@ pytest-cov
 pytest-django
 pytest-pythonpath
 pytest-mock
+pytest-timeout
 logutils
 flower
 uwsgitop


### PR DESCRIPTION
update our event data search algorithm to be a bit lazier in event data
discovery; this drastically improves processing speeds for stdout >5MB

see: https://github.com/ansible/awx/issues/417