### PR TITLE
Add capacity adjuster slider label

### DIFF
--- a/awx/ui/client/lib/components/input/lookup.partial.html
+++ b/awx/ui/client/lib/components/input/lookup.partial.html
@@ -23,12 +23,13 @@
             <span class="form-control Form-textInput Form-textInput--variableHeight LabelList-lookupTags"
                 ng-if="state._lookupTags">
                 <div class="LabelList-tagContainer" ng-repeat="tag in state._value track by $index">
-                <div class="LabelList-deleteContainer" ng-click="vm.removeTag(tag)">
-                    <i class="fa fa-times LabelList-tagDelete"></i>
-                </div>
-                <div class="LabelList-tag LabelList-tag--deletable">
-                    <span ng-if="tag.hostname" class="LabelList-name">{{ tag.hostname }}</span>
-                    <span ng-if="!tag.hostname" class="LabelList-name">{{ tag }}</span>
+                    <div class="LabelList-tag LabelList-tag--deletable">
+                        <span ng-if="tag.hostname" class="LabelList-name">{{ tag.hostname }}</span>
+                        <span ng-if="!tag.hostname" class="LabelList-name">{{ tag }}</span>
+                    </div>
+                    <div class="LabelList-deleteContainer" ng-click="vm.removeTag(tag)">
+                        <i class="fa fa-times LabelList-tagDelete"></i>
+                    </div>
                 </div>
             </span>
         </div>

--- a/awx/ui/client/src/instance-groups/capacity-adjuster/capacity-adjuster.block.less
+++ b/awx/ui/client/src/instance-groups/capacity-adjuster/capacity-adjuster.block.less
@@ -1,7 +1,18 @@
 .CapacityAdjuster {
+    margin-right: @at-space-4x;
+    position: relative;
+
+    &-valueLabel {
+        bottom: @at-space-5x;
+        color: @at-color-body-text;
+        font-size: @at-font-size;
+        position: absolute;
+        text-align: center;
+        width: 100%;
+    }
+
     .at-InputSlider {
         align-items: center;
-        margin-right: @at-space-4x;
     }
 
     .at-InputSlider p {

--- a/awx/ui/client/src/instance-groups/capacity-adjuster/capacity-adjuster.partial.html
+++ b/awx/ui/client/src/instance-groups/capacity-adjuster/capacity-adjuster.partial.html
@@ -1,4 +1,5 @@
 <div class="CapacityAdjuster">
+    <span class="CapacityAdjuster-valueLabel">{{ state.capacity_adjustment }}</span>
     <div class="at-InputSlider">
         <p>{{min_capacity.label}} {{min_capacity.value}}</p>
             <input string-to-number

--- a/awx/ui/client/src/shared/directives.js
+++ b/awx/ui/client/src/shared/directives.js
@@ -75,12 +75,8 @@ angular.module('AWDirectives', ['RestServices', 'Utilities'])
         require: 'ngModel',
         restrict: 'A',
         link: function(scope, element, attrs, ngModel) {
-            ngModel.$parsers.push(function(value) {
-                return '' + value;
-            });
-            ngModel.$formatters.push(function(value) {
-                return parseFloat(value);
-            });
+            ngModel.$parsers.push(value => value.toFixed(2));
+            ngModel.$formatters.push(value => parseFloat(value));
         }
     };
 })


### PR DESCRIPTION
##### SUMMARY
Issues:
https://github.com/ansible/awx/issues/1436

* Add capacity adjuster slider value label
* Rolled-in fix for instance policy labels

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
_Policy Instance Tags_
<img width="663" alt="screen shot 2018-03-15 at 11 48 39 am" src="https://user-images.githubusercontent.com/15881645/37475941-42bd7830-284a-11e8-8851-0d66d40d069e.png">

___

_Slider Label_
![2018-03-15 11_55_01](https://user-images.githubusercontent.com/15881645/37475804-eff2634a-2849-11e8-8b68-1702f3d93b8e.gif)
