### PR TITLE
Fix server error with absent client_secret

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -998,7 +998,7 @@ class OAuth2ApplicationSerializer(BaseSerializer):
     def to_representation(self, obj):
         ret = super(OAuth2ApplicationSerializer, self).to_representation(obj)
         if obj.client_type == 'public':
-            ret.pop('client_secret')
+            ret.pop('client_secret', None)
         return ret
         
         


### PR DESCRIPTION
I couldn't view `/api/v2/applications/1/`.

```
awx_1        | Traceback (most recent call last):
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
awx_1        |     response = get_response(request)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
awx_1        |     response = self._get_response(request)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 217, in _get_response
awx_1        |     response = self.process_exception_by_middleware(e, request)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 215, in _get_response
awx_1        |     response = response.render()
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/template/response.py", line 107, in render
awx_1        |     self.content = self.rendered_content
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/response.py", line 72, in rendered_content
awx_1        |     ret = renderer.render(self.data, accepted_media_type, context)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/renderers.py", line 716, in render
awx_1        |     context = self.get_context(data, accepted_media_type, renderer_context)
awx_1        |   File "./awx/api/renderers.py", line 29, in get_context
awx_1        |     return super(BrowsableAPIRenderer, self).get_context(data, accepted_media_type, renderer_context)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/renderers.py", line 650, in get_context
awx_1        |     raw_data_put_form = self.get_raw_data_form(data, view, 'PUT', request)
awx_1        |   File "./awx/api/renderers.py", line 43, in get_raw_data_form
awx_1        |     return super(BrowsableAPIRenderer, self).get_raw_data_form(data, view, method, request)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/renderers.py", line 554, in get_raw_data_form
awx_1        |     serializer = view.get_serializer(instance=instance)
awx_1        |   File "./awx/api/generics.py", line 303, in get_serializer
awx_1        |     serializer._data = self.update_raw_data(serializer.data)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/serializers.py", line 533, in data
awx_1        |     ret = super(Serializer, self).data
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/serializers.py", line 262, in data
awx_1        |     self._data = self.to_representation(self.instance)
awx_1        |   File "./awx/api/serializers.py", line 1001, in to_representation
awx_1        |     ret.pop('client_secret')
awx_1        |   File "/usr/lib64/python2.7/collections.py", line 143, in pop
awx_1        |     raise KeyError(key)
awx_1        | KeyError: 'client_secret'
```

I need this fix to keep things working.