### PR TITLE
Alt Galaxy Support

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -139,7 +139,7 @@
         register: doesRequirementsExist
 
       - name: fetch galaxy roles from requirements.yml
-        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/ --force
+        command: alt-galaxy install --role-file=requirements.yml --roles-path={{project_path|quote}}/roles/ --force
         args:
           chdir: "{{project_path|quote}}/roles"
         when: doesRequirementsExist.stat.exists

--- a/installer/image_build/templates/Dockerfile.j2
+++ b/installer/image_build/templates/Dockerfile.j2
@@ -39,6 +39,7 @@ RUN yum -y install epel-release && \
     yum -y remove gcc postgresql-devel libxml2-devel libxslt-devel cyrus-sasl-devel openldap-devel xmlsec1-devel krb5-devel xmlsec1-openssl-devel libtool-ltdl-devel gcc-c++ python-devel && \
     yum -y clean all && \
     rm -rf /root/.cache
+RUN curl -L https://github.com/gantsign/alt-galaxy/releases/download/1.3.3/alt-galaxy_linux_amd64.tar.xz | tar xJ --directory /usr/local/bin
 
 RUN mkdir -p /var/log/tower
 RUN mkdir -p /etc/tower


### PR DESCRIPTION
##### SUMMARY
Introduce [Alt Galaxy](https://github.com/gantsign/alt-galaxy) support.

For now, this just replaces ansible-galaxy calls by alt-galaxy calls. I would like to have some reviews, for - maybe - introduce a new flag somewhere to enable siwtch on demand.

related #1365 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 1.0.4.28
```


##### ADDITIONAL INFORMATION
I wanted to begun by a simple proof of concept, and it's already 60x faster to update roles :)
