### PR TITLE
Customizable template for OpenShift PostgreSQL deployment

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-rabbitmq_version: "3.7.4"
-
 awx_web_mem_request: 1
 awx_web_cpu_request: 500
 
@@ -12,3 +10,8 @@ awx_rabbitmq_cpu_request: 500
 
 awx_memcached_mem_request: 1
 awx_memcached_cpu_request: 500
+
+rabbitmq_version: "3.7.4"
+
+openshift_pg_emptydir: no
+openshift_pg_pvc_name: postgresql

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -51,19 +51,44 @@
     awx_task_kubernetes_image: "{{ dockerhub_base }}/awx_task:{{ dockerhub_version }}"
   when: dockerhub_base is defined
 
-- name: Deploy and Activate Postgres (Kubernetes)
-  shell: "helm install --name awx --namespace {{ awx_kubernetes_namespace }} --set postgresUser={{ pg_username }},postgresPassword={{ pg_password }},postgresDatabase={{ pg_database }},persistence.size={{ pg_volume_capacity|default('5')}}Gi stable/postgresql"
+- name: Deploy PostgreSQL (OpenShift)
+  block:
+    - name: Template PostgreSQL Deployment
+      template:
+        src: postgresql-persistent.yml.j2
+        dest: "{{ kubernetes_base_path }}/postgresql-persistent.yml"
+        mode: '0600'
+
+    - name: Deploy and Activate Postgres
+      shell: |
+        {{ openshift_oc_bin }} new-app --file={{ kubernetes_base_path }}/postgresql-persistent.yml \
+          -e MEMORY_LIMIT={{ pg_memory_limit|default('512') }}Mi \
+          -e DATABASE_SERVICE_NAME=postgresql  \
+          -e POSTGRESQL_MAX_CONNECTIONS={{ pg_max_connections|default(1024) }} \
+          -e POSTGRESQL_USER={{ pg_username }} \
+          -e POSTGRESQL_PASSWORD={{ pg_password }} \
+          -e POSTGRESQL_DATABASE={{ pg_database }} \
+          -e POSTGRESQL_VERSION=9.5 \
+          -n {{ awx_kubernetes_namespace }}
+      register: openshift_pg_activate
   when:
-    - (pg_hostname is not defined or pg_hostname == '') and (postgres_svc_details is defined and postgres_svc_details.rc != 0)
+    - pg_hostname is not defined or pg_hostname == ''
+    - postgres_svc_details is defined and postgres_svc_details.rc != 0
+    - openshift_host is defined
+
+- name: Deploy and Activate Postgres (Kubernetes)
+  shell: |
+    helm install --name awx --namespace {{ awx_kubernetes_namespace }} \
+      --set postgresUser={{ pg_username }} \
+      --set postgresPassword={{ pg_password }} \
+      --set postgresDatabase={{ pg_database }} \
+      --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
+      stable/postgresql
+  when:
+    - pg_hostname is not defined or pg_hostname == ''
+    - postgres_svc_details is defined and postgres_svc_details.rc != 0
     - kubernetes_context is defined
   register: kubernetes_pg_activate
-
-- name: Deploy and Activate Postgres (OpenShift)
-  shell: "{{ openshift_oc_bin }} new-app --template=postgresql-persistent -e MEMORY_LIMIT={{ pg_memory_limit|default('512') }}Mi -e NAMESPACE=openshift -e DATABASE_SERVICE_NAME=postgresql  -e POSTGRESQL_USER={{ pg_username }} -e POSTGRESQL_PASSWORD={{ pg_password }} -e POSTGRESQL_DATABASE={{ pg_database }} -e VOLUME_CAPACITY={{ pg_volume_capacity|default('5')}}Gi -e POSTGRESQL_VERSION=9.5 -n {{ awx_openshift_project }}"
-  when:
-    - (pg_hostname is not defined or pg_hostname == '') and (postgres_svc_details is defined and postgres_svc_details.rc != 0)
-    - openshift_host is defined
-  register: openshift_pg_activate
 
 - name: Set postgresql hostname to helm package service
   set_fact:
@@ -75,7 +100,7 @@
 - name: Wait for Postgres to activate
   pause:
     seconds: 60
-  when: kubernetes_pg_activate|changed
+  when: openshift_pg_activate.changed or kubernetes_pg_activate.changed
 
 - name: Ensure directory exists
   file:

--- a/installer/roles/kubernetes/tasks/openshift.yml
+++ b/installer/roles/kubernetes/tasks/openshift.yml
@@ -29,11 +29,6 @@
   when: openshift_token is defined
   no_log: true
 
-- name: Set postgresql service name
-  set_fact:
-    postgresql_service_name: "postgresql"
-  when: "pg_hostname is not defined or pg_hostname == ''"
-
 - name: Get Project Detail
   shell: "{{ openshift_oc_bin }} get project {{ awx_openshift_project }}"
   register: project_details
@@ -42,3 +37,24 @@
 - name: Create AWX Openshift Project
   shell: "{{ openshift_oc_bin }} new-project {{ awx_openshift_project }}"
   when: project_details.rc != 0
