### PR TITLE
set $HOME via an API call so AWX_TASK_ENV isn't marked as readonly

### DIFF
--- a/installer/image_build/files/launch_awx_task.sh
+++ b/installer/image_build/files/launch_awx_task.sh
@@ -18,6 +18,7 @@ else
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'root@localhost', 'password')" | awx-manage shell
     awx-manage create_preload_data
 fi
+echo 'from django.conf import settings; x = settings.AWX_TASK_ENV; x["HOME"] = "/var/lib/awx"; settings.AWX_TASK_ENV = x' | awx-manage shell
 awx-manage provision_instance --hostname=$(hostname)
 awx-manage register_queue --queuename=tower --instance_percent=100
 supervisord -c /supervisor_task.conf

--- a/installer/image_build/files/settings.py
+++ b/installer/image_build/files/settings.py
@@ -23,8 +23,6 @@ ALLOWED_HOSTS = ['*']
 
 INTERNAL_API_URL = 'http://awxweb:8052'
 
-AWX_TASK_ENV['HOME'] = '/var/lib/awx'
-
 # Container environments don't like chroots
 AWX_PROOT_ENABLED = False
 

--- a/installer/kubernetes/templates/configmap.yml.j2
+++ b/installer/kubernetes/templates/configmap.yml.j2
@@ -30,7 +30,6 @@ data:
     SECRET_KEY = file('/etc/tower/SECRET_KEY', 'rb').read().strip()
     ALLOWED_HOSTS = ['*']
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
-    AWX_TASK_ENV['HOME'] = '/var/lib/awx'
     SERVER_EMAIL = 'root@localhost'
     DEFAULT_FROM_EMAIL = 'webmaster@localhost'
     EMAIL_SUBJECT_PREFIX = '[AWX] '

--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -31,7 +31,6 @@ data:
     SECRET_KEY = file('/etc/tower/SECRET_KEY', 'rb').read().strip()
     ALLOWED_HOSTS = ['*']
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
-    AWX_TASK_ENV['HOME'] = '/var/lib/awx'
     SERVER_EMAIL = 'root@localhost'
     DEFAULT_FROM_EMAIL = 'webmaster@localhost'
     EMAIL_SUBJECT_PREFIX = '[AWX] '


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/1315