### PR TITLE
Bump angular-scheduler version to 0.3.2

### DIFF
--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -102,7 +102,7 @@
     "angular-md5": "^0.1.8",
     "angular-moment": "^0.10.1",
     "angular-sanitize": "~1.6.6",
-    "angular-scheduler": "git+https://git@github.com/ansible/angular-scheduler#v0.3.1",
+    "angular-scheduler": "git+https://git@github.com/ansible/angular-scheduler#v0.3.2",
     "angular-tz-extensions": "git+https://git@github.com/ansible/angular-tz-extensions#v0.5.1",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^3.3.7",


### PR DESCRIPTION
##### SUMMARY
Update Angular-Scheduler dependency version to 0.3.2 

Issues:
https://github.com/ansible/awx/issues/1326
https://github.com/ansible/awx/issues/1324

##### ISSUE TYPE
 - Bugfix Pull Request

##### ADDITIONAL INFORMATION
Connect: https://github.com/ansible/awx/pull/1231
