### PR TITLE
Fix k8s installer playbook

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -29,8 +29,8 @@ rabbitmq_cpu_request: 500
 memcached_mem_request: 1
 memcached_cpu_request: 500
 
-kubernetes_rabbitmq_version: "3.7.4"
-kubernetes_rabbitmq_image: "ansible/awx_rabbitmq"
+kubernetes_rabbitmq_version: "3.7.7"
+kubernetes_rabbitmq_image: "rabbitmq"
 
 kubernetes_memcached_version: "latest"
 kubernetes_memcached_image: "memcached"

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -233,9 +233,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: RABBITMQ_USE_LONGNAME
-              value: "true"
-            - name: RABBITMQ_NODENAME
-              value: "rabbit@$(MY_POD_IP)"
+              value: "false"
             - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The installer playbook doesn't seem to be working with k8s. The RABBITMQ_NODENAME isn't being populated correctly. The ansible/awx-rabbitmq docker image does some seemingly unnecessary things with permissions and users and the official rabbitmq image seems to work just fine without needing to specify a nodename, the defaults work.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
