### PR TITLE
Allow AWX projects directory to be a volume

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -90,3 +90,7 @@ pg_port=5432
 #awx_container_search_domains=example.com,ansible.com
 # Alternate DNS servers
 #awx_alternate_dns_servers="10.1.2.3,10.2.3.4"
+
+# AWX project data folder. If you need access to the location where AWX stores the projects
+# it manages from the docker host, you can set this to turn it into a volume for the container.
+#project_data_dir=/var/lib/awx/projects

--- a/installer/local_docker/tasks/standalone.yml
+++ b/installer/local_docker/tasks/standalone.yml
@@ -79,6 +79,7 @@
     state: started
     restart_policy: unless-stopped
     image: "{{ awx_web_docker_actual_image }}"
+    volumes: "{{ project_data_dir + ':/var/lib/awx/projects:rw' if project_data_dir is defined else omit }}"
     user: root
     ports:
       - "{{ host_port }}:8052"
@@ -112,6 +113,7 @@
     state: started
     restart_policy: unless-stopped
     image: "{{ awx_task_docker_actual_image }}"
+    volumes: "{{ project_data_dir + ':/var/lib/awx/projects:rw' if project_data_dir is defined else omit }}"
     links: "{{ awx_task_container_links|list }}"
     user: root
     hostname: awx


### PR DESCRIPTION
##### SUMMARY
This allows the AWX projects directory to optionally be mounted inside the container as a volume. This is related to #857.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.2.83
```

##### ADDITIONAL INFORMATION
My personal use case for this is that we need to dynamically modify some of the playbooks before they run, as they're essentially used for one-shot operations amongst groups of servers. The projects themselves are kept in SCM as normal, but it's our intent to write an automated system that would write a playbook into the project that calls roles from that project, then run that playbook via the jobs API on AWX. Other reasons are detailed in #857 and this would also simplify the use of the manual SCM type.