### PR TITLE
Map users in organizations based on saml groups

### DIFF
--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -1196,7 +1196,9 @@ register(
     category_slug='saml',
     placeholder=collections.OrderedDict([
         ('saml_attr', 'organization'),
+        ('saml_admin_attr', 'organization_admin'),
         ('remove', True),
+        ('remove_admins', True),
     ]),
     feature_required='enterprise_auth',
 )

--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -54,7 +54,7 @@ def prevent_inactive_login(backend, details, user=None, *args, **kwargs):
         raise AuthInactive(backend)
 
 
-def _update_m2m_from_expression(user, rel, expr, remove=True):
+def _update_m2m_from_expression(user, rel, expr, remove=True, saml_team_names=False):
     '''
     Helper function to update m2m relationship based on user matching one or
     more expressions.
@@ -70,6 +70,9 @@ def _update_m2m_from_expression(user, rel, expr, remove=True):
         if isinstance(expr, (six.string_types, type(re.compile('')))):
             expr = [expr]
         for ex in expr:
+            if saml_team_names:
+                if ex in saml_team_names:
+                    should_add = True
             if isinstance(ex, six.string_types):
                 if user.username == ex or user.email == ex:
                     should_add = True
@@ -104,16 +107,24 @@ def update_user_orgs(backend, details, user=None, *args, **kwargs):
             except IndexError:
                 continue
 
+        team_map = backend.setting('SOCIAL_AUTH_SAML_TEAM_ATTR') or {}
+        saml_team_names = False
+        if team_map.get('saml_attr'):
+            saml_team_names = set(kwargs
+                                  .get('response', {})
+                                  .get('attributes', {})
+                                  .get(team_map['saml_attr'], []))
+
         # Update org admins from expression(s).
         remove = bool(org_opts.get('remove', True))
         admins_expr = org_opts.get('admins', None)
         remove_admins = bool(org_opts.get('remove_admins', remove))
-        _update_m2m_from_expression(user, org.admin_role.members, admins_expr, remove_admins)
+        _update_m2m_from_expression(user, org.admin_role.members, admins_expr, remove_admins, saml_team_names)
 
         # Update org users from expression(s).
         users_expr = org_opts.get('users', None)
         remove_users = bool(org_opts.get('remove_users', remove))
-        _update_m2m_from_expression(user, org.member_role.members, users_expr, remove_users)
+        _update_m2m_from_expression(user, org.member_role.members, users_expr, remove_users, saml_team_names)
 
 
 def update_user_teams(backend, details, user=None, *args, **kwargs):

--- a/awx/sso/tests/functional/test_pipeline.py
+++ b/awx/sso/tests/functional/test_pipeline.py
@@ -149,6 +149,7 @@ class TestSAMLAttr():
                 'idp_name': u'idp',
                 'attributes': {
                     'memberOf': ['Default1', 'Default2'],
+                    'admins': ['Default3'],
                     'groups': ['Blue', 'Red'],
                     'User.email': ['cmeyers@redhat.com'],
                     'User.LastName': ['Meyers'],
@@ -176,7 +177,9 @@ class TestSAMLAttr():
         class MockSettings():
             SOCIAL_AUTH_SAML_ORGANIZATION_ATTR = {
                 'saml_attr': 'memberOf',
+                'saml_admin_attr': 'admins',
                 'remove': True,
+                'remove_admins': True,
             }
             SOCIAL_AUTH_SAML_TEAM_ATTR = {
                 'saml_attr': 'groups',


### PR DESCRIPTION
##### SUMMARY
Related to #217 
First implementation do not allow to add users as organization admins, only as organisation members.
If anybody as a better idea I'm open.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
1.0.4.0
```
