### PR TITLE
force boolean evaluation

### DIFF
--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -223,5 +223,5 @@
   file:
     path: "{{ docker_base_path }}"
     state: absent
-  when: cleanup_docker_base|default(True)
+  when: cleanup_docker_base|default(True)|bool
   delegate_to: localhost

--- a/installer/roles/image_push/tasks/main.yml
+++ b/installer/roles/image_push/tasks/main.yml
@@ -25,7 +25,7 @@
         tag: "{{ awx_version }}"
         state: absent
   delegate_to: localhost
-  when: docker_remove_local_images|default(False)
+  when: docker_remove_local_images|default(False)|bool
 
 - name: Tag and Push Container Images
   block:


### PR DESCRIPTION
##### SUMMARY
make sure configuration variables for installer, cleanup_docker_base and docker_remove_local_images, are evaluated as boolean, so that, for example, setting `cleanup_docker_base=false` in `installer/inventory` really preserves the docker build directory

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.6.40
```


##### ADDITIONAL INFORMATION
