### PR TITLE
Fix bug with non-event model

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -930,7 +930,11 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
         '''
         if self.status in ACTIVE_STATES:
             return False  # tally of events is only available at end of run
-        return self.emitted_events == self.get_event_queryset().count()
+        try:
+            event_qs = self.get_event_queryset()
+        except NotImplementedError:
+            return True  # Model without events, such as WFJT
+        return self.emitted_events == event_qs.count()
 
     def result_stdout_raw_handle(self, enforce_max_bytes=True):
         """

--- a/awx/main/tests/functional/models/test_unified_job.py
+++ b/awx/main/tests/functional/models/test_unified_job.py
@@ -141,3 +141,16 @@ class TestMetaVars:
         )
         data = job.awx_meta_vars()
         assert data['awx_schedule_id'] == schedule.pk
+
+
+@pytest.mark.django_db
+def test_event_processing_not_finished():
+    job = Job.objects.create(emitted_events=2, status='finished')
+    job.event_class.objects.create(job=job)
+    assert not job.event_processing_finished
+
+
+@pytest.mark.django_db
+def test_event_model_undefined():
+    wj = WorkflowJob.objects.create(name='foobar', status='finished')
+    assert wj.event_processing_finished


### PR DESCRIPTION
There was a bug where attempting to delete a workflow job would give a `NotImplementedError`. This is because the mixin for preventing deletion when jobs are running is applied to all types.

That is to say, we should prevent deleting a workflow job when it has outstanding jobs, but there is no meaningful check for a workflow job's events all having been processed. Given that bug, safest to just return False for this particular method.

This property is not present on the workflow job serializer.