### PR TITLE
Add some env variables to the web deployment

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -133,6 +133,21 @@ spec:
         - name: {{ kubernetes_deployment_name }}-web
           image: {{ kubernetes_web_image | default(dockerhub_web_image) }}
           imagePullPolicy: Always
+          env:
+            - name: DATABASE_USER
+              value: {{ pg_username }}
+            - name: DATABASE_NAME
+              value: {{ pg_database }}
+            - name: DATABASE_HOST
+              value: {{ pg_hostname|default('postgresql') }}
+            - name: DATABASE_PORT
+              value: "{{ pg_port|default('5432') }}"
+            - name: DATABASE_PASSWORD
+              value: {{ pg_password }}
+            - name: MEMCACHED_HOST
+              value: {{ memcached_hostname|default('localhost') }}
+            - name: RABBITMQ_HOST
+              value: {{ rabbitmq_hostname|default('localhost') }}
           ports:
             - containerPort: 8052
           volumeMounts:


### PR DESCRIPTION
This allows the start script to properly wait on services to come
online rather than getting stuck and waiting for the full timeout
