### PR TITLE
Support for expect ansible module

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -21,6 +21,7 @@ backports.ssl-match-hostname==3.5.0.1
 boto==2.47.0    # last which does not break ec2 scripts
 boto3==1.6.2
 ovirt-engine-sdk-python==4.2.4    # minimum set inside Ansible facts module requirements
+pexpect==4.5.0
 python-memcached==1.59    # same as AWX requirement
 psphere==0.5.2
 psutil==5.4.3    # same as AWX requirement


### PR DESCRIPTION
##### SUMMARY
Adding support for ansible `expect` module as per #1818 .
All is needed is that pip `pexpect` module should be added as a dependency.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
N/A

