### PR TITLE
adhere to RFC5545 regarding UNTIL timezones

### DIFF
--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -130,22 +130,19 @@ def test_utc_until(job_template, until, dtend):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('until, dtend', [
-    ['20180602T170000', '2018-06-02 16:00:00+00:00'],
-    ['20180602T000000', '2018-06-01 16:00:00+00:00'],
+@pytest.mark.parametrize('dtstart, until', [
+    ['20180601T120000Z', '20180602T170000'],
+    ['TZID=America/New_York:20180601T120000', '20180602T170000'],
 ])
-def test_tzinfo_until(job_template, until, dtend):
-    rrule = 'DTSTART;TZID=America/New_York:20180601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL={}'.format(until)  # noqa
+def test_tzinfo_naive_until(job_template, dtstart, until):
+    rrule = 'DTSTART;{} RRULE:FREQ=DAILY;INTERVAL=1;UNTIL={}'.format(dtstart, until)  # noqa
     s = Schedule(
         name='Some Schedule',
         rrule=rrule,
         unified_job_template=job_template
     )
-    s.save()
-
-    assert str(s.next_run) == '2018-06-01 16:00:00+00:00'  # UTC = +4 EST
-    assert str(s.next_run) == str(s.dtstart)
-    assert str(s.dtend) == dtend
+    with pytest.raises(ValueError):
+        s.save()
 
 
 @pytest.mark.django_db

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -50,7 +50,10 @@ A list of _valid_ zone identifiers (which can vary by system) can be found at:
 
 UNTIL and Timezones
 ===================
-RFC5545 specifies that:
+`DTSTART` values provided to awx _must_ provide timezone information (they may
+not be naive dates).
+
+Additionally, RFC5545 specifies that:
 
 > Furthermore, if the "DTSTART" property is specified as a date with local
 > time, then the UNTIL rule part MUST also be specified as a date with local
@@ -58,19 +61,16 @@ RFC5545 specifies that:
 > a date with local time and time zone reference, then the UNTIL rule part
 > MUST be specified as a date with UTC time.
 
-Given this, this RRULE:
+Given this, `RRULE` values that specify `UNTIL` datetimes must *always* be in UTC.
 
+Valid:
     `DTSTART:20180601T120000Z RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20180606T170000Z`
+    `DTSTART;TZID=America/New_York:20180601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20180606T170000Z`
 
-...will be interpretted as "Starting on June 1st, 2018 at noon UTC, repeat
-daily, ending on June 6th, 2018 at 5PM UTC".
+Not Valid:
 
-This RRULE:
-
+    `DTSTART:20180601T120000Z RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20180606T170000`
     `DTSTART;TZID=America/New_York:20180601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20180606T170000`
-
-...will be interpretted as "Starting on June 1st, 2018 at noon EDT, repeat
-daily, ending on June 6th, 2018 at 5PM EDT".
 
 
 Previewing Schedules


### PR DESCRIPTION
If the "DTSTART" property is specified as a date with UTC time or a date with
local time and time zone reference, then the UNTIL rule part MUST be specified
as a date with UTC time.

see: https://github.com/ansible/ansible-tower/issues/823