### PR TITLE
ansible virtualenv: re-add netaddr Python package

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -20,6 +20,7 @@ azure-mgmt-containerinstance>=0.3.1
 backports.ssl-match-hostname==3.5.0.1
 boto==2.47.0    # last which does not break ec2 scripts
 boto3==1.6.2
+netaddr
 ovirt-engine-sdk-python==4.2.4    # minimum set inside Ansible facts module requirements
 pexpect==4.5.0    # same as AWX requirement
 python-memcached==1.59    # same as AWX requirement

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -59,6 +59,7 @@ monotonic==1.4            # via humanfriendly
 msrest==0.4.26
 msrestazure==0.4.22
 munch==2.2.0              # via openstacksdk
+netaddr==0.7.19
 netifaces==0.10.6         # via openstacksdk
 ntlm-auth==1.0.6          # via requests-credssp, requests-ntlm
 oauthlib==2.0.6           # via requests-oauthlib


### PR DESCRIPTION
##### SUMMARY
`ansible` virtualenv: re-add `netaddr` Python package

`netaddr` was installed as an indirect dependency of `shade` 1.20 but was removed with the upgrade to 1.27.

Closes #1763

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - requirements/requirements_ansible.txt

##### AWX VERSION
```
awx: 1.0.6.11
```