### PR TITLE
Add ability to select to prefer IPv4 addresses for ansible_ssh_host

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1822,7 +1822,7 @@ class RunInventoryUpdate(BaseTask):
                 cp.set(section, 'ssl_verify', "false")
 
             cloudforms_opts = dict(inventory_update.source_vars_dict.items())
-            for opt in ['version', 'purge_actions', 'clean_group_keys', 'nest_tags', 'suffix']:
+            for opt in ['version', 'purge_actions', 'clean_group_keys', 'nest_tags', 'suffix', 'prefer_ipv4']:
                 if opt in cloudforms_opts:
                     cp.set(section, opt, cloudforms_opts[opt])
 

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1757,6 +1757,8 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             self.instance.credential, 'password'
         )
 
+        self.instance.source_vars_dict['prefer_ipv4'] = True
+
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
             config = ConfigParser.ConfigParser()
@@ -1765,6 +1767,7 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             assert config.get('cloudforms', 'username') == 'bob'
             assert config.get('cloudforms', 'password') == 'secret'
             assert config.get('cloudforms', 'ssl_verify') == 'false'
+            assert config.get('cloudforms', 'prefer_ipv4') == 'true'
 
             cache_path = config.get('cache', 'path')
             assert cache_path.startswith(env['AWX_PRIVATE_DATA_DIR'])

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1757,7 +1757,7 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             self.instance.credential, 'password'
         )
 
-        self.instance.source_vars['prefer_ipv4'] = True
+        self.instance.source_vars = '{"prefer_ipv4": True}'
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
@@ -1767,7 +1767,7 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             assert config.get('cloudforms', 'username') == 'bob'
             assert config.get('cloudforms', 'password') == 'secret'
             assert config.get('cloudforms', 'ssl_verify') == 'false'
-            assert config.get('cloudforms', 'prefer_ipv4') == 'true'
+            assert config.get('cloudforms', 'prefer_ipv4') == 'True'
 
             cache_path = config.get('cache', 'path')
             assert cache_path.startswith(env['AWX_PRIVATE_DATA_DIR'])

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1757,7 +1757,7 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             self.instance.credential, 'password'
         )
 
-        self.instance.source_vars_dict['prefer_ipv4'] = True
+        self.instance.source_vars['prefer_ipv4'] = True
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args

--- a/awx/plugins/inventory/cloudforms.ini.example
+++ b/awx/plugins/inventory/cloudforms.ini.example
@@ -31,6 +31,9 @@ nest_tags = False
 # Note: This suffix *must* include the leading '.' as it is appended to the hostname as is
 # suffix = .example.org
 
+# If true, will try and use an IPv4 address for the ansible_ssh_host rather than just the first IP address in the list
+prefer_ipv4 = False
+
 [cache]
 
 # Maximum time to trust the cache in seconds


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently Cloudforms can return a mix of IPv4 and IPv6 addresses in the
ipaddresses field and this mix comes in a "random" order (that is the
first entry may be IPv4 sometimes but IPv6 other times). If you wish to
always use IPv4 for the ansible_ssh_host value then this is problematic.

This change adds a new prefer_ipv4 flag which will look for the first
IPv4 address in the ipaddresses list and uses that instead of just the
first entry.

Upstream PR has been made to Ansible repo as https://github.com/ansible/ansible/pull/35584

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A - cloudforms.py tested manually
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
