### PR TITLE
System Setting for Orgainization User/Team permissions.

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -35,7 +35,7 @@ register(
 register(
     'OAUTH2_PROVIDER',
     field_class=OAuth2ProviderField,
-    default={'ACCESS_TOKEN_EXPIRE_SECONDS': 315360000000, 
+    default={'ACCESS_TOKEN_EXPIRE_SECONDS': 315360000000,
              'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600},
     label=_('OAuth 2 Timeout Settings'),
     help_text=_('Dictionary for customizing OAuth 2 timeouts, available items are '

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2483,6 +2483,10 @@ class RoleAccess(BaseAccess):
 
     @check_superuser
     def can_unattach(self, obj, sub_obj, relationship, data=None, skip_sub_obj_read_check=False):
+        if isinstance(obj.content_object, Team):
+            if not settings.ORGS_CAN_ASSIGN_USERS_TEAM:
+                return False
+
         if not skip_sub_obj_read_check and relationship in ['members', 'member_role.parents', 'parents']:
             # If we are unattaching a team Role, check the Team read access
             if relationship == 'parents':

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -547,7 +547,7 @@ class UserAccess(BaseAccess):
         return False
 
     def can_attach(self, obj, sub_obj, relationship, *args, **kwargs):
-        if not settings.MANAGE_ORGANIZTAION_AUTH:
+        if not settings.MANAGE_ORGANIZATION_AUTH:
             return False
 
         # Reverse obj and sub_obj, defer to RoleAccess if this is a role assignment.

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -44,24 +44,11 @@ register(
 )
 
 register(
-    'ORGS_CAN_CREATE_USERS',
+    'MANAGE_ORGANIZATION_AUTH',
     field_class=fields.BooleanField,
-    label=_('Organization Admins can create users.'),
-    help_text=_('Enable Organizations to create users. You may want to '
-                'disable this if you populate your users from some external source '
-                'like LDAP or SAML.'),
-    category=_('System'),
-    category_slug='system',
-)
-
-register(
-    'ORGS_CAN_ASSIGN_USERS_TEAM',
-    field_class=fields.BooleanField,
-    label=_('Organization Admins can assign users to teams.'),
-    help_text=_('Enable Organizations to assign users to teams. You may want to '
-                'disable this if you populate your users from some external source '
-                'like LDAP or SAML. This will prevent team assignments for '
-                'Organization and Team admins.'),
+    label=_('Organizations Can Manage Users and Teams'),
+    help_text=_('Controls whether Orgainzations have the privileges to create and manage users and teams. '
+                'You may want to disable this ability if you are using an LDAP or SAML integration.'),
     category=_('System'),
     category_slug='system',
 )
@@ -113,6 +100,7 @@ register(
     category_slug='system',
 )
 
+
 def _load_default_license_from_file():
     try:
         license_file = os.environ.get('AWX_LICENSE_FILE', '/etc/tower/license')
@@ -123,6 +111,7 @@ def _load_default_license_from_file():
     except Exception:
         logger.warning('Could not read license from "%s".', license_file, exc_info=True)
     return {}
+
 
 register(
     'LICENSE',
@@ -504,6 +493,7 @@ register(
     category=_('Logging'),
     category_slug='logging',
 )
+
 
 def logging_validate(serializer, attrs):
     if not serializer.instance or \

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -46,8 +46,8 @@ register(
 register(
     'MANAGE_ORGANIZATION_AUTH',
     field_class=fields.BooleanField,
-    label=_('Organizations Can Manage Users and Teams'),
-    help_text=_('Controls whether Orgainzations have the privileges to create and manage users and teams. '
+    label=_('Organization Admins Can Manage Users and Teams'),
+    help_text=_('Controls whether any Organization Admin has the privileges to create and manage users and teams. '
                 'You may want to disable this ability if you are using an LDAP or SAML integration.'),
     category=_('System'),
     category_slug='system',

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -44,6 +44,29 @@ register(
 )
 
 register(
+    'ORGS_CAN_CREATE_USERS',
+    field_class=fields.BooleanField,
+    label=_('Organization Admins can create users.'),
+    help_text=_('Enable Organizations to create users. You may want to '
+                'disable this if you populate your users from some external source '
+                'like LDAP or SAML.'),
+    category=_('System'),
+    category_slug='system',
+)
+
+register(
+    'ORGS_CAN_ASSIGN_USERS_TEAM',
+    field_class=fields.BooleanField,
+    label=_('Organization Admins can assign users to teams.'),
+    help_text=_('Enable Organizations to assign users to teams. You may want to '
+                'disable this if you populate your users from some external source '
+                'like LDAP or SAML. This will prevent team assignments for '
+                'Organization and Team admins.'),
+    category=_('System'),
+    category_slug='system',
+)
+
+register(
     'TOWER_ADMIN_ALERTS',
     field_class=fields.BooleanField,
     label=_('Enable Administrator Alerts'),
@@ -90,7 +113,6 @@ register(
     category_slug='system',
 )
 
-
 def _load_default_license_from_file():
     try:
         license_file = os.environ.get('AWX_LICENSE_FILE', '/etc/tower/license')
@@ -101,7 +123,6 @@ def _load_default_license_from_file():
     except Exception:
         logger.warning('Could not read license from "%s".', license_file, exc_info=True)
     return {}
-
 
 register(
     'LICENSE',
@@ -483,7 +504,6 @@ register(
     category=_('Logging'),
     category_slug='logging',
 )
-
 
 def logging_validate(serializer, attrs):
     if not serializer.instance or \

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -340,7 +340,7 @@ AUTHENTICATION_BACKENDS = (
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'main.OAuth2Application'
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = 'main.OAuth2AccessToken'
 
-OAUTH2_PROVIDER = {'ACCESS_TOKEN_EXPIRE_SECONDS': 31536000000, 
+OAUTH2_PROVIDER = {'ACCESS_TOKEN_EXPIRE_SECONDS': 31536000000,
                    'AUTHORIZATION_CODE_EXPIRE_SECONDS': 600}
 
 # LDAP server (default to None to skip using LDAP authentication).
@@ -945,6 +945,8 @@ FACT_CACHE_PORT = 6564
 
 # Note: This setting may be overridden by database settings.
 ORG_ADMINS_CAN_SEE_ALL_USERS = True
+ORGS_CAN_CREATE_USERS = True
+ORGS_CAN_ASSIGN_USERS_TEAM = True
 
 # Note: This setting may be overridden by database settings.
 TOWER_ADMIN_ALERTS = True

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -945,8 +945,7 @@ FACT_CACHE_PORT = 6564
 
 # Note: This setting may be overridden by database settings.
 ORG_ADMINS_CAN_SEE_ALL_USERS = True
-ORGS_CAN_CREATE_USERS = True
-ORGS_CAN_ASSIGN_USERS_TEAM = True
+MANAGE_ORGANIZATION_AUTH = True
 
 # Note: This setting may be overridden by database settings.
 TOWER_ADMIN_ALERTS = True

--- a/awx/ui/client/src/configuration/system-form/sub-forms/system-misc.form.js
+++ b/awx/ui/client/src/configuration/system-form/sub-forms/system-misc.form.js
@@ -21,10 +21,7 @@ export default ['i18n', function(i18n) {
             ORG_ADMINS_CAN_SEE_ALL_USERS: {
                 type: 'toggleSwitch',
             },
-            ORGS_CAN_CREATE_USERS: {
-                type: 'toggleSwitch',
-            },
-            ORGS_CAN_ASSIGN_USERS_TEAM: {
+            MANAGE_ORGANIZATION_AUTH: {
                 type: 'toggleSwitch',
             },
             SESSION_COOKIE_AGE: {

--- a/awx/ui/client/src/configuration/system-form/sub-forms/system-misc.form.js
+++ b/awx/ui/client/src/configuration/system-form/sub-forms/system-misc.form.js
@@ -21,6 +21,12 @@ export default ['i18n', function(i18n) {
             ORG_ADMINS_CAN_SEE_ALL_USERS: {
                 type: 'toggleSwitch',
             },
+            ORGS_CAN_CREATE_USERS: {
+                type: 'toggleSwitch',
+            },
+            ORGS_CAN_ASSIGN_USERS_TEAM: {
+                type: 'toggleSwitch',
+            },
             SESSION_COOKIE_AGE: {
                 type: 'number',
                 integer: true,


### PR DESCRIPTION
Implements a system wide setting toggle to restrict if org admins can create users and assign teams. This ability is True by default.

related #166 #1526 