### PR TITLE
Networking

### DIFF
--- a/awx/ui/client/src/network-ui/buttons.fsm.js
+++ b/awx/ui/client/src/network-ui/buttons.fsm.js
@@ -1,0 +1,96 @@
+/* Copyright (c) 2017 Red Hat, Inc. */
+var inherits = require('inherits');
+var fsm = require('./fsm.js');
+
+function _State () {
+}
+inherits(_State, fsm._State);
+
+
+function _Ready () {
+    this.name = 'Ready';
+}
+inherits(_Ready, _State);
+var Ready = new _Ready();
+exports.Ready = Ready;
+
+function _Start () {
+    this.name = 'Start';
+}
+inherits(_Start, _State);
+var Start = new _Start();
+exports.Start = Start;
+
+function _ButtonPressed () {
+    this.name = 'ButtonPressed';
+}
+inherits(_ButtonPressed, _State);
+var ButtonPressed = new _ButtonPressed();
+exports.ButtonPressed = ButtonPressed;
+
+
+
+
+_Ready.prototype.onMouseDown = function (controller, msg_type, $event) {
+
+    var i = 0;
+    var buttons = controller.scope.all_buttons;
+    var button = null;
+    for (i = 0; i < buttons.length; i++) {
+        button = buttons[i];
+        if (button.is_selected(controller.scope.mouseX, controller.scope.mouseY)) {
+            button.fsm.handle_message(msg_type, $event);
+            controller.changeState(ButtonPressed);
+            break;
+        }
+        button = null;
+    }
+    if (button === null) {
+        controller.delegate_channel.send(msg_type, $event);
+    }
+
+};
+_Ready.prototype.onMouseDown.transitions = ['ButtonPressed'];
+
+_Ready.prototype.onMouseMove = function (controller, msg_type, $event) {
+
+    if (!controller.scope.hide_buttons) {
+
+        var i = 0;
+        var buttons = controller.scope.all_buttons;
+        var button = null;
+        for (i = 0; i < buttons.length; i++) {
+            button = buttons[i];
+            button.mouse_over = false;
+            if (button.is_selected(controller.scope.mouseX, controller.scope.mouseY)) {
+                button.mouse_over = true;
+            }
+        }
+    }
+
+    controller.delegate_channel.send(msg_type, $event);
+};
+
+
+_Start.prototype.start = function (controller) {
+
+    controller.changeState(Ready);
+
+};
+_Start.prototype.start.transitions = ['Ready'];
+
+
+
+_ButtonPressed.prototype.onMouseUp = function (controller, msg_type, $event) {
+
+    var i = 0;
+    var buttons = controller.scope.all_buttons;
+    var button = null;
+    for (i = 0; i < buttons.length; i++) {
+        button = buttons[i];
+        button.fsm.handle_message(msg_type, $event);
+    }
+    controller.changeState(Ready);
+
+};
+_ButtonPressed.prototype.onMouseUp.transitions = ['Ready'];

--- a/awx/ui/client/src/network-ui/move.fsm.js
+++ b/awx/ui/client/src/network-ui/move.fsm.js
@@ -144,7 +144,7 @@ _Ready.prototype.onNewDevice = function (controller, msg_type, message) {
         scope.create_inventory_host(device);
         scope.selected_devices.push(device);
         device.selected = true;
-        scope.$emit('addSearchOption', device);
+        scope.$emit('awxNet-addSearchOption', device);
         controller.changeState(Placing);
     }
 };
