### PR TITLE
related #1199 - azure_rm inventory should add "ansible_connection: winrm"

### DIFF
--- a/awx/plugins/inventory/azure_rm.py
+++ b/awx/plugins/inventory/azure_rm.py
@@ -616,6 +616,7 @@ class AzureInventory(object):
 
             # Add windows details
             if machine.os_profile is not None and machine.os_profile.windows_configuration is not None:
+                host_vars['ansible_connection'] = 'winrm'
                 host_vars['windows_auto_updates_enabled'] = \
                     machine.os_profile.windows_configuration.enable_automatic_updates
                 host_vars['windows_timezone'] = machine.os_profile.windows_configuration.time_zone


### PR DESCRIPTION
##### SUMMARY

azure_rm inventory should add "ansible_connection: winrm" in host_vars for windows hosts

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - awx/awx/plugins/inventory/azure_rm.py

##### AWX VERSION

```
AWX 1.0.2.327
```

##### STEPS TO REPRODUCE

Run azure_rm (Microsoft Azure Resource Manager Inventory in AWX) to inventory a Windows host.

Look at the variables in the output.

##### EXPECTED RESULTS

A windows host should be reached with winrm.

I expect this variable to be present in the host variables:

```
ansible_connection: winrm
```

##### ACTUAL RESULTS

The variable ansible_connection: winrm is missing.

Ansible will use the standard SSH connexion mechanism, which will obviously fail.

We get information about the OS from Azure, though:

```
os_disk: 
  operating_system_type: Windows
```
So when this information is present, azure_rm inventory should also set the variable 

```
ansible_connection: winrm
```