### PR TITLE
Fixing some issues defining resource requests in openshift and k8s

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,6 +117,15 @@ To complete a deployment to OpenShift, you will obviously need access to an Open
 
 You will also need to have the `oc` command in your PATH. The `install.yml` playbook will call out to `oc` when logging into, and creating objects on the cluster.
 
+The default resource requests per-pod requires:
+
+> Memory: 6GB
+> CPU: 3 cores
+
+This can be tuned by overriding the variables found in [/installer/openshift/defaults/main.yml](/installer/openshift/defaults/main.yml). Special care should be taken when doing this as undersized instances will experience crashes and resource exhaustion.
+
+For more detail on how resource requests are formed see: [https://docs.openshift.com/container-platform/latest/dev_guide/compute_resources.html#dev-compute-resources](https://docs.openshift.com/container-platform/latest/dev_guide/compute_resources.html#dev-compute-resources)
+
 #### Deploying to Minishift
 
 Install Minishift by following the [installation guide](https://docs.openshift.org/latest/minishift/getting-started/installing.html).
@@ -288,6 +297,15 @@ A Kubernetes deployment will require you to have access to a Kubernetes cluster 
 - [helm](https://docs.helm.sh/using_helm/#quickstart-guide)
 
 The installation program will reference `kubectl` directly. `helm` is only necessary if you are letting the installer configure PostgreSQL for you.
+
+The default resource requests per-pod requires:
+
+> Memory: 6GB
+> CPU: 3 cores
+
+This can be tuned by overriding the variables found in [/installer/kubernetes/defaults/main.yml](/installer/kubernetes[/defaults/main.yml). Special care should be taken when doing this as undersized instances will experience crashes and resource exhaustion.
+
+For more detail on how resource requests are formed see: [https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 ### Pre-build steps
 

--- a/installer/kubernetes/defaults/main.yml
+++ b/installer/kubernetes/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+awx_web_mem_request: 1
+awx_web_cpu_request: 500
+
+awx_task_mem_request: 2
+awx_task_cpu_request: 1500
+
+awx_rabbitmq_mem_request: 2
+awx_rabbitmq_cpu_request: 500
+
+awx_memcached_mem_request: 1
+awx_memcached_cpu_request: 500

--- a/installer/kubernetes/templates/configmap.yml.j2
+++ b/installer/kubernetes/templates/configmap.yml.j2
@@ -16,8 +16,8 @@ data:
     # Automatically deprovision pods that go offline
     AWX_AUTO_DEPROVISION_INSTANCES = True
 
-    SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|default(1500) / 1000) * 4)|int }}
-    SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|default(2) * 1024) / 100)|int }}
+    SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|int / 1000) * 4)|int }}
+    SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|int * 1024) / 100)|int }}
 
     #Autoprovisioning should replace this
     CLUSTER_HOST_ID = socket.gethostname()

--- a/installer/kubernetes/templates/deployment.yml.j2
+++ b/installer/kubernetes/templates/deployment.yml.j2
@@ -23,8 +23,8 @@ spec:
               name: awx-application-config
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "500m"
+              memory: "{{ awx_web_mem_request }}Gi"
+              cpu: "{{ awx_web_cpu_request }}m"
         - name: awx-celery
           image: {{ awx_task_kubernetes_image }}
           imagePullPolicy: Always
@@ -52,11 +52,8 @@ spec:
               value: {{ default_admin_password|default('password') }}
           resources:
             requests:
-              memory: "{{ awx_task_cpu_request|default('2') }}Gi"
-              cpu: "{{ awx_task_mem_request|default('1500') }}m"
-            limit:
-              memory: "{{ awx_task_cpu_request|default('2') }}Gi"
-              cpu: "{{ awx_task_mem_request|default('1500') }}m"
+              memory: "{{ awx_task_mem_request }}Gi"
+              cpu: "{{ awx_task_cpu_request }}m"
         - name: awx-rabbit
           image: ansible/awx_rabbitmq:{{ rabbitmq_version }}
           imagePullPolicy: Always
@@ -96,14 +93,14 @@ spec:
               value: "/etc/rabbitmq/rabbitmq"
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "500m"
+              memory: "{{ awx_rabbitmq_mem_request }}Gi"
+              cpu: "{{ awx_rabbitmq_cpu_request }}m"
         - name: awx-memcached
           image: memcached
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "500m"
+              memory: "{{ awx_memcached_mem_request }}Gi"
+              cpu: "{{ awx_memcached_cpu_request }}m"
       volumes:
         - name: awx-application-config
           configMap:

--- a/installer/openshift/defaults/main.yml
+++ b/installer/openshift/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+awx_web_mem_request: 1
+awx_web_cpu_request: 500
+
+awx_task_mem_request: 2
+awx_task_cpu_request: 1500
+
+awx_rabbitmq_mem_request: 2
+awx_rabbitmq_cpu_request: 500
+
+awx_memcached_mem_request: 1
+awx_memcached_cpu_request: 500

--- a/installer/openshift/templates/configmap.yml.j2
+++ b/installer/openshift/templates/configmap.yml.j2
@@ -16,8 +16,8 @@ data:
     # Automatically deprovision pods that go offline
     AWX_AUTO_DEPROVISION_INSTANCES = True
 
-    SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|default(1500) / 1000) * 4)|int }}
-    SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|default(2) * 1024) / 100)|int }}
+    SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|int / 1000) * 4)|int }}
+    SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|int * 1024) / 100)|int }}
 
     #Autoprovisioning should replace this
     CLUSTER_HOST_ID = socket.gethostname()

--- a/installer/openshift/templates/deployment.yml.j2
+++ b/installer/openshift/templates/deployment.yml.j2
@@ -23,8 +23,8 @@ spec:
               name: awx-application-config
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "500m"
+              memory: "{{ awx_web_mem_request }}Gi"
+              cpu: "{{ awx_web_cpu_request }}m"
         - name: awx-celery
           image: {{ awx_task_openshift_image }}
           imagePullPolicy: Always
@@ -52,11 +52,8 @@ spec:
               value: {{ default_admin_password|default('password') }}
           resources:
             requests:
-              memory: "{{ awx_task_cpu_request|default('2') }}Gi"
-              cpu: "{{ awx_task_mem_request|default('1500') }}m"
-            limit:
-              memory: "{{ awx_task_cpu_request|default('2') }}Gi"
-              cpu: "{{ awx_task_mem_request|default('1500') }}m"
+              memory: "{{ awx_task_mem_request }}Gi"
+              cpu: "{{ awx_task_cpu_request }}m"
         - name: awx-rabbit
           image: ansible/awx_rabbitmq:{{ rabbitmq_version }}
           imagePullPolicy: Always
@@ -94,14 +91,14 @@ spec:
               value: "/etc/rabbitmq/rabbitmq"
           resources:
             requests:
-              memory: "2Gi"
-              cpu: "500m"
+              memory: "{{ awx_rabbitmq_mem_request }}Gi"
+              cpu: "{{ awx_rabbitmq_cpu_request }}m"
         - name: awx-memcached
           image: memcached
           resources:
             requests:
-              memory: "1Gi"
-              cpu: "500m"
+              memory: "{{ awx_memcached_mem_request }}Gi"
+              cpu: "{{ awx_memcached_cpu_request }}m"
       volumes:
         - name: awx-application-config
           configMap:


### PR DESCRIPTION
* Allow overriding all container resource requests by setting defaults/
* Fix an issue where template vars were reversed in the deployment config
* Remove `limit` usage to allow for resource ballooning if it's available
* Fix type error when using templated values in the config map for resources

ref: #1568 