### PR TITLE
invoke main() in config watcher script

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -225,6 +225,10 @@ def handle_ha_toplogy_worker_ready(sender, **kwargs):
         logger.info("Workers on tower node '{}' unsubscribed from queues {} and subscribed to queues {}"
                     .format(instance.hostname, removed_queues, added_queues))
 
+    # Expedite the first hearbeat run so a node comes online quickly.
+    cluster_node_heartbeat.apply([])
+    apply_cluster_membership_policies.apply([])
+
 
 @celeryd_init.connect
 def handle_update_celery_routes(sender=None, conf=None, **kwargs):

--- a/tools/scripts/config-watcher
+++ b/tools/scripts/config-watcher
@@ -25,6 +25,9 @@ def write_hash(f, h):
 
 
 def main():
+    settings_file = "/etc/tower/settings.py"
+    hash_file = "/var/lib/awx/.configsha"
+
     while 1:
         rpc = childutils.getRPCInterface(os.environ)
         headers, payload = childutils.listener.wait(sys.stdin, sys.stdout)
@@ -32,13 +35,13 @@ def main():
             childutils.listener.ok(sys.stdout)
             continue
         try:
-            current_hash = hash("/etc/tower/settings.py")
+            current_hash = hash(settings_file)
         except:
             sys.stderr.write("Could not open settings.py, skipping config watcher")
             childutils.listener.ok(sys.stdout)
             continue
         try:
-            if current_hash == last_hash("/var/lib/awx/.configsha"):
+            if current_hash == last_hash(hash_file):
                 childutils.listener.ok(sys.stdout)
                 continue
             else:
@@ -51,8 +54,11 @@ def main():
                         sys.stderr.write('Restarting %s\n' % program)
                         rpc.supervisor.stopProcess(program)
                         rpc.supervisor.startProcess(program)
-                    
         except:
             sys.stderr.write("No previous hash found")
-        write_hash("/var/lib/awx/.configsha")
+
+        write_hash(hash_file, current_hash)
         childutils.listener.ok(sys.stdout)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* correctly call main()
* call rehash with needed file param

The config map watcher should emit the below logs in the web container. When the config map is changed, it will restart the services.

```
RESULT 2
--
  | OKREADY
  | No previous hash foundRESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | RESULT 2
  | OKREADY
  | Config changed, reloading services2018-03-01 22:03:01,889 INFO waiting for daphne to stop

```