### PR TITLE
Removed unused settings (replaced by source_vars)

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -886,8 +886,7 @@ SATELLITE6_GROUP_FILTER = r'^.+$'
 SATELLITE6_HOST_FILTER = r'^.+$'
 SATELLITE6_EXCLUDE_EMPTY_GROUPS = True
 SATELLITE6_INSTANCE_ID_VAR = 'foreman.id'
-SATELLITE6_GROUP_PREFIX = 'foreman_'
-SATELLITE6_GROUP_PATTERNS = ["{app}-{tier}-{color}", "{app}-{color}", "{app}", "{tier}"]
+# SATELLITE6_GROUP_PREFIX and SATELLITE6_GROUP_PATTERNS defined in source vars
 
 # ---------------------
 # ----- CloudForms -----


### PR DESCRIPTION
See the commit https://github.com/ansible/awx/commit/323d7757dd6b371d3cfdb385bd1bd059a9f053d7

> Move Satellite 6 .ini configurations from env variables to source_vars

This removed the use of both of these settings. By keeping them in the settings file `defaults.py`, people will likely mistake how they are supposed to set them.