### PR TITLE
[Proof of Principle] Allow consumption of vaulted hostvars

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -790,10 +790,11 @@ class BaseTask(LogErrorsTask):
         return False
 
     def build_inventory(self, instance, **kwargs):
-        json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
+        # json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
+        yaml_data = yaml.dump(instance.inventory.get_script_data(hostvars=True), default_flow_style=False)
         handle, path = tempfile.mkstemp(dir=kwargs.get('private_data_dir', None))
         f = os.fdopen(handle, 'w')
-        f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint %r\n' % json_data)
+        f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint %r\n' % yaml_data)
         f.close()
         os.chmod(path, stat.S_IRUSR | stat.S_IXUSR | stat.S_IWUSR)
         return path


### PR DESCRIPTION
This implements an example which is detailed here:

https://github.com/AlanCoding/Ansible-inventory-file-examples/tree/master/scripts/vault

and this implementation makes that example run fully inside of AWX.

Previously, based on several conversations I have been having, this was not believed to be possible. This PR proves conclusively that it is possible.

This directly solves #1317 @wenottingham on what you were saying

> If we support vaulted individual variables in host/group vars, we may allow for editing those. But not vaulted files in projects.

That was not possible, this is needed to make it work. Disclaimer is that you can't do it in the UI, it still breaks some other stuff, etc.

This also just "happens" to solve #991 

The real reason for doing this, however, is #223. This is still not a fully implementation, however. The reason is that there's no way for us to get the vaulted data in using `ansible-inventory`. This proof-of-principle is my justification for subsequently filing a feature request of Ansible core to add an `ansible-inventory` option to delay decryption. This will make the SCM inventory feature substantially better, by blowing through all vault technicalities on update, and allowing decryption via JT `credentials`. Again, we still need a new feature from Ansible core to do this, but provided we can get this, we have a solution far superior to the alternatives.

### How to use

You need basic required resources:

 - single variable data encrypted by `ansible-vault` (see example)
 - vault credential corresponding to your encrypted data
 - inventory / host / job template / vault credential attached, etc
 
Go to the host in the API

PATCH

```json
{
    "variables": "connection: local\nshould_be_artemis_here: !vault |\n          $ANSIBLE_VAULT;1.2;AES256;alan\n          33343133656536356166303131613166626361303662396435326663613636336561636533396138\n          3636626133333136313935376362326462363862316230660a646363393535366430333033336131\n          35333237616137383462626232656639386265316239643634663134383265646532623463633662\n          6435343233666431360a323466616465366439343963333839396538386431646163353763333762\n          6131"
}
```

The variables here are being treated as a simple text field, which is what we need.

Launch the job with a JT that debugs hostvars.

Now bask in the glory of your decrypted secrets.

![screen shot 2018-02-23 at 12 01 17 pm](https://user-images.githubusercontent.com/1385596/36606857-ee8a004c-1892-11e8-9547-cb0f42bb6822.png)

The example's secret is "artemis" above.