@@ -464,7 +464,7 @@ _EditLabel.prototype.onKeyDown = function (controller, msg_type, $event) {
 	} else if ($event.keyCode >= 186 && $event.keyCode <=222) { //Punctuation
         item.name += $event.key;
 	} else if ($event.keyCode === 13) { //Enter
-        controller.scope.$emit('editSearchOption', item);
+        controller.scope.$emit('awxNet-editSearchOption', item);
         controller.changeState(Selected2);
     }
     if (item.constructor.name === "Device") {

--- a/awx/ui/client/src/network-ui/network-details/details.controller.js
+++ b/awx/ui/client/src/network-ui/network-details/details.controller.js
@@ -24,7 +24,7 @@
  			HostsService.put(host).then(function(response){
                 $scope.saveConfirmed = true;
                 if(_.has(response, "data")){
-                    $scope.$parent.$broadcast('hostUpdateSaved', response.data);
+                    $scope.$parent.$broadcast('awxNet-hostUpdateSaved', response.data);
                 }
                 setTimeout(function(){
                     $scope.saveConfirmed = false;
@@ -33,7 +33,7 @@
 
  		};
 
-        $scope.$parent.$on('showDetails', (e, data, canAdd) => {
+        $scope.$parent.$on('awxNet-showDetails', (e, data, canAdd) => {
             if (!_.has(data, 'host_id')) {
                 $scope.item = data;
                 $scope.canAdd = canAdd;

--- a/awx/ui/client/src/network-ui/network-nav/network.nav.controller.js
+++ b/awx/ui/client/src/network-ui/network-nav/network.nav.controller.js
@@ -21,17 +21,17 @@ function NetworkingController (models, $state, $scope, strings) {
     };
 
     vm.redirectButtonHandler = (string) => {
-        $scope.$broadcast('toolbarButtonEvent', string);
+        $scope.$broadcast('awxNet-toolbarButtonEvent', string);
     };
 
     vm.jumpTo = (thing) => {
         vm.jumpToPanelExpanded = !vm.jumpToPanelExpanded;
         vm.keyPanelExpanded = false;
         if (thing && typeof thing === 'string') {
-            $scope.$broadcast('jumpTo', thing);
+            $scope.$broadcast('awxNet-jumpTo', thing);
         }
         if (thing && typeof thing === 'object') {
-            $scope.$broadcast('search', thing);
+            $scope.$broadcast('awxNet-search', thing);
         }
     };
 
@@ -40,7 +40,7 @@ function NetworkingController (models, $state, $scope, strings) {
         vm.jumpToPanelExpanded = false;
     };
 
-    $scope.$on('overall_toolbox_collapsed', () => {
+    $scope.$on('awxNet-overall_toolbox_collapsed', () => {
         vm.leftPanelIsExpanded = !vm.leftPanelIsExpanded;
     });
 
@@ -48,7 +48,7 @@ function NetworkingController (models, $state, $scope, strings) {
         vm.breadcrumb_groups = _.sortBy(groups, 'distance').reverse();
     });
 
-    $scope.$on('instatiateSelect', (e, devices) => {
+    $scope.$on('awxNet-instatiateSelect', (e, devices) => {
         for(var i = 0; i < devices.length; i++){
             let device = devices[i];
             $scope.devices.push({
@@ -67,7 +67,7 @@ function NetworkingController (models, $state, $scope, strings) {
         });
     });
 
-    $scope.$on('addSearchOption', (e, device) => {
+    $scope.$on('awxNet-addSearchOption', (e, device) => {
         $scope.devices.push({
                 value: device.id,
                 text: device.name,
@@ -76,7 +76,7 @@ function NetworkingController (models, $state, $scope, strings) {
             });
     });
 
-    $scope.$on('editSearchOption', (e, device) => {
+    $scope.$on('awxNet-editSearchOption', (e, device) => {
         for(var i = 0; i < $scope.devices.length; i++){
             if(device.id === $scope.devices[i].id){
                 $scope.devices[i].text = device.name;
@@ -85,7 +85,7 @@ function NetworkingController (models, $state, $scope, strings) {
         }
     });
 
-    $scope.$on('removeSearchOption', (e, device) => {
+    $scope.$on('awxNet-removeSearchOption', (e, device) => {
         for (var i = 0; i < $scope.devices.length; i++) {
             if ($scope.devices[i].id === device.id) {
                 $scope.devices.splice(i, 1);
@@ -93,13 +93,13 @@ function NetworkingController (models, $state, $scope, strings) {
         }
     });
 
-    $('#networking-search').on('select2:select', () => {
-        $scope.$broadcast('search', $scope.device);
+    $('#networking-search').on('select2:select', (e) => {
+        $scope.$broadcast('awxNet-search', $scope.device);
     });
 
     $('#networking-search').on('select2:open', () => {
         $('.select2-dropdown').addClass('Networking-dropDown');
-        $scope.$broadcast('SearchDropdown');
+        $scope.$broadcast('awxNet-SearchDropdown');
     });
 
     $('#networking-search').on('select2:close', () => {
@@ -107,7 +107,7 @@ function NetworkingController (models, $state, $scope, strings) {
             $('.select2-container-active').removeClass('select2-container-active');
             $(':focus').blur();
         }, 1);
-        $scope.$broadcast('SearchDropdownClose');
+        $scope.$broadcast('awxNet-SearchDropdownClose');
     });
 
 }

--- a/awx/ui/client/src/network-ui/network.ui.controller.js
+++ b/awx/ui/client/src/network-ui/network.ui.controller.js
@@ -6,6 +6,7 @@ var hotkeys = require('./hotkeys.fsm.js');
 var toolbox_fsm = require('./toolbox.fsm.js');
 var view = require('./view.fsm.js');
 var move = require('./move.fsm.js');
+var buttons = require('./buttons.fsm.js');
 var time = require('./time.fsm.js');
 var test_fsm = require('./test.fsm.js');
 var util = require('./util.js');
@@ -220,6 +221,7 @@ var NetworkUIController = function($scope,
   $scope.view_controller = new fsm.FSMController($scope, "view_fsm", view.Start, $scope);
   $scope.move_controller = new fsm.FSMController($scope, "move_fsm", move.Start, $scope);
   $scope.details_panel_controller = new fsm.FSMController($scope, "details_panel_fsm", details_panel_fsm.Start, $scope);
+  $scope.buttons_controller = new fsm.FSMController($scope, "buttons_fsm", buttons.Start, $scope);
   $scope.time_controller = new fsm.FSMController($scope, "time_fsm", time.Start, $scope);
   $scope.test_controller = new fsm.FSMController($scope, "test_fsm", test_fsm.Start, $scope);
 
@@ -312,8 +314,11 @@ var NetworkUIController = function($scope,
   $scope.inventory_toolbox_controller.delegate_channel = new fsm.Channel($scope.inventory_toolbox_controller,
                                                             $scope.details_panel_controller,
                                                             $scope);
-  $scope.time_controller.delegate_channel = new fsm.Channel($scope.time_controller,
+  $scope.buttons_controller.delegate_channel = new fsm.Channel($scope.buttons_controller,
                                                             $scope.inventory_toolbox_controller,
+                                                            $scope);
+  $scope.time_controller.delegate_channel = new fsm.Channel($scope.time_controller,
+                                                            $scope.buttons_controller,
                                                             $scope);
   $scope.mode_controller.delegate_channel = new fsm.Channel($scope.mode_controller,
                                                             $scope.time_controller,

--- a/awx/ui/client/src/network-ui/network.ui.controller.js
+++ b/awx/ui/client/src/network-ui/network.ui.controller.js
@@ -600,7 +600,7 @@ var NetworkUIController = function($scope,
         $scope.first_channel.send('DetailsPanelClose', {});
     };
 
-    $scope.$on('hostUpdateSaved', (e, host) => {
+    $scope.$on('awxNet-hostUpdateSaved', (e, host) => {
         if (host.variables !== "" && $scope.selected_devices.length === 1) {
             host.data = jsyaml.safeLoad(host.variables);
             $scope.selected_devices[0].type = host.data.type;
@@ -612,7 +612,7 @@ var NetworkUIController = function($scope,
             $scope.first_channel.send('DetailsPanel', {});
             $scope.removeContextMenu();
             $scope.update_toolbox_heights();
-            $scope.$emit('showDetails', item, canAdd);
+            $scope.$emit('awxNet-showDetails', item, canAdd);
         }
 
         // show details for devices
@@ -694,7 +694,7 @@ var NetworkUIController = function($scope,
             index = $scope.devices.indexOf(devices[i]);
             if (index !== -1) {
                 $scope.devices.splice(index, 1);
-                $scope.$emit('removeSearchOption', devices[i]);
+                $scope.$emit('awxNet-removeSearchOption', devices[i]);
                 $scope.send_control_message(new messages.DeviceDestroy($scope.client_id,
                                                                        devices[i].id,
                                                                        devices[i].x,
@@ -728,7 +728,7 @@ var NetworkUIController = function($scope,
         $scope.action_icons[0].fsm.handle_message("Disable", {});
         $scope.action_icons[1].fsm.handle_message("Enable", {});
         $scope.overall_toolbox_collapsed = !$scope.overall_toolbox_collapsed;
-        $scope.$emit('overall_toolbox_collapsed');
+        $scope.$emit('awxNet-overall_toolbox_collapsed');
     };
 
     $scope.onToggleToolboxButtonRight = function () {
@@ -736,22 +736,22 @@ var NetworkUIController = function($scope,
         $scope.action_icons[0].fsm.handle_message("Enable", {});
         $scope.action_icons[1].fsm.handle_message("Disable", {});
         $scope.overall_toolbox_collapsed = !$scope.overall_toolbox_collapsed;
-        $scope.$emit('overall_toolbox_collapsed');
+        $scope.$emit('awxNet-overall_toolbox_collapsed');
     };
 
-    $scope.$on('toolbarButtonEvent', function(e, functionName){
+    $scope.$on('awxNet-toolbarButtonEvent', function(e, functionName){
         $scope[`on${functionName}Button`]();
     });
 
-    $scope.$on('SearchDropdown', function(){
+    $scope.$on('awxNet-SearchDropdown', function(){
         $scope.first_channel.send('SearchDropdown', {});
     });
 
-    $scope.$on('SearchDropdownClose', function(){
+    $scope.$on('awxNet-SearchDropdownClose', function(){
         $scope.first_channel.send('SearchDropdownClose', {});
     });
 
-    $scope.$on('search', function(e, device){
+    $scope.$on('awxNet-search', function(e, device){
 
         var searched;
         for(var i = 0; i < $scope.devices.length; i++){
@@ -802,7 +802,7 @@ var NetworkUIController = function($scope,
         $scope.animations.push(pan_animation);
     };
 
-    $scope.$on('jumpTo', function(e, zoomLevel) {
+    $scope.$on('awxNet-jumpTo', function(e, zoomLevel) {
         var v_center = $scope.to_virtual_coordinates($scope.graph.width/2, $scope.graph.height/2);
         switch (zoomLevel){
             case 'site':
@@ -820,7 +820,7 @@ var NetworkUIController = function($scope,
         }
     });
 
-    $scope.$on('zoom', (e, zoomPercent) => {
+    $scope.$on('awxNet-zoom', (e, zoomPercent) => {
         let v_center = $scope.to_virtual_coordinates($scope.graph.width/2, $scope.graph.height/2);
         let scale = Math.pow(10, (zoomPercent - 120) / 40);
         $scope.jump_to_animation(v_center.x, v_center.y, scale, false);
@@ -1319,7 +1319,7 @@ var NetworkUIController = function($scope,
         }
 
         $scope.updateInterfaceDots();
-        $scope.$emit('instatiateSelect', $scope.devices);
+        $scope.$emit('awxNet-instatiateSelect', $scope.devices);
         $scope.update_device_variables();
     };
 

--- a/awx/ui/client/src/network-ui/zoom-widget/zoom.directive.js
+++ b/awx/ui/client/src/network-ui/zoom-widget/zoom.directive.js
@@ -43,17 +43,17 @@ export default [
 
             scope.zoomTo = function() {
                 scope.zoom = Math.ceil(scope.zoom / 10) * 10;
-                this.$parent.$broadcast('zoom', scope.zoom);
+                this.$parent.$broadcast('awxNet-zoom', scope.zoom);
             };
 
             scope.zoomOut = function(){
                 scope.zoom = scope.zoom - 10 > 0 ? scope.zoom - 10 : 0;
-                this.$parent.$broadcast('zoom', scope.zoom);
+                this.$parent.$broadcast('awxNet-zoom', scope.zoom);
             };
 
             scope.zoomIn = function(){
                 scope.zoom = scope.zoom + 10 < 200 ? scope.zoom + 10 : 200;
-                this.$parent.$broadcast('zoom', scope.zoom);
+                this.$parent.$broadcast('awxNet-zoom', scope.zoom);
             };
         }
     };


### PR DESCRIPTION
##### SUMMARY
This fixes the name spacing on all the $emit/$broadcast/$on to prefix them with `awxNet-` so they don't collide with any other events in Tower. I've also fixed the context menus by re-inserting the buttons FSM. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
