### PR TITLE
Standardize Slack backend API method

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-import time
 import logging
 from slackclient import SlackClient
 
@@ -26,40 +25,8 @@ class SlackBackend(AWXBaseEmailBackend):
         self.color = None
         if hex_color.startswith("#") and (len(hex_color) == 4 or len(hex_color) == 7):
             self.color = hex_color
-        self.connection = None
-
-    def open(self):
-        if self.connection is not None:
-            return False
-        self.connection = SlackClient(self.token)
-        if not self.connection.rtm_connect():
-            if not self.fail_silently:
-                raise Exception("Slack Notification Token is invalid")
-
-        start = time.time()
-        time.clock()
-        elapsed = 0
-        while elapsed < WEBSOCKET_TIMEOUT:
-            events = self.connection.rtm_read()
-            if any(event['type'] == 'hello' for event in events):
-                return True
-            elapsed = time.time() - start
-            time.sleep(0.5)
-
-        raise RuntimeError("Slack Notification unable to establish websocket connection after {} seconds".format(WEBSOCKET_TIMEOUT))
-
-    def close(self):
-        if self.connection is None:
-            return
-        self.connection = None
 
     def send_messages(self, messages):
-        if self.color:
-            return self._send_attachments(messages)
-        else:
-            return self._send_rtm_messages(messages)
-
-    def _send_attachments(self, messages):
         connection = SlackClient(self.token)
         sent_messages = 0
         for m in messages:
@@ -67,34 +34,22 @@ class SlackBackend(AWXBaseEmailBackend):
                 for r in m.recipients():
                     if r.startswith('#'):
                         r = r[1:]
-                    ret = connection.api_call("chat.postMessage",
-                                              channel=r,
-                                              attachments=[{
-                                                  "color": self.color,
-                                                  "text": m.subject
-                                              }])
+                    if self.color:
+                        ret = connection.api_call("chat.postMessage",
+                                                  channel=r,
+                                                  attachments=[{
+                                                      "color": self.color,
+                                                      "text": m.subject
+                                                  }])
+                    else:
+                        ret = connection.api_call("chat.postMessage",
+                                                  channel=r,
+                                                  text=m.subject)
                     logger.debug(ret)
                     if ret['ok']:
                         sent_messages += 1
                     else:
                         raise RuntimeError("Slack Notification unable to send {}: {}".format(r, m.subject))
-            except Exception as e:
-                logger.error(smart_text(_("Exception sending messages: {}").format(e)))
-                if not self.fail_silently:
-                    raise
-        return sent_messages
-
-    def _send_rtm_messages(self, messages):
-        if self.connection is None:
-            self.open()
-        sent_messages = 0
-        for m in messages:
-            try:
-                for r in m.recipients():
-                    if r.startswith('#'):
-                        r = r[1:]
-                    self.connection.rtm_send_message(r, m.subject)
-                    sent_messages += 1
             except Exception as e:
                 logger.error(smart_text(_("Exception sending messages: {}").format(e)))
                 if not self.fail_silently:


### PR DESCRIPTION
Signed-off-by: walkafwalka <41709139+walkafwalka@users.noreply.github.com>

##### SUMMARY
The Slack backend was using two different APIs: the [RTM API](https://api.slack.com/rtm) for basic messaging and the [Web API](https://api.slack.com/web) for attachments. I simplified the backend by using the Web API for both.

The rationale behind choosing the Web API over the RTM API or the [Events API](https://api.slack.com/events-api) was heavily influence by a [Medium article sponsored by Slack](https://medium.com/slack-developer-blog/getting-started-with-slacks-apis-f930c73fc889). The Web API is more commonly used and is less resource-intensive.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.42
```


##### ADDITIONAL INFORMATION