### PR TITLE
ansible-inventory: use 'export' switch

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -95,7 +95,7 @@ class AnsibleInventoryLoader(object):
             potential_path = os.path.join(path.strip('"'), 'ansible-inventory')
             if os.path.isfile(potential_path) and os.access(potential_path, os.X_OK):
                 logger.debug('Using system install of ansible-inventory CLI: {}'.format(potential_path))
-                return [potential_path, '-i', self.source]
+                return [potential_path, '-i', self.source, '--export']
 
         # Stopgap solution for group_vars, do not use backported module for official
         # vendored cloud modules or custom scripts TODO: remove after Ansible 2.3 deprecation


### PR DESCRIPTION
##### SUMMARY
`ansible-inventory export` switch is available since Ansible 2.5.0, it optimizes inventory for reuse instead of inspection.

`export` switch is used unconditionally because `ansible` virtual environment (`/var/lib/awx/venv/ansible/`) - which provides Ansible 2.5.3 - is used by inventory jobs.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- awx/main/management/commands/inventory_import.py

##### AWX VERSION
```
awx: 1.0.6.11
```