### PR TITLE
Make CSRF tokens work under clusters without ssl termination

### DIFF
--- a/installer/kubernetes/templates/configmap.yml.j2
+++ b/installer/kubernetes/templates/configmap.yml.j2
@@ -21,7 +21,9 @@ data:
     SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
 
     REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR']
-    
+
+    CSRF_COOKIE_SECURE = False
+
     STATIC_ROOT = '/var/lib/awx/public/static'
     PROJECTS_ROOT = '/var/lib/awx/projects'
     JOBOUTPUT_ROOT = '/var/lib/awx/job_status'

--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -22,6 +22,8 @@ data:
     
     REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR']
 
+    CSRF_COOKIE_SECURE = False
+
     STATIC_ROOT = '/var/lib/awx/public/static'
     PROJECTS_ROOT = '/var/lib/awx/projects'
     JOBOUTPUT_ROOT = '/var/lib/awx/job_status'


### PR DESCRIPTION
We made this change on the standalone install, but we need to apply it to the clustering deploys also