+
+- name: Ensure PostgreSQL PVC is available
+  block:
+    - name: Check PVC status
+      command: "{{ openshift_oc_bin }} get pvc {{ openshift_pg_pvc_name }} -n {{ awx_openshift_project }} -o=jsonpath='{.status.phase}'"
+      register: pg_pvc_status
+      ignore_errors: yes
+
+    - name: Ensure PostgreSQL PVC is available
+      assert:
+        that:
+          - pg_pvc_status.stdout == "Bound"
+        msg: "Ensure a PVC named '{{ openshift_pg_pvc_name }}' is created and bound in the '{{ awx_openshift_project }}' namespace."
+  when:
+    - pg_hostname is not defined or pg_hostname == ''
+    - openshift_pg_emptydir is defined and openshift_pg_emptydir != true
+
+- name: Set postgresql service name
+  set_fact:
+    postgresql_service_name: "postgresql"
+  when: "pg_hostname is not defined or pg_hostname == ''"

--- a/installer/roles/kubernetes/templates/postgresql-persistent.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-persistent.yml.j2
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: postgresql-persistent-template
+message: |-
+  The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.
+
+         Username: ${POSTGRESQL_USER}
+         Password: ${POSTGRESQL_PASSWORD}
+    Database Name: ${POSTGRESQL_DATABASE}
+   Connection URL: postgresql://${DATABASE_SERVICE_NAME}:5432/
+
+  For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/9.5.
+metadata:
+  annotations:
+    description: |-
+      PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/blob/master/9.5.
+
+      NOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.
+    iconClass: icon-postgresql
+    openshift.io/display-name: PostgreSQL (Persistent)
+    tags: database,postgresql
+    template.openshift.io/documentation-url: https://docs.openshift.org/latest/using_images/db_images/postgresql.html
+    template.openshift.io/long-description: This template provides a standalone
+      PostgreSQL server with a database created.  The database is stored on persistent
+      storage.  The database name, username, and password are chosen via parameters
+      when provisioning this service.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+    template.openshift.io/support-url: https://access.redhat.com
+  name: postgresql-persistent
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+      template.openshift.io/expose-password: '{.data[''database-password'']}'
+      template.openshift.io/expose-username: '{.data[''database-user'']}'
+    name: ${DATABASE_SERVICE_NAME}
+  stringData:
+    database-name: ${POSTGRESQL_DATABASE}
+    database-password: ${POSTGRESQL_PASSWORD}
+    database-user: ${POSTGRESQL_USER}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    ports:
+    - name: postgresql
+      nodePort: 0
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${DATABASE_SERVICE_NAME}
+  spec:
+    replicas: 1
+    selector:
+      name: ${DATABASE_SERVICE_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: ${DATABASE_SERVICE_NAME}
+      spec:
+        containers:
+        - capabilities: {}
+          env:
+          - name: POSTGRESQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: ${DATABASE_SERVICE_NAME}
+          - name: POSTGRESQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: ${DATABASE_SERVICE_NAME}
+          - name: POSTGRESQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: ${DATABASE_SERVICE_NAME}
+          - name: POSTGRESQL_MAX_CONNECTIONS
+            value: ${POSTGRESQL_MAX_CONNECTIONS}
+          image: ' '
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 1
+          name: postgresql
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE
+                -c 'SELECT 1'
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: ${DATABASE_SERVICE_NAME}-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        volumes:
+        - name: ${DATABASE_SERVICE_NAME}-data
+{% if openshift_pg_emptydir | bool %}
+          emptyDir: {}
+{% else %}
+          persistentVolumeClaim:
+            claimName: {{ openshift_pg_pvc_name }}
+{% endif %}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - postgresql
+        from:
+          kind: ImageStreamTag
+          name: postgresql:${POSTGRESQL_VERSION}
+          namespace: ${NAMESPACE}
+        lastTriggeredImage: ""
+      type: ImageChange
+    - type: ConfigChange
+  status: {}
+parameters:
+- description: Maximum amount of memory the container can use.
+  displayName: Memory Limit
+  name: MEMORY_LIMIT
+  required: true
+  value: 512Mi
+- description: The OpenShift Namespace where the ImageStream resides.
+  displayName: Namespace
+  name: NAMESPACE
+  value: openshift
+- description: The name of the OpenShift Service exposed for the database.
+  displayName: Database Service Name
+  name: DATABASE_SERVICE_NAME
+  required: true
+  value: postgresql
+- description: Username for PostgreSQL user that will be used for accessing the
+    database.
+  displayName: PostgreSQL Connection Username
+  from: user[A-Z0-9]{3}
+  generate: expression
+  name: POSTGRESQL_USER
+  required: true
+- description: Password for the PostgreSQL connection user.
+  displayName: PostgreSQL Connection Password
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+  name: POSTGRESQL_PASSWORD
+  required: true
+- description: Name of the PostgreSQL database accessed.
+  displayName: PostgreSQL Database Name
+  name: POSTGRESQL_DATABASE
+  required: true
+  value: sampledb
+- description: Version of PostgreSQL image to be used (9.2, 9.4, 9.5 or latest).
+  displayName: Version of PostgreSQL Image
+  name: POSTGRESQL_VERSION
+  required: true
+  value: "9.5"


### PR DESCRIPTION
##### SUMMARY
`oc new-app --template=postgresql-persistent` has been kind of a pain. It would attempt to create a Persistent Volume, but does not allow you to specify the storageClass.

This code assumes that a Persistent Volume is already available and will fail with a helpful error message if it is not.
