### PR TITLE
from six.moves import xrange for Python 3

### DIFF
--- a/awx/lib/awx_display_callback/events.py
+++ b/awx/lib/awx_display_callback/events.py
@@ -29,6 +29,8 @@ import threading
 import uuid
 import memcache
 
+from six.moves import xrange
+
 __all__ = ['event_context']
 
 

--- a/awx/main/queue.py
+++ b/awx/main/queue.py
@@ -5,6 +5,8 @@
 import logging
 import os
 
+from six.moves import xrange
+
 # Django
 from django.conf import settings
 

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -5,6 +5,7 @@ import json
 import os
 import six
 from datetime import timedelta
+from six.moves import xrange
 
 # Django
 from django.core.urlresolvers import resolve

--- a/awx/main/tests/functional/models/fact/test_get_timeline.py
+++ b/awx/main/tests/functional/models/fact/test_get_timeline.py
@@ -1,6 +1,8 @@
 import pytest
 
 from datetime import timedelta
+from six.moves import xrange
+
 from django.utils import timezone
 
 from awx.main.models import Fact
@@ -19,7 +21,7 @@ def setup_common(hosts, fact_scans, ts_from=None, ts_to=None, epoch=timezone.now
                 continue
             facts_known.append(f)
     fact_objs = Fact.get_timeline(hosts[0].id, module=module_name, ts_from=ts_from, ts_to=ts_to)
-    return (facts_known, fact_objs) 
+    return (facts_known, fact_objs)
 
 
 @pytest.mark.django_db
@@ -27,7 +29,7 @@ def test_all(hosts, fact_scans, monkeypatch_jsonbfield_get_db_prep_save):
     epoch = timezone.now()
     ts_from = epoch - timedelta(days=1)
     ts_to = epoch + timedelta(days=10)
-    
+
     (facts_known, fact_objs) = setup_common(hosts, fact_scans, ts_from, ts_to, module_name=None, epoch=epoch)
     assert 9 == len(facts_known)
     assert 9 == len(fact_objs)
@@ -53,7 +55,7 @@ def test_empty_db(hosts, fact_scans, monkeypatch_jsonbfield_get_db_prep_save):
     epoch = timezone.now()
     ts_from = epoch - timedelta(days=1)
     ts_to = epoch + timedelta(days=10)
-    
+
     fact_objs = Fact.get_timeline(hosts[0].id, 'ansible', ts_from, ts_to)
 
     assert 0 == len(fact_objs)
@@ -64,7 +66,7 @@ def test_no_results(hosts, fact_scans, monkeypatch_jsonbfield_get_db_prep_save):
     epoch = timezone.now()
     ts_from = epoch - timedelta(days=100)
     ts_to = epoch - timedelta(days=50)
-    
+
     (facts_known, fact_objs) = setup_common(hosts, fact_scans, ts_from, ts_to, epoch=epoch)
     assert 0 == len(fact_objs)
 

--- a/awx/main/tests/functional/test_notifications.py
+++ b/awx/main/tests/functional/test_notifications.py
@@ -5,6 +5,8 @@ from requests.adapters import HTTPAdapter
 from requests.utils import select_proxy
 from requests.exceptions import ConnectionError
 
+from six.moves import xrange
+
 from awx.api.versioning import reverse
 from awx.main.models.notifications import NotificationTemplate, Notification
 from awx.main.models.inventory import Inventory, InventorySource

--- a/awx/main/tests/unit/api/serializers/test_job_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_serializers.py
@@ -3,6 +3,8 @@ import pytest
 import mock
 import json
 
+from six.moves import xrange
+
 # AWX
 from awx.api.serializers import (
     JobSerializer,

--- a/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
@@ -2,6 +2,8 @@
 import pytest
 import mock
 
+from six.moves import xrange
+
 # AWX
 from awx.api.serializers import (
     JobTemplateSerializer,

--- a/awx/main/tests/unit/utils/test_event_filter.py
+++ b/awx/main/tests/unit/utils/test_event_filter.py
@@ -3,6 +3,8 @@ import base64
 import json
 from StringIO import StringIO
 
+from six.moves import xrange
+
 from awx.main.utils import OutputEventFilter
 
 MAX_WIDTH = 78


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__ so for each Python file that contains a call to __xrange()__, this PR adds __from six import xrange__.