### PR TITLE
pin pluggy at 0.6.0

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,6 +5,7 @@ ipython==5.2.1
 unittest2
 pep8
 flake8
+pluggy==0.6.0
 pyflakes
 pytest==3.6.0
 pytest-cov
@@ -21,3 +22,4 @@ matplotlib
 backports.tempfile  # support in unit tests for py32+ tempfile.TemporaryDirectory
 mockldap
 sdb
+atomicwrites==1.1.5


### PR DESCRIPTION
##### SUMMARY
This will fix the `_io.BufferedWriter` test failures we have been seeing in Jenkins and Shippable.  

Cause: 3 days ago, `atomicwriter` release 1.2.0.  This package is a dependency for most of our dev pytest packages.  Also needed to pin pluggy to 0.6.0 because of `pytest-xdist`.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API