### PR TITLE
Omit placeholder vars with survey password defaults

### DIFF
--- a/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
@@ -215,6 +215,24 @@ class TestWorkflowJobTemplateNodeSerializerSurveyPasswords():
         assert 'var1' in attrs['survey_passwords']
         assert attrs['extra_data']['var1'] == '$encrypted$foooooo'
 
+    def test_accept_password_default(self, jt, mocker):
+        '''
+        If user provides "$encrypted$" without a corresponding DB value for the
+        node, but survey question has a default, then variables are accepted
+        with that particular var omitted so on launch time the default takes effect
+        '''
+        serializer = WorkflowJobTemplateNodeSerializer()
+        wfjt = WorkflowJobTemplate(name='fake-wfjt')
+        jt.survey_spec['spec'][0]['default'] = '$encrypted$bar'
+        attrs = serializer.validate({
+            'unified_job_template': jt,
+            'workflow_job_template': wfjt,
+            'extra_data': {'var1': '$encrypted$'}
+        })
+        assert 'survey_passwords' in attrs
+        assert attrs['survey_passwords'] == {}
+        assert attrs['extra_data'] == {}
+
 
 @mock.patch('awx.api.serializers.WorkflowJobTemplateNodeSerializer.get_related', lambda x,y: {})
 class TestWorkflowJobNodeSerializerGetRelated():

--- a/docs/prompting.md
+++ b/docs/prompting.md
@@ -240,6 +240,9 @@ of what happened.
  - survey password durability
    - schedule has survey password answers from WFJT survey
    - WFJT node has answers to different password questions from JT survey
+   - Saving with "$encrypted$" value will either
+     - become a no-op, removing the key if a valid question default exists
+     - replace with the database value if question was previously answered
    - final job it spawns has both answers encrypted
  - POST to associate credential to WFJT node
    - requires admin to WFJT and execute to JT


### PR DESCRIPTION
This introduces a new expected behavior, and you can see this comes from breaking an existing code branch into 2 new branches.

If you have a WFJT node or schedule, you may POST/PUT/PATCH with `extra_data`, where some of the variables in `extra_data` have a value of `$encrypted$`, which is a magic string that indicates that substitution from some database value will be done. The critical question here is _which_ database value should be substituted.

The new behavior is that if the _node itself_ does not have a saved value, then all vars with value of "$encrypted$" are ignored, if and only if the JT has a valid default value for that question, and that question is of password type. They are removed from `extra_data`, as well as from the password-tracking `survey_passwords` dict which co-exists on the model.

In this case, it is as-if the user did not provide a value for that variable.

When the job runs, the default will be decrypted and substituted anyway. That is this behavior (totally ignoring the submitted variable) is ideal.

EDIT: minor note added in acceptance doc