### PR TITLE
Installer: increase nginx worker_processes

### DIFF
--- a/installer/image_build/files/nginx.conf
+++ b/installer/image_build/files/nginx.conf
@@ -1,6 +1,6 @@
 #user awx;
 
-worker_processes  1;
+worker_processes  8;
 
 error_log  /dev/stdout warn;
 pid        /tmp/nginx.pid;


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
uwsgi is running with 5 processes. only one nginx worker is a bottleneck and leads to http 502 errors on real setups


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

