### PR TITLE
Add border between invalid and active template flags

### DIFF
--- a/awx/ui/client/lib/components/list/_index.less
+++ b/awx/ui/client/lib/components/list/_index.less
@@ -81,6 +81,10 @@
     border-top-right-radius: @at-border-radius;
 }
 
+.at-Row--active .at-Row--invalid {
+    border-left: @at-white solid 1px;
+}
+
 .at-Row--invalid {
     align-items: center;
     background: @at-color-error;

--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -103,17 +103,6 @@ function(NotificationsList, CompletedJobsList, i18n) {
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate) || !canGetAllRelatedResources',
                     awLookupWhen: 'canGetAllRelatedResources'
                 },
-                custom_virtualenv: {
-                    label: i18n._('Ansible Environment'),
-                    type: 'select',
-                    defaultText: i18n._('Select Ansible Environment'),
-                    ngOptions: 'venv for venv in custom_virtualenvs_options track by venv',
-                    awPopOver: "<p>" + i18n._("Select the custom Python virtual environment for this job template to run on.") + "</p>",
-                    dataTitle: i18n._('Ansible Environment'),
-                    dataContainer: 'body',
-                    dataPlacement: 'right',
-                    ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAdd)'
-                },
                 playbook: {
                     label: i18n._('Playbook'),
                     type:'select',
@@ -197,15 +186,6 @@ function(NotificationsList, CompletedJobsList, i18n) {
                     },
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)',
                 },
-                instance_groups: {
-                    label: i18n._('Instance Groups'),
-                    type: 'custom',
-                    awPopOver: "<p>" + i18n._("Select the Instance Groups for this Job Template to run on.") + "</p>",
-                    dataTitle: i18n._('Instance Groups'),
-                    dataContainer: 'body',
-                    dataPlacement: 'right',
-                    control: '<instance-groups-multiselect instance-groups="instance_groups" field-is-disabled="!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)"></instance-groups-multiselect>',
-                },
                 job_tags: {
                     label: i18n._('Job Tags'),
                     type: 'select',
@@ -250,6 +230,26 @@ function(NotificationsList, CompletedJobsList, i18n) {
                     awPopOver: "<p>" + i18n._("Optional labels that describe this job template, such as 'dev' or 'test'. Labels can be used to group and filter job templates and completed jobs.") + "</p>",
                     dataContainer: 'body',
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
+                },
+                custom_virtualenv: {
+                    label: i18n._('Ansible Environment'),
+                    type: 'select',
+                    defaultText: i18n._('Select Ansible Environment'),
+                    ngOptions: 'venv for venv in custom_virtualenvs_options track by venv',
+                    awPopOver: "<p>" + i18n._("Select the custom Python virtual environment for this job template to run on.") + "</p>",
+                    dataTitle: i18n._('Ansible Environment'),
+                    dataContainer: 'body',
+                    dataPlacement: 'right',
+                    ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAdd)'
+                },
+                instance_groups: {
+                    label: i18n._('Instance Groups'),
+                    type: 'custom',
+                    awPopOver: "<p>" + i18n._("Select the Instance Groups for this Job Template to run on.") + "</p>",
+                    dataTitle: i18n._('Instance Groups'),
+                    dataContainer: 'body',
+                    dataPlacement: 'right',
+                    control: '<instance-groups-multiselect instance-groups="instance_groups" field-is-disabled="!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)"></instance-groups-multiselect>',
                 },
                 diff_mode: {
                     label: i18n._('Show Changes'),

--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -268,7 +268,6 @@ function(NotificationsList, CompletedJobsList, i18n) {
                 checkbox_group: {
                     label: i18n._('Options'),
                     type: 'checkbox_group',
-                    class: 'Form-formGroup--fullWidth',
                     fields: [{
                         name: 'become_enabled',
                         label: i18n._('Enable Privilege Escalation'),


### PR DESCRIPTION
##### SUMMARY
* Arrange job template fields to match mockups
* Clearly define active and invalid borders by separating them with a thin border

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
@trahman73 
<img width="993" alt="screen shot 2018-03-09 at 12 01 59 pm" src="https://user-images.githubusercontent.com/15881645/37220113-97bac81c-2393-11e8-8322-0590c96e10dc.png">
<img width="382" alt="screen shot 2018-03-09 at 12 04 18 pm" src="https://user-images.githubusercontent.com/15881645/37220114-97cb0a06-2393-11e8-9680-c627436f3183.png">

