### PR TITLE
adding functionality for breadcrumb

### DIFF
--- a/awx/ui/client/src/network-ui/models.js
+++ b/awx/ui/client/src/network-ui/models.js
@@ -661,6 +661,29 @@ Group.prototype.update_membership = function (devices, groups) {
     return [old_devices, this.devices, device_ids, old_groups, this.groups, group_ids];
 };
 
+Group.prototype.is_in_breadcrumb = function(viewport){
+    var groupY1 = this.top_extent();
+    var groupX1 = this.left_extent();
+    var groupY2 = this.bottom_extent();
+    var groupX2 = this.right_extent();
+
+    var viewportY1 = viewport.top_extent();
+    var viewportX1 = viewport.left_extent();
+    var viewportY2 = viewport.bottom_extent();
+    var viewportX2 = viewport.right_extent();
+
+    if ( viewportX1 > groupX1 &&
+            viewportY1 > groupY1 &&
+                viewportX2 < groupX2 &&
+                    viewportY2 < groupY2) {
+                        this.on_screen = true;
+                        return true;
+    } else {
+        this.on_screen = false;
+        return false;
+    }
+};
+
 
 function ToolBox(id, name, type, x, y, width, height) {
     this.id = id;

--- a/awx/ui/client/src/network-ui/models.js
+++ b/awx/ui/client/src/network-ui/models.js
@@ -672,12 +672,12 @@ Group.prototype.is_in_breadcrumb = function(viewport){
     var viewportY2 = viewport.bottom_extent();
     var viewportX2 = viewport.right_extent();
 
-    if ( viewportX1 > groupX1 &&
-            viewportY1 > groupY1 &&
-                viewportX2 < groupX2 &&
-                    viewportY2 < groupY2) {
-                        this.on_screen = true;
-                        return true;
+    if (viewportX1 > groupX1 &&
+        viewportY1 > groupY1 &&
+        viewportX2 < groupX2 &&
+        viewportY2 < groupY2) {
+            this.on_screen = true;
+            return true;
     } else {
         this.on_screen = false;
         return false;

--- a/awx/ui/client/src/network-ui/network-nav/network.nav.block.less
+++ b/awx/ui/client/src/network-ui/network-nav/network.nav.block.less
@@ -105,9 +105,12 @@
     padding-left:20px;
 }
 
+.Networking-breadCrumbBarItem{
+    margin: 0px;
+    padding-left:0px;
+}
+
 .Networking-breadCrumbText{
-    color:@default-link;
-    text-transform: uppercase;
     font-size: 14px;
 }
 

--- a/awx/ui/client/src/network-ui/network-nav/network.nav.controller.js
+++ b/awx/ui/client/src/network-ui/network-nav/network.nav.controller.js
@@ -14,6 +14,7 @@ function NetworkingController (models, $state, $scope, strings, CreateSelect2) {
     vm.leftPanelIsExpanded = true;
     vm.jumpToPanelExpanded = false;
     vm.keyPanelExpanded = false;
+    vm.groups = [];
     $scope.devices = [];
     vm.close = () => {
         $state.go('inventories');
@@ -41,6 +42,10 @@ function NetworkingController (models, $state, $scope, strings, CreateSelect2) {
 
     $scope.$on('overall_toolbox_collapsed', () => {
         vm.leftPanelIsExpanded = !vm.leftPanelIsExpanded;
+    });
+
+    $scope.$on('awxNet-breadcrumbGroups', (e, groups) => {
+        vm.breadcrumb_groups = _.sortBy(groups, 'distance').reverse();
     });
 
     $scope.$on('instatiateSelect', (e, devices) => {

--- a/awx/ui/client/src/network-ui/network-nav/network.nav.view.html
+++ b/awx/ui/client/src/network-ui/network-nav/network.nav.view.html
@@ -117,10 +117,14 @@
             </div>
         </div>
         <div class="Networking-toolbar Networking-breadCrumbBar">
-            <div class="Networking-breadCrumbText">Foo </div><div class="Networking-breadCrumbSlash">/</div>
-            <div class="Networking-breadCrumbText">Bar </div><div class="Networking-breadCrumbSlash">/</div>
-            <div class="Networking-breadCrumbText">Bread </div><div class="Networking-breadCrumbSlash">/</div>
-            <div class="Networking-breadCrumbText Networking-breadCrumbText--last">crumb</div>
+            <ol class="Networking-breadCrumbBarItem">
+                <li class="BreadCrumb-item Networking-breadCrumbText" ng-repeat="group in vm.breadcrumb_groups | limitTo:(vm.breadcrumb_groups.length-1)">
+                    <span>{{group.name}}</span>
+                </li>
+                <li class="BreadCrumb-item Networking-breadCrumbText" ng-repeat="group in vm.breadcrumb_groups | limitTo:-1" class="active">
+                    <span>{{group.name}}</span>
+                </li>
+            </ol>
         </div>
 
     </div>

--- a/awx/ui/client/src/network-ui/network.ui.controller.js
+++ b/awx/ui/client/src/network-ui/network.ui.controller.js
@@ -132,7 +132,40 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
   $scope.view_port = {'x': 0,
                       'y': 0,
                       'width': 0,
-                      'height': 0};
+                      'height': 0,
+                      top_extent: function (scaledY) {
+                          this.x1 = this.x;
+                          this.x2 = this.x + this.width;
+                          this.y1 = this.y;
+                          this.y2 = this.y + this.height;
+                          var y2 = this.y2 !== null ? this.y2 : scaledY;
+                          return (this.y1 < y2? this.y1 : y2);
+                      },
+                      left_extent: function (scaledX) {
+                          this.x1 = this.x;
+                          this.x2 = this.x + this.width;
+                          this.y1 = this.y;
+                          this.y2 = this.y + this.height;
+                          var x2 = this.x2 !== null ? this.x2 : scaledX;
+                          return (this.x1 < x2? this.x1 : x2);
+                      },
+                      bottom_extent: function (scaledY) {
+                          this.x1 = this.x;
+                          this.x2 = this.x + this.width;
+                          this.y1 = this.y;
+                          this.y2 = this.y + this.height;
+                          var y2 = this.y2 !== null ? this.y2 : scaledY;
+                          return (this.y1 > y2? this.y1 : y2);
+                      },
+                      right_extent: function (scaledX) {
+                          this.x1 = this.x;
+                          this.x2 = this.x + this.width;
+                          this.y1 = this.y;
+                          this.y2 = this.y + this.height;
+                          var x2 = this.x2 !== null ? this.x2 : scaledX;
+                          return (this.x1 > x2? this.x1 : x2);
+                      }
+                  };
   $scope.trace_id_seq = util.natural_numbers(0);
   $scope.trace_order_seq = util.natural_numbers(0);
   $scope.trace_id = $scope.trace_id_seq();
@@ -1208,6 +1241,18 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
         $scope.groups.push(group);
     };
 
+    $scope.breadcrumbGroups = function(){
+        let breadcrumbGroups = [];
+        for(var i = 0; i < $scope.groups.length; i++){
+            let group = $scope.groups[i];
+            if(group.is_in_breadcrumb($scope.view_port)){
+                group.distance = util.distance(group.x1, group.y1, group.x2, group.y2);
+                breadcrumbGroups.push(group);
+            }
+        }
+        return breadcrumbGroups;
+    };
+
     $scope.forDevice = function(device_id, data, fn) {
         var i = 0;
         for (i = 0; i < $scope.devices.length; i++) {
@@ -1418,7 +1463,6 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
             }
         }
     };
-
 
     $scope.onGroupLabelEdit = function(data) {
         $scope.edit_group_label(data);
@@ -1814,6 +1858,7 @@ var NetworkUIController = function($scope, $document, $location, $window, $http,
 
         $scope.updateInterfaceDots();
         $scope.$emit('instatiateSelect', $scope.devices);
+        $scope.$emit('awxNet-breadcrumbGroups', $scope.breadcrumbGroups());
     };
 
     $scope.updateInterfaceDots = function() {

--- a/awx/ui/client/src/network-ui/view.fsm.js
+++ b/awx/ui/client/src/network-ui/view.fsm.js
@@ -83,6 +83,7 @@ _Scale.prototype.onMouseWheel = function (controller, msg_type, message) {
       var item = controller.scope.context_menus[0];
       item.enabled = false;
       controller.scope.$emit('awxNet-UpdateZoomWidget', controller.scope.current_scale, true);
+      controller.scope.$emit('awxNet-breadcrumbGroups', controller.scope.breadcrumbGroups());
       controller.scope.updatePanAndScale();
       controller.changeState(Ready);
 };


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds the functionality for the breadcrumb to the Network UI. The idea is that when the user zooms in on a group, when the bounds of the group's square become greater than the viewport, then the title of the group will be shown in the breadcrumb. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

![breadcrumb](https://user-images.githubusercontent.com/7010629/36498129-3ca445be-16f2-11e8-9d8f-c61e2461524c.gif)
