### PR TITLE
Adjust some wording in the UI.

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/factories/get-sync-status-msg.factory.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/factories/get-sync-status-msg.factory.js
@@ -4,7 +4,7 @@ export default
             var status = params.status,
             launch_class = '',
             launch_tip = i18n._('Start sync process'),
-            schedule_tip = i18n._('Schedule future inventory syncs'),
+            schedule_tip = i18n._('Schedule inventory syncs'),
             stat, stat_class, status_tip;
 
             stat = status;

--- a/awx/ui/client/src/job-results/job-results.partial.html
+++ b/awx/ui/client/src/job-results/job-results.partial.html
@@ -211,7 +211,7 @@
                         <div class="JobResults-resultRowText">
                             <a href="{{ project_update_link }}"
                                 ng-hide="job.summary_fields.project.scm_type==='' || !project_status"
-                                aw-tool-tip="{{'View project sync results' | translate}}"
+                                aw-tool-tip="{{'View project checkout results' | translate}}"
                                 data-placement="top">
                                 <i class="JobResults-statusResultIcon
                                     fa icon-job-{{ project_status }}">

--- a/awx/ui/client/src/management-jobs/management-jobs.list.js
+++ b/awx/ui/client/src/management-jobs/management-jobs.list.js
@@ -35,7 +35,7 @@ export default function(){
                 label: 'Schedule',
                 mode: 'all',
                 ngClick: 'configureSchedule()',
-                awToolTip: 'Schedule future job template runs',
+                awToolTip: 'Schedule job template runs',
                 dataPlacement: 'top',
             }
         }

--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-projects.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-projects.controller.js
@@ -35,8 +35,8 @@ export default ['$scope', '$rootScope', '$log', '$stateParams', 'Rest', 'Alert',
                     $scope.projects.forEach(function(project, i) {
                         $scope.projects[i].statusIcon = GetProjectIcon(project.status);
                         $scope.projects[i].statusTip = GetProjectToolTip(project.status);
-                        $scope.projects[i].scm_update_tooltip = "Start an SCM update";
-                        $scope.projects[i].scm_schedule_tooltip = "Schedule future SCM updates";
+                        $scope.projects[i].scm_update_tooltip = "Get latest SCM revision";
+                        $scope.projects[i].scm_schedule_tooltip = "Schedule SCM revision updates";
                         $scope.projects[i].scm_type_class = "";
 
                         if (project.status === 'failed' && project.summary_fields.last_update && project.summary_fields.last_update.status === 'canceled') {

--- a/awx/ui/client/src/projects/edit/projects-edit.controller.js
+++ b/awx/ui/client/src/projects/edit/projects-edit.controller.js
@@ -132,7 +132,7 @@ export default ['$scope', '$rootScope', '$stateParams', 'ProjectsForm', 'Rest',
                     });
 
                     $scope.scmBranchLabel = ($scope.scm_type.value === 'svn') ? 'Revision #' : 'SCM Branch';
-                    $scope.scm_update_tooltip = i18n._("Start an SCM update");
+                    $scope.scm_update_tooltip = i18n._("Get latest SCM revision");
                     $scope.scm_type_class = "";
                     if (data.status === 'running' || data.status === 'updating') {
                         $scope.scm_update_tooltip = i18n._("SCM update currently running");

--- a/awx/ui/client/src/projects/factories/get-project-tool-tip.factory.js
+++ b/awx/ui/client/src/projects/factories/get-project-tool-tip.factory.js
@@ -11,23 +11,23 @@ export default
                 case 'pending':
                 case 'waiting':
                 case 'new':
-                    result = i18n._('Queued. Click for details');
+                    result = i18n._('Update queued. Click for details');
                     break;
                 case 'updating':
                 case 'running':
-                    result = i18n._('Running! Click for details');
+                    result = i18n._('Update running. Click for details');
                     break;
                 case 'successful':
-                    result = i18n._('Success! Click for details');
+                    result = i18n._('Update succeeded. Click for details');
                     break;
                 case 'failed':
-                    result = i18n._('Failed. Click for details');
+                    result = i18n._('Update failed. Click for details');
                     break;
                 case 'missing':
-                    result = i18n._('Missing. Click for details');
+                    result = i18n._('Update missing. Click for details');
                     break;
                 case 'canceled':
-                    result = i18n._('Canceled. Click for details');
+                    result = i18n._('Update canceled. Click for details');
                     break;
             }
             return result;

--- a/awx/ui/client/src/projects/list/projects-list.controller.js
+++ b/awx/ui/client/src/projects/list/projects-list.controller.js
@@ -73,8 +73,8 @@ export default ['$scope', '$rootScope', '$log', 'Rest', 'Alert',
         function buildTooltips(project) {
             project.statusIcon = GetProjectIcon(project.status);
             project.statusTip = GetProjectToolTip(project.status);
-            project.scm_update_tooltip = i18n._("Start an SCM update");
-            project.scm_schedule_tooltip = i18n._("Schedule future SCM updates");
+            project.scm_update_tooltip = i18n._("Get latest SCM revision");
+            project.scm_schedule_tooltip = i18n._("Schedule SCM revision updates");
             project.scm_type_class = "";
 
             if (project.status === 'failed' && project.summary_fields.last_update && project.summary_fields.last_update.status === 'canceled') {

--- a/awx/ui/client/src/projects/projects.form.js
+++ b/awx/ui/client/src/projects/projects.form.js
@@ -186,7 +186,7 @@ export default ['i18n', 'NotificationsList', 'TemplateList',
                     ngDisabled: '!(project_obj.summary_fields.user_capabilities.edit || canAdd)'
                 }, {
                     name: 'scm_update_on_launch',
-                    label: i18n._('Update on Launch'),
+                    label: i18n._('Update Revision on Launch'),
                     type: 'checkbox',
                     awPopOver: '<p>' + i18n._('Each time a job runs using this project, update the revision of the project prior to starting the job.') + '</p>',
                     dataTitle: i18n._('SCM Update'),

--- a/awx/ui/client/src/templates/templates.list.js
+++ b/awx/ui/client/src/templates/templates.list.js
@@ -88,7 +88,7 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Schedule'),
                 mode: 'all',
                 ngClick: 'scheduleJob(template)',
-                awToolTip: i18n._('Schedule future job template runs'),
+                awToolTip: i18n._('Schedule job template runs'),
                 dataPlacement: 'top',
             },
             copy: {


### PR DESCRIPTION

##### SUMMARY

We still get a good deal of confusion about our two types of SCM jobs - the 'update' that updates the revision to use, and the 'checkout' that checks out the actual repo.

This changes assorted wording to help make the purpose more clear.

Additionally:
- expand tooltips of SCM status icon
- remove 'future' from schedule tooltips, as it's mostly superfluous
