### PR TITLE
Allow autocomplete on the AWX login page

### DIFF
--- a/awx/ui/client/src/login/loginModal/loginModal.partial.html
+++ b/awx/ui/client/src/login/loginModal/loginModal.partial.html
@@ -44,7 +44,7 @@
                 <form id="login-form"
                     name="loginForm"
                     class="form-horizontal"
-                    autocomplete="off" novalidate>
+                    novalidate>
                     <div class="form-group LoginModal-formGroup">
                         <label class="LoginModal-label
                             col-md-12" translate>USERNAME
@@ -54,7 +54,7 @@
                                 class="form-control LoginModal-field"
                                 ng-model="login_username"
                                 id="login-username"
-                                autocomplete="off" required>
+                                required>
                             <div class="error"
                                 ng-show="loginForm.login_username.$dirty &&
                                 loginForm.login_username.$error.required" translate>
@@ -73,8 +73,8 @@
                                 name="login_password"
                                 id="login-password"
                                 class="form-control LoginModal-field"
-                                ng-model="login_password" required
-                                autocomplete="off">
+                                ng-model="login_password"
+                                required>
                             <div class="error"
                                 ng-show="loginForm.login_password.$dirty
                                 &&


### PR DESCRIPTION
Signed-off-by: walkafwalka <41709139+walkafwalka@users.noreply.github.com>

##### SUMMARY
> The login form sets the "autocomplete=off" tag on the AWX login modal - this disables browser auto-fill.
> Doesn't seem like there's a good reason to force this, so we shouldn't.

See #444.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION

```
awx: 1.0.6.42
```

##### ADDITIONAL INFORMATION