### PR TITLE
basestring to six.string_types for Python 3

### DIFF
--- a/awx/api/renderers.py
+++ b/awx/api/renderers.py
@@ -5,6 +5,8 @@
 from rest_framework import renderers
 from rest_framework.request import override_method
 
+import six
+
 
 class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
     '''
@@ -69,7 +71,7 @@ class PlainTextRenderer(renderers.BaseRenderer):
     format = 'txt'
 
     def render(self, data, media_type=None, renderer_context=None):
-        if not isinstance(data, basestring):
+        if not isinstance(data, six.string_types):
             data = unicode(data)
         return data.encode(self.charset)
 

--- a/awx/conf/serializers.py
+++ b/awx/conf/serializers.py
@@ -1,6 +1,8 @@
 # Django REST Framework
 from rest_framework import serializers
 
+import six
+
 # Tower
 from awx.api.fields import VerbatimField
 from awx.api.serializers import BaseSerializer
@@ -45,12 +47,12 @@ class SettingFieldMixin(object):
     """Mixin to use a registered setting field class for API display/validation."""
 
     def to_representation(self, obj):
-        if getattr(self, 'encrypted', False) and isinstance(obj, basestring) and obj:
+        if getattr(self, 'encrypted', False) and isinstance(obj, six.string_types) and obj:
             return '$encrypted$'
         return obj
 
     def to_internal_value(self, value):
-        if getattr(self, 'encrypted', False) and isinstance(value, basestring) and value.startswith('$encrypted$'):
+        if getattr(self, 'encrypted', False) and isinstance(value, six.string_types) and value.startswith('$encrypted$'):
             raise serializers.SkipField()
         obj = super(SettingFieldMixin, self).to_internal_value(value)
         return super(SettingFieldMixin, self).to_representation(obj)

--- a/awx/conf/utils.py
+++ b/awx/conf/utils.py
@@ -6,6 +6,8 @@ import glob
 import os
 import shutil
 
+import six
+
 # AWX
 from awx.conf.registry import settings_registry
 
@@ -13,7 +15,7 @@ __all__ = ['comment_assignments', 'conf_to_dict']
 
 
 def comment_assignments(patterns, assignment_names, dry_run=True, backup_suffix='.old'):
-    if isinstance(patterns, basestring):
+    if isinstance(patterns, six.string_types):
         patterns = [patterns]
     diffs = []
     for pattern in patterns:
@@ -32,7 +34,7 @@ def comment_assignments(patterns, assignment_names, dry_run=True, backup_suffix=
 def comment_assignments_in_file(filename, assignment_names, dry_run=True, backup_filename=None):
     from redbaron import RedBaron, indent
 
-    if isinstance(assignment_names, basestring):
+    if isinstance(assignment_names, six.string_types):
         assignment_names = [assignment_names]
     else:
         assignment_names = assignment_names[:]

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -74,7 +74,7 @@ class JSONField(upstream_JSONField):
 
 class JSONBField(upstream_JSONBField):
     def get_prep_lookup(self, lookup_type, value):
-        if isinstance(value, basestring) and value == "null":
+        if isinstance(value, six.string_types) and value == "null":
             return 'null'
         return super(JSONBField, self).get_prep_lookup(lookup_type, value)
 

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -3,6 +3,8 @@ import os
 import json
 from copy import copy, deepcopy
 
+import six
+
 # Django
 from django.conf import settings
 from django.db import models
@@ -161,7 +163,7 @@ class SurveyJobTemplateMixin(models.Model):
                     decrypted_default = default
                     if (
                         survey_element['type'] == "password" and
-                        isinstance(decrypted_default, basestring) and
+                        isinstance(decrypted_default, six.string_types) and
                         decrypted_default.startswith('$encrypted$')
                     ):
                         decrypted_default = decrypt_value(get_encryption_key('value', pk=None), decrypted_default)
@@ -184,7 +186,7 @@ class SurveyJobTemplateMixin(models.Model):
         if (survey_element['type'] == "password"):
             password_value = data.get(survey_element['variable'])
             if (
-                isinstance(password_value, basestring) and
+                isinstance(password_value, six.string_types) and
                 password_value == '$encrypted$'
             ):
                 if survey_element.get('default') is None and survey_element['required']:
@@ -241,7 +243,7 @@ class SurveyJobTemplateMixin(models.Model):
                     errors.append("'%s' value is expected to be a list." % survey_element['variable'])
                 else:
                     choice_list = copy(survey_element['choices'])
-                    if isinstance(choice_list, basestring):
+                    if isinstance(choice_list, six.string_types):
                         choice_list = choice_list.split('\n')
                     for val in data[survey_element['variable']]:
                         if val not in choice_list:
@@ -249,7 +251,7 @@ class SurveyJobTemplateMixin(models.Model):
                                                                                            choice_list))
         elif survey_element['type'] == 'multiplechoice':
             choice_list = copy(survey_element['choices'])
-            if isinstance(choice_list, basestring):
+            if isinstance(choice_list, six.string_types):
                 choice_list = choice_list.split('\n')
             if survey_element['variable'] in data:
                 if data[survey_element['variable']] not in choice_list:
@@ -372,7 +374,7 @@ class SurveyJobMixin(models.Model):
             extra_vars = json.loads(self.extra_vars)
             for key in self.survey_passwords:
                 value = extra_vars.get(key)
-                if value and isinstance(value, basestring) and value.startswith('$encrypted$'):
+                if value and isinstance(value, six.string_types) and value.startswith('$encrypted$'):
                     extra_vars[key] = decrypt_value(get_encryption_key('value', pk=None), value)
             return json.dumps(extra_vars)
         else:

--- a/awx/main/tests/factories/tower.py
+++ b/awx/main/tests/factories/tower.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.models import User
 
+import six
+
 from awx.main.models import (
     Organization,
     Project,
@@ -148,7 +150,7 @@ def create_survey_spec(variables=None, default_type='integer', required=True, mi
         vars_list = variables
     else:
         vars_list = [variables]
-    if isinstance(variables[0], basestring):
+    if isinstance(variables[0], six.string_types):
         slogan = variables[0]
     else:
         slogan = variables[0].get('question_name', 'something')
@@ -415,14 +417,14 @@ def create_workflow_job_template(name, organization=None, persisted=True, **kwar
 
     wfjt = mk_workflow_job_template(name,
                                     organization=organization,
-                                    spec=spec, 
+                                    spec=spec,
                                     extra_vars=extra_vars,
                                     persisted=persisted)
 
-    
 
-    workflow_jt_nodes = generate_workflow_job_template_nodes(wfjt, 
-                                                             persisted, 
+
+    workflow_jt_nodes = generate_workflow_job_template_nodes(wfjt,
+                                                             persisted,
                                                              workflow_job_template_nodes=kwargs.get('workflow_job_template_nodes', []))
 
     '''
