### PR TITLE
Add SSL suport and enable SSL by default for docker install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -439,7 +439,11 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 *host_port*
 
-> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. Defaults to *80*.
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. Defaults to *443*.
+
+*ssl_certificate*
+
+> Optionally, provide the path to a file that contains a certificate and its private key.
 
 *use_docker_compose*
 
@@ -523,7 +527,7 @@ After the playbook run completes, Docker will report up to 5 running containers.
 ```bash
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                NAMES
 e240ed8209cd        awx_task:1.0.0.8    "/tini -- /bin/sh ..."   2 minutes ago       Up About a minute   8052/tcp                             awx_task
-1cfd02601690        awx_web:1.0.0.8     "/tini -- /bin/sh ..."   2 minutes ago       Up About a minute   0.0.0.0:80->8052/tcp                 awx_web
+1cfd02601690        awx_web:1.0.0.8     "/tini -- /bin/sh ..."   2 minutes ago       Up About a minute   0.0.0.0:443->8052/tcp                 awx_web
 55a552142bcd        memcached:alpine    "docker-entrypoint..."   2 minutes ago       Up 2 minutes        11211/tcp                            memcached
 84011c072aad        rabbitmq:3          "docker-entrypoint..."   2 minutes ago       Up 2 minutes        4369/tcp, 5671-5672/tcp, 25672/tcp   rabbitmq
 97e196120ab3        postgres:9.6        "docker-entrypoint..."   2 minutes ago       Up 2 minutes        5432/tcp                             postgres

--- a/installer/inventory
+++ b/installer/inventory
@@ -34,7 +34,8 @@ dockerhub_version=latest
 
 # Common Docker parameters
 postgres_data_dir=/tmp/pgdocker
-host_port=80
+host_port=443
+#ssl_certificate=
 
 # Docker Compose Install
 # use_docker_compose=false

--- a/installer/roles/image_build/files/nginx.conf
+++ b/installer/roles/image_build/files/nginx.conf
@@ -36,7 +36,10 @@ http {
     }
 
     server {
-        listen 8052 default_server;
+        listen 8052 ssl default_server;
+
+        ssl_certificate /etc/nginx/awxweb.pem;
+        ssl_certificate_key /etc/nginx/awxweb.pem;
 
         # If you have a domain name, this is where to add it
         server_name _;

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -48,6 +48,10 @@ RUN OFFICIAL=yes pip install /tmp/{{ awx_sdist_file }}
 
 RUN echo "{{ awx_version }}" > /var/lib/awx/.tower_version
 ADD nginx.conf /etc/nginx/nginx.conf
+RUN openssl req -newkey rsa:4906 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem -subj "/CN=localhost/" && \
+    cat certificate.pem key.pem > /etc/nginx/awxweb.pem && \
+    chmod 0600 /etc/nginx/awxweb.pem && \
+    rm certificate.pem key.pem
 ADD supervisor.conf /supervisor.conf
 ADD supervisor_task.conf /supervisor_task.conf
 ADD launch_awx.sh /usr/bin/launch_awx.sh

--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -84,6 +84,7 @@
       {{
         [project_data_dir + ':/var/lib/awx/projects:rw'] if project_data_dir is defined else []
         + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
+        + [ssl_certificate + ':/etc/nginx/awxweb.pem:ro'] if ssl_certificate is defined else []
       }}
     user: root
     ports:


### PR DESCRIPTION
Signed-off-by: walkafwalka <41709139+walkafwalka@users.noreply.github.com>

##### SUMMARY
Adds support for SSL and enables SSL by default. If a path SSL certificate and private key are provided, then it is mounted to the docker volume, otherwise an SSL certificate and key are generated.

Fixes #1549.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.6.44
```


##### ADDITIONAL INFORMATION
Note that with this change, reverting to HTTP would not be as simple as setting a variable. I planned on submitting another PR in the future to do so. Please let me know if this would be required before merging this PR.

Also, this merge would require an image push to DockerHub.