### PR TITLE
bump python-dateutil to latest

### DIFF
--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -65,6 +65,7 @@ def test_valid_survey_answer(post, admin_user, project, inventory, survey_spec_f
     ("DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=1;BYYEARDAY=100", "BYYEARDAY not supported"),  # noqa
     ("DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=1;BYWEEKNO=20", "BYWEEKNO not supported"),
     ("DTSTART:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=2000", "COUNT > 999 is unsupported"),  # noqa
+    ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "A valid TZID must be provided"),  # noqa
     ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
     ("DTSTART:20030925T104941Z RRULE:FREQ=DAILY;INTERVAL=10;COUNT=500;UNTIL=20040925T104941Z", "RRULE may not contain both COUNT and UNTIL"),  # noqa
     ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -38,6 +38,7 @@ pycrypto==2.6.1
 pygerduty==0.37.0
 pyOpenSSL==17.5.0
 pyparsing==2.2.0
+python-dateutil==2.7.0  # contains support for TZINFO= parsing
 python-logstash==0.4.6
 python-memcached==1.59
 python-radius==1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -182,7 +182,7 @@ pyjwt==1.6.0              # via adal, social-auth-core, twilio
 pyopenssl==17.5.0
 pyparsing==2.2.0
 pyrad==2.1                # via django-radius
-python-dateutil==2.6.1    # via adal, azure-cosmosdb-table, azure-storage-common, botocore
+python-dateutil==2.7.0
 python-ldap==2.5.2        # via django-auth-ldap
 python-logstash==0.4.6
 python-memcached==1.59


### PR DESCRIPTION
this change provides support for numerous bug fixes, along with
support for parsing TZINFO= from rrule strings

related: https://github.com/ansible/ansible-tower/issues/823
related: https://github.com/dateutil/dateutil/issues/614