### PR TITLE
Raise 400 error on removal of credential on launch

### DIFF
--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -2884,6 +2884,7 @@ class JobTemplateLaunch(RetrieveAPIView):
         ):
             # make a list of the current credentials
             existing_credentials = obj.credentials.all()
+            template_credentials = list(existing_credentials)  # save copy of existing
             new_credentials = []
             for key, conditional in (
                 ('credential', lambda cred: cred.credential_type.kind != 'ssh'),
@@ -2910,6 +2911,11 @@ class JobTemplateLaunch(RetrieveAPIView):
             # combine the list of "new" and the filtered list of "old"
             new_credentials.extend([cred.pk for cred in existing_credentials])
             if new_credentials:
+                # If provided list doesn't contain the pre-existing credentials
+                # defined on the template, add them back here
+                for cred_obj in template_credentials:
+                    if cred_obj.pk not in new_credentials:
+                        new_credentials.append(cred_obj.pk)
                 modern_data['credentials'] = new_credentials
 
         # credential passwords were historically provided as top-level attributes


### PR DESCRIPTION
Primary tracking issue for this is in #932

This change doesn't actually change what the user can do, but it enforces a more restrictive format for the API contract.

Previous behavior:

```json
{
  "credentials": []
}
```

This meant "launch the JT with the existing credentials". I completely see how this is confusing API behavior.

New behavior

```json
{
  "credentials": []
}
```

Means "launch the JT with exactly no credentials". If it launches, then the job which is spawned will have no related credentials. This is not always possible. If the JT has credentials, then we will still not remove them. In that case, a 400 error will be raised.

I have tried to add some polish to those error messages.

Example:

```json
{
    "credentials": [
        "Cannot assign multiple Vault (id=alan) credentials.",
        "Removing Machine credential without replacement is not supported. Provided list lacked credential(s): mikasa-2."
    ]
}
```

I caused 2 credential-related error simultaneously.

The JT had credentials `[2]` and I launched, providing credentials `[11, 12]`. The two that I provided were of the same type (not allowed), and I did not provide any of the type of credential pk=2 (also not allowed).

I hope this will make the API better self-documenting and reduce surprises.