### PR TITLE
Update ActivityStreamMiddleware to log settings

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -96,7 +96,8 @@ class ActivityStreamMiddleware(threading.local):
                     analytics_logger.info('Activity Stream update entry for %s' % str(instance.object1),
                                           extra=dict(changes=instance.changes, relationship=instance.object_relationship_type,
                                           actor=drf_user.username, operation=instance.operation,
-                                          object1=instance.object1, object2=instance.object2))
+                                          object1=instance.object1, object2=instance.object2,
+                                          setting=instance.setting))
                 except IntegrityError:
                     logger.debug("Integrity Error saving Activity Stream instance for id : " + str(instance.id))
             # else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, when a user creates/changes a setting, an ActivityStream instance is created and logged by the ActivityStreamMiddleware. The `ActivityStream.changes` field does not include the Settings's `key` field in either the create or update case. Only the `ActivityStream.setting` field stores the `Setting.key` field, but the `setting` field is not currently logged by the middleware.  

I propose logging the `setting` field to help with auditing.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.5.22
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
A more general solution may be needed here. On create, the object id is included in the ActivityStream.changes, but on update, it is not. Right now, on update, the object id is not included in any of the fields logged by the ActivityStreamMiddleware, and there is no single field that could be logged to solve the issue for all object types - each type has a separate field in ActivityStream. Although this commit fixes the issue for Setting, it does not fix it for any of the other types - see logged ActivityStream for JobTemplate update below:

```
{"cluster_host_id": "awx", 
"relationship": "", 
"level": "INFO", 
"type": "splunk", 
"@timestamp": "2018-04-11T22:49:16.160Z", 
"host": "awxweb", 
"actor": "admin", 
"object1": "job_template", 
"object2": "",
"setting": {}, 
"logger_name": "awx.analytics.activity_stream", 
"message": "Activity Stream update entry for job_template", 
"changes": "{\"description\": [\"\", \"TEST\"]}", 
"operation": "update"}
```

If a more general solution is desired, please let me know and I will open an issue for discussion. Some possibilities I see are: always including the object ID in the `changed` field or logging the appropriate relational field based on the `object1` field.

For Setting, the ActivityStream log before:

```
{"cluster_host_id": "awx",
"relationship": "",
"level": "INFO",
"type": "splunk",
"@timestamp": "2018-04-11T19:15:22.352Z",
"host": "awxweb",
"actor": "admin",
"object1": "setting",
"object2": "",
"logger_name": "awx.analytics.activity_stream",
"message": "Activity Stream update entry for setting",
"changes": "{\"value\": [30, 31]}",
"operation": "update"}
```

and after:
```
{"cluster_host_id": "awx",
"relationship": "",
"level": "INFO",
"type": "splunk",
"@timestamp": "2018-04-11T20:50:26.119Z",
"host": "awxweb",
"actor": "admin",
"object1": "setting",
"object2": "",
"setting": {"category": "jobs", "name": "SCHEDULE_MAX_JOBS"},
"logger_name": "awx.analytics.activity_stream",
"message": "Activity Stream update entry for setting",
"changes": "{\"value\": [32, 33]}",
"operation": "update"}
```
