### PR TITLE
add a few schedule RRULE parsing improvements

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3887,6 +3887,7 @@ class SchedulePreviewSerializer(BaseSerializer):
     # - BYYEARDAY
     # - BYWEEKNO
     # - Multiple DTSTART or RRULE elements
+    # - Can't contain both COUNT and UNTIL
     # - COUNT > 999
     def validate_rrule(self, value):
         rrule_value = value
@@ -3921,6 +3922,8 @@ class SchedulePreviewSerializer(BaseSerializer):
             raise serializers.ValidationError(_("BYYEARDAY not supported."))
         if 'byweekno' in rrule_value.lower():
             raise serializers.ValidationError(_("BYWEEKNO not supported."))
+        if 'COUNT' in rrule_value and 'UNTIL' in rrule_value:
+            raise serializers.ValidationError(_("RRULE may not contain both COUNT and UNTIL"))
         if match_count:
             count_val = match_count.groups()[0].strip().split("=")
             if int(count_val[1]) > 999:

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -150,14 +150,13 @@ class Schedule(CommonModel, LaunchTimeConfig):
                     # > UTC time.
                     raise ValueError('RRULE UNTIL values must be specified in UTC')
 
-        try:
-            first_event = x[0]
-            if first_event < now() - datetime.timedelta(days=365 * 5):
-                # For older DTSTART values, if there are more than 1000 recurrences...
-                if len(x[:1001]) > 1000:
-                    raise ValueError('RRULE values that yield more than 1000 events are not allowed.')
-        except IndexError:
-            pass
+        if 'MINUTELY' in rrule or 'HOURLY' in rrule:
+            try:
+                first_event = x[0]
+                if first_event < now() - datetime.timedelta(days=365 * 5):
+                    raise ValueError('RRULE values with more than 1000 events are not allowed.')
+            except IndexError:
+                pass
         return x
 
     def __unicode__(self):

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -66,6 +66,7 @@ def test_valid_survey_answer(post, admin_user, project, inventory, survey_spec_f
     ("DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=1;BYWEEKNO=20", "BYWEEKNO not supported"),
     ("DTSTART:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=2000", "COUNT > 999 is unsupported"),  # noqa
     ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
+    ("DTSTART:20030925T104941Z RRULE:FREQ=DAILY;INTERVAL=10;COUNT=500;UNTIL=20040925T104941Z", "RRULE may not contain both COUNT and UNTIL"),  # noqa
     ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),
     ("DTSTART:20300308T050000 RRULE:FREQ=DAILY;INTERVAL=1", "DTSTART cannot be a naive datetime"),
     ("DTSTART:19700101T000000Z RRULE:FREQ=MINUTELY;INTERVAL=1", "more than 1000 events are not allowed"),  # noqa


### PR DESCRIPTION
The old detection was a bit too aggressive; the worst offenders are old dates with MINUTELY or HOURLY