### PR TITLE
Fix wait_fors in standalone Docker installs

### DIFF
--- a/installer/image_build/files/launch_awx_task.sh
+++ b/installer/image_build/files/launch_awx_task.sh
@@ -6,8 +6,8 @@ if [ `id -u` -ge 500 ]; then
 fi
 
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=localhost port=11211" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=localhost port=5672" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=11211" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=5672" all
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db -U $DATABASE_USER -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
 
 awx-manage migrate --noinput --fake-initial

--- a/installer/kubernetes/templates/deployment.yml.j2
+++ b/installer/kubernetes/templates/deployment.yml.j2
@@ -36,6 +36,10 @@ spec:
               value: ({{ pg_port|default('5432') }})
             - name: DATABASE_PASSWORD
               value: {{ pg_password }}
+            - name: MEMCACHED_HOST
+              value: {{ memcached_hostname|default('localhost') }}
+            - name: RABBITMQ_HOST
+              value: {{ rabbitmq_hostname|default('localhost') }}
             - name: AWX_ADMIN_USER
               value: {{ default_admin_user|default('admin') }}
             - name: AWX_ADMIN_PASSWORD

--- a/installer/openshift/templates/deployment.yml.j2
+++ b/installer/openshift/templates/deployment.yml.j2
@@ -36,6 +36,10 @@ spec:
               value: ({{ pg_port|default('5432') }})
             - name: DATABASE_PASSWORD
               value: {{ pg_password }}
+            - name: MEMCACHED_HOST
+              value: {{ memcached_hostname|default('localhost') }}
+            - name: RABBITMQ_HOST
+              value: {{ rabbitmq_hostname|default('localhost') }}
             - name: AWX_ADMIN_USER
               value: {{ default_admin_user|default('admin') }}
             - name: AWX_ADMIN_PASSWORD


### PR DESCRIPTION
##### SUMMARY
This wasnt causing anything to "break" but the `wait_for`s in `launch_awx_task.sh` were timing out in standalone Docker installs.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.3.25
```

