### PR TITLE
Pass extra vars via file rather than directly on the commandline.

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -654,11 +654,21 @@ class CredentialType(CommonModelNameNotUnique):
             extra_vars[var_name] = Template(tmpl).render(**namespace)
             safe_extra_vars[var_name] = Template(tmpl).render(**safe_namespace)
 
+        def build_extra_vars_file(vars, private_dir):
+            handle, path = tempfile.mkstemp(dir = private_dir)
+            f = os.fdopen(handle, 'w')
+            f.write(json.dumps(vars))
+            f.close()
+            os.chmod(path, stat.S_IRUSR)
+            return path
+
         if extra_vars:
-            args.extend(['-e', json.dumps(extra_vars)])
+            path = build_extra_vars_file(extra_vars, private_data_dir)
+            args.extend(['-e', '@%s' % path])
 
         if safe_extra_vars:
-            safe_args.extend(['-e', json.dumps(safe_extra_vars)])
+            path = build_extra_vars_file(safe_extra_vars, private_data_dir)
+            safe_args.extend(['-e', '@%s' % path])
 
 
 @CredentialType.default

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -725,6 +725,14 @@ class BaseTask(LogErrorsTask):
             '': '',
         }
 
+    def build_extra_vars_file(self, vars, **kwargs):
+        handle, path = tempfile.mkstemp(dir=kwargs.get('private_data_dir', None))
+        f = os.fdopen(handle, 'w')
+        f.write(json.dumps(vars))
+        f.close()
+        os.chmod(path, stat.S_IRUSR)
+        return path
+
     def add_ansible_venv(self, venv_path, env, add_awx_lib=True):
         env['VIRTUAL_ENV'] = venv_path
         env['PATH'] = os.path.join(venv_path, "bin") + ":" + env['PATH']
@@ -1234,7 +1242,8 @@ class RunJob(BaseTask):
                 extra_vars.update(json.loads(job.display_extra_vars()))
             else:
                 extra_vars.update(json.loads(job.decrypted_extra_vars()))
-        args.extend(['-e', json.dumps(extra_vars)])
+        extra_vars_path = self.build_extra_vars_file(vars=extra_vars, **kwargs)
+        args.extend(['-e', '@%s' % (extra_vars_path)])
 
         # Add path to playbook (relative to project.local_path).
         args.append(job.playbook)
@@ -1464,7 +1473,8 @@ class RunProjectUpdate(BaseTask):
             'scm_revision_output': self.revision_path,
             'scm_revision': project_update.project.scm_revision,
         })
-        args.extend(['-e', json.dumps(extra_vars)])
+        extra_vars_path = self.build_extra_vars_file(vars=extra_vars, **kwargs)
+        args.extend(['-e', '@%s' % (extra_vars_path)])
         args.append('project_update.yml')
         return args
 
@@ -2181,7 +2191,8 @@ class RunAdHocCommand(BaseTask):
                     "{} are prohibited from use in ad hoc commands."
                 ).format(", ".join(removed_vars)))
             extra_vars.update(ad_hoc_command.extra_vars_dict)
-        args.extend(['-e', json.dumps(extra_vars)])
+        extra_vars_path = self.build_extra_vars_file(vars=extra_vars, **kwargs)
+        args.extend(['-e', '@%s' % (extra_vars_path)])
 
         args.extend(['-m', ad_hoc_command.module_name])
         args.extend(['-a', ad_hoc_command.module_args])

--- a/awx/main/tests/unit/models/test_survey_models.py
+++ b/awx/main/tests/unit/models/test_survey_models.py
@@ -120,7 +120,9 @@ def test_job_safe_args_redacted_passwords(job):
     run_job = RunJob()
     safe_args = run_job.build_safe_args(job, **kwargs)
     ev_index = safe_args.index('-e') + 1
-    extra_vars = json.loads(safe_args[ev_index])
+    extra_var_file = open(safe_args[ev_index][1:],'r')
+    extra_vars = json.load(extra_var_file)
+    extra_var_file.close()
     assert extra_vars['secret_key'] == '$encrypted$'
 
 
@@ -129,7 +131,9 @@ def test_job_args_unredacted_passwords(job, tmpdir_factory):
     run_job = RunJob()
     args = run_job.build_args(job, **kwargs)
     ev_index = args.index('-e') + 1
-    extra_vars = json.loads(args[ev_index])
+    extra_var_file = open(args[ev_index][1:],'r')
+    extra_vars = json.load(extra_var_file)
+    extra_var_file.close()
     assert extra_vars['secret_key'] == 'my_password'
 
 


### PR DESCRIPTION

##### SUMMARY

The extra vars file created lives in the playbook private runtime
directory, and will be reaped along with the rest of the directory.

##### ISSUE TYPE
 - Feature/Bugfix/??? Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
any
```

##### ADDITIONAL INFORMATION

Briefly tested on different  version both with and without bwrap. Not tested with isolated execution, but would appear to put things in the proper place to work.
