### PR TITLE
Fix project_data_dir not being added to docker-compose.yml

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -32,7 +32,6 @@ awx_secret_key=awxsecret
 # awx_kubernetes_namespace=awx
 
 # Common Docker parameters
-ansible_custom_modules_dir=/var/opt/ansible/modules
 postgres_data_dir=/tmp/pgdocker
 host_port=80
 

--- a/installer/inventory
+++ b/installer/inventory
@@ -32,6 +32,7 @@ awx_secret_key=awxsecret
 # awx_kubernetes_namespace=awx
 
 # Common Docker parameters
+ansible_custom_modules_dir=/var/opt/ansible/modules
 postgres_data_dir=/tmp/pgdocker
 host_port=80
 

--- a/installer/local_docker/templates/docker-compose.yml.j2
+++ b/installer/local_docker/templates/docker-compose.yml.j2
@@ -15,6 +15,10 @@ services:
     hostname: awxweb
     user: root
     restart: unless-stopped
+    {% if project_data_dir is defined %}
+    volumes:
+      - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
@@ -65,6 +69,10 @@ services:
     hostname: awx
     user: root
     restart: unless-stopped
+    {% if project_data_dir is defined %}
+    volumes:
+      - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}    
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
{{ project_data_dir }} was absent from the docker-compose.yml.j2 file.
This fixes it
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer
