### PR TITLE
add want_hostcollections for sat6 source vars

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1850,6 +1850,7 @@ class RunInventoryUpdate(BaseTask):
 
             group_patterns = '[]'
             group_prefix = 'foreman_'
+            want_hostcollections = 'False'
             foreman_opts = dict(inventory_update.source_vars_dict.items())
             foreman_opts.setdefault('ssl_verify', 'False')
             for k, v in foreman_opts.items():
@@ -1857,6 +1858,8 @@ class RunInventoryUpdate(BaseTask):
                     group_patterns = v
                 elif k == 'satellite6_group_prefix' and isinstance(v, basestring):
                     group_prefix = v
+                elif k == 'satellite6_want_hostcollections' and isinstance(v, bool):
+                    want_hostcollections = v
                 else:
                     cp.set(section, k, six.text_type(v))
 
@@ -1869,6 +1872,7 @@ class RunInventoryUpdate(BaseTask):
             cp.add_section(section)
             cp.set(section, 'group_patterns', group_patterns)
             cp.set(section, 'want_facts', True)
+            cp.set(section, 'want_hostcollections', want_hostcollections)
             cp.set(section, 'group_prefix', group_prefix)
 
             section = 'cache'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related: https://github.com/ansible/awx/issues/1808
Added the want_hostcollections key to the source vars so users can enable host collections as they can do with [foreman.ini.](https://github.com/ansible/awx/blob/devel/awx/plugins/inventory/foreman.ini.example#L146)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.9
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

  | 111 | 11.691 INFO     Group "foreman_content_view_cv_rhel7" added |  
-- | -- | -- | --
  | 112 | 11.703 INFO     Group "foreman_environment_production" added |  
  | 113 | 11.742 INFO     Group "foreman_hostcollection_application_numbercruncher" added |  
  | 114 | 11.801 INFO     Group "foreman_hostcollection_test" added |  
  | 115 | 11.848 INFO     Group "foreman_hostgroup_infra" added |  
  | 116 | 11.897 INFO     Group "foreman_hostgroup_infra_inttest" added


```
