### PR TITLE
patch for #2118

### DIFF
--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -1,12 +1,13 @@
 import re
 import urlparse
+from six import u
 
 REPLACE_STR = '$encrypted$'
 
 
 class UriCleaner(object):
     REPLACE_STR = REPLACE_STR
-    SENSITIVE_URI_PATTERN = re.compile(ur'(\w+:(\/?\/?)[^\s]+)', re.MULTILINE)  # NOQA
+    SENSITIVE_URI_PATTERN = re.compile(u(r'(\w+:(\/?\/?)[^\s]+)'), re.MULTILINE)  # NOQA
 
     @staticmethod
     def remove_sensitive(cleartext):


### PR DESCRIPTION
##### SUMMARY
First patch, please review and feedback.
related #2118
The fix is for building the code with python 3.7 where the setup.py fails on compilation of the redact.py due to an unsupported unicode prefix on the regular expression, remediated by using the six lib to convert the regex back to the expected unicode.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.6.42
```


##### ADDITIONAL INFORMATION
My branch https://github.com/ansible/awx/compare/devel...h4ck3rm1k3:local?expand=1 contains the start of patches to build a local version of awx in the user space, I am attempting to compile and build awx from source.

