### PR TITLE
Use use-context to set Kubernetes context

### DIFF
--- a/installer/roles/kubernetes/tasks/kubernetes.yml
+++ b/installer/roles/kubernetes/tasks/kubernetes.yml
@@ -1,5 +1,5 @@
 - name: Set the Kubernetes Context
-  shell: "kubectl config set-context {{ kubernetes_context }}"
+  shell: "kubectl config use-context {{ kubernetes_context }}"
 
 - name: Get Namespace Detail
   shell: "kubectl get namespace {{ kubernetes_namespace }}"


### PR DESCRIPTION
##### SUMMARY
`kubectl config use-context` is the command to set the current context,
not `set-context`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.12
```


##### ADDITIONAL INFORMATION

Before

```
changed: [localhost] => {"changed": true, "cmd": "kubectl config set-context minikube", "delta": "0:00:00.217270", 
"end": "2018-06-04 11:04:57.845746", "rc": 0, "start": "2018-06-04 11:04:57.628476", "stderr": "", 
"stderr_lines": [], "stdout": "Context \"minikube\" modified.", "stdout_lines": ["Context \"minikube\" modified."]}
```

After

```
changed: [localhost] => {"changed": true, "cmd": "kubectl config use-context minikube", "delta": "0:00:00.208674", 
"end": "2018-06-04 11:36:37.740606", "rc": 0, "start": "2018-06-04 11:36:37.531932", "stderr": "", 
"stderr_lines": [], "stdout": "Switched to context \"minikube\".", "stdout_lines": ["Switched to context \"minikube\"."]}
```