### PR TITLE
fixes sso auth backends

### DIFF
--- a/awx/sso/views.py
+++ b/awx/sso/views.py
@@ -11,7 +11,8 @@ from django.http import HttpResponse
 from django.views.generic import View
 from django.views.generic.base import RedirectView
 from django.utils.encoding import smart_text
-from django.contrib import auth
+from awx.api.serializers import UserSerializer
+from rest_framework.renderers import JSONRenderer
 
 logger = logging.getLogger('awx.sso.views')
 
@@ -39,8 +40,12 @@ class CompleteView(BaseRedirectView):
     def dispatch(self, request, *args, **kwargs):
         response = super(CompleteView, self).dispatch(request, *args, **kwargs)
         if self.request.user and self.request.user.is_authenticated():
-            auth.login(self.request, self.request.user)
             logger.info(smart_text(u"User {} logged in".format(self.request.user.username)))
+            response.set_cookie('userLoggedIn', 'true')
+            current_user = UserSerializer(self.request.user)
+            current_user = JSONRenderer().render(current_user.data)
+            current_user = urllib.quote('%s' % current_user, '')
+            response.set_cookie('current_user', current_user)
         return response
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/awx/issues/1418

`auth.login()` was being called a second time unnecessarily, which was clearing the `user.backend`.  This is already done within each auth backend.  

I also brought back the UserLoggedIn boolean which is needed for the UI (the user will otherwise be wrongly redirected to the login screen after being successfully authenticated).  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.5.163
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

I have tested this manually for SAML (using OneLogin) and GitHub (single).  

![saml_fix](https://user-images.githubusercontent.com/11698892/39064484-acf66a0e-449c-11e8-8ed3-dfc65b3f0941.gif)
