### PR TITLE
Denote invalid template when no inventory and no prompt-for-inventory

### DIFF
--- a/awx/ui/client/features/templates/list-templates.controller.js
+++ b/awx/ui/client/features/templates/list-templates.controller.js
@@ -64,7 +64,7 @@ function ListTemplatesController(
 
     vm.isInvalid = (template) => {
         if(isJobTemplate(template)) {
-            return (template.inventory === null || template.project == null)
+            return template.project === null || (template.inventory === null && template.ask_inventory_on_launch === false);
         } else {
             return false;
         }


### PR DESCRIPTION
##### SUMMARY
Link: https://github.com/ansible/awx/issues/276
Job Templates
    * No Project
    * No Inventory (and no prompt-for-inventory)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
