### PR TITLE
Reset project revision when changing certain fields

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1040,6 +1040,11 @@ class ProjectSerializer(UnifiedJobTemplateSerializer, ProjectOptionsSerializer):
             for fd in ('scm_update_on_launch', 'scm_delete_on_update', 'scm_clean'):
                 if get_field_from_model_or_attrs(fd):
                     raise serializers.ValidationError({fd: _('Update options must be set to false for manual projects.')})
+        # If client modifies any attributes affecting checking, must reset SCM revision
+        # so that next update will perform a checkout
+        if 'scm_revision' not in attrs:
+            if any(fd in attrs for fd in ('scm_type', 'scm_url', 'scm_branch')):
+                attrs['scm_revision'] = ''
         return super(ProjectSerializer, self).validate(attrs)
 
 

--- a/awx/main/tests/functional/api/test_project.py
+++ b/awx/main/tests/functional/api/test_project.py
@@ -36,3 +36,16 @@ def test_project_invalid_custom_virtualenv(get, patch, project, admin):
     assert resp.data['custom_virtualenv'] == [
         '/foo/bar is not a valid virtualenv in {}'.format(settings.BASE_VENV_PATH)
     ]
+
+
+@pytest.mark.django_db
+def test_project_edit_resets_revision(patch, project, admin_user):
+    old_rev = project.scm_revision
+    assert old_rev != ''  # counting on fixture to have dummy revision
+    patch(
+        project.get_absolute_url(), {'scm_url': 'http://foobar.invalid'},
+        user=admin_user, expect=200
+    )
+    project.refresh_from_db()
+    assert project.scm_revision != old_rev
+    assert project.scm_revision == ''


### PR DESCRIPTION
Description of underlying problem that this fixes:

If a client changed _just_ the SCM URL field of a project, and then re-ran a JT that uses that project, then it would continue to run just as before with the old source tree. This change assures that the source tree will be wiped clean on any subsequent updates if any of these fields are changed.

The selection of fields are all those that obviously impact the checkout. Let me know if I missed any.