### PR TITLE
Include stack trace for delete_inventory logs

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -578,10 +578,10 @@ def delete_inventory(self, inventory_id, user_id):
             )
             logger.debug('Deleted inventory %s as user %s.' % (inventory_id, user_id))
         except Inventory.DoesNotExist:
-            logger.error("Delete Inventory failed due to missing inventory: " + str(inventory_id))
+            logger.exception("Delete Inventory failed due to missing inventory: " + str(inventory_id))
             return
         except DatabaseError:
-            logger.warning('Database error deleting inventory {}, but will retry.'.format(inventory_id))
+            logger.exception('Database error deleting inventory {}, but will retry.'.format(inventory_id))
             self.retry(countdown=10)
 
 


### PR DESCRIPTION
Current behavior is just a single-line message. Testing:

```
In [1]: from awx.main.tasks import delete_inventory

In [3]: delete_inventory.delay(38232, None)
Out[3]: <AsyncResult: 404c4d9d-0b9f-413b-aa7a-7385550990e8>
```

yields

```
awx_1        | 2018-03-08 12:33:18,638 ERROR    awx.main.tasks Delete Inventory failed due to missing inventory: 283934
awx_1        | Traceback (most recent call last):
awx_1        |   File "/awx_devel/awx/main/tasks.py", line 573, in delete_inventory
awx_1        |     i = Inventory.objects.get(id=inventory_id)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
awx_1        |     return getattr(self.get_queryset(), name)(*args, **kwargs)
awx_1        |   File "/venv/awx/lib/python2.7/site-packages/django/db/models/query.py", line 380, in get
awx_1        |     self.model._meta.object_name
awx_1        | DoesNotExist: Inventory matching query does not exist.
```

From celery documentation, I had through that the retry method, itself, would throw an exception. Maybe it does, but it doesn't print the stack trace like I assumed.

This is because we've seen the DatabaseError case, and wanted to see if we could correlate the DB locks to other messages in the logs.