### PR TITLE
Set shell to bash explicitly in Makefile. Set shell option -e.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ requirements_ansible: virtualenv_ansible
 	else \
 	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/ansible/bin/pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
+	$(VENV_BASE)/ansible/bin/pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt || true
 
 requirements_ansible_dev:
 	if [ "$(VENV_BASE)" ]; then \
@@ -184,7 +184,7 @@ requirements_awx: virtualenv_awx
 	else \
 	    cat requirements/requirements.txt requirements/requirements_git.txt | $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/awx/bin/pip uninstall --yes -r requirements/requirements_tower_uninstall.txt
+	$(VENV_BASE)/awx/bin/pip uninstall --yes -r requirements/requirements_tower_uninstall.txt || true
 
 requirements_awx_dev:
 	$(VENV_BASE)/awx/bin/pip install -r requirements/requirements_dev.txt
@@ -198,10 +198,10 @@ requirements_test: requirements
 # "Install" awx package in development mode.
 develop:
 	@if [ "$(VIRTUAL_ENV)" ]; then \
-	    pip uninstall -y awx; \
+	    pip uninstall -y awx || true; \
 	    $(PYTHON) setup.py develop; \
 	else \
-	    pip uninstall -y awx; \
+	    pip uninstall -y awx || true; \
 	    $(PYTHON) setup.py develop; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+.SHELLFLAGS = -ec
 PYTHON ?= python
 PYTHON_VERSION = $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_version; print(get_python_version())")
 SITELIB=$(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")


### PR DESCRIPTION
 ##### SUMMARY
Requirements_awx and requirements_ansible use bash style conditionals that are incompatible with /bin/sh, the default SHELL for make on some linux variants and is not updated from env.SHELL per gnu docs.

The default .SHELLFLAGS = is -c which will also continue after an error instead of stopping make.

Setting SHELL and .SHELLFLAGS explicitly should improve compatibility regardless of make defaults and make any shell errors stop make so a failed target is easily noticed and fixed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.7.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
git clone https://github.com/ansible/awx /awx_devel
echo /awx_devel > /tmp/awx.egg-link
cp Makefile /tmp/
mkdir /tmp/requirements
cp requirements/requirements.txt \
	requirements/requirements_git.txt \
	requirements/requirements_ansible.txt \
	requirements/requirements_ansible_git.txt \
	requirements/requirements_dev.txt \
	requirements/requirements_ansible_uninstall.txt \
	requirements/requirements_tower_uninstall.txt \
	/tmp/requirements/ 
cd /tmp
make requirements_ansible requirements_awx
# Note shell error regarding [[ on stderr
```
