### PR TITLE
Don't capitalise last name

### DIFF
--- a/awx/ui/client/src/users/users.form.js
+++ b/awx/ui/client/src/users/users.form.js
@@ -36,8 +36,7 @@ export default ['i18n', function(i18n) {
                     label: i18n._('Last Name'),
                     type: 'text',
                     ngDisabled: '!(user_obj.summary_fields.user_capabilities.edit || canAdd)',
-                    required: true,
-                    capitalize: true
+                    required: true
                 },
                 organization: {
                     label: i18n._('Organization'),


### PR DESCRIPTION
##### SUMMARY
Making assumptions about names is always a risky situation, even having a separate first and last name field should be avoided wherever possible. In this specific case, applying auto-capitalisation to the first character of the last name field makes it impossible to correctly enter my (and many other) Dutch surname. Common initial parts of Dutch surnames are 'de', 'van', 'van der' and other combinations. These are always lowercase.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 1.0.6.26
```


##### ADDITIONAL INFORMATION
Fun additional trivia: when it comes to sorting these names alphabetically you are supposed to ignore the prefix. In the case of my name you'd index it under 'M', not 'v'.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
