### PR TITLE
Bump copyright date.

### DIFF
--- a/awx/ui/client/lib/components/components.strings.js
+++ b/awx/ui/client/lib/components/components.strings.js
@@ -76,7 +76,7 @@ function ComponentsStrings (BaseString) {
         APPLICATIONS: t.s('Applications'),
         SETTINGS: t.s('Settings'),
         FOOTER_ABOUT: t.s('About'),
-        FOOTER_COPYRIGHT: t.s('Copyright © 2017 Red Hat, Inc.')
+        FOOTER_COPYRIGHT: t.s('Copyright © 2018 Red Hat, Inc.')
     };
 
     ns.relaunch = {


### PR DESCRIPTION
We don't need to do this at the source code level, but we should do it for the app as a whole.
