### PR TITLE
Bugfix for ca_trust_dir

### DIFF
--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -80,11 +80,9 @@
     state: started
     restart_policy: unless-stopped
     image: "{{ awx_web_docker_actual_image }}"
-    volumes: >
-      {{
-        [project_data_dir + ':/var/lib/awx/projects:rw'] if project_data_dir is defined else []
-        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
-      }}
+    volumes:
+      - "{{ project_data_dir + ':/var/lib/awx/projects:rw' if project_data_dir is defined else [] }}"
+      - "{{ ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro' if ca_trust_dir is defined else [] }}"
     user: root
     ports:
       - "{{ host_port }}:8052"
@@ -111,6 +109,11 @@
       MEMCACHED_PORT: "11211"
       AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
       AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+    register: awx_web_container
+
+- name: Update CA trust in awx_web container
+  command: docker exec awx_web '/usr/bin/update-ca-trust'
+  when: awx_web_container.changed
 
 - name: Activate AWX Task Container
   docker_container:


### PR DESCRIPTION
Hello,

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed syntax as ca_trust_dir was not correctly mounted in awx_web container when it's defined with a standalone installation.
Also added a command to update CA trust inside awx_web container after creation. 
As soon as the anchors are mounted from host to the container the CA trust store itself is not updated. To update it we have to run a command inside the container after the mount is done.

It has been tested with CentOS 7 and RHEL 7 installations. LDAP authentication is now possible with self signed certs as soon as the CA's are integrated into the container.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.6.363
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
**Steps to reproduce:**
- git clone and use the development branch
- Edit inventory variables:
```
postgres_data_dir=/opt/pgdocker
project_data_dir=/opt/awxprojects
ca_trust_dir=/etc/pki/ca-trust/source/anchors
```
- ansible-playbook -i inventory install.yml
- docker exec -it awx_web /bin/bash
- ls -al /etc/pki/ca-trust/source/anchors/ (you will see, that there are not your own CA's inside as they should be)

And the ultimate test to verify somethng is wrong (inside awx_web container):
Get a unique string from one of your CA certs you want to integrate and grep inside the container in the ca-bundle.trust.crt:
`grep SU9OMRQwEgYDVQQDEwtRQklUUk9PVC1DQTAeFw0xNDEyMDMxMzMxMTZaFw0yNDEy /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt`

After fixing the standalone.yml inside the local_docker tasks everything was working fine for me and I could finally use the LDAP authentication.
```
[root@awxweb awx]# grep SU9OMRQwEgYDVQQDEwtRQklUUk9PVC1DQTAeFw0xNDEyMDMxMzMxMTZaFw0yNDEy /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
SU9OMRQwEgYDVQQDEwtRQklUUk9PVC1DQTAeFw0xNDEyMDMxMzMxMTZaFw0yNDEy
[root@awxweb awx]# ls -al /etc/pki/ca-trust/source/anchors/
total 48
drwxr-xr-x. 2 root root 4096 Jul 25 08:55 .
drwxr-xr-x  4 root root   80 May 31 18:02 ..
-rw-r--r--. 1 root root 1964 Jul 23 13:55 CENSORED-CA.pem
-rw-r--r--. 1 root root 1996 Jul 23 13:55 CENSORED-CA-1.pem
-rw-r--r--. 1 root root 2634 Jul 23 13:55 CENSORED-CA.pem
-rw-r--r--  1 root root 4566 Jul 24 10:08 CENSORED-CHAIN.pem
-rw-r--r--. 1 root root 2443 Jul 23 13:55 CENSORED-CA.pem
-rw-r--r--. 1 root root 1935 Jul 23 13:55 CENSORED-ROOT-CA.pem
-rw-r--r--. 1 root root 2228 Jul 23 13:55 CENSORED Enterprise CA.pem
-rw-r--r--. 1 root root 2037 Jul 23 13:55 CENSORED Root CA.pem
-rw-r--r--. 1 root root 2683 Jul 23 13:55 SERVICE-Issuing-CA.pem
-rw-r--r--. 1 root root 2021 Jul 23 13:55 SERVICE-Root-CA.pem

```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
I hope this contribution is helpful for others.

Best regards,
Dennis