### PR TITLE
Added support for traefik container to handle ssl support. related #1549

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -109,3 +109,13 @@ secret_key=awxsecret
 # /etc/pki/ca-trust in the awx_task and awx_web containers.
 # NOTE: only obeyed in local_docker install
 #ca_trust_dir=/etc/pki/ca-trust
+
+# traefik/SSL Configuration
+# This will setup a traefik container in front of the awx_web container to handle ssl
+# The traefik container is is enabled if the ssl_cert variable is set.
+# awx_fqdn refers to the fqdn that traefik will use for your awx instance
+# ssl_cert and ssl_key should be full-paths to ssl cert/key on the host machine.
+# This will not put them in place automatically. They must already exist on the host
+awx_fqdn=awx.local
+ssl_cert=/etc/pki/tls/cert.pem
+ssl_key=/etc/pki/tls/key.key

--- a/installer/roles/local_docker/files/traefik.toml
+++ b/installer/roles/local_docker/files/traefik.toml
@@ -1,0 +1,27 @@
+debug = true
+
+defaultEntryPoints = ["http", "https"]
+
+[api]
+address = ":8080"
+
+[docker]
+endpoint = "unix:///tmp/docker.sock"
+
+# Can be overridden by setting the "traefik.domain" label on a container.
+domain = "awx.local"
+
+# Enable watch docker changes.
+watch = true
+
+[entrypoints]
+  [entryPoints.http]
+    address = ":80"
+    [entryPoints.http.redirect]
+      entryPoint = "https"
+  [entryPoints.https]
+    address = ":443"
+      [entryPoints.https.tls]
+        [[entryPoints.https.tls.certificates]]
+        certFile = "/certs/cert.pem"
+        keyFile = "/certs/key.key"

--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -111,6 +111,8 @@
       MEMCACHED_PORT: "11211"
       AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
       AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+    labels:
+      traefik.frontend.rule: "Host:{{ awx_fqdn|default('awx.local') }}"
 
 - name: Activate AWX Task Container
   docker_container:
@@ -147,3 +149,26 @@
       MEMCACHED_PORT: "11211"
       AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
       AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+
+- name: traefik block
+  block:
+    - name: Copy traefik.toml to host
+      copy:
+        src: files/traefik.toml
+        dest: /etc/traefik.toml
+
+    - name: Activate traefik container
+      docker_container:
+        name: traefik
+        state: started
+        restart_policy: unless-stopped
+        image: traefik
+        volumes:
+          - /var/run/docker.sock:/tmp/docker.sock:ro
+          - "{{ ssl_cert }}:/certs/cert.pem:ro"
+          - "{{ ssl_key }}:/certs/key.key:ro"
+          - files/traefik.toml:/etc/traefik/traefik.toml:ro
+        ports:
+          - 80:80
+          - 443:443
+  when: ssl_cert is defined and ssl_cert != ''


### PR DESCRIPTION
Co-authored-by: Ben Sebastian <hippieben@gmail.com>
Co-authored-by: Steven Anthony <derbious@gmail.com>
Signed-off-by: Nathan Chowning <nchowning@covermymeds.com>
Signed-off-by: Ben Sebastian <hippieben@gmail.com>
Signed-off-by: Steven Anthony <derbious@gmail.com>

##### SUMMARY
This change adds the ability to use a traefik container in front of the awx_web container to handle ssl. related #1549 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.5.26
```