### PR TITLE
Have bubblewrap mount a new /proc in the wrapped environment.

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -766,7 +766,7 @@ def wrap_args_with_proot(args, cwd, **kwargs):
     '''
     from django.conf import settings
     cwd = os.path.realpath(cwd)
-    new_args = [getattr(settings, 'AWX_PROOT_CMD', 'bwrap'), '--unshare-pid', '--dev-bind', '/', '/']
+    new_args = [getattr(settings, 'AWX_PROOT_CMD', 'bwrap'), '--unshare-pid', '--dev-bind', '/', '/', '--proc', '/proc']
     hide_paths = [settings.AWX_PROOT_BASE_PATH]
     if not kwargs.get('isolated'):
         hide_paths.extend(['/etc/tower', '/var/lib/awx', '/var/log',


### PR DESCRIPTION
Since we're running with a new pid namespace, we should have
a new /proc that is in that namespace. Otherwise things will
be weird.
