### PR TITLE
update dev pytest

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -6,7 +6,7 @@ unittest2
 pep8
 flake8
 pyflakes
-pytest==3.5.1
+pytest==3.6.0
 pytest-cov
 pytest-django
 pytest-pythonpath


### PR DESCRIPTION
##### SUMMARY
Upgrades pytest to 3.6.0 to fix the following error on test runs:

```
pluggy.PluginValidationError: Plugin 'timeout' could not be loaded: (pytest 3.5.1 (/venv/awx/lib/python2.7/site-packages), Requirement.parse('pytest>=3.6.0'))!
```

One of our pytest plugins ‘timeout’ requires pytest 3.6.0.  Upgrading pytest to 3.6.0 fixes this. I have tested it locally.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
This is due to this recent release of pytest-timeout -- https://pypi.org/project/pytest-timeout/