### PR TITLE
add a make target for forcibly reloading uwsgi in the dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,12 @@ clean: clean-ui clean-dist
 	find . -type f -regex ".*\.py[co]$$" -delete
 	find . -type d -name "__pycache__" -delete
 
+# force uwsgi to reload (useful if you introduced a syntax error and uwsgi
+# died)
+pyreload:
+	docker exec -it tools_awx_1 bash -c "pgrep uwsgi | head -n1 | xargs kill -HUP"
+
+
 # convenience target to assert environment variables are defined
 guard-%:
 	@if [ "$${$*}" = "" ]; then \


### PR DESCRIPTION
this is useful if you suspect that file changes aren't being mapped to
the underlying container and triggering autoreload; it's also useful for
times where you introduce a syntax error and uwsgi gets stuck with:

`--- no python application found, check your startup logs for errors ---`

...requiring you to re-run docker-compose