### PR TITLE
Added nginx_status to nginx.conf

### DIFF
--- a/installer/roles/image_build/files/nginx.conf
+++ b/installer/roles/image_build/files/nginx.conf
@@ -42,7 +42,14 @@ http {
 
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
-
+        
+        location /nginx_status {
+          stub_status on;
+          access_log off;
+          allow 127.0.0.1;
+          deny all;
+        }
+        
         location /static/ {
             alias /var/lib/awx/public/static/;
         }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Datadog, Sysdig and other monitoring services can use the `/nginx_status` path for metrics, this simply adds this route to be accessed by localhost

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API nginx

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
All
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
