### PR TITLE
Fix token based openshift logins during installation - fixes #489

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -10,6 +10,7 @@ dockerhub_base=ansible
 
 # Openshift Install
 # Will need to set -e openshift_password=developer -e docker_registry_password=$(oc whoami -t)
+#           or set -e openshift_token=TOKEN
 # openshift_host=127.0.0.1:8443
 # openshift_project=awx
 # openshift_user=developer

--- a/installer/roles/kubernetes/tasks/openshift_auth.yml
+++ b/installer/roles/kubernetes/tasks/openshift_auth.yml
@@ -23,7 +23,17 @@
     - openshift_user is defined
     - openshift_password is defined
     - openshift_token is not defined
+  register: openshift_auth_result
+  ignore_errors: true
   no_log: true
+
+- name: OpenShift authentication failed on TLS verification
+  fail:
+    msg: "Failed to verify TLS, consider settings openshift_skip_tls_verify=True {{ openshift_auth_result.stderr }}"
+  when:
+    - openshift_skip_tls_verify is not defined or not openshift_skip_tls_verify
+    - openshift_auth_result.rc != 0
+    - openshift_auth_result.stderr | search("certificate that does not match its hostname")
 
 - name: Authenticate with OpenShift via token
   shell: |
@@ -31,4 +41,11 @@
       --token {{ openshift_token }} \
       --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
   when: openshift_token is defined
+  register: openshift_auth_result
+  ignore_errors: true
   no_log: true
+
+- name: OpenShift authentication failed
+  fail:
+    msg: "{{ openshift_auth_result.stderr }}"
+  when: openshift_auth_result.rc != 0


### PR DESCRIPTION
##### SUMMARY
This PR fixes token based logins during installation.  This is useful when, for instance, OpenShift is configured for oauth authentication and passwords aren't used.

Related #489

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.6.48
```


##### ADDITIONAL INFORMATION
```

```
