### PR TITLE
Fix variable reference in k8s etcd template

### DIFF
--- a/installer/kubernetes/templates/etcd.yml.j2
+++ b/installer/kubernetes/templates/etcd.yml.j2
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: etcd
-  namespace: {{ awx_kubernetes_project }}
+  namespace: {{ awx_kubernetes_namespace }}
 spec:
   replicas: 1
   template:
@@ -31,7 +31,7 @@ metadata:
   labels:
     name: awx-etcd
   name: etcd
-  namespace: {{ awx_kubernetes_project }}
+  namespace: {{ awx_kubernetes_namespace }}
 spec:
   ports:
     - name: etcd


### PR DESCRIPTION
##### SUMMARY
The variable defined in the inventory file is `awx_kubernetes_namespace` not `awx_kubernetes_project`

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.3.5
```
