### PR TITLE
adds csrf flag to support http

### DIFF
--- a/installer/image_build/files/settings.py
+++ b/installer/image_build/files/settings.py
@@ -30,6 +30,8 @@ AWX_PROOT_ENABLED = False
 CLUSTER_HOST_ID = "awx"
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
 
+CSRF_COOKIE_SECURE = False
+
 
 ###############################################################################
 # EMAIL SETTINGS


### PR DESCRIPTION
##### SUMMARY
Link: 

Changes the CSRF_COOKIE_SECURE variable to False.  Otherwise it gets set to True by default.  

This will allow login over http as well as https.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX version: 1.0.4-73
AWX install method: docker for mac
Ansible version: N/A
Operating System:
Web Browser:
```