@@ -438,5 +440,3 @@ def create_workflow_job_template(name, organization=None, persisted=True, **kwar
                    #jobs=jobs,
                    workflow_job_template_nodes=workflow_jt_nodes,
                    survey=spec,)
-
-

--- a/awx/main/tests/unit/utils/test_formatters.py
+++ b/awx/main/tests/unit/utils/test_formatters.py
@@ -1,3 +1,5 @@
+import six
+
 from awx.main.models import Job, JobEvent
 
 from awx.main.utils.formatters import LogstashFormatter
@@ -13,7 +15,7 @@ def test_log_from_job_event_object():
 
     # Check entire body of data for any exceptions from getattr on event object
     for fd in data_for_log:
-        if not isinstance(data_for_log[fd], basestring):
+        if not isinstance(data_for_log[fd], six.string_types):
             continue
         assert 'Exception' not in data_for_log[fd], 'Exception delivered in data: {}'.format(data_for_log[fd])
 

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -611,7 +611,7 @@ def parse_yaml_or_json(vars_str, silent_failure=True):
     '''
     if isinstance(vars_str, dict):
         return vars_str
-    elif isinstance(vars_str, basestring) and vars_str == '""':
+    elif isinstance(vars_str, six.string_types) and vars_str == '""':
         return {}
 
     try:

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -7,6 +7,8 @@ import json
 import time
 import logging
 
+import six
+
 
 class TimeFormatter(logging.Formatter):
     '''
@@ -41,7 +43,7 @@ class LogstashFormatter(LogstashFormatterVersion1):
             data = copy(raw_data['ansible_facts'])
         else:
             data = copy(raw_data)
-        if isinstance(data, basestring):
+        if isinstance(data, six.string_types):
             data = json.loads(data)
         data_for_log = {}
 

--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 
 import ldap
+import six
 
 # Django
 from django.dispatch import receiver
@@ -249,7 +250,7 @@ class TowerSAMLIdentityProvider(BaseSAMLIdentityProvider):
 
     def get_user_permanent_id(self, attributes):
         uid = attributes[self.conf.get('attr_user_permanent_id', OID_USERID)]
-        if isinstance(uid, basestring):
+        if isinstance(uid, six.string_types):
             return uid
         return uid[0]
 
@@ -321,10 +322,10 @@ def _update_m2m_from_groups(user, ldap_user, rel, opts, remove=True):
     elif opts is True:
         should_add = True
     else:
-        if isinstance(opts, basestring):
+        if isinstance(opts, six.string_types):
             opts = [opts]
         for group_dn in opts:
-            if not isinstance(group_dn, basestring):
+            if not isinstance(group_dn, six.string_types):
                 continue
             if ldap_user._get_groups().is_member_of(group_dn):
                 should_add = True

--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -5,6 +5,8 @@
 import re
 import logging
 
+import six
+
 # Python Social Auth
 from social_core.exceptions import AuthException
 
@@ -65,10 +67,10 @@ def _update_m2m_from_expression(user, rel, expr, remove=True):
     elif expr is True:
         should_add = True
     else:
-        if isinstance(expr, (basestring, type(re.compile('')))):
+        if isinstance(expr, (six.string_types, type(re.compile('')))):
             expr = [expr]
         for ex in expr:
-            if isinstance(ex, basestring):
+            if isinstance(ex, six.string_types):
                 if user.username == ex or user.email == ex:
                     should_add = True
             elif isinstance(ex, type(re.compile(''))):
@@ -172,7 +174,7 @@ def update_user_orgs_by_saml_attr(backend, details, user=None, *args, **kwargs):
         org.member_role.members.add(user)
 
     if org_map.get('remove', True):
-        [o.member_role.members.remove(user) for o in 
+        [o.member_role.members.remove(user) for o in
             Organization.objects.filter(Q(member_role__members=user) & ~Q(id__in=org_ids))]
 
 
@@ -212,7 +214,5 @@ def update_user_teams_by_saml_attr(backend, details, user=None, *args, **kwargs)
             team.member_role.members.add(user)
 
     if team_map.get('remove', True):
-        [t.member_role.members.remove(user) for t in 
+        [t.member_role.members.remove(user) for t in
             Team.objects.filter(Q(member_role__members=user) & ~Q(id__in=team_ids))]
-
-


### PR DESCRIPTION
__basestring__ was removed in Python 3 in favor of __str__ so this PR replaces all instance of __basestring__ with __six.string_types__.