### PR TITLE
Switch nginx worker process to auto

### DIFF
--- a/installer/image_build/files/nginx.conf
+++ b/installer/image_build/files/nginx.conf
@@ -1,6 +1,6 @@
 #user awx;
 
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /dev/stdout warn;
 pid        /tmp/nginx.pid;


### PR DESCRIPTION
This uses some internal logic from nginx to determine the optimal
number of worker processes given the available number of cores (and
some other details).

This might help busier systems.
