### PR TITLE
Add support for TZID in schedule rrules

### DIFF
--- a/awx/ui/client/src/scheduler/factories/r-rule-to-api.factory.js
+++ b/awx/ui/client/src/scheduler/factories/r-rule-to-api.factory.js
@@ -1,9 +1,11 @@
 export default
     function RRuleToAPI() {
-        return function(rrule) {
-            var response;
-            response = rrule.replace(/(^.*(?=DTSTART))(DTSTART=.*?;)(.*$)/, function(str, p1, p2, p3) {
-                return p2.replace(/\;/,'').replace(/=/,':') + ' ' + 'RRULE:' + p1 + p3;
+        return function(rrule, scope) {
+            let localTime = scope.schedulerLocalTime;
+            let timeZone = scope.schedulerTimeZone.name;
+
+            let response = rrule.replace(/(^.*(?=DTSTART))(DTSTART.*?)(=.*?;)(.*$)/, (str, p1, p2, p3, p4) => {
+                return p2 + ';TZID=' + timeZone + ':' + localTime + ' ' + 'RRULE:' + p4;
             });
             return response;
         };

--- a/awx/ui/client/src/scheduler/factories/schedule-post.factory.js
+++ b/awx/ui/client/src/scheduler/factories/schedule-post.factory.js
@@ -14,7 +14,7 @@ export default
                 newSchedule = scheduler.getValue();
                 rrule = scheduler.getRRule();
                 schedule.name = newSchedule.name;
-                schedule.rrule = RRuleToAPI(rrule.toString());
+                schedule.rrule = RRuleToAPI(rrule.toString(), scope);
                 schedule.description = (/error/.test(rrule.toText())) ? '' : rrule.toText();
 
                 if (scope.isFactCleanup) {

--- a/awx/ui/client/src/scheduler/schedulerAdd.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerAdd.controller.js
@@ -7,11 +7,11 @@
 export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
     '$scope', '$rootScope', 'CreateSelect2', 'ParseTypeChange', 'GetBasePath',
     'Rest', 'ParentObject', 'JobTemplateModel', '$q', 'Empty', 'SchedulePost',
-    'ProcessErrors', 'SchedulerInit', '$location', 'PromptService', 'RRuleToAPI',
+    'ProcessErrors', 'SchedulerInit', '$location', 'PromptService', 'RRuleToAPI', 'moment',
     function($filter, $state, $stateParams, $http, Wait,
         $scope, $rootScope, CreateSelect2, ParseTypeChange, GetBasePath,
         Rest, ParentObject, JobTemplate, $q, Empty, SchedulePost,
-        ProcessErrors, SchedulerInit, $location, PromptService, RRuleToAPI) {
+        ProcessErrors, SchedulerInit, $location, PromptService, RRuleToAPI, moment) {
 
     var base = $scope.base || $location.path().replace(/^\//, '').split('/')[0],
         scheduler,
@@ -322,12 +322,12 @@ export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
 
             $http.post('/api/v2/schedules/preview/', {'rrule': req})
                 .then(({data}) => {
-
                     $scope.preview_list = data;
                     for (let tz in data) {
                         $scope.preview_list.isEmpty = data[tz].length === 0;
                         $scope.preview_list[tz] = data[tz].map(function(date) {
-                            return date.replace(/Z/, '');
+                            date = date.replace(/Z/, '');
+                            return moment.parseZone(date).format("MM-DD-YYYY HH:mm:ss");
                         });
                     }
                 });

--- a/awx/ui/client/src/scheduler/schedulerAdd.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerAdd.controller.js
@@ -313,12 +313,15 @@ export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
         $http.post('/api/v2/schedules/preview/', {'rrule': req})
             .then(({data}) => {
                 $scope.preview_list = data;
-                for (let tz in data) {
-                    $scope.preview_list.isEmpty = data[tz].length === 0;
-                    $scope.preview_list[tz] = data[tz].map(function(date) {
+                let parsePreviewList = (tz) => {
+                    return data[tz].map(function(date) {
                         date = date.replace(/Z/, '');
                         return moment.parseZone(date).format("MM-DD-YYYY HH:mm:ss");
                     });
+                };
+                for (let tz in data) {
+                    $scope.preview_list.isEmpty = data[tz].length === 0;
+                    $scope.preview_list[tz] = parsePreviewList(tz);
                 }
             });
     }, 300);

--- a/awx/ui/client/src/scheduler/schedulerEdit.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerEdit.controller.js
@@ -131,8 +131,9 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
 
             $http.get('/api/v2/schedules/zoneinfo/').then(({data}) => {
                 scheduler.scope.timeZones = data;
-                scheduler.scope.schedulerTimeZone = _.find(data, (zone) => {
-                    return zone.name === scheduler.scope.current_timezone.name;
+                scheduler.scope.schedulerTimeZone = _.find(data, function(x) {
+                    let tz = $scope.schedule_obj.rrule.match(/TZID=\s*(.*?)\s*:/)[1];
+                    return x.name === tz;
                 });
             });
             scheduler.inject('form-container', false);

--- a/awx/ui/client/src/scheduler/schedulerEdit.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerEdit.controller.js
@@ -89,12 +89,15 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
         $http.post('/api/v2/schedules/preview/', {'rrule': req})
             .then(({data}) => {
                 $scope.preview_list = data;
-                for (let tz in data) {
-                    $scope.preview_list.isEmpty = data[tz].length === 0;
-                    $scope.preview_list[tz] = data[tz].map(function(date) {
+                let parsePreviewList = (tz) => {
+                    return data[tz].map(function(date) {
                         date = date.replace(/Z/, '');
                         return moment.parseZone(date).format("MM-DD-YYYY HH:mm:ss");
                     });
+                };
+                for (let tz in data) {
+                    $scope.preview_list.isEmpty = data[tz].length === 0;
+                    $scope.preview_list[tz] = parsePreviewList(tz);
                 }
             });
     }, 300);

--- a/awx/ui/client/src/scheduler/schedulerEdit.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerEdit.controller.js
@@ -1,7 +1,7 @@
-export default ['$filter', '$state', '$stateParams', 'Wait', '$scope',
+export default ['$filter', '$state', '$stateParams', 'Wait', '$scope', 'moment',
 '$rootScope', '$http', 'CreateSelect2', 'ParseTypeChange', 'ParentObject', 'ProcessErrors', 'Rest',
 'GetBasePath', 'SchedulerInit', 'SchedulePost', 'JobTemplateModel', '$q', 'Empty', 'PromptService', 'RRuleToAPI',
-function($filter, $state, $stateParams, Wait, $scope,
+function($filter, $state, $stateParams, Wait, $scope, moment,
     $rootScope, $http, CreateSelect2, ParseTypeChange, ParentObject, ProcessErrors, Rest,
     GetBasePath, SchedulerInit, SchedulePost, JobTemplate, $q, Empty, PromptService, RRuleToAPI) {
 
@@ -95,7 +95,8 @@ function($filter, $state, $stateParams, Wait, $scope,
                 for (let tz in data) {
                     $scope.preview_list.isEmpty = data[tz].length === 0;
                     $scope.preview_list[tz] = data[tz].map(function(date) {
-                        return date.replace(/Z/, '');
+                        date = date.replace(/Z/, '');
+                        return moment.parseZone(date).format("MM-DD-YYYY HH:mm:ss");
                     });
                 }
             });

--- a/awx/ui/client/src/scheduler/schedulerEdit.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerEdit.controller.js
@@ -85,10 +85,7 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
         callSelect2();
     });
 
-    $scope.$on("setPreviewPane", (event) => {
-        let rrule = event.currentScope.rrule.toString();
-        let req = RRuleToAPI(rrule, $scope);
-
+    let previewList = _.debounce(function(req) {
         $http.post('/api/v2/schedules/preview/', {'rrule': req})
             .then(({data}) => {
                 $scope.preview_list = data;
@@ -100,6 +97,12 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
                     });
                 }
             });
+    }, 300);
+
+    $scope.$on("setPreviewPane", (event) => {
+        let rrule = event.currentScope.rrule.toString();
+        let req = RRuleToAPI(rrule, $scope);
+        previewList(req);
     });
 
     Wait('start');

--- a/awx/ui/client/src/scheduler/schedulerForm.partial.html
+++ b/awx/ui/client/src/scheduler/schedulerForm.partial.html
@@ -630,14 +630,14 @@
                 SchedulerFormDetail-occurrenceList"
                 ng-show="dateChoice == 'utc'">
                 <li ng-repeat="occurrence in preview_list.utc">
-                    {{ occurrence | date:'MM-dd-yyyy HH:mm:ss'}} UTC
+                    {{ occurrence }} UTC
                 </li>
             </ul>
             <ul class="occurrence-list mono-space
                 SchedulerFormDetail-occurrenceList"
                 ng-show="dateChoice == 'local'">
                 <li ng-repeat="occurrence in preview_list.local">
-                    {{ occurrence | date:'MM-dd-yyyy HH:mm:ss'}}
+                    {{ occurrence }}
                 </li>
             </ul>
 

--- a/awx/ui/client/src/scheduler/schedulerForm.partial.html
+++ b/awx/ui/client/src/scheduler/schedulerForm.partial.html
@@ -28,12 +28,6 @@
                     name="schedulerName"
                     id="schedulerName"
                     ng-model="schedulerName" required
-                    ng-model-options="{
-                        'updateOn': 'default blur',
-                        'debounce': {
-                        'default': 300,
-                        'blur': 0
-                    }}"
                     ng-disabled="!(schedule_obj.summary_fields.user_capabilities.edit || canAdd)"
                     placeholder="Schedule name">
                 <div class="error"

--- a/awx/ui/client/src/scheduler/schedulerForm.partial.html
+++ b/awx/ui/client/src/scheduler/schedulerForm.partial.html
@@ -28,6 +28,12 @@
                     name="schedulerName"
                     id="schedulerName"
                     ng-model="schedulerName" required
+                    ng-model-options="{
+                        'updateOn': 'default blur',
+                        'debounce': {
+                        'default': 300,
+                        'blur': 0
+                    }}"
                     ng-disabled="!(schedule_obj.summary_fields.user_capabilities.edit || canAdd)"
                     placeholder="Schedule name">
                 <div class="error"
@@ -578,7 +584,7 @@
             </p>
         </div>
         <div class="SchedulerFormDetail-container"
-            ng-show="schedulerIsValid">
+            ng-show="schedulerIsValid &&  !preview_list.isEmpty">
             <label class="SchedulerFormDetail-label">
                 Schedule Description
             </label>
@@ -623,15 +629,15 @@
             <ul class="occurrence-list mono-space
                 SchedulerFormDetail-occurrenceList"
                 ng-show="dateChoice == 'utc'">
-                <li ng-repeat="occurrence in occurrence_list">
-                    {{ occurrence.utc }}
+                <li ng-repeat="occurrence in preview_list.utc">
+                    {{ occurrence | date:'MM-dd-yyyy HH:mm:ss'}} UTC
                 </li>
             </ul>
             <ul class="occurrence-list mono-space
                 SchedulerFormDetail-occurrenceList"
                 ng-show="dateChoice == 'local'">
-                <li ng-repeat="occurrence in occurrence_list">
-                    {{ occurrence.local }}
+                <li ng-repeat="occurrence in preview_list.local">
+                    {{ occurrence | date:'MM-dd-yyyy HH:mm:ss'}}
                 </li>
             </ul>
 


### PR DESCRIPTION
##### SUMMARY
This commit contains changes in how we are sending the schedule rrule string to the API.
* We are now including the local timezone information `TZID=NNNNN` in the rrule string. 
* The UI POSTs an rrule to a new endpoint `/api/v2/schedules/preview/`, and it returns the next 10 occurrences in local and UTC time.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION
see: https://github.com/ansible/ansible-tower/issues/823
