### PR TITLE
Reduce default verbosity of dev-specific callback logging

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -125,7 +125,7 @@ class BaseWorker(object):
             except QueueEmpty:
                 continue
             except Exception as e:
-                logger.error("Exception on worker, restarting: " + str(e))
+                logger.error("Exception on worker {}, restarting: ".format(idx) + str(e))
                 continue
             try:
                 self.perform_work(body, *args)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1142,6 +1142,7 @@ LOGGING = {
         },
         'awx.main.commands.run_callback_receiver': {
             'handlers': ['callback_receiver'],
+            'level': 'INFO'  # in debug mode, includes full callback data
         },
         'awx.main.dispatch': {
             'handlers': ['dispatcher'],

--- a/awx/settings/local_settings.py.docker_compose
+++ b/awx/settings/local_settings.py.docker_compose
@@ -196,6 +196,7 @@ LOGGING['handlers']['syslog'] = {
 LOGGING['loggers']['django.request']['handlers'] = ['console']
 LOGGING['loggers']['rest_framework.request']['handlers'] = ['console']
 LOGGING['loggers']['awx']['handlers'] = ['console', 'external_logger']
+LOGGING['loggers']['awx.main.commands.run_callback_receiver']['handlers'] = []  # propogates to awx
 LOGGING['loggers']['awx.main.tasks']['handlers'] = ['console', 'external_logger']
 LOGGING['loggers']['awx.main.scheduler']['handlers'] = ['console', 'external_logger']
 LOGGING['loggers']['django_auth_ldap']['handlers'] = ['console']


### PR DESCRIPTION
##### SUMMARY
I appreciate the ability to get more data about the callback receiver in the logs, but echoing out the data to the terminal creates a volume of information that is absolutely deafening while it's running, and doesn't convey much context.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
1.0.8-9
```


##### ADDITIONAL INFORMATION
Before:

![screen shot 2018-09-18 at 3 27 27 pm](https://user-images.githubusercontent.com/1385596/45711573-04fce980-bb58-11e8-8d53-01c278388b9b.png)

Note that the entry is actually duplicated, in addition to being very verbose. Also, this information isn't really about the job, it's about the project update beforehand, so it's only tangentially related in the first place.

I have to page up 43 times to get from the end of this stream back to the start.

After:

![screen shot 2018-09-18 at 3 26 12 pm](https://user-images.githubusercontent.com/1385596/45711619-28279900-bb58-11e8-981b-03c361ee1ba0.png)

Not duplicated, and condenses those roughly 43 pages to roughly 2 pages. People can still turn back on the detailed body information, if they choose.