### PR TITLE
add csrf & session settings

### DIFF
--- a/installer/kubernetes/templates/configmap.yml.j2
+++ b/installer/kubernetes/templates/configmap.yml.j2
@@ -20,6 +20,9 @@ data:
     CLUSTER_HOST_ID = socket.gethostname()
     SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
 
+    SESSION_COOKIE_SECURE = False
+    CSRF_COOKIE_SECURE = False 
+
     REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR']
     
     STATIC_ROOT = '/var/lib/awx/public/static'

--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -20,6 +20,9 @@ data:
     CLUSTER_HOST_ID = socket.gethostname()
     SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
     
+    SESSION_COOKIE_SECURE = False
+    CSRF_COOKIE_SECURE = False
+    
     REMOTE_HOST_HEADERS = ['HTTP_X_FORWARDED_FOR']
 
     STATIC_ROOT = '/var/lib/awx/public/static'


### PR DESCRIPTION
##### SUMMARY
Adds the following settings to the Kubernetes and Openshift installer settings.  This will allow users to log in over http.  

    SESSION_COOKIE_SECURE = False
    CSRF_COOKIE_SECURE = False

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.4.53
```


##### ADDITIONAL INFORMATION
related to new Session Auth Feature