### PR TITLE
fix bugs with UJT optimizations

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -910,7 +910,8 @@ class InventorySourceAccess(BaseAccess):
 
     model = InventorySource
     select_related = ('created_by', 'modified_by', 'inventory')
-    prefetch_related = ('credentials',)
+    prefetch_related = ('credentials__credential_type', 'last_job',
+                        'source_script', 'source_project')
 
     def filtered_queryset(self):
         return self.model.objects.filter(inventory__in=Inventory.accessible_pk_qs(self.user, 'read_role'))


### PR DESCRIPTION
Fixes https://github.com/ansible/awx/issues/1546

Fixes https://github.com/ansible/awx/issues/1545

I tested the inventory source list & sublists, deleting an inventory script, and made sure the UJT list still worked.

This was kind of an obvious logic flag, where setting the cache keys for the UnifiedJobTemplate serializer would obviously inherit down to the subclasses, for which those fields are not valid. This can be solved by over-riding the field for each subclass, but that's not a reasonable expectation, so I named the field differently for the use on the polymorphic base.