### PR TITLE
six.string_types and six.test_type for Python 3

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -3,6 +3,8 @@ import os
 import json
 from copy import copy, deepcopy
 
+import six
+
 # Django
 from django.conf import settings
 from django.db import models
@@ -197,7 +199,7 @@ class SurveyJobTemplateMixin(models.Model):
                 errors.append("'%s' value missing" % survey_element['variable'])
         elif survey_element['type'] in ["textarea", "text", "password"]:
             if survey_element['variable'] in data:
-                if type(data[survey_element['variable']]) not in (str, unicode):
+                if type(data[survey_element['variable']]) not in six.string_types:
                     errors.append("Value %s for '%s' expected to be a string." % (data[survey_element['variable']],
                                                                                   survey_element['variable']))
                     return errors

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -3,8 +3,6 @@ import os
 import json
 from copy import copy, deepcopy
 
-import six
-
 # Django
 from django.conf import settings
 from django.db import models
@@ -199,7 +197,7 @@ class SurveyJobTemplateMixin(models.Model):
                 errors.append("'%s' value missing" % survey_element['variable'])
         elif survey_element['type'] in ["textarea", "text", "password"]:
             if survey_element['variable'] in data:
-                if type(data[survey_element['variable']]) not in six.string_types:
+                if type(data[survey_element['variable']]) not in (str, unicode):
                     errors.append("Value %s for '%s' expected to be a string." % (data[survey_element['variable']],
                                                                                   survey_element['variable']))
                     return errors

--- a/awx/main/tests/functional/api/test_fact_view.py
+++ b/awx/main/tests/functional/api/test_fact_view.py
@@ -2,6 +2,8 @@ import mock
 import pytest
 import json
 
+import six
+
 from awx.api.versioning import reverse
 from awx.main.utils import timestamp_apiformat
 from django.utils import timezone
@@ -105,7 +107,7 @@ def test_content(hosts, fact_scans, get, user, fact_ansible_json, monkeypatch_js
 
     assert fact_known.host_id == response.data['host']
     # TODO: Just make response.data['facts'] when we're only dealing with postgres, or if jsonfields ever fixes this bug
-    assert fact_ansible_json == (json.loads(response.data['facts']) if isinstance(response.data['facts'], unicode) else response.data['facts'])
+    assert fact_ansible_json == (json.loads(response.data['facts']) if isinstance(response.data['facts'], six.text_type) else response.data['facts'])
     assert timestamp_apiformat(fact_known.timestamp) == response.data['timestamp']
     assert fact_known.module == response.data['module']
 
@@ -117,7 +119,7 @@ def _test_search_by_module(hosts, fact_scans, get, user, fact_json, module_name)
     (fact_known, response) = setup_common(hosts, fact_scans, get, user, module_name=module_name, get_params=params)
 
     # TODO: Just make response.data['facts'] when we're only dealing with postgres, or if jsonfields ever fixes this bug
-    assert fact_json == (json.loads(response.data['facts']) if isinstance(response.data['facts'], unicode) else response.data['facts'])
+    assert fact_json == (json.loads(response.data['facts']) if isinstance(response.data['facts'], six.text_type) else response.data['facts'])
     assert timestamp_apiformat(fact_known.timestamp) == response.data['timestamp']
     assert module_name == response.data['module']
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -9,6 +9,7 @@ from pyparsing import (
 )
 
 import django
+import six
 
 from awx.main.utils.common import get_search_fields
 
@@ -54,12 +55,12 @@ class SmartFilter(object):
                 self.result = Host.objects.filter(**kwargs)
 
         def strip_quotes_traditional_logic(self, v):
-            if type(v) is unicode and v.startswith('"') and v.endswith('"'):
+            if type(v) is six.text_type and v.startswith('"') and v.endswith('"'):
                 return v[1:-1]
             return v
 
         def strip_quotes_json_logic(self, v):
-            if type(v) is unicode and v.startswith('"') and v.endswith('"') and v != u'"null"':
+            if type(v) is six.text_type and v.startswith('"') and v.endswith('"') and v != u'"null"':
                 return v[1:-1]
             return v
 


### PR DESCRIPTION
 Separate out the easier part of #1175 to clear all the non-__unicode()__ issues first.

The __unicode__ data type was removed in Python 3 because all str are Unicode so this PR:
* Change all instances of __(str, unicode)__ to [__six.string_types__](https://pythonhosted.org/six/#six.string_types)
* Change remaining instances of __unicode__ to [__six.text_type__](https://pythonhosted.org/six/#six.text_type)