### PR TITLE
Enable source variables for Azure inventory

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1907,11 +1907,16 @@ class RunInventoryUpdate(BaseTask):
             cp.set(section, 'group_by_resource_group', 'yes')
             cp.set(section, 'group_by_location', 'yes')
             cp.set(section, 'group_by_tag', 'yes')
+
             if inventory_update.source_regions and 'all' not in inventory_update.source_regions:
                 cp.set(
                     section, 'locations',
                     ','.join([x.strip() for x in inventory_update.source_regions.split(',')])
                 )
+
+            azure_rm_opts = dict(inventory_update.source_vars_dict.items())
+            for k,v in azure_rm_opts.items():
+                cp.set(section, k, six.text_type(v))
 
         # Return INI content.
         if cp.sections():

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1879,6 +1879,10 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             )
             return cred
         self.instance.get_cloud_credential = get_cred
+        self.instance.source_vars = {
+            'include_powerstate': 'yes',
+            'group_by_resource_group': 'no'
+        }
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
@@ -1891,8 +1895,9 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             config = ConfigParser.ConfigParser()
             config.read(env['AZURE_INI_PATH'])
             assert config.get('azure', 'include_powerstate') == 'yes'
-            assert config.get('azure', 'group_by_resource_group') == 'yes'
+            assert config.get('azure', 'group_by_resource_group') == 'no'
             assert config.get('azure', 'group_by_location') == 'yes'
+            assert 'group_by_security_group' not in config.items('azure')
             assert config.get('azure', 'group_by_tag') == 'yes'
             assert config.get('azure', 'locations') == 'north,south,east,west'
             return ['successful', 0]
@@ -1919,6 +1924,11 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             )
             return cred
         self.instance.get_cloud_credential = get_cred
+        self.instance.source_vars = {
+            'include_powerstate': 'yes',
+            'group_by_resource_group': 'no',
+            'group_by_security_group': 'no'
+        }
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
@@ -1930,8 +1940,9 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             config = ConfigParser.ConfigParser()
             config.read(env['AZURE_INI_PATH'])
             assert config.get('azure', 'include_powerstate') == 'yes'
-            assert config.get('azure', 'group_by_resource_group') == 'yes'
+            assert config.get('azure', 'group_by_resource_group') == 'no'
             assert config.get('azure', 'group_by_location') == 'yes'
+            assert config.get('azure', 'group_by_security_group') == 'no'
             assert config.get('azure', 'group_by_tag') == 'yes'
             assert 'locations' not in config.items('azure')
             return ['successful', 0]

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/add/sources-add.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/add/sources-add.controller.js
@@ -164,7 +164,7 @@ export default ['$state', '$stateParams', '$scope', 'SourcesFormDefinition',
             else{
                 $scope.credentialBasePath = (source === 'ec2') ? GetBasePath('credentials') + '?kind=aws' : GetBasePath('credentials') + (source === '' ? '' : '?kind=' + (source));
             }
-            if (source === 'ec2' || source === 'custom' || source === 'vmware' || source === 'openstack' || source === 'scm' || source === 'cloudforms' || source === "satellite6") {
+            if (source === 'ec2' || source === 'custom' || source === 'vmware' || source === 'openstack' || source === 'scm' || source === 'cloudforms' || source === "satellite6" || source === "azure_rm") {
                 $scope.envParseType = 'yaml';
 
                 var varName;

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
@@ -66,7 +66,7 @@ export default ['$state', '$stateParams', '$scope', 'ParseVariableString',
             if (source === 'ec2' || source === 'custom' ||
                 source === 'vmware' || source === 'openstack' ||
                 source === 'scm' || source === 'cloudforms'  ||
-                source === 'satellite6') {
+                source === 'satellite6' || source === 'azure_rm') {
 
                 var varName;
                 if (source === 'scm') {

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
@@ -303,6 +303,30 @@ return {
             dataContainer: 'body',
             subForm: 'sourceSubForm'
         },
+        azure_rm_variables: {
+            id: 'azure_rm_variables',
+            label: i18n._('Source Variables'), //"{{vars_label}}" ,
+            ngShow: "source && source.value == 'azure_rm'",
+            type: 'textarea',
+            class: 'Form-textAreaLabel Form-formGroup--fullWidth',
+            rows: 6,
+            'default': '---',
+            parseTypeName: 'envParseType',
+            dataTitle: i18n._("Source Variables"),
+            dataPlacement: 'right',
+            awPopOver: "<p>" + i18n._("Override variables found in azure_rm.ini and used by the inventory update script. For a detailed description of these variables ") +
+                "<a href=\"https://github.com/ansible/ansible/blob/devel/contrib/inventory/azure_rm.ini\" target=\"_blank\">" +
+                i18n._("view azure_rm.ini in the Ansible github repo.") + "</a></p>" +
+                "<p>" + i18n._("Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two.") + "</p>" +
+                i18n._("JSON:") + "<br />\n" +
+                "<blockquote>{<br />&emsp;\"somevar\": \"somevalue\",<br />&emsp;\"password\": \"magic\"<br /> }</blockquote>\n" +
+                i18n._("YAML:") + "<br />\n" +
+                "<blockquote>---<br />somevar: somevalue<br />password: magic<br /></blockquote>\n" +
+                "<p>" + i18n._("View JSON examples at ") + '<a href="http://www.json.org" target="_blank">www.json.org</a></p>' +
+                "<p>" + i18n._("View YAML examples at ") + '<a href="http://docs.ansible.com/YAMLSyntax.html" target="_blank">docs.ansible.com</a></p>',
+            dataContainer: 'body',
+            subForm: 'sourceSubForm'
+        },
         verbosity: {
             label: i18n._('Verbosity'),
             type: 'select',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enable source variables to be set for Azure Resouce Manager Inventory Sources within azure_rm.ini. This is mostly copied and adapted from the other inventory sources that have this enabled already.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
  - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
