### PR TITLE
Put credentials on their own line in the launch preview

### DIFF
--- a/awx/ui/client/src/templates/prompt/prompt.block.less
+++ b/awx/ui/client/src/templates/prompt/prompt.block.less
@@ -143,6 +143,7 @@
 }
 .Prompt-previewRowValue {
     flex: 1 0 auto;
+    max-width: 508px;
 }
 .Prompt-noSelectedItem {
     height: 30px;

--- a/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.partial.html
+++ b/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.partial.html
@@ -6,9 +6,9 @@
             <span ng-if="promptData.prompts.jobType.value.value === 'check'">{{:: vm.strings.get('prompt.CHECK') }}</span>
         </div>
     </div>
-    <div class="Prompt-previewRow--flex">
+    <div class="Prompt-previewRow--flex" ng-if="promptData.prompts.credentials.value && promptData.prompts.credentials.value.length > 0">
         <div class="Prompt-previewRowTitle">{{:: vm.strings.get('prompt.CREDENTIAL') }}</div>
-        <div class="Prompt-previewRowValue"  style="display: flex">
+        <div class="Prompt-previewRowValue">
             <div class="Prompt-previewTagContainer u-wordwrap" ng-repeat="credential in promptData.prompts.credentials.value">
                 <div class="Prompt-previewTag">
                     <span ng-switch="promptData.prompts.credentials.credentialTypes[credential.credential_type]">
@@ -28,7 +28,7 @@
         <div class="Prompt-previewRowTitle">{{:: vm.strings.get('prompt.INVENTORY') }}</div>
         <div class="Prompt-previewRowValue" ng-bind="promptData.prompts.inventory.value.name"></div>
     </div>
-    <div class="Prompt-previewRow--flex">
+    <div class="Prompt-previewRow--flex" ng-if="promptData.prompts.limit.value">
         <div class="Prompt-previewRowTitle">{{:: vm.strings.get('prompt.LIMIT') }}</div>
         <div class="Prompt-previewRowValue" ng-bind="promptData.prompts.limit.value"></div>
     </div>
@@ -36,7 +36,7 @@
         <div class="Prompt-previewRowTitle">{{:: vm.strings.get('prompt.VERBOSITY') }}</div>
         <div class="Prompt-previewRowValue" ng-bind="promptData.prompts.verbosity.value.label"></div>
     </div>
-    <div class="Prompt-previewRow--noflex">
+    <div class="Prompt-previewRow--noflex" ng-if="promptData.prompts.tags.value && promptData.prompts.tags.value.length > 0">
         <div class="Prompt-previewRowTitle">
             <span>{{:: vm.strings.get('prompt.JOB_TAGS') }}&nbsp;</span>
             <span ng-click="vm.showJobTags = !vm.showJobTags">
@@ -52,7 +52,7 @@
             </div>
         </div>
     </div>
-    <div class="Prompt-previewRow--noflex">
+    <div class="Prompt-previewRow--noflex" ng-if="promptData.prompts.skipTags.value && promptData.prompts.skipTags.value.length > 0">
         <div class="Prompt-previewRowTitle">
             <span>{{:: vm.strings.get('prompt.SKIP_TAGS') }}&nbsp;</span>
             <span ng-click="vm.showSkipTags = !vm.showSkipTags">


### PR DESCRIPTION
##### SUMMARY
As reported in 1279, specifying several credentials would cause the list to flow outside the bounds of the modal.  To fix this, I dropped each credential down to a new line.  This brings it in line with the templates list implementation.

I also hid some rows on the preview if the values are empty (credentials, limit, job tags, skip tags, etc) per feedback from @trahman73.

related #1279 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

Preview should now look like:

<img width="816" alt="screen shot 2018-02-26 at 4 10 26 pm" src="https://user-images.githubusercontent.com/9889020/36695515-95d90518-1b0f-11e8-9bba-696327f0cf8a.png">
