### PR TITLE
Fixed bug preventing users from selecting non-default inventory on job launch

### DIFF
--- a/awx/ui/client/features/templates/list-templates.controller.js
+++ b/awx/ui/client/features/templates/list-templates.controller.js
@@ -23,6 +23,7 @@ function ListTemplatesController(
     resolvedModels,
     strings,
     Wait,
+    Empty
 ) {
     const vm = this || {};
     const [jobTemplate, workflowTemplate] = resolvedModels;
@@ -34,8 +35,8 @@ function ListTemplatesController(
     vm.templateTypes = mapChoices(choices);
     vm.activeId = parseInt($state.params.job_template_id || $state.params.workflow_template_id);
 
-    $scope.canAddJobTemplate = jobTemplate.options('actions.POST')
-    $scope.canAddWorkflowJobTemplate = workflowTemplate.options('actions.POST')
+    $scope.canAddJobTemplate = jobTemplate.options('actions.POST');
+    $scope.canAddWorkflowJobTemplate = workflowTemplate.options('actions.POST');
     $scope.canAdd = ($scope.canAddJobTemplate || $scope.canAddWorkflowJobTemplate);
 
     // smart-search
@@ -169,7 +170,7 @@ function ListTemplatesController(
             })
             .catch(createErrorHandler('copy job template', 'POST'))
             .finally(() => Wait('stop'));
-    };
+    }
 
     function copyWorkflowTemplate(template) {
         Wait('start');
@@ -251,7 +252,7 @@ function ListTemplatesController(
                     .request('delete', template.id)
                     .then(() => handleSuccessfulDelete(template))
                     .catch(createErrorHandler('delete template', 'DELETE'))
-                    .finally(() => Wait('stop'))
+                    .finally(() => Wait('stop'));
             },
             hdr: strings.get('DELETE'),
             resourceName: $filter('sanitize')(template.name),
@@ -321,7 +322,7 @@ function ListTemplatesController(
                     return selectedJobTemplate
                         .postLaunch({ id: template.id })
                         .then(({ data }) => {
-                            $state.go('jobResult', { id: data.job }, { reload: true })
+                            $state.go('jobResult', { id: data.job }, { reload: true });
                         });
                 }
 
@@ -333,7 +334,7 @@ function ListTemplatesController(
                         launchConf: launchData.data,
                         launchOptions: launchOptions.data
                     }),
-                    triggerModalOpen: true, 
+                    triggerModalOpen: true,
                 };
 
                 if (launchData.data.survey_enabled) {
@@ -378,7 +379,7 @@ function ListTemplatesController(
             jobLaunchData.verbosity = $scope.promptData.prompts.verbosity.value.value;
         }
 
-        if ($scope.promptData.launchConf.ask_inventory_on_launch && !_.isEmpty($scope.promptData.prompts.inventory.value.id)){
+        if ($scope.promptData.launchConf.ask_inventory_on_launch && !Empty($scope.promptData.prompts.inventory.value.id)){
             jobLaunchData.inventory_id = $scope.promptData.prompts.inventory.value.id;
         }
 
@@ -422,7 +423,7 @@ function ListTemplatesController(
         .then((launchRes) => {
             $state.go('jobResult', { id: launchRes.data.job }, { reload: true });
         })
-        .catch(createErrorHandler('launch job template', 'POST'))
+        .catch(createErrorHandler('launch job template', 'POST'));
     };
 }
 
@@ -439,6 +440,7 @@ ListTemplatesController.$inject = [
     'resolvedModels',
     'TemplatesStrings',
     'Wait',
+    'Empty'
 ];
 
 export default ListTemplatesController;


### PR DESCRIPTION
##### SUMMARY
[_.isEmpty](https://lodash.com/docs/4.17.4#isEmpty) will return true if it's passed an integer and in this case it was.  With lodash > 4.0.0 we could use _.isNil here but for now the Empty helper service should do the trick.  This change should allow the user to select an inventory when launching from the templates list whether a default is selected on the JT or not as long as the prompt box is checked.

related #1281 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.4.17
```

I also fixed some jshint errors in this file
