### PR TITLE
Bind mount to custom certs to `source/anchors` subfolder

### DIFF
--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -83,7 +83,7 @@
     volumes: >
       {{
         [project_data_dir + ':/var/lib/awx/projects:rw'] if project_data_dir is defined else []
-        + [ca_trust_dir + ':/etc/pki/ca-trust:ro'] if ca_trust_dir is defined else []
+        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
       }}
     user: root
     ports:
@@ -121,7 +121,7 @@
     volumes: >
       {{
         [project_data_dir + ':/var/lib/awx/projects:rw'] if project_data_dir is defined else []
-        + [ca_trust_dir + ':/etc/pki/ca-trust:ro'] if ca_trust_dir is defined else []
+        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
       }}
     links: "{{ awx_task_container_links|list }}"
     user: root

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -22,7 +22,7 @@ services:
       - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
     {% endif %}
     {% if ca_trust_dir is defined %}
-      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
+      - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
     {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
@@ -81,7 +81,7 @@ services:
       - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
     {% endif %}
     {% if ca_trust_dir is defined %}
-      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
+      - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
     {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}


### PR DESCRIPTION
##### SUMMARY

Instead of bind mounting custom certificates to `/etc/pki/ca-trust` which replaces the whole directory, it's better to mount it to a subdirectory`/etc/pki/ca-trust/source/anchors`, which works out of the box.

See [this](https://www.happyassassin.net/2015/01/14/trusting-additional-cas-in-fedora-rhel-centos-dont-append-to-etcpkitlscertsca-bundle-crt-or-etcpkitlscert-pem/).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
Not relevant
