### PR TITLE
Hide client_secret from activity stream

### DIFF
--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -211,7 +211,7 @@ class ApiRootView(APIView):
 class ApiOAuthAuthorizationRootView(APIView):
 
     permission_classes = (AllowAny,)
-    view_name = _("API OAuth Authorization Root")
+    view_name = _("API OAuth 2 Authorization Root")
     versioning_class = None
 
     def get(self, request, format=None):
@@ -1499,7 +1499,7 @@ class UserMeList(ListAPIView):
 
 class OAuth2ApplicationList(ListCreateAPIView):
 
-    view_name = _("OAuth Applications")
+    view_name = _("OAuth 2 Applications")
 
     model = OAuth2Application
     serializer_class = OAuth2ApplicationSerializer
@@ -1507,7 +1507,7 @@ class OAuth2ApplicationList(ListCreateAPIView):
 
 class OAuth2ApplicationDetail(RetrieveUpdateDestroyAPIView):
 
-    view_name = _("OAuth Application Detail")
+    view_name = _("OAuth 2 Application Detail")
 
     model = OAuth2Application
     serializer_class = OAuth2ApplicationSerializer
@@ -1515,7 +1515,7 @@ class OAuth2ApplicationDetail(RetrieveUpdateDestroyAPIView):
 
 class ApplicationOAuth2TokenList(SubListCreateAPIView):
 
-    view_name = _("OAuth Application Tokens")
+    view_name = _("OAuth 2 Application Tokens")
 
     model = OAuth2AccessToken
     serializer_class = OAuth2TokenSerializer

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -335,18 +335,18 @@ def update_scm_url(scm_type, url, username=True, password=True,
 
 
 def get_allowed_fields(obj, serializer_mapping):
-    from django.contrib.auth.models import User
 
     if serializer_mapping is not None and obj.__class__ in serializer_mapping:
         serializer_actual = serializer_mapping[obj.__class__]()
         allowed_fields = [x for x in serializer_actual.fields if not serializer_actual.fields[x].read_only] + ['id']
     else:
         allowed_fields = [x.name for x in obj._meta.fields]
-
-    if isinstance(obj, User):
+    if obj._meta.model_name == 'user':
         field_blacklist = ['last_login']
         allowed_fields = [f for f in allowed_fields if f not in field_blacklist]
-
+    if obj._meta.model_name == 'oauth2application':
+        field_blacklist = ['client_secret']
+        allowed_fields = [f for f in allowed_fields if f not in field_blacklist]
     return allowed_fields
 
 


### PR DESCRIPTION
##### SUMMARY
Link: https://github.com/ansible/awx/issues/1416
Step 1 for making the client_secret more secure.  Hides client_secret from the activity stream.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.4.40
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
