### PR TITLE
ldap attributes filter in user_groups()

### DIFF
--- a/awx/sso/ldap_group_types.py
+++ b/awx/sso/ldap_group_types.py
@@ -42,6 +42,7 @@ class PosixUIDGroupType(LDAPGroupType):
                 )
 
             search = group_search.search_with_additional_term_string(filterstr)
+            search.attrlist = [self.name_attr]
             groups = search.execute(ldap_user.connection)
         except (KeyError, IndexError):
             pass
@@ -72,4 +73,3 @@ class PosixUIDGroupType(LDAPGroupType):
             is_member = False
 
         return is_member
-


### PR DESCRIPTION
ldap search currently fetches ALL attributes which is a waste of bandwidth resources and
woefully slow on large ldap groups when it only needs to parse the name_attr

##### SUMMARY
related #2034 

see uses of attrlist in https://github.com/django-auth-ldap/django-auth-ldap/blob/master/CHANGES


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.24
```


