### PR TITLE
Use persistent postgres_data_dir per default

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -32,7 +32,7 @@ dockerhub_version=latest
 # task_mem_request=2
 
 # Common Docker parameters
-postgres_data_dir=/tmp/pgdocker
+postgres_data_dir=/var/lib/awx/pgdocker
 host_port=80
 
 # Docker Compose Install


### PR DESCRIPTION
##### SUMMARY
Users might forget to change the default path. So let's set it to something that survives a reboot.

Related to https://github.com/ansible/awx/issues/427

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
devel
```