### PR TITLE
call node init procedures as early as possible

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -225,6 +225,10 @@ def handle_ha_toplogy_worker_ready(sender, **kwargs):
         logger.info("Workers on tower node '{}' unsubscribed from queues {} and subscribed to queues {}"
                     .format(instance.hostname, removed_queues, added_queues))
 
+    # Expedite the first hearbeat run so a node comes online quickly.
+    cluster_node_heartbeat.apply([])
+    apply_cluster_membership_policies.apply([])
+
 
 @celeryd_init.connect
 def handle_update_celery_routes(sender=None, conf=None, **kwargs):


### PR DESCRIPTION
* invoke the first heartbeat as early as possible. Results in a much
better user experience where when a user scales up an awx node, the node
appears with capacity earlier.

```
            "created": "2018-03-01T16:26:54.472370Z",
            "modified": "2018-03-01T16:27:06.949773Z",
```