### PR TITLE
Properly removing context menu

### DIFF
--- a/awx/ui/client/src/network-ui/group.js
+++ b/awx/ui/client/src/network-ui/group.js
@@ -572,6 +572,11 @@ _Placing.prototype.onMouseDown = function (controller) {
 _Placing.prototype.onMouseDown.transitions = ['Resize'];
 
 
+_ContextMenu.prototype.end = function (controller) {
+
+    controller.scope.removeContextMenu();
+};
+
 _ContextMenu.prototype.onLabelEdit = function (controller) {
 
     controller.changeState(EditLabel);
@@ -581,8 +586,6 @@ _ContextMenu.prototype.onLabelEdit.transitions = ['EditLabel'];
 
 _ContextMenu.prototype.onMouseDown = function (controller) {
 
-    var item = controller.scope.context_menus[0];
-    item.enabled = false;
     controller.changeState(Ready);
 
 };

--- a/awx/ui/client/src/network-ui/move.js
+++ b/awx/ui/client/src/network-ui/move.js
@@ -491,8 +491,10 @@ _Placing.prototype.onMouseMove = function (controller) {
 _Placing.prototype.onMouseMove.transitions = ['Move'];
 
 
+_ContextMenu.prototype.end = function (controller) {
 
-
+    controller.scope.removeContextMenu();
+};
 
 _ContextMenu.prototype.onLabelEdit = function (controller) {
 
@@ -503,8 +505,6 @@ _ContextMenu.prototype.onLabelEdit.transitions = ['EditLabel'];
 
 _ContextMenu.prototype.onMouseDown = function (controller) {
 
-    var item = controller.scope.context_menus[0];
-    item.enabled = false;
     controller.changeState(Ready);
 
 };

--- a/awx/ui/client/src/network-ui/network.ui.controller.js
+++ b/awx/ui/client/src/network-ui/network.ui.controller.js
@@ -584,9 +584,22 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
     $document.bind("keydown", $scope.onKeyDown);
 
     // Conext Menu Button Handlers
+
+    $scope.removeContextMenu = function(){
+        let context_menu = $scope.context_menus[0];
+        context_menu.enabled = false;
+        context_menu.x = -100000;
+        context_menu.y = -100000;
+        context_menu.buttons.forEach(function(button, index){
+            button.enabled = false;
+            button.x = -100000;
+            button.y = -100000;
+        });
+    }
+
     $scope.onDetailsContextButton = function (panelBoolean) {
         if (!$scope.disconnected) {
-
+            $scope.removeContextMenu();
             // show details for devices
             if ($scope.selected_devices.length === 1){
 
@@ -605,7 +618,7 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
                              let host = response.data;
                              host.host_id = host.id;
                              $scope.$emit('showDetails', host, panelBoolean !== null ? panelBoolean: true);
-                             $scope.context_menus[0].enabled = false;
+
                          })
                          .catch(({data, status}) => {
                              ProcessErrors($scope, data, status, null, { hdr: 'Error!', msg: 'Failed to get host data: ' + status });
@@ -617,27 +630,24 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
             else if($scope.selected_interfaces.length === 1){
                 let selected_interface  = $scope.selected_interfaces[0];
                 $scope.$emit('showDetails', selected_interface, panelBoolean !== null ? panelBoolean: true);
-                $scope.context_menus[0].enabled = false;
             }
 
             // show details for links
             else if($scope.selected_links.length === 1){
                 let link  = $scope.selected_links[0];
                 $scope.$emit('showDetails', link, panelBoolean !== null ? panelBoolean: true);
-                $scope.context_menus[0].enabled = false;
             }
 
             //show details for groups, racks, and sites
             else if ($scope.selected_groups.length === 1){
                 let group = $scope.selected_groups[0];
                 $scope.$emit('showDetails', group, panelBoolean !== null ? panelBoolean: true);
-                $scope.context_menus[0].enabled = false;
             }
          }
     };
 
     $scope.onRenameContextButton = function (button) {
-        $scope.context_menus[0].enabled = false;
+        $scope.removeContextMenu();
         $scope.first_channel.send("LabelEdit", {});
     };
 
@@ -650,7 +660,6 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
         var all_links = $scope.links.slice();
         $scope.selected_devices = [];
         $scope.selected_links = [];
-        $scope.context_menus[0].enabled = false;
         $scope.move_controller.changeState(move.Ready);
         for (i = 0; i < links.length; i++) {
             index = $scope.links.indexOf(links[i]);
@@ -697,8 +706,6 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
         var selected_groups = $scope.selected_groups;
         $scope.selected_groups = [];
         $scope.group_controller.changeState(group.Ready);
-        $scope.context_menus[0].enabled = false;
-
 
         function removeSingleGroup(group){
             index = $scope.groups.indexOf(group);
@@ -744,6 +751,7 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
     };
 
     $scope.onDeleteContextMenu = function($event){
+        $scope.removeContextMenu();
         if($scope.selected_devices.length === 1){
             $scope.deleteDevice();
         }

--- a/awx/ui/client/src/network-ui/rack.fsm.js
+++ b/awx/ui/client/src/network-ui/rack.fsm.js
@@ -525,7 +525,10 @@ _Move.prototype.onMouseMove = function (controller) {
 
 _Move.prototype.onTouchMove = _Move.prototype.onMouseMove;
 
+_ContextMenu.prototype.end = function (controller) {
 
+    controller.scope.removeContextMenu();
+};
 
 _ContextMenu.prototype.onLabelEdit = function (controller) {
 
@@ -536,8 +539,6 @@ _ContextMenu.prototype.onLabelEdit.transitions = ['EditLabel'];
 
 _ContextMenu.prototype.onMouseDown = function (controller) {
 
-    var item = controller.scope.context_menus[0];
-    item.enabled = false;
     controller.changeState(Ready);
 
 };

--- a/awx/ui/client/src/network-ui/site.fsm.js
+++ b/awx/ui/client/src/network-ui/site.fsm.js
@@ -634,7 +634,10 @@ _Move.prototype.onMouseMove = function (controller) {
 
 _Move.prototype.onTouchMove = _Move.prototype.onMouseMove;
 
+_ContextMenu.prototype.end = function (controller) {
 
+    controller.scope.removeContextMenu();
+};
 
 _ContextMenu.prototype.onLabelEdit = function (controller) {
 
@@ -645,8 +648,6 @@ _ContextMenu.prototype.onLabelEdit.transitions = ['EditLabel'];
 
 _ContextMenu.prototype.onMouseDown = function (controller) {
 
-    var item = controller.scope.context_menus[0];
-    item.enabled = false;
     controller.changeState(Ready);
 
 };


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
@benthomasson discovered that the button_pressed events were still being capture even when the context menu was no longer displayed. This PR moves the context menu out of the page view. I had to cascade this change to `move.js`, as well as the FSM's for groups, racks, and sites. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
