### PR TITLE
Fix missing controller error within projects.edit.templates

### DIFF
--- a/awx/ui/client/features/templates/index.js
+++ b/awx/ui/client/features/templates/index.js
@@ -1,11 +1,11 @@
 import TemplatesStrings from './templates.strings';
-import ListController from './list-templates.controller';
+import TemplatesListController from './list-templates.controller';
 
 const MODULE_NAME = 'at.features.templates';
 
 angular
     .module(MODULE_NAME, [])
-    .controller('ListController', ListController)
+    .controller('TemplatesListController', TemplatesListController)
     .service('TemplatesStrings', TemplatesStrings);
 
 export default MODULE_NAME;

--- a/awx/ui/client/features/templates/list-templates.controller.js
+++ b/awx/ui/client/features/templates/list-templates.controller.js
@@ -38,6 +38,10 @@ function ListTemplatesController(
     $scope.canAddWorkflowJobTemplate = workflowTemplate.options('actions.POST')
     $scope.canAdd = ($scope.canAddJobTemplate || $scope.canAddWorkflowJobTemplate);
 
+    if($state.$current.name !== 'projects.edit.templates') {
+        $scope.standAlone = $state.$current.name !== 'projects.edit.templates';
+    }
+
     // smart-search
     const name = 'templates';
     const iterator = 'template';

--- a/awx/ui/client/features/templates/list.route.js
+++ b/awx/ui/client/features/templates/list.route.js
@@ -1,4 +1,3 @@
-import ListController from './list-templates.controller';
 const listTemplate = require('~features/templates/list.view.html');
 import { N_ } from '../../src/i18n';
 
@@ -33,7 +32,7 @@ export default {
     searchPrefix: 'template',
     views: {
         '@': {
-            controller: ListController,
+            controller: 'TemplatesListController',
             templateUrl: listTemplate,
             controllerAs: 'vm',
         }

--- a/awx/ui/client/features/templates/list.view.html
+++ b/awx/ui/client/features/templates/list.view.html
@@ -1,13 +1,22 @@
 <div ui-view="form"></div>
-<at-panel>
-    <at-panel-heading hide-dismiss="true">
+<div id="relatedList" conditional-attributes="{'at-panel' : standAlone}">
+    <div ng-if="standAlone" conditional-attributes="{ 'at-panel-heading' : standAlone }" hide-dismiss="true">
         {{:: vm.strings.get('list.PANEL_TITLE') }}
         <div class="at-Panel-headingTitleBadge" ng-show="template_dataset.count">
             {{ template_dataset.count }}
         </div>
-    </at-panel-heading>
+    </div>
 
-    <at-panel-body>
+    <div ng-if="!standAlone">
+        <h5>
+            {{:: vm.strings.get('list.PANEL_TITLE') }}
+            <div class="at-Panel-headingTitleBadge" ng-show="template_dataset.count">
+                {{ template_dataset.count }}
+            </div>
+        </h5>
+    </div>
+
+    <div conditional-attributes="{ 'at-panel-body': standAlone }">
         <div class="at-List-toolbar">
             <smart-search
                 class="at-List-search"
@@ -37,7 +46,7 @@
                             {{:: vm.strings.get('list.ADD_DD_JT_LABEL') }}
                         </a>
                     </li>
-                    <li>
+                    <li ng-if="standAlone">
                         <a ui-sref="templates.addWorkflowJobTemplate">
                             {{:: vm.strings.get('list.ADD_DD_WF_LABEL') }}
                         </a>
@@ -117,6 +126,6 @@
             base-path="unified_job_templates"
             query-set="querySet">
         </paginate>
-    </at-panel-body>
+    </div>
     <prompt prompt-data="promptData" open-modal="openModal" on-finish="launchJob()"></launch>
-</at-panel>
+    </div>

--- a/awx/ui/client/features/templates/list.view.html
+++ b/awx/ui/client/features/templates/list.view.html
@@ -18,27 +18,15 @@
 
     <div conditional-attributes="{ 'at-panel-body': standAlone }">
         <div class="at-List-toolbar">
-            <smart-search
-                class="at-List-search"
-                django-model="templates"
-                base-path="unified_job_templates"
-                iterator="template"
-                list="list"
-                dataset="template_dataset"
-                collection="collection"
-                search-tags="searchTags"
-                query-set="querySet">
+            <smart-search class="at-List-search" django-model="templates" base-path="unified_job_templates" iterator="template" list="list"
+                dataset="template_dataset" collection="collection" search-tags="searchTags" query-set="querySet">
             </smart-search>
             <div class="at-List-toolbarAction" ng-show="canAdd">
-                <button
-                    type="button"
-                    class="at-List-toolbarActionButton at-Button--success"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
+                <button type="button" class="at-List-toolbarActionButton at-Button--success" data-toggle="dropdown" aria-haspopup="true"
                     aria-expanded="false">
-                        &#43; {{:: vm.strings.get('list.ADD_BUTTON_LABEL') }}
-                        <span class="at-List-toolbarDropdownCarat"></span>
-                        <span class="sr-only">Toggle Dropdown</span>
+                    &#43; {{:: vm.strings.get('list.ADD_BUTTON_LABEL') }}
+                    <span class="at-List-toolbarDropdownCarat"></span>
+                    <span class="sr-only">Toggle Dropdown</span>
                 </button>
                 <ul class="dropdown-menu at-List-toolbarActionDropdownMenu">
                     <li>
@@ -56,76 +44,48 @@
         </div>
         <at-list results="templates">
             <!-- TODO: implement resources are missing red indicator as present in mockup -->
-            <at-row ng-repeat="template in templates"
-                ng-class="{'at-Row--active': (template.id === vm.activeId)}"
-                template-id="{{ template.id }}">
+            <at-row ng-repeat="template in templates" ng-class="{'at-Row--active': (template.id === vm.activeId)}" template-id="{{ template.id }}">
                 <div class="at-Row-items">
-                    <at-row-item
-                        header-value="{{ template.name }}"
-                        header-link="/#/templates/job_template/{{ template.id }}"
-                        header-tag="{{ vm.templateTypes[template.type] }}"
+                    <at-row-item header-value="{{ template.name }}" header-link="/#/templates/job_template/{{ template.id }}" header-tag="{{ vm.templateTypes[template.type] }}"
                         ng-if="template.type === 'job_template'">
                     </at-row-item>
-                    <at-row-item
-                        header-value="{{ template.name }}"
-                        header-link="/#/templates/workflow_job_template/{{ template.id }}"
-                        header-tag="{{ vm.templateTypes[template.type] }}"
+                    <at-row-item header-value="{{ template.name }}" header-link="/#/templates/workflow_job_template/{{ template.id }}" header-tag="{{ vm.templateTypes[template.type] }}"
                         ng-if="template.type === 'workflow_job_template'">
                     </at-row-item>
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_ACTIVITY') }}"
-                        smart-status="template">
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_ACTIVITY') }}" smart-status="template">
                     </at-row-item>
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_INVENTORY') }}"
-                        value="{{ template.summary_fields.inventory.name }}"
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_INVENTORY') }}" value="{{ template.summary_fields.inventory.name }}"
                         value-link="/#/inventories/inventory/{{ template.summary_fields.inventory.id }}">
                     </at-row-item>
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_PROJECT') }}"
-                        value="{{ template.summary_fields.project.name }}"
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_PROJECT') }}" value="{{ template.summary_fields.project.name }}"
                         value-link="/#/projects/{{ template.summary_fields.project.id }}">
                     </at-row-item>
                     <!-- TODO: add see more for creds -->
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_CREDENTIALS') }}"
-                        tag-values="template.summary_fields.credentials"
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_CREDENTIALS') }}" tag-values="template.summary_fields.credentials"
                         tags-are-creds="true">
                     </at-row-item>
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_MODIFIED') }}"
-                        value="{{ vm.getModified(template) }}">
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_MODIFIED') }}" value="{{ vm.getModified(template) }}">
                     </at-row-item>
-                    <at-row-item
-                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_RAN') }}"
-                        value="{{ vm.getLastRan(template) }}">
+                    <at-row-item label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_RAN') }}" value="{{ vm.getLastRan(template) }}">
                     </at-row-item>
                     <labels-list class="LabelList" show-delete="false" is-row-item="true">
                     </labels-list>
                 </div>
                 <div class="at-Row-actions">
-                    <at-row-action icon="icon-launch" ng-click="vm.runTemplate(template)"
-                        ng-show="template.summary_fields.user_capabilities.start">
+                    <at-row-action icon="icon-launch" ng-click="vm.runTemplate(template)" ng-show="template.summary_fields.user_capabilities.start">
                     </at-row-action>
-                    <at-row-action icon="fa-calendar" ng-click="vm.scheduleTemplate(template)"
-                        ng-show="template.summary_fields.user_capabilities.schedule">
+                    <at-row-action icon="fa-calendar" ng-click="vm.scheduleTemplate(template)" ng-show="template.summary_fields.user_capabilities.schedule">
                     </at-row-action>
-                    <at-row-action icon="fa-copy" ng-click="vm.copyTemplate(template)"
-                        ng-show="template.summary_fields.user_capabilities.copy">
+                    <at-row-action icon="fa-copy" ng-click="vm.copyTemplate(template)" ng-show="template.summary_fields.user_capabilities.copy">
                     </at-row-action>
-                    <at-row-action icon="fa-trash" ng-click="vm.deleteTemplate(template)"
-                        ng-show="template.summary_fields.user_capabilities.delete">
+                    <at-row-action icon="fa-trash" ng-click="vm.deleteTemplate(template)" ng-show="template.summary_fields.user_capabilities.delete">
                     </at-row-action>
                 </div>
             </at-row>
         </at-list>
-        <paginate
-            collection="collection"
-            dataset="template_dataset"
-            iterator="template"
-            base-path="unified_job_templates"
-            query-set="querySet">
+        <paginate collection="collection" dataset="template_dataset" iterator="template" base-path="unified_job_templates" query-set="querySet">
         </paginate>
     </div>
-    <prompt prompt-data="promptData" open-modal="openModal" on-finish="launchJob()"></launch>
-    </div>
+    <prompt prompt-data="promptData" open-modal="openModal" on-finish="launchJob()">
+        </launch>
+</div>

--- a/awx/ui/client/lib/components/index.js
+++ b/awx/ui/client/lib/components/index.js
@@ -36,6 +36,7 @@ import relaunch from '~components/relaunchButton/relaunchButton.component';
 
 import BaseInputController from '~components/input/base.controller';
 import ComponentsStrings from '~components/components.strings';
+import conditionalAttributes from '~components/utility/conditional-attributes.directive';
 
 const MODULE_NAME = 'at.lib.components';
 
@@ -76,6 +77,7 @@ angular
     .directive('atTopNavItem', topNavItem)
     .directive('atTruncate', truncate)
     .component('atRelaunch', relaunch)
+    .directive('conditionalAttributes', conditionalAttributes)
     .service('BaseInputController', BaseInputController)
     .service('ComponentsStrings', ComponentsStrings);
 

--- a/awx/ui/client/lib/components/panel/body.directive.js
+++ b/awx/ui/client/lib/components/panel/body.directive.js
@@ -2,7 +2,7 @@ const templateUrl = require('~components/panel/body.partial.html');
 
 function atPanelBody () {
     return {
-        restrict: 'E',
+        restrict: 'EA',
         replace: true,
         transclude: true,
         templateUrl,

--- a/awx/ui/client/lib/components/panel/heading.directive.js
+++ b/awx/ui/client/lib/components/panel/heading.directive.js
@@ -7,7 +7,7 @@ function link (scope, el, attrs, panel) {
 
 function atPanelHeading () {
     return {
-        restrict: 'E',
+        restrict: 'EA',
         require: '^^atPanel',
         replace: true,
         transclude: true,

--- a/awx/ui/client/lib/components/panel/panel.directive.js
+++ b/awx/ui/client/lib/components/panel/panel.directive.js
@@ -2,7 +2,6 @@ const templateUrl = require('~components/panel/panel.partial.html');
 
 function atPanelLink (scope, el, attrs, controller) {
     const panelController = controller;
-
     panelController.init(scope);
 }
 
@@ -28,7 +27,7 @@ AtPanelController.$inject = ['$state'];
 
 function atPanel () {
     return {
-        restrict: 'E',
+        restrict: 'EA',
         replace: true,
         require: 'atPanel',
         transclude: true,

--- a/awx/ui/client/lib/components/utility/conditional-attributes.directive.js
+++ b/awx/ui/client/lib/components/utility/conditional-attributes.directive.js
@@ -1,43 +1,29 @@
-function conditionalAttributesLink(scope, el, attrs, controller) {
-    console.log(scope);
-}
-
 let compileLoopControl = 0;
 
-function conditionalAttributes($compile) {
+function conditionalAttributes ($compile) {
     return {
         priority: 100,
         terminal: true,
-        compile: function () {
-            return {
-                pre: function (scope, element, attr) {
-                    let directives = scope.$eval(attr.conditionalAttributes);
-                    compileLoopControl++;
-
-                    if (compileLoopControl >= 10) {
-                        return;
-                    }
-
-                    for (var key in directives) {
-                        if (directives.hasOwnProperty(key)) {
-                            if (directives[key]) {
-                                attr.$set(key, true);
-                            } else {
-                                attr.$set(key, null);
-                            }
-                        }
-                    }
-
-                    attr.$set('conditionalAttributes', null);
-                    $compile(element)(scope);
-                    compileLoopControl = 0;
-
+        compile: () => ({
+            pre: (scope, element, attr) => {
+                const directives = scope.$eval(attr.conditionalAttributes);
+                compileLoopControl++;
+                if (compileLoopControl >= 10) {
+                    return;
                 }
+                Object.keys(directives).forEach((key) => {
+                    if (directives[key]) {
+                        attr.$set(key, true);
+                    } else {
+                        attr.$set(key, null);
+                    }
+                });
+                attr.$set('conditionalAttributes', null);
+                $compile(element)(scope);
+                compileLoopControl = 0;
             }
-        }
+        })
     };
 }
-
-conditionalAttributes.$inject = ['$compile']
-
+conditionalAttributes.$inject = ['$compile'];
 export default conditionalAttributes;

--- a/awx/ui/client/lib/components/utility/conditional-attributes.directive.js
+++ b/awx/ui/client/lib/components/utility/conditional-attributes.directive.js
@@ -1,0 +1,43 @@
+function conditionalAttributesLink(scope, el, attrs, controller) {
+    console.log(scope);
+}
+
+let compileLoopControl = 0;
+
+function conditionalAttributes($compile) {
+    return {
+        priority: 100,
+        terminal: true,
+        compile: function () {
+            return {
+                pre: function (scope, element, attr) {
+                    let directives = scope.$eval(attr.conditionalAttributes);
+                    compileLoopControl++;
+
+                    if (compileLoopControl >= 10) {
+                        return;
+                    }
+
+                    for (var key in directives) {
+                        if (directives.hasOwnProperty(key)) {
+                            if (directives[key]) {
+                                attr.$set(key, true);
+                            } else {
+                                attr.$set(key, null);
+                            }
+                        }
+                    }
+
+                    attr.$set('conditionalAttributes', null);
+                    $compile(element)(scope);
+                    compileLoopControl = 0;
+
+                }
+            }
+        }
+    };
+}
+
+conditionalAttributes.$inject = ['$compile']
+
+export default conditionalAttributes;

--- a/awx/ui/client/src/projects/main.js
+++ b/awx/ui/client/src/projects/main.js
@@ -15,12 +15,14 @@ import GetProjectIcon from './factories/get-project-icon.factory';
 import GetProjectToolTip from './factories/get-project-tool-tip.factory';
 import ProjectsTemplatesRoute from './projects-templates.route';
 import ProjectsStrings from './projects.strings';
+import ProjectTemplatesListController from '~features/templates/list-templates.controller';
 
 export default
 angular.module('Projects', [])
     .controller('ProjectsList', ProjectsList)
     .controller('ProjectsAdd', ProjectsAdd)
     .controller('ProjectsEdit', ProjectsEdit)
+    .controller('ProjectTemplatesListController', ProjectTemplatesListController)
     .factory('GetProjectPath', GetProjectPath)
     .factory('GetProjectIcon', GetProjectIcon)
     .factory('GetProjectToolTip', GetProjectToolTip)

--- a/awx/ui/client/src/projects/projects-templates.route.js
+++ b/awx/ui/client/src/projects/projects-templates.route.js
@@ -1,4 +1,5 @@
 import { N_ } from '../i18n';
+const listTemplate = require('~features/templates/list.view.html');
 
 export default {
     url: "/templates",
@@ -16,24 +17,24 @@ export default {
         label: N_("JOB TEMPLATES")
     },
     views: {
-        // TODO: this controller was removed and replaced
-        // with the new features/templates controller
-        // this view should be updated with the new
-        // expanded list
         'related': {
-            templateProvider: function(FormDefinition, GenerateForm) {
-                let html = GenerateForm.buildCollection({
-                    mode: 'edit',
-                    related: 'templates',
-                    form: typeof(FormDefinition) === 'function' ?
-                        FormDefinition() : FormDefinition
-                });
-                return html;
-            },
-            controller: 'TemplatesListController'
+            controller: 'ProjectTemplatesListController',
+            templateUrl: listTemplate,
+            controllerAs: 'vm',
         }
     },
     resolve: {
+        resolvedModels: [
+            'JobTemplateModel',
+            'WorkflowJobTemplateModel',
+            (JobTemplate, WorkflowJobTemplate) => {
+                const models = [
+                    new JobTemplate(['options']),
+                    new WorkflowJobTemplate(['options']),
+                ];
+                return Promise.all(models);
+            },
+        ],
         ListDefinition: ['TemplateList', '$transition$', (TemplateList, $transition$) => {
             let id = $transition$.params().project_id;
             TemplateList.actions.add.ngClick = `$state.go('templates.addJobTemplate', {project_id: ${id}})`;

--- a/awx/ui/client/src/shared/paginate/paginate.controller.js
+++ b/awx/ui/client/src/shared/paginate/paginate.controller.js
@@ -66,16 +66,8 @@ export default ['$scope', '$stateParams', '$state', '$filter', 'GetBasePath', 'Q
             if(!$scope.querySet) {
                 $state.go('.', {
                     [$scope.iterator + '_search']: queryset
-                }, {notify: false});
+                }, {notify: false, reload: true});
             }
-            qs.search(path, queryset).then((res) => {
-                if($scope.querySet) {
-                    // Update the query set
-                    $scope.querySet = queryset;
-                }
-                $scope.dataset = res.data;
-                $scope.collection = res.data.results;
-            });
         };
 
         function calcLast() {


### PR DESCRIPTION
related #960

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This commit fixes #960 by:
- Defining TemplatesListController for the projects.edit.templates view 
- Defining resolve.resolvedModels within the project-templates route
It also implements the new, expanded view as there was a TODO 
for that within the code. The route now uses the 
awx/ui/client/features/templates/list.view.html file as the 
view template.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.4.8
```
