### PR TITLE
lint: Remove uswgitop duplicate + max width pep8 + ignore E402

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -15,7 +15,6 @@ pytest-timeout
 pytest-xdist
 logutils
 flower
-uwsgitop
 jupyter
 matplotlib
 backports.tempfile  # support in unit tests for py32+ tempfile.TemporaryDirectory

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,13 @@
 # E261 - At least two spaces before inline comment
 # E302 - Expected 2 blank lines found 0
 # E303 - Too many blank lines
+# E402 - module level import not at top of file
 # W291 - Trailing whitespace
 # W391 - Blank line at end of file
 # W293 - Blank line contains whitespace
-ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293
+ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,E402,W291,W391,W293
 exclude=.tox,venv,awx/lib/site-packages,awx/plugins/inventory/ec2.py,awx/plugins/inventory/gce.py,awx/plugins/inventory/vmware.py,awx/plugins/inventory/openstack.py,awx/ui,awx/api/urls.py,awx/main/migrations,awx/main/tests/data,installer/openshift/settings.py
+max-line-length=160
 
 [flake8]
 max-line-length=160


### PR DESCRIPTION
##### SUMMARY

Currently this issue rises when running  `tox -e api-lint`:

```
Double requirement given: uwsgitop (from -r /home/spredzy/Projects/github.com/Spredzy/ansible/awx/requirements/requirements_dev.txt
(line 18)) (already in uwsgitop==0.10.0 (from -r /home/spredzy/Projects/github.com/Spredzy/ansible/awx/requirements/requirements.txt (line 220)), name='uwsgitop')
```

Since `uswgitop` is present in `requirements.txt` it doesn't have to be
in `requirements_dev.txt`.

Also we specify max-width-length for flake8, but not for pep8, this
leads to one receiving hundreads of warning when running pep8. This
can be avoided the exact same way it has been done for flake8

As we follow some of Ansible core pattern for import, E402 should be
ignored the same way they do it[1]

[1] https://github.com/ansible/ansible/blob/devel/tox.ini#L25-L28

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

  - N/A

##### AWX VERSION

- devel

##### ADDITIONAL INFORMATION

  - N/A