### PR TITLE
pin botocore to avoid dependency hell re: latest python-dateutil

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,6 +6,7 @@ azure==3.0.0
 backports.ssl-match-hostname==3.5.0.1
 boto==2.47.0
 boto3==1.6.2
+botocore<1.9.8  # botocore 1.9.8 pinned python-dateutil < 2.7.0 (our TZID fixes) https://github.com/boto/botocore/pull/1402
 channels==1.1.8
 celery==3.1.25
 daphne==1.3.0   # Last before backwards-incompatible channels 2 upgrade

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -96,7 +96,7 @@ baron==0.6.6              # via redbaron
 billiard==3.3.0.23        # via celery
 boto3==1.6.2
 boto==2.47.0
-botocore==1.9.5           # via boto3, s3transfer
+botocore==1.9.7
 celery==3.1.25
 certifi==2018.1.18        # via msrest
 cffi==1.11.5              # via azure-datalake-store, cryptography


### PR DESCRIPTION
boto decided to pin python-dateutil on a version _lower than_ what we
need for the `python-dateutil==2.7.0` `TZID=` bug fix:

https://github.com/dateutil/dateutil/pull/619
https://github.com/boto/botocore/commit/90d7692702be1a423af15e0f49b58365f2a400f2#diff-b4ef698db8ca845e5845c4618278f29a

If this is fixed upstream in `boto` (potentially via https://github.com/boto/botocore/pull/1406), we can remove this pin.