### PR TITLE
Allow authenticating with Openshift via a token

### DIFF
--- a/installer/check_vars/tasks/check_openshift.yml
+++ b/installer/check_vars/tasks/check_openshift.yml
@@ -12,11 +12,12 @@
     - openshift_user is defined and openshift_user != ''
     msg: "Set the value of 'openshift_user' in the inventory file."
 
-- name: openshift_password should be defined
+- name: openshift_password or openshift_token should be defined
   assert:
     that:
-    - openshift_password is defined and openshift_password != ''
-    msg: "Set the value of 'openshift_password' in the inventory file."
+    - (openshift_password is defined and openshift_password != '') or
+      (openshift_token is defined and openshift_token != '')
+    msg: "Set the value of 'openshift_password' or 'openshift_token' in the inventory file."
 
 - name: docker_registry should be defined if not using dockerhub
   assert:

--- a/installer/openshift/tasks/main.yml
+++ b/installer/openshift/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
-- name: Authenticate with OpenShift
+- name: Authenticate with OpenShift via user and password
   shell: "oc login {{ openshift_host }} -u {{ openshift_user }} -p {{ openshift_password }}"
+  when:
+  - openshift_user is defined
+  - openshift_password is defined
+  - openshift_token is not defined
+
+- name: Authenticate with OpenShift via token
+  shell: "oc login {{ openshift_host }} --token {{ openshift_token }}"
+  when: openshift_token is defined
 
 - name: Get Project Detail
   shell: "oc get project {{ awx_openshift_project }}"


### PR DESCRIPTION
Instead of username/password the installer should be able to use just the token

Fixes #869