### PR TITLE
Sync tower verify_ssl parameter with tower-cli

### DIFF
--- a/awx/main/migrations/0027_v330_add_tower_verify.py
+++ b/awx/main/migrations/0027_v330_add_tower_verify.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+# AWX
+from awx.main.migrations import _credentialtypes as credentialtypes
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0026_v330_emitted_events'),
+    ]
+
+    operations = [
+        migrations.RunPython(credentialtypes.add_tower_verify_field),
+    ]

--- a/awx/main/migrations/_credentialtypes.py
+++ b/awx/main/migrations/_credentialtypes.py
@@ -184,6 +184,14 @@ def create_rhv_tower_credtype(apps, schema_editor):
     CredentialType.setup_tower_managed_defaults()
 
 
+def add_tower_verify_field(apps, schema_editor):
+    tower_credtype = CredentialType.objects.get(
+        kind='cloud', name='Ansible Tower', managed_by_tower=True
+    )
+    tower_credtype.inputs = CredentialType.defaults.get('tower')().inputs
+    tower_credtype.save()
+
+
 def add_azure_cloud_environment_field(apps, schema_editor):
     azure_rm_credtype = CredentialType.objects.get(kind='cloud',
                                                    name='Microsoft Azure Resource Manager')

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1181,6 +1181,11 @@ def tower(cls):
                 'label': 'Password',
                 'type': 'string',
                 'secret': True,
+            }, {
+                'id': 'verify_ssl',
+                'label': 'Verify SSL',
+                'type': 'boolean',
+                'secret': False
             }],
             'required': ['host', 'username', 'password'],
         },
@@ -1189,6 +1194,7 @@ def tower(cls):
                 'TOWER_HOST': '{{host}}',
                 'TOWER_USERNAME': '{{username}}',
                 'TOWER_PASSWORD': '{{password}}',
+                'TOWER_VERIFY_SSL': '{{verify_ssl}}'
             }
         },
     )

--- a/awx/plugins/inventory/tower.py
+++ b/awx/plugins/inventory/tower.py
@@ -54,7 +54,14 @@ def parse_configuration():
     host_name = os.environ.get("TOWER_HOST", None)
     username = os.environ.get("TOWER_USERNAME", None)
     password = os.environ.get("TOWER_PASSWORD", None)
-    ignore_ssl = os.environ.get("TOWER_IGNORE_SSL", "1").lower() in ("1", "yes", "true")
+    ignore_ssl = False
+    ssl_negative_var = os.environ.get("TOWER_IGNORE_SSL", None)
+    if ssl_negative_var:
+        ignore_ssl = ssl_negative_var.lower() in ("1", "yes", "true")
+    else:
+        ssl_positive_var = os.environ.get("TOWER_VERIFY_SSL", None)
+        if ssl_positive_var:
+            ignore_ssl = ssl_positive_var.lower() not in ('true', '1', 't', 'y', 'yes')
     inventory = os.environ.get("TOWER_INVENTORY", None)
     license_type = os.environ.get("TOWER_LICENSE_TYPE", "enterprise")
 


### PR DESCRIPTION
Add new input for the tower type credential
elsewhere, tests are being added for verify_ssl in modules
tower-cli also updating to use the original tower.py var

This is a full 3-repo effort

 - Ansible, trying to test that this works at all https://github.com/ansible/ansible/pull/37597
 - Ported Matt's old variable to tower-cli use, so they will still have parity https://github.com/ansible/tower-cli/pull/498