### PR TITLE
Fixed parentless function

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -602,7 +602,7 @@ def save_user_session_membership(sender, **kwargs):
         return
     UserSessionMembership.objects.create(user=user, session=session, created=timezone.now())
     for membership in UserSessionMembership.get_memberships_over_limit(user):
-        emit_channel_notification(
+        consumers.emit_channel_notification(
             'control-limit_reached',
             dict(group_name='control',
                  reason=unicode(_('limit_reached')),


### PR DESCRIPTION
Signed-off-by: HNKNTA <hnknta@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The function `emit_channel_notification` doesn't exist in the `signals.py` file, but exists in `consumers.py`. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.4.131
```

