### PR TITLE
Add netapp-lib to ansible requirements

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -20,6 +20,7 @@ azure-mgmt-containerinstance>=0.3.1
 backports.ssl-match-hostname==3.5.0.1
 boto==2.47.0    # last which does not break ec2 scripts
 boto3==1.6.2
+netapp-lib==2017.10.30
 ovirt-engine-sdk-python==4.2.4    # minimum set inside Ansible facts module requirements
 pexpect==4.5.0    # same as AWX requirement
 python-memcached==1.59    # same as AWX requirement


### PR DESCRIPTION
This enables the use of the NetApp ansible modules within AWX.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add netapp-lib to the ansible requirements in order to enable the use of the NetApp ansible modules.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.12
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
