### PR TITLE
Remove credential from node and schedule summary fields

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3107,6 +3107,12 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
             ret['extra_data'] = obj.display_extra_data()
         return ret
 
+    def get_summary_fields(self, obj):
+        summary_fields = super(LaunchConfigurationBaseSerializer, self).get_summary_fields(obj)
+        # Credential would be an empty dictionary in this case
+        summary_fields.pop('credential', None)
+        return summary_fields
+
     def validate(self, attrs):
         attrs = super(LaunchConfigurationBaseSerializer, self).validate(attrs)
 


### PR DESCRIPTION
This removes stray data in summary fields for WFJT nodes and schedules that looks like `"credential": {},`, following the same pattern as what was done for JTs, themselves

https://github.com/ansible/awx/blob/b38aa3dfb6b7b9986d5302f5f5f966b7a4ef1be7/awx/api/serializers.py#L2599-L2600