### PR TITLE
fix token expiration time

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -35,7 +35,10 @@ register(
 register(
     'OAUTH2_PROVIDER',
     field_class=OAuth2ProviderField,
-    default={'ACCESS_TOKEN_EXPIRE_SECONDS': 315360000000, 'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600},
+    default={'ACCESS_TOKEN_EXPIRE_SECONDS': 315360000000, 
+             'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600, 
+             'REFRESH_TOKEN_EXPIRE_SECONDS': 315360000000
+             },
     label=_('OAuth 2 Timeout Settings'),
     help_text=_('Dictionary for customizing OAuth 2 timeouts, available items are '
                 '`ACCESS_TOKEN_EXPIRE_SECONDS`, the duration of access tokens in the number '

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -340,7 +340,10 @@ AUTHENTICATION_BACKENDS = (
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'main.OAuth2Application'
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'main.OAuth2AccessToken'
 
-OAUTH2_PROVIDER = {}
+OAUTH2_PROVIDER = {'ACCESS_TOKEN_EXPIRE_SECONDS': 31536000000, 
+                   'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600, 
+                   'REFRESH_TOKEN_EXPIRE_SECONDS': 31536000000
+                   }
 
 # LDAP server (default to None to skip using LDAP authentication).
 # Note: This setting may be overridden by database settings.


### PR DESCRIPTION
##### SUMMARY
Sets the token expiration time to 10000 years.  It was far too short before.  

Thanks to @ryanpetrello for the hawk eyes.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
awx: 1.0.4.49


