### PR TITLE
Update to latest asgi-amqp

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -513,6 +513,11 @@ AWX_INCONSISTENT_TASK_INTERVAL = 60 * 3
 # property value of the original queue name.
 AWX_CELERY_QUEUES_STATIC = ['tower_broadcast_all',]
 
+ASGI_AMQP = {
+    'INIT_FUNC': 'awx.prepare_env',
+    'MODEL': 'awx.main.models.channels.ChannelGroup',
+}
+
 # Django Caching Configuration
 if is_testing():
     CACHES = {

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,6 @@
 apache-libcloud==2.0.0
 appdirs==1.4.2
-asgi-amqp==1.0.3
+asgi-amqp==1.1.1
 asgiref==1.1.2
 azure==2.0.0rc6
 backports.ssl-match-hostname==3.5.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 apache-libcloud==2.0.0
 appdirs==1.4.2
-asgi-amqp==1.0.3
+asgi-amqp==1.1.1
 asgiref==1.1.2
 asn1crypto==0.22.0        # via cryptography
 attrs==17.2.0             # via automat, service-identity


### PR DESCRIPTION
Fixes issue with a websockets not recovering / connecting if rabbitmq goes away.
