### PR TITLE
Steps toward python 3 support

### DIFF
--- a/awx/lib/awx_display_callback/events.py
+++ b/awx/lib/awx_display_callback/events.py
@@ -148,7 +148,7 @@ class EventContext(object):
         if event not in ('playbook_on_stats',) and "res" in event_data and len(str(event_data['res'])) > max_res:
             event_data['res'] = {}
         event_dict = dict(event=event, event_data=event_data)
-        for key in event_data.keys():
+        for key in list(event_data.keys()):
             if key in ('job_id', 'ad_hoc_command_id', 'project_update_id', 'uuid', 'parent_uuid', 'created',):
                 event_dict[key] = event_data.pop(key)
             elif key in ('verbosity', 'pid'):
@@ -159,12 +159,12 @@ class EventContext(object):
         return {}
 
     def dump(self, fileobj, data, max_width=78, flush=False):
-        b64data = base64.b64encode(json.dumps(data))
+        b64data = base64.b64encode(json.dumps(data).encode('utf-8'))
         with self.display_lock:
             # pattern corresponding to OutputEventFilter expectation
             fileobj.write(u'\x1b[K')
             for offset in xrange(0, len(b64data), max_width):
-                chunk = b64data[offset:offset + max_width]
+                chunk = b64data[offset:offset + max_width].decode('ascii')
                 escaped_chunk = u'{}\x1b[{}D'.format(chunk, len(chunk))
                 fileobj.write(escaped_chunk)
             fileobj.write(u'\x1b[K')

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -815,7 +815,7 @@ class BaseTask(Task):
         json_data = json.dumps(instance.inventory.get_script_data(hostvars=True))
         handle, path = tempfile.mkstemp(dir=kwargs.get('private_data_dir', None))
         f = os.fdopen(handle, 'w')
-        f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint %r\n' % json_data)
+        f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint(%r)\n' % json_data)
         f.close()
         os.chmod(path, stat.S_IRUSR | stat.S_IXUSR | stat.S_IWUSR)
         return path


### PR DESCRIPTION
##### SUMMARY
Fix some issues found while trying to run a task using a Python 3 virtualenv

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 1.0.7.6
```


##### ADDITIONAL INFORMATION
Patch 1: Generate Python3 compatible inventory script

The script generated at https://github.com/ansible/awx/blob/devel/awx/main/tasks.py#L818 fails when `python` in $PATH is actually Python 3:

To reproduce: run a job with a Python 3 virtualenv.

```
 [WARNING]:  * Failed to parse /tmp/awx_25_CkF7Vq/tmpeQA96V with script plugin:
Inventory script (/tmp/awx_25_CkF7Vq/tmpeQA96V) had an execution error:   File
"/tmp/awx_25_CkF7Vq/tmpeQA96V", line 3     print '{"all": {"vars": ...
^ SyntaxError: invalid syntax
 [WARNING]: Unable to parse /tmp/awx_25_CkF7Vq/tmpeQA96V as an inventory source
```

Patch 2: Make awx_display callback work with Python 3.

There are a few issues that prevent the callback from working on Py3, mostly related to Unicode support (but also to changes in dict.keys() method now returning an iterator). After fixing the above issue, jobs run but instead of any output, there are error messages from the callback:

```
 [WARNING]: Failure using method (v2_runner_item_on_ok) in callback plugin
(<awx_display_callback.module.AWXDefaultCallbackModule object at
0x7fcce32e5e10>): a bytes-like object is required, not 'str'
 [WARNING]: Failure using method (v2_runner_on_ok) in callback plugin
(<awx_display_callback.module.AWXDefaultCallbackModule object at
0x7fcce32e5e10>): a bytes-like object is required, not 'str'
 [WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin
(<awx_display_callback.module.AWXDefaultCallbackModule object at
0x7fcce32e5e10>): a bytes-like object is required, not 'str'
```

With these two patches, I can run jobs with Python 3 (running inventory scripts still needs a hack that's outside the scope for this issue I guess).