### PR TITLE
Inventory source can_change - remove credential check

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -928,7 +928,6 @@ class InventorySourceAccess(BaseAccess):
         if obj and obj.inventory:
             return (
                 self.user.can_access(Inventory, 'change', obj.inventory, None) and
-                self.check_related('credential', Credential, data, obj=obj, role_field='use_role') and
                 self.check_related('source_project', Project, data, obj=obj, role_field='use_role')
             )
         # Can't change inventory sources attached to only the inventory, since

--- a/awx/main/tests/functional/test_rbac_inventory.py
+++ b/awx/main/tests/functional/test_rbac_inventory.py
@@ -155,7 +155,7 @@ def test_host_access(organization, inventory, group, user, group_factory):
 def test_inventory_source_credential_check(rando, inventory_source, credential):
     inventory_source.inventory.admin_role.members.add(rando)
     access = InventorySourceAccess(rando)
-    assert not access.can_change(inventory_source, {'credential': credential})
+    assert not access.can_attach(inventory_source, credential, 'credentials', {'id': credential.pk})
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes https://github.com/ansible/awx/issues/1664

This is pretty direct fallout from https://github.com/ansible/awx/pull/1277

We check access in the serializer now https://github.com/AlanCoding/awx-1/blob/bb6032cff64a13c35f6c4f04b7820c7de0c854cb/awx/api/serializers.py#L1783 as a hacky stop-gap, or in the can_attach method.