### PR TITLE
remove tower-license dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ awx/ui/build_test
 awx/ui/client/languages
 awx/ui/templates/ui/index.html
 awx/ui/templates/ui/installing.html
+/tower-license
 /tower-license/**
 
 # Tower setup playbook testing


### PR DESCRIPTION
somehow this was added even though it is in .gitignore