### PR TITLE
#2073 - Support setting to prevent Tower from pulling roles

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -278,6 +278,16 @@ register(
 )
 
 register(
+    'AWX_ROLES_ENABLED',
+    field_class=fields.BooleanField,
+    default=True,
+    label=_('Enable Role Download'),
+    help_text=_('Allows roles to be dynamically downlaoded from a requirements.yml file for SCM projects.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
     'STDOUT_MAX_BYTES_DISPLAY',
     field_class=fields.IntegerField,
     min_value=0,

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1521,6 +1521,7 @@ class RunProjectUpdate(BaseTask):
             'scm_full_checkout': True if project_update.job_type == 'run' else False,
             'scm_revision_output': self.revision_path,
             'scm_revision': project_update.project.scm_revision,
+            'roles_enabled': getattr(settings, 'AWX_ROLES_ENABLED', True)
         })
         extra_vars_path = self.build_extra_vars_file(vars=extra_vars, **kwargs)
         args.extend(['-e', '@%s' % (extra_vars_path)])

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -13,6 +13,7 @@
 # scm_accept_hostkey: true/false (only for git, set automatically)
 # scm_revision: current revision in tower
 # scm_revision_output: where to store gathered revision (temporary file)
+# roles_enabled: Allow us to pull roles from a requirements.yml file
 
 - hosts: all
   connection: local
@@ -152,4 +153,4 @@
           chdir: "{{project_path|quote}}/roles"
         when: doesRequirementsExist.stat.exists and scm_result is defined
 
-      when: scm_full_checkout|bool
+      when: scm_full_checkout|bool and roles_enabled|bool

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -649,6 +649,11 @@ AWX_REBUILD_SMART_MEMBERSHIP = False
 # By default, allow arbitrary Jinja templating in extra_vars defined on a Job Template
 ALLOW_JINJA_IN_EXTRA_VARS = 'template'
 
+# Enable dynamically pulling roles from a requirement.yml file
+# when updating SCM projects 
+# Note: This setting may be overridden by database settings.
+AWX_ROLES_ENABLED = True
+
 # Enable bubblewrap support for running jobs (playbook runs only).
 # Note: This setting may be overridden by database settings.
 AWX_PROOT_ENABLED = True

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -77,6 +77,11 @@ CELERYD_LOG_COLOR = True
 
 CALLBACK_QUEUE = "callback_tasks"
 
+# Enable dynamically pulling roles from a requirement.yml file
+# when updating SCM projects
+# Note: This setting may be overridden by database settings.
+AWX_ROLES_ENABLED = True
+
 # Enable PROOT for tower-qa integration tests.
 # Note: This setting may be overridden by database settings.
 AWX_PROOT_ENABLED = True

--- a/awx/ui/client/src/configuration/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/jobs-form/configuration-jobs.form.js
@@ -58,6 +58,9 @@ export default ['i18n', function(i18n) {
                 type: 'text',
                 reset: 'ANSIBLE_FACT_CACHE_TIMEOUT',
             },
+            AWX_ROLES_ENABLED: {
+                type: 'toggleSwitch',
+            },
             AWX_TASK_ENV: {
                 type: 'textarea',
                 reset: 'AWX_TASK_ENV',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a setting in Tower => Settings => Jobs which prevents Tower from downloading roles from requirements.yml files when running a job template from an SCM based project. #2073

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.36
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
