### PR TITLE
Adding more helpful job extra vars

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1364,6 +1364,9 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
             for name in ('awx', 'tower'):
                 r['{}_user_id'.format(name)] = self.created_by.pk
                 r['{}_user_name'.format(name)] = self.created_by.username
+                r['{}_user_email'.format(name)] = self.created_by.email
+                r['{}_user_first_name'.format(name)] = self.created_by.first_name
+                r['{}_user_last_name'.format(name)] = self.created_by.last_name
         else:
             wj = self.get_workflow_job()
             if wj:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2217,18 +2217,7 @@ class RunAdHocCommand(BaseTask):
         if ad_hoc_command.verbosity:
             args.append('-%s' % ('v' * min(5, ad_hoc_command.verbosity)))
 
-        # Define special extra_vars for AWX, combine with ad_hoc_command.extra_vars
-        extra_vars = {
-            'tower_job_id': ad_hoc_command.pk,
-            'awx_job_id': ad_hoc_command.pk,
-        }
-        if ad_hoc_command.created_by:
-            extra_vars.update({
-                'tower_user_id': ad_hoc_command.created_by.pk,
-                'tower_user_name': ad_hoc_command.created_by.username,
-                'awx_user_id': ad_hoc_command.created_by.pk,
-                'awx_user_name': ad_hoc_command.created_by.username,
-            })
+        extra_vars = ad_hoc_command.awx_meta_vars()
 
         if ad_hoc_command.extra_vars_dict:
             redacted_extra_vars, removed_vars = extract_ansible_vars(ad_hoc_command.extra_vars_dict)

--- a/awx/main/tests/unit/models/test_unified_job_unit.py
+++ b/awx/main/tests/unit/models/test_unified_job_unit.py
@@ -93,6 +93,12 @@ class TestMetaVars:
             'awx_job_launch_type': 'manual',
             'awx_user_name': 'joe',
             'tower_user_name': 'joe',
+            'awx_user_email': '',
+            'tower_user_email': '',
+            'awx_user_first_name': '',
+            'tower_user_first_name': '',
+            'awx_user_last_name': '',
+            'tower_user_last_name': '',
             'awx_user_id': 47,
             'tower_user_id': 47
         }


### PR DESCRIPTION
* Adds email, first name, last name as extra vars to job launches
* Remove old ad-hoc command extra vars population... use our
  base-class method instead

ref: #1515 