### PR TITLE
fix bug scheduling WFJT without prompts

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -432,7 +432,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, Notificatio
         copy_m2m_relationships(self, unified_jt, fields)
         return unified_jt
 
-    def _accept_or_ignore_job_kwargs(self, _exclude_errors=None, **kwargs):
+    def _accept_or_ignore_job_kwargs(self, _exclude_errors=(), **kwargs):
         '''
         Override in subclass if template accepts _any_ prompted params
         '''

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -353,7 +353,7 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
         workflow_job.copy_nodes_from_original(original=self)
         return workflow_job
 
-    def _accept_or_ignore_job_kwargs(self, **kwargs):
+    def _accept_or_ignore_job_kwargs(self, _exclude_errors=(), **kwargs):
         prompted_fields = {}
         rejected_fields = {}
         accepted_vars, rejected_vars, errors_dict = self.accept_or_ignore_variables(kwargs.get('extra_vars', {}))

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -28,6 +28,12 @@ def test_non_job_extra_vars_prohibited(post, project, admin_user):
 
 
 @pytest.mark.django_db
+def test_wfjt_schedule_accepted(post, workflow_job_template, admin_user):
+    url = reverse('api:workflow_job_template_schedules_list', kwargs={'pk': workflow_job_template.id})
+    post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE}, admin_user, expect=201)
+
+
+@pytest.mark.django_db
 def test_valid_survey_answer(post, admin_user, project, inventory, survey_spec_factory):
     job_template = JobTemplate.objects.create(
         name='test-jt',


### PR DESCRIPTION
This is a bug, it needs fixing. Without catching this kwarg, the validation of the schedule passes a kwarg which is not allowed and raises an error that it shouldn't.