### PR TITLE
set_stats fails in callback plugin on isolated node #2123

### DIFF
--- a/awx/lib/awx_display_callback/module.py
+++ b/awx/lib/awx_display_callback/module.py
@@ -308,7 +308,8 @@ class BaseCallbackModule(CallbackBase):
         if custom_artifact_data:
             # create the directory for custom stats artifacts to live in (if it doesn't exist)
             custom_artifacts_dir = os.path.join(os.getenv('AWX_PRIVATE_DATA_DIR'), 'artifacts')
-            os.makedirs(custom_artifacts_dir, mode=stat.S_IXUSR + stat.S_IWUSR + stat.S_IRUSR)
+            if not os.path.isdir(custom_artifacts_dir):
+                os.makedirs(custom_artifacts_dir, mode=stat.S_IXUSR + stat.S_IWUSR + stat.S_IRUSR)
 
             custom_artifacts_path = os.path.join(custom_artifacts_dir, 'custom')
             with codecs.open(custom_artifacts_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
Signed-off-by: RThur <harshax@gmail.com>

##### SUMMARY
Added if condition to create artifact path if it does not exist. It appears that the custom artifact path is created automatically on isolated nodes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
/awx/lib/awx_display_callback/module.py
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
$ make VERSION
awx: 1.0.6.42
```



