### PR TITLE
prevent tower group delete and update

### DIFF
--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('awx.api.permissions')
 
 __all__ = ['ModelAccessPermission', 'JobTemplateCallbackPermission',
            'TaskPermission', 'ProjectUpdatePermission', 'InventoryInventorySourcesUpdatePermission',
-           'UserPermission', 'IsSuperUser']
+           'UserPermission', 'IsSuperUser', 'InstanceGroupTowerPermission',]
 
 
 class ModelAccessPermission(permissions.BasePermission):
@@ -227,3 +227,12 @@ class IsSuperUser(permissions.BasePermission):
 
     def has_permission(self, request, view):
         return request.user and request.user.is_superuser
+
+
+class InstanceGroupTowerPermission(ModelAccessPermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method not in permissions.SAFE_METHODS:
+            if obj.name == "tower":
+                return False
+        return super(InstanceGroupTowerPermission, self).has_object_permission(request, view, obj)
+

--- a/awx/api/views.py
+++ b/awx/api/views.py
@@ -77,8 +77,14 @@ from awx.main.utils import (
 from awx.main.utils.encryption import encrypt_value
 from awx.main.utils.filters import SmartFilter
 from awx.main.utils.insights import filter_insights_api_response
-
-from awx.api.permissions import * # noqa
+from awx.api.permissions import (
+    JobTemplateCallbackPermission,
+    TaskPermission,
+    ProjectUpdatePermission,
+    InventoryInventorySourcesUpdatePermission,
+    UserPermission,
+    InstanceGroupTowerPermission,
+)
 from awx.api.renderers import * # noqa
 from awx.api.serializers import * # noqa
 from awx.api.metadata import RoleMetadata, JobTypeMetadata
@@ -651,6 +657,7 @@ class InstanceGroupDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAP
     view_name = _("Instance Group Detail")
     model = InstanceGroup
     serializer_class = InstanceGroupSerializer
+    permission_classes = (InstanceGroupTowerPermission,)
 
 
 class InstanceGroupUnifiedJobsList(SubListAPIView):


### PR DESCRIPTION
* related to https://github.com/ansible/ansible-tower/issues/7931
* The Tower Instance group is special. It should always exist, so
prevent any delete to it.
* Only allow super users to associate/disassociate instances the 'tower'
instance group.
* Do not allow fields of tower instance group to be changed.