### PR TITLE
FIX nginx use selected log formatting

### DIFF
--- a/installer/roles/image_build/files/nginx.conf
+++ b/installer/roles/image_build/files/nginx.conf
@@ -16,6 +16,8 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
+    access_log /dev/stdout main;
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

FIX nginx access log logging, to use defined "main" logformat, especially useful for reverse proxy setups, where X-Forwarded-For header should be logged.

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
1.0.6.25
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
