### PR TITLE
Increases the angular-tz-extension tag in package.json

### DIFF
--- a/awx/ui/client/src/scheduler/schedulerAdd.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerAdd.controller.js
@@ -293,6 +293,7 @@ export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
         scheduler.scope.schedulerTimeZone = _.find(data, (zone) => {
             return zone.name === scheduler.scope.current_timezone.name;
         });
+        $scope.scheduleTimeChange();
     });
     if($scope.schedulerUTCTime) {
         // The UTC time is already set

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -106,7 +106,7 @@
     "angular-moment": "^0.10.1",
     "angular-sanitize": "~1.6.6",
     "angular-scheduler": "git+https://git@github.com/ansible/angular-scheduler#v0.3.2",
-    "angular-tz-extensions": "git+https://git@github.com/ansible/angular-tz-extensions#v0.5.1",
+    "angular-tz-extensions": "git+https://git@github.com/ansible/angular-tz-extensions#v0.5.2",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^3.3.7",
     "bootstrap-datepicker": "^1.7.1",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The angular-tz-extensions was changed to accomodate for an issue with
UTC dates not getting parsed correctly. Relates to #1648. This was an issue that was fixed in release_3.2.2 and needed to be updated. Thanks to @marshmalien for all the help!

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.4.0.8

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
You'll probably need to run `make clean-ui` before rebuilding the UI. 
