### PR TITLE
Change schedule queryset logic to avoid server error

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2159,13 +2159,9 @@ class ScheduleAccess(BaseAccess):
     prefetch_related = ('unified_job_template', 'credentials',)
 
     def filtered_queryset(self):
-        qs = self.model.objects.all()
-
-        unified_pk_qs = UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role')
-        inv_src_qs = InventorySource.objects.filter(inventory_id=Inventory._accessible_pk_qs(Inventory, self.user, 'read_role'))
-        return qs.filter(
-            Q(unified_job_template_id__in=unified_pk_qs) |
-            Q(unified_job_template_id__in=inv_src_qs.values_list('pk', flat=True)))
+        return self.model.objects.filter(
+            unified_job_template__in=UnifiedJobTemplateAccess(self.user).filtered_queryset()
+        )
 
     @check_superuser
     def can_add(self, data):


### PR DESCRIPTION
This is one of those strange subtle cases with the Django ORM where it makes a huge difference to do `Model.objects.filter(Q(related__in=A) | Q(related__in=B))` as opposed to `Model.objects.filter(related__in=(A | B))`.

I don't know if it's worth it to get too far into the specifics of why this is the case.

Manually testing shows it fixes https://github.com/ansible/awx/issues/802

Compare to the last queryset I posted in the issue, here is the revised SQL for the same endpoint viewed by the same org admin user.

```sql
SELECT
   COUNT(*) AS "__count" 
FROM
   "main_schedule" 
WHERE
   "main_schedule"."unified_job_template_id" IN 
   (
      SELECT
         W0."id" AS Col1 
      FROM
         "main_unifiedjobtemplate" W0 
         LEFT OUTER JOIN
            "main_inventorysource" W1 
            ON (W0."id" = W1."unifiedjobtemplate_ptr_id") 
      WHERE
         (
            W0."id" IN 
            (
               SELECT DISTINCT
                  V0."object_id" AS Col1 
               FROM
                  "main_rbac_role_ancestors" V0 
               WHERE
                  (
                     V0."ancestor_id" IN 
                     (
                        SELECT
                           U0."id" AS Col1 
                        FROM
                           "main_rbac_roles" U0 
                           INNER JOIN
                              "main_rbac_roles_members" U1 
                              ON (U0."id" = U1."role_id") 
                        WHERE
                           U1."user_id" = 4
                     )
                     AND V0."content_type_id" IN 
                     (
                        20,
                        22,
                        30
                     )
                     AND V0."role_field" = 'read_role'
                  )
            )
            OR W1."inventory_id" IN 
            (
               SELECT DISTINCT
                  V0."object_id" AS Col1 
               FROM
                  "main_rbac_role_ancestors" V0 
               WHERE
                  (
                     V0."ancestor_id" IN 
                     (
                        SELECT
                           U0."id" AS Col1 
                        FROM
                           "main_rbac_roles" U0 
                           INNER JOIN
                              "main_rbac_roles_members" U1 
                              ON (U0."id" = U1."role_id") 
                        WHERE
                           U1."user_id" = 4
                     )
                     AND V0."content_type_id" = 37 
                     AND V0."role_field" = 'read_role'
                  )
            )
         )
   )
```

This query is more complex than the prior one, but at least the code is easier to follow.

I have tried to write a unit test for this, and came up with this so far

```python
    def test_schedule_queryset(self, rando, organization, inventory):
        from awx.main.models import SystemJobTemplate
        sjt = SystemJobTemplate.objects.create(name='test-system-jt')
        sjt.jobs.create()
        sjt.jobs.create()
        inventory.inventory_sources.create(name='asdf')
        job_template = JobTemplate.objects.create(name='test-job_template', inventory=inventory)
        job_template.jobs.create()
        job_template.jobs.create()
        organization.admin_role.members.add(rando)
        Schedule.objects.create(unified_job_template=job_template, rrule=self.rrule)
        assert len(list(ScheduleAccess(rando).filtered_queryset())) == 1
```

This fails to reproduce the bug. It's still not actually guaranteed that the issue (seen using postgres) will still occur in the test suite using sqlite3.