### PR TITLE
Fixed js error when adding first workflow node

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow.service.js
+++ b/awx/ui/client/src/templates/workflows/workflow.service.js
@@ -73,7 +73,7 @@ export default ['$q', function($q){
                 placeholder: true,
                 isNew: true,
                 edited: false,
-                isRoot: _.get(params, 'parent.isStartNode') ? true : _.get(params, 'parent.source.isStartNode', false)
+                isRoot: (params.betweenTwoNodes) ? _.get(params, 'parent.source.isStartNode', false) : _.get(params, 'parent.isStartNode', false)
             };
 
             let parentNode = (params.betweenTwoNodes) ? this.searchTree({element: params.tree, matchingId: params.parent.source.id}) : this.searchTree({element: params.tree, matchingId: params.parent.id});

--- a/awx/ui/client/src/templates/workflows/workflow.service.js
+++ b/awx/ui/client/src/templates/workflows/workflow.service.js
@@ -73,7 +73,7 @@ export default ['$q', function($q){
                 placeholder: true,
                 isNew: true,
                 edited: false,
-                isRoot: params.parent.source.isStartNode ? true : false
+                isRoot: _.get(params, 'parent.isStartNode') ? true : _.get(params, 'parent.source.isStartNode', false)
             };
 
             let parentNode = (params.betweenTwoNodes) ? this.searchTree({element: params.tree, matchingId: params.parent.source.id}) : this.searchTree({element: params.tree, matchingId: params.parent.id});


### PR DESCRIPTION
##### SUMMARY
Fixes a bug that came out of https://github.com/ansible/awx/pull/1671

When addPlaceholderNode is called, the parent that gets passed in can be structured in two different ways depending on whether or not the new node is to be added between two other nodes.  The isRoot check should reflect accordingly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
