### PR TITLE
Avoid failure if ip is not a command

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -156,4 +156,7 @@ try:
     socket.gethostbyname('docker.for.mac.internal')
     os.environ['SDB_NOTIFY_HOST'] = 'docker.for.mac.internal'
 except Exception:
-    os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
+    ip_route = os.popen('ip route').read()
+    if ip_route:
+        os.environ['SDB_NOTIFY_HOST'] = ip_route.split(' ')[2]
+    del ip_route


### PR DESCRIPTION
We need to make this case a no-op if AWX is ever going to be deployed in unconventional environments (and it's in those environments one would expect to use the development settings).

```
>>> from awx.main.models import *
sh: ip: command not found
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/awx-0.0.0-py2.7.egg/awx/main/models/__init__.py", line 8, in <module>
    from awx.main.models.base import * # noqa
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/awx-0.0.0-py2.7.egg/awx/main/models/base.py", line 11, in <module>
    from taggit.managers import TaggableManager
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/taggit/managers.py", line 8, in <module>
    from django.contrib.contenttypes.fields import GenericRelation
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/contrib/contenttypes/fields.py", line 5, in <module>
    from django.contrib.contenttypes.models import ContentType
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/contrib/contenttypes/models.py", line 139, in <module>
    class ContentType(models.Model):
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/contrib/contenttypes/models.py", line 140, in ContentType
    app_label = models.CharField(max_length=100)
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 1061, in __init__
    super(CharField, self).__init__(*args, **kwargs)
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 172, in __init__
    self.db_tablespace = db_tablespace or settings.DEFAULT_INDEX_TABLESPACE
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/conf/__init__.py", line 41, in _setup
    self._wrapped = Settings(settings_module)
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/django/conf/__init__.py", line 110, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/alancoding/.virtualenvs/cli/lib/python2.7/site-packages/awx-0.0.0-py2.7.egg/awx/settings/development.py", line 159, in <module>
    os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
IndexError: list index out of range
```

In some of these cases, `ip` just isn't a command, and the return value is just an empty string.