### PR TITLE
Corrected alternate dns servers entries in docker-compose template

### DIFF
--- a/installer/local_docker/templates/docker-compose.yml.j2
+++ b/installer/local_docker/templates/docker-compose.yml.j2
@@ -24,24 +24,24 @@ services:
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
     {% endif %}
-    {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}
+    {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
     {% for awx_container_search_domain in awx_container_search_domains_list %}
       - {{ awx_container_search_domain }}
     {% endfor %}
-    {% elif awx_container_search_domains is defined -%}
+    {% elif awx_container_search_domains is defined %}
     dns_search: "{{ awx_container_search_domains }}"
-    {%- endif %}
-    {% if (awx_alternate_dns_servers is defined) and (',' in awx_alternate_dns_servers) -%}
+    {% endif %}
+    {% if (awx_alternate_dns_servers is defined) and (',' in awx_alternate_dns_servers) %}
     {% set awx_alternate_dns_servers_list = awx_alternate_dns_servers.split(',') %}
     dns:
     {% for awx_alternate_dns_server in awx_alternate_dns_servers_list %}
       - {{ awx_alternate_dns_server }}
     {% endfor %}
     {% elif awx_alternate_dns_servers is defined -%}
-    dns: "{{ awx_alternate_dns_servers }}"
-    {%- endif %}
+      dns: "{{ awx_alternate_dns_servers }}"
+    {% endif %}
     environment:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
@@ -83,16 +83,16 @@ services:
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
     {% endif %}
-    {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) -%}    
+    {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}    
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
     {% for awx_container_search_domain in awx_container_search_domains_list %}
       - {{ awx_container_search_domain }}
     {% endfor %}
-    {% elif awx_container_search_domains is defined -%}
+    {% elif awx_container_search_domains is defined %}
     dns_search: "{{ awx_container_search_domains }}"
-    {%- endif %}
-    {% if (awx_alternate_dns_servers is defined) and (',' in awx_alternate_dns_servers) -%}
+    {% endif %}
+    {% if (awx_alternate_dns_servers is defined) and (',' in awx_alternate_dns_servers) %}
     {% set awx_alternate_dns_servers_list = awx_alternate_dns_servers.split(',') %}
     dns:
     {% for awx_alternate_dns_server in awx_alternate_dns_servers_list %}
@@ -100,7 +100,7 @@ services:
     {% endfor %}
     {% elif awx_alternate_dns_servers is defined -%}
     dns: "{{ awx_alternate_dns_servers }}"
-    {%- endif %}
+    {% endif %}
     environment:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}


### PR DESCRIPTION
##### SUMMARY
As lstrip_blocks: True was added, this broke the formating when adding alternate DNS servers within the template. Removing the extra white space removals within the if and endif statements fixed the resulting yml formating.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer
