### PR TITLE
fix a bug in custom venv support that breaks legacy `POST /api/v1/jobs`

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -518,7 +518,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
     def ansible_virtualenv_path(self):
         # the order here enforces precedence (it matters)
         for virtualenv in (
-            self.job_template.custom_virtualenv,
+            self.job_template.custom_virtualenv if self.job_template else None,
             self.project.custom_virtualenv,
             self.project.organization.custom_virtualenv
         ):

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -1,6 +1,6 @@
 import pytest
 
-from awx.main.models import JobTemplate
+from awx.main.models import JobTemplate, Job
 
 
 @pytest.mark.django_db
@@ -38,3 +38,14 @@ def test_awx_custom_virtualenv(inventory, project, machine_credential):
     job.job_template.custom_virtualenv = '/venv/fancy-jt'
     job.job_template.save()
     assert job.ansible_virtualenv_path == '/venv/fancy-jt'
+
+
+@pytest.mark.django_db
+def test_awx_custom_virtualenv_without_jt(project):
+    project.custom_virtualenv = '/venv/fancy-proj'
+    project.save()
+    job = Job(project=project)
+    job.save()
+
+    job = Job.objects.get(pk=job.id)
+    assert job.ansible_virtualenv_path == '/venv/fancy-proj'


### PR DESCRIPTION
see: https://github.com/ansible/ansible-tower/issues/7876