### PR TITLE
fix a bug that breaks workflows w/ a survey password + inventory sync

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -355,7 +355,8 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, Notificatio
         fields = self._get_unified_job_field_names()
         unallowed_fields = set(kwargs.keys()) - set(fields)
         if unallowed_fields:
-            raise Exception('Fields {} are not allowed as overrides.'.format(unallowed_fields))
+            logger.warn('Fields {} are not allowed as overrides.'.format(unallowed_fields))
+            map(kwargs.pop, unallowed_fields)
 
         unified_job = copy_model_by_class(self, unified_job_class, fields, kwargs)
 


### PR DESCRIPTION
prior versions of awx did not raise an exception for this scenario
- they simply ignored kwargs that they couldn't accept.  this change is
a sort of middle ground - it ignores them, but gives a clue in the logs
as to why

see: https://github.com/ansible/awx/issues/955
related: https://github.com/ansible/awx/pull/803