### PR TITLE
Updates to callback scripts

### DIFF
--- a/tools/scripts/request_tower_configuration.ps1
+++ b/tools/scripts/request_tower_configuration.ps1
@@ -1,7 +1,8 @@
 ﻿Param(
     [string]$tower_url,
     [string]$host_config_key,
-    [string]$job_template_id
+    [string]$job_template_id,
+    [string]$extra_vars
 )
 
 Set-StrictMode -Version 2
@@ -10,24 +11,36 @@ $ErrorActionPreference = "Stop"
 If(-not $tower_url -or -not $host_config_key -or -not $job_template_id)
 {
     Write-Host "Requests server configuration from Ansible Tower"
-    Write-Host "Usage: $($MyInvocation.MyCommand.Name) <server address>[:server port] <host config key> <job template id>"
-    Write-Host "Example: $($MyInvocation.MyCommand.Name) example.towerhost.net 44d7507f2ead49af5fca80aa18fd24bc 38"
+    Write-Host "Usage: $($MyInvocation.MyCommand.Name) https://<server address>[:server port] <host config key> <job template id>"
+    Write-Host "Example: $($MyInvocation.MyCommand.Name) https://example.towerhost.net 44d7507f2ead49af5fca80aa18fd24bc 38"
+    Write-Host "Example with extra_vars: $($MyInvocation.MyCommand.Name) https://example.towerhost.net 44d7507f2ead49af5fca80aa18fd24bc 38 '{ key: value, dict: { key: value }}'"
     Exit 1
 }
 
 $retry_attempts = 10
 $attempt = 0
 
-$data = @{
-    host_config_key=$host_config_key
+If(-not $extra_vars)
+{
+    $data = @{
+        host_config_key=$host_config_key
+    }
+} Else {
+    $data = @{
+        host_config_key=$host_config_key
+        extra_vars=$extra_vars
+    }
 }
 
 While ($attempt -lt $retry_attempts) {
     Try {
-        $resp = Invoke-WebRequest -Method POST -Body $data -Uri http://$tower_url/api/v1/job_templates/$job_template_id/callback/ -UseBasicParsing
+        $resp = Invoke-WebRequest -ContentType application/json -Method POST -Body (ConvertTo-Json $data) -Uri $tower_url/api/v2/job_templates/$job_template_id/callback/
 
-        If($resp.StatusCode -eq 202) {
+        If ($resp.StatusCode -match '^2[0-9]+$') {
             Exit 0
+        } ElseIf ($resp.StatusCode -eq 404) {
+            Write-Host "$resp.StatusCode received... encountered problem, halting"
+            Exit 1
         }
     }
     Catch {


### PR DESCRIPTION
 that include retry functionality for bash and extra_vars handling for PowerShell

Signed-off-by: Rob Ruma <robruma@users.noreply.github.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current callback scripts are missing some useful functionality.
I've simply added functionality to the scripts to retry the callback if any other status code that 2** and 404.
I've also added extra_vars handling to the PowerShell script and updated the URL to api v2.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.4.116
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
