### PR TITLE
[WIP] non-blocking/blocking lock system for inventory computed fields

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -27,7 +27,7 @@ from django.contrib.sessions.models import Session
 from awx.api.serializers import * # noqa
 from awx.main.utils import model_instance_diff, model_to_dict, camelcase_to_underscore
 from awx.main.utils import ignore_inventory_computed_fields, ignore_inventory_group_removal, _inventory_updates
-from awx.main.tasks import update_inventory_computed_fields
+from awx.main.tasks import schedule_inventory_computed_fields_update
 from awx.main.fields import is_implicit_parent
 
 from awx.main import consumers
@@ -112,7 +112,7 @@ def emit_update_inventory_computed_fields(sender, **kwargs):
     except Inventory.DoesNotExist:
         pass
     else:
-        update_inventory_computed_fields.delay(inventory.id, True)
+        schedule_inventory_computed_fields_update(inventory.id)
 
 
 def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
@@ -133,7 +133,7 @@ def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
         pass
     else:
         if inventory is not None:
-            update_inventory_computed_fields.delay(inventory.id, True)
+            schedule_inventory_computed_fields_update(inventory.id)
 
 
 def rebuild_role_ancestor_list(reverse, model, instance, pk_set, action, **kwargs):


### PR DESCRIPTION
Redo of https://github.com/ansible/awx/pull/1628

I did have a bug in the implementation of the concept - after a worker takes the "compute" lock, it did not release the "wait" lock. In order to accomplish this coherently, it has to release the wait lock after it begins computing. That's kind of ugly with the context managers, and this may need some additional error handling to make double-sure the "wait" lock is released. If it were not released, the computed fields for that inventory would stop updating.

I have been testing with these two contrived scenarios:

```python
# case 1
from awx.main.tasks import schedule_inventory_computed_fields_update
var = [schedule_inventory_computed_fields_update(42) for i in range(200)]
# case 2
from awx.main.tasks import update_inventory_computed_fields
var = [update_inventory_computed_fields.delay(42) for i in range(200)]
```

Output corresponding to case 2 along with some additional logs:

https://gist.github.com/AlanCoding/47750c077b6e472e33e742232860a590

For more on the current behavior, I wanted to look into the performance with a large number of parallel threads running computed fields in current devel:

https://gist.github.com/AlanCoding/7c0cc3433cd7e3047b5c6c7fdc9fbc85

This is a no-op task, and execution time goes from 0.2->1.3 at maximum roughly. Because it's no-op, this should not be because of database locking (in the ORM actions themselves), and it's probably due to a simple scarcity of compute resources. Worker number limits at 20 and the VM only has 4 cores to work with.