### PR TITLE
Update standalone.yml

### DIFF
--- a/installer/local_docker/tasks/standalone.yml
+++ b/installer/local_docker/tasks/standalone.yml
@@ -116,7 +116,7 @@
     volumes: "{{ project_data_dir + ':/var/lib/awx/projects:rw' if project_data_dir is defined else omit }}"
     links: "{{ awx_task_container_links|list }}"
     user: root
-    hostname: awx
+    hostname: "{{ ansible_hostname | default('awx') }}"
     dns_search_domains: "{{ awx_container_search_domains.split(',') if awx_container_search_domains is defined else omit }}"
     dns_servers: "{{ awx_alternate_dns_servers.split(',') if awx_alternate_dns_servers is defined else omit }}"
     env:


### PR DESCRIPTION
Updated Hostname in AWX Task Container to use hostname of machine instead of default 'awx'. With default still set to 'awx' if not provided.

Should be configurable in "inventory" file.

##### SUMMARY
When you have more than one instance. It will default the first instance to 'awx' as its name. Instead of letting the users configure it or it using the hostname by default. This is something that should be defaulted to machine name or be able to be changed in the inventory file.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer