### PR TITLE
Fixed permissions multi-select deselect bug

### DIFF
--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
@@ -82,6 +82,7 @@ export default ['$rootScope', '$scope', 'GetBasePath', 'Rest', '$q', 'Wait', 'Pr
     scope.removeObject = function(obj){
         let resourceType = scope.currentTab();
         delete scope.allSelected[resourceType][obj.id];
+        obj.isSelected = false;
     };
 
     scope.toggleKeyPane = function() {

--- a/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
+++ b/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
@@ -146,10 +146,6 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
             scope[`${list.iterator}_dataset`] = scope.dataset.data;
             scope[`${list.name}`] = scope[`${list.iterator}_dataset`].results;
 
-            scope.$watch(`allSelected.${list.name}`, function(){
-                _.forEach(scope[`${list.name}`], isSelected);
-            }, true);
-
             scope.$watch(list.name, function(){
                 _.forEach(scope[`${list.name}`], isSelected);
                 optionsRequestDataProcessing();
@@ -198,7 +194,6 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
             }
 
             function isSelected(item){
-                item.isSelected = false;
                 _.forEach(scope.allSelected[list.name], (selectedRow) => {
                     if(selectedRow.id === item.id) {
                         item.isSelected = true;


### PR DESCRIPTION
##### SUMMARY
Rolled back some changes made previously to address a different issue.  Confirmed that the original issue is still fixed by rolling back this code.

The things that we want to make sure work are:

a) The user can click the checkbox to select and deselect items in the permissions modal.
b) Selecting/Deselecting options across pages is reflected in Step 2 down below.
c) Removing items in Step 2 deselects the checkbox in Step 1.

Step 1/Step 2 referenced above reflected in this screenshot:
<img width="859" alt="screen shot 2018-03-23 at 11 00 42 am" src="https://user-images.githubusercontent.com/9889020/37836700-83f8415a-2e89-11e8-85a8-e5b3edf9163e.png">


link https://github.com/ansible/awx/issues/1555

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.4.129
```