### PR TITLE
add import_playbook as a top-level playbook indicator

### DIFF
--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -13,7 +13,7 @@ from django.utils.encoding import smart_str
 __all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory']
 
 
-valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|include):\s*?.*?$')
+valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$')
 valid_inventory_re = re.compile(r'^[a-zA-Z0-9_.=\[\]]')
 
 


### PR DESCRIPTION
##### SUMMARY
Adds `import_playbook`, in addition to those that contain `hosts` and `includes`, to the list of potential top-level playbooks available for selection in the Templates UI. 

related https://github.com/ansible/awx/issues/544

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.3.59
```

##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
playbook selector for Templates included playbooks that contain 'import_playbook'
```
