### PR TITLE
Fix project_data_dir templating for local_docker install

### DIFF
--- a/installer/local_docker/templates/docker-compose.yml.j2
+++ b/installer/local_docker/templates/docker-compose.yml.j2
@@ -15,6 +15,10 @@ services:
     hostname: awxweb
     user: root
     restart: unless-stopped
+    {% if project_data_dir is defined %}
+    volumes:
+      - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
@@ -65,6 +69,10 @@ services:
     hostname: awx
     user: root
     restart: unless-stopped
+    {% if project_data_dir is defined %}
+    volumes:
+      - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}    
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
{{ project_data_dir }} was not present in the compose file

This fix the issue by adding it to both awx_web and awx_tasks
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer
