### PR TITLE
only import the redbaron library on-demand

### DIFF
--- a/awx/conf/utils.py
+++ b/awx/conf/utils.py
@@ -6,9 +6,6 @@ import glob
 import os
 import shutil
 
-# RedBaron
-from redbaron import RedBaron, indent
-
 # AWX
 from awx.conf.registry import settings_registry
 
@@ -33,6 +30,8 @@ def comment_assignments(patterns, assignment_names, dry_run=True, backup_suffix=
 
 
 def comment_assignments_in_file(filename, assignment_names, dry_run=True, backup_filename=None):
+    from redbaron import RedBaron, indent
+
     if isinstance(assignment_names, basestring):
         assignment_names = [assignment_names]
     else:


### PR DESCRIPTION
redbaron is a library we use to facilitate parsing local settings files;
at _import_ time it generates a parse tree and caches it to disk at
`/tmp`; this process is _really_ time consuming, and only necessary if
we're actually *using* the library

right now, we're importing this library and paying the penalty
_every_ time we load the awx application

even _with_ the cache, there's no reason to run this code if we're
not actually using the library