### PR TITLE
Make user_capabilities False for read tokens

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -341,7 +341,10 @@ class BaseAccess(object):
 
             # Actions not possible for reason unrelated to RBAC
             # Cannot copy with validation errors, or update a manual group/project
-            if display_method == 'copy' and isinstance(obj, JobTemplate):
+            if 'write' not in getattr(self.user, 'oauth_scopes', ['write']):
+                user_capabilities[display_method] = False  # Read tokens cannot take any actions
+                continue
+            elif display_method == 'copy' and isinstance(obj, JobTemplate):
                 if obj.validation_errors:
                     user_capabilities[display_method] = False
                     continue

--- a/awx/main/tests/unit/api/serializers/conftest.py
+++ b/awx/main/tests/unit/api/serializers/conftest.py
@@ -39,6 +39,7 @@ def get_summary_fields_assert():
 def get_summary_fields_mock_and_run():
     def fn(serializer_class, model_obj):
         serializer = serializer_class()
+        serializer.show_capabilities = []
         serializer.context['view'] = mock.Mock(kwargs={})
         return serializer.get_summary_fields(model_obj)
     return fn


### PR DESCRIPTION
Connect https://github.com/ansible/awx/issues/1370

tested with 

```
tower-cli login admin --scope=read
tower-cli login admin --scope=write
```