### PR TITLE
pin pytest-timeout

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 pytest-django
 pytest-pythonpath
 pytest-mock
-pytest-timeout
+pytest-timeout=1.2.1
 pytest-xdist
 logutils
 flower


### PR DESCRIPTION
newer versions require a newer version of pytest:
https://bitbucket.org/pytest-dev/pytest-timeout/commits/3ac3e2f098669a9a16273a3fa5aaaf25b8a6ccc3#Lsetup.pyT15