### PR TITLE
AWX launchers should wait for other containers to be ready

### DIFF
--- a/installer/roles/image_build/files/launch_awx.sh
+++ b/installer/roles/image_build/files/launch_awx.sh
@@ -4,5 +4,11 @@ if [ `id -u` -ge 500 ]; then
     cat /tmp/passwd > /etc/passwd
     rm /tmp/passwd
 fi
+
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=11211" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=5672" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db -U $DATABASE_USER -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
+
 awx-manage collectstatic --noinput --clear
 supervisord -c /supervisor.conf


### PR DESCRIPTION
##### SUMMARY
AWX launchers should wait for other containers to be ready.

As stated in issue #1548, awx_web container starts too early. This pull requests mimics the setup in launch_awx_task.sh to leverage ansible's `wait_for` module. During launch ansible will run locally and wait for several services to be up before getting starting supervisord.

I prefer this approach to using `depends_on` conditions with docker compose because a) this is being deprecated in composer syntax v3 (see https://docs.docker.com/compose/startup-order); and b) mimics what's already been done for launch_awx_task.sh.

Note that I went with a "full copy-and-paste" and you might want to review the inclusion of the database setup (last line in the patch).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.6
```