### PR TITLE
Validation clause for WFJT node to follow credential prompt rule

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3254,6 +3254,9 @@ class WorkflowJobTemplateNodeSerializer(LaunchConfigurationBaseSerializer):
             cred = deprecated_fields['credential']
             attrs['credential'] = cred
             if cred is not None:
+                if not ujt_obj.ask_credential_on_launch:
+                    raise serializers.ValidationError({"credential": _(
+                        "Related template is not configured to accept credentials on launch.")})
                 cred = Credential.objects.get(pk=cred)
                 view = self.context.get('view', None)
                 if (not view) or (not view.request) or (view.request.user not in cred.use_role):


### PR DESCRIPTION
We have a rule that workflow job template nodes cannot set a field if its template does not as for the field on launch.

For attaching credentials, we have a validation check to prevent this scenario and raise a 400

https://github.com/ansible/awx/blob/605a2c7e010b25cef47e55bef3d274b623513d0f/awx/api/views.py#L713-L714

A bug was discovered where the deprecated method did _not_ follow the rule, which can be used by a PATCH directly to the URL of the WFJT node with data `{"credential": 10}`.

This addition outright copies the error message we raise when the modern API is used, and raises in the validation block for receiving the credential by the deprecated API.

Tested manually, toggling `ask_credential_on_launch` true/false.