### PR TITLE
Bumping uirouter version and locking it to make ui tests pass

### DIFF
--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -57,7 +57,7 @@
     "grunt-concurrent": "^2.3.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-newer": "^1.2.0",
-    "hard-source-webpack-plugin": "^0.4.9",
+    "hard-source-webpack-plugin": "^0.5.8",
     "html-loader": "^0.5.1",
     "html-webpack-harddisk-plugin": "^0.1.0",
     "html-webpack-plugin": "^2.30.1",
@@ -94,7 +94,7 @@
     "webpack-merge": "^4.1.0"
   },
   "dependencies": {
-    "@uirouter/angularjs": "^1.0.7",
+    "@uirouter/angularjs": "1.0.18",
     "angular": "~1.6.6",
     "angular-breadcrumb": "git+https://git@github.com/ansible/angular-breadcrumb#0.4.1",
     "angular-codemirror": "git+https://git@github.com/ansible/angular-codemirror#v1.1.2",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
PR's on awx/devel are failing due to a dependency upgrade. There was a breaking change in uirouter 1.0.19 so going to lock it at 1.0.18. There was an issue with hard-source-webpack-plugin that was effecting the UI dev watcher that I'm including in this change.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
