### PR TITLE
Tweaked smart status icon styling to prevent overlap with action buttons

### DIFF
--- a/awx/ui/client/src/smart-status/smart-status.block.less
+++ b/awx/ui/client/src/smart-status/smart-status.block.less
@@ -11,14 +11,14 @@
 }
 
 .SmartStatus-icon {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
 
 }
 
 .SmartStatus-iconDirectionPlaceholder {
-    width: 16px;
-    height: 8px;
+    width: 14px;
+    height: 7px;
     border: 1px solid #d7d7d7;
     background: #f2f2f2;
 }
@@ -32,8 +32,8 @@
 }
 
 .SmartStatus-iconIndicator {
-    width: 16px;
-    height: 8px;
+    width: 14px;
+    height: 7px;
 }
 
 .SmartStatus-iconIndicator--success {
@@ -45,8 +45,8 @@
 }
 
 .SmartStatus-iconPlaceholder {
-    height: 15px;
-    width: 15px;
+    height: 14px;
+    width: 14px;
     border: 1px solid #d7d7d7;
     background: #f2f2f2;
 }


### PR DESCRIPTION
##### SUMMARY
Status icons were just a little bit too big and were overlapping with the action icons on the home screen.

related #1091 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
