### PR TITLE
disallow changing token-app

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -938,7 +938,7 @@ class UserAuthorizedTokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'expires', 'scope', 'application',
         )
-        read_only_fields = ('user', 'token', 'expires', 'application')
+        read_only_fields = ('user', 'token', 'expires')
         
     def get_token(self, obj):
         request = self.context.get('request', None)
@@ -1045,7 +1045,7 @@ class OAuth2TokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'application', 'expires', 'scope',
         )
-        read_only_fields = ('user', 'token', 'expires', 'application')
+        read_only_fields = ('user', 'token', 'expires')
 
     def get_modified(self, obj):
         if obj is None:
@@ -1104,6 +1104,20 @@ class OAuth2TokenSerializer(BaseSerializer):
             )
         return obj
         
+        
+class OAuth2TokenDetailSerializer(OAuth2TokenSerializer):
+
+    refresh_token = serializers.SerializerMethodField()
+    token = serializers.SerializerMethodField()
+
+    class Meta:
+        model = OAuth2AccessToken
+        fields = (
+            '*', '-name', 'description', 'user', 'token', 'refresh_token',
+            'application', 'expires', 'scope',
+        )
+        read_only_fields = ('user', 'token', 'expires', 'application')       
+
 
 class OAuth2AuthorizedTokenSerializer(BaseSerializer):
     
@@ -1116,7 +1130,7 @@ class OAuth2AuthorizedTokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'expires', 'scope', 'application',
         )
-        read_only_fields = ('user', 'token', 'expires', 'application',)
+        read_only_fields = ('user', 'token', 'expires')
         
     def get_token(self, obj):
         request = self.context.get('request', None)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1107,16 +1107,8 @@ class OAuth2TokenSerializer(BaseSerializer):
         
 class OAuth2TokenDetailSerializer(OAuth2TokenSerializer):
 
-    refresh_token = serializers.SerializerMethodField()
-    token = serializers.SerializerMethodField()
-
     class Meta:
-        model = OAuth2AccessToken
-        fields = (
-            '*', '-name', 'description', 'user', 'token', 'refresh_token',
-            'application', 'expires', 'scope',
-        )
-        read_only_fields = ('user', 'token', 'expires', 'application')       
+        read_only_fields = ('*', 'user', 'application')       
 
 
 class OAuth2AuthorizedTokenSerializer(BaseSerializer):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -938,8 +938,7 @@ class UserAuthorizedTokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'expires', 'scope', 'application',
         )
-        read_only_fields = ('user', 'token', 'expires')
-        read_only_on_update_fields = ('application',)
+        read_only_fields = ('user', 'token', 'expires', 'application')
         
     def get_token(self, obj):
         request = self.context.get('request', None)
@@ -1046,7 +1045,7 @@ class OAuth2TokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'application', 'expires', 'scope',
         )
-        read_only_fields = ('user', 'token', 'expires')
+        read_only_fields = ('user', 'token', 'expires', 'application')
 
     def get_modified(self, obj):
         if obj is None:
@@ -1117,8 +1116,7 @@ class OAuth2AuthorizedTokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'expires', 'scope', 'application',
         )
-        read_only_fields = ('user', 'token', 'expires')
-        read_only_on_update_fields = ('application',)
+        read_only_fields = ('user', 'token', 'expires', 'application',)
         
     def get_token(self, obj):
         request = self.context.get('request', None)
@@ -1171,8 +1169,7 @@ class OAuth2PersonalTokenSerializer(BaseSerializer):
             '*', '-name', 'description', 'user', 'token', 'refresh_token',
             'application', 'expires', 'scope',
         )
-        read_only_fields = ('user', 'token', 'expires')
-        read_only_on_update_fields = ('application',)
+        read_only_fields = ('user', 'token', 'expires', 'application')
 
     def get_modified(self, obj):
         if obj is None:

--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -1587,7 +1587,7 @@ class OAuth2TokenDetail(RetrieveUpdateDestroyAPIView):
     view_name = _("OAuth Token Detail")
 
     model = OAuth2AccessToken
-    serializer_class = OAuth2TokenSerializer
+    serializer_class = OAuth2TokenDetailSerializer
 
 
 class OAuth2TokenActivityStreamList(ActivityStreamEnforcementMixin, SubListAPIView):


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/awx/issues/1376

Blocks changing the application field on a token via PUT or PATCH as this field should be immutable.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX version: 1.0.4-73
AWX install method: docker for mac
Ansible version: N/A
Operating System:
Web Browser:
```


##### ADDITIONAL INFORMATION

