### PR TITLE
ui tooling fixes / updates for oauth changes

### DIFF
--- a/awx/ui/build/webpack.watch.js
+++ b/awx/ui/build/webpack.watch.js
@@ -52,7 +52,7 @@ const watch = {
         publicPath: '/static/',
         host: '127.0.0.1',
         port: 3000,
-        https: true
+        https: true,
         proxy: {
             '/': {
                 target: TARGET,


### PR DESCRIPTION
##### SUMMARY
- fix npm watch script (missing comma syntax error when trying to run)
- use basic auth by default in test setup scripts
