### PR TITLE
Miscellaneous Python 3 changes: execfile(), file(), reduce(), StandardError

### DIFF
--- a/awx/lib/awx_display_callback/minimal.py
+++ b/awx/lib/awx_display_callback/minimal.py
@@ -25,4 +25,5 @@ import ansible
 
 # Because of the way Ansible loads plugins, it's not possible to import
 # ansible.plugins.callback.minimal when being loaded as the minimal plugin. Ugh.
-execfile(os.path.join(os.path.dirname(ansible.__file__), 'plugins', 'callback', 'minimal.py'))
+with open(os.path.join(os.path.dirname(ansible.__file__), 'plugins', 'callback', 'minimal.py')) as in_file:
+    exec(in_file.read())

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -44,7 +44,7 @@ def could_be_playbook(project_path, dir_path, filename):
     # show up.
     matched = False
     try:
-        for n, line in enumerate(file(playbook_path)):
+        for n, line in enumerate(open(playbook_path)):
             if valid_playbook_re.match(line):
                 matched = True
             # Any YAML file can also be encrypted with vault;

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -18,6 +18,7 @@ import contextlib
 import tempfile
 import six
 import psutil
+from functools import reduce
 from StringIO import StringIO
 
 from decimal import Decimal

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -1,4 +1,5 @@
 import re
+from functools import reduce
 from pyparsing import (
     infixNotation,
     opAssoc,

--- a/awx/plugins/ansible_inventory/backport.py
+++ b/awx/plugins/ansible_inventory/backport.py
@@ -322,4 +322,5 @@ if __name__ == '__main__':
         imp.load_source('ansible.cli.inventory', __file__ + '.py', f)
     ansible_path = distutils.spawn.find_executable('ansible')
     sys.argv[0] = 'ansible-inventory'
-    execfile(ansible_path)
+    with open(ansible_path) as in_file:
+        exec(in_file.read())

--- a/tools/scripts/compilemessages.py
+++ b/tools/scripts/compilemessages.py
@@ -31,7 +31,7 @@ def has_bom(fn):
     return sample.startswith((codecs.BOM_UTF8, codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE))
 
 
-def popen_wrapper(args, os_err_exc_type=StandardError, stdout_encoding='utf-8'):
+def popen_wrapper(args, os_err_exc_type=Exception, stdout_encoding='utf-8'):
     """
     Friendly wrapper around Popen.
     Returns stdout output, stderr output and OS status code.


### PR DESCRIPTION
Miscellaneous changes required for Python 3 which are required because __execfile()__, __file()__, __reduce()__, and __StandardError__ were all removed from Python 3.
* __execfile()__ --> __with open() as in_file: exec(in_file.read())__
* __file()__ --> __open()__
* __reduce()__ --> __from functools import reduce__ 
* __StandardError__ --> __Exception__