### PR TITLE
Fix error where list directive requires results attribute

### DIFF
--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
@@ -33,7 +33,7 @@
             </div>
         </div>
 
-        <at-list>
+        <at-list results="instance_groups">
             <at-row ng-repeat="instance_group in instance_groups"
                 ng-class="{'at-Row--active': (instance_group.id === vm.activeId)}">
 


### PR DESCRIPTION
##### SUMMARY
* Fixes error by passing instance_groups to the list directive's results attribute.

![image](https://user-images.githubusercontent.com/15881645/37482677-37da3406-285b-11e8-84b6-91f0755d53ea.png)

##### COMPONENT NAME
 - UI


