### PR TITLE
support dns servers: fixes https://github.com/ansible/awx/issues/1004

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -80,3 +80,5 @@ pg_port=5432
 # Container networking configuration
 # Set the awx_task and awx_web containers' search domain(s)
 #awx_container_search_domains=example.com,ansible.com
+# Alternate DNS servers
+#awx_alternate_dns_servers="10.1.2.3,10.2.3.4"

--- a/installer/local_docker/tasks/main.yml
+++ b/installer/local_docker/tasks/main.yml
@@ -168,6 +168,7 @@
     links: "{{ awx_web_container_links|list }}"
     hostname: awxweb
     dns_search_domains: "{{ awx_container_search_domains.split(',') if awx_container_search_domains is defined else omit }}"
+    dns_servers: "{{ awx_alternate_dns_servers.split(',') if awx_alternate_dns_servers is defined else omit }}"
     env:
       http_proxy: "{{ http_proxy | default('') }}"
       https_proxy: "{{ https_proxy | default('') }}"
@@ -198,6 +199,7 @@
     user: root
     hostname: awx
     dns_search_domains: "{{ awx_container_search_domains.split(',') if awx_container_search_domains is defined else omit }}"
+    dns_servers: "{{ awx_alternate_dns_servers.split(',') if awx_alternate_dns_servers is defined else omit }}"
     env:
       http_proxy: "{{ http_proxy | default('') }}"
       https_proxy: "{{ https_proxy | default('') }}"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/1004 so that you can alternatively point at different DNS so that the web container can contact ansible servers with only hostnames relevent to the org.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.2.63
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before
```
➜  ~ docker inspect --format "{{ .HostConfig.Dns }}" awx_web
<no value>
```

After
```
➜  ~ docker inspect --format "{{ .HostConfig.Dns }}" 5ad1577bb21a
[10.1.2.3 10.2.3.4]
```
