### PR TITLE
Fix the Slack notification back end so it works.

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -46,7 +46,7 @@ class SlackBackend(AWXBaseEmailBackend):
                 for r in m.recipients():
                     if r.startswith('#'):
                         r = r[1:]
-                    self.connection.rtm_send_message(r, m.subject)
+                    self.connection.api_call("chat.postMessage", channel=r, text=m.subject)
                     sent_messages += 1
             except Exception as e:
                 logger.error(smart_text(_("Exception sending messages: {}").format(e)))


### PR DESCRIPTION


##### SUMMARY
Make the Slack notification backend work.

I have tested this on my Ansible Tower installation using the AMI build
and a bot token for Slack.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- Notification/Slack

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AMI Description
Ansible Tower 3.2.2 on CentOS 7 x86_64
```


##### ADDITIONAL INFORMATION
Create a Slack notification in Ansible Tower.  Hit 'test'.  Get nothing.  Apply this fix.  Notifications now start working.