### PR TITLE
More restrictive inventory env vars management

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -155,7 +155,7 @@ class AnsibleInventoryLoader(object):
 
         if self.tmp_private_dir:
             shutil.rmtree(self.tmp_private_dir, True)
-        if proc.returncode != 0 or 'file not found' in stderr:
+        if proc.returncode != 0:
             raise RuntimeError('%s failed (rc=%d) with stdout:\n%s\nstderr:\n%s' % (
                 self.method, proc.returncode, stdout, stderr))
 

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1235,6 +1235,14 @@ class InventorySourceOptions(BaseModel):
             )
         return None
 
+    def get_inventory_plugin_name(self):
+        if self.source in CLOUD_PROVIDERS or self.source == 'custom':
+            # TODO: today, all vendored sources are scripts
+            # in future release inventory plugins will replace these
+            return 'script'
+        # in other cases we do not specify which plugin to use
+        return None
+
     def get_deprecated_credential(self, kind):
         for cred in self.credentials.all():
             if cred.credential_type.kind == kind:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1158,6 +1158,8 @@ class RunJob(BaseTask):
         if job.project:
             env['PROJECT_REVISION'] = job.project.scm_revision
         env['ANSIBLE_RETRY_FILES_ENABLED'] = "False"
+        env['ANSIBLE_INVENTORY_ENABLED'] = 'script'
+        env['ANSIBLE_INVENTORY_UNPARSED_FAILED'] = 'True'
         env['MAX_EVENT_RES'] = str(settings.MAX_EVENT_RES_DATA)
         if not kwargs.get('isolated'):
             env['ANSIBLE_CALLBACK_PLUGINS'] = plugin_path
@@ -1940,6 +1942,9 @@ class RunInventoryUpdate(BaseTask):
         env['INVENTORY_UPDATE_ID'] = str(inventory_update.pk)
         # Always use the --export option for ansible-inventory
         env['ANSIBLE_INVENTORY_EXPORT'] = str(True)
+        plugin_name = inventory_update.get_inventory_plugin_name()
+        if plugin_name is not None:
+            env['ANSIBLE_INVENTORY_ENABLED'] = plugin_name
 
         # Set environment variables specific to each source.
         #


### PR DESCRIPTION
I'm salvaging this from the punted attempts at using inventory plugins.

In short, Ansible always uses inventory plugins, we just happen to almost always use the script plugin. This is merely explicitly declaring that plugin.

https://github.com/ansible/ansible/pull/37019

I want to add `ANSIBLE_ERROR_ON_VAULT_FAIL` too, but it's not ready yet.