### PR TITLE
automatically delete project files in entire cluster

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -466,6 +466,14 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
             models.Q(ProjectUpdate___project=self)
         )
 
+    def delete(self, *args, **kwargs):
+        path_to_delete = self.get_project_path(check_if_exists=False)
+        r = super(Project, self).delete(*args, **kwargs)
+        if self.scm_type and path_to_delete:  # non-manual, concrete path
+            from awx.main.tasks import delete_project_files
+            delete_project_files.delay(path_to_delete)
+        return r
+
 
 class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManagerProjectUpdateMixin):
     '''


### PR DESCRIPTION
Resolves https://github.com/ansible/awx/issues/426

Tested with integration testing that creates & deletes project. Some logs:

```
awx_1        | 18:42:06 celeryd.1   | 2018-09-19 18:42:06,187 INFO     awx.main.tasks Success removing project files /projects/_90__project_smokepresident
awx_1        | 18:42:06 celeryd.1   | 2018-09-19 18:42:06,189 DEBUG    awx.main.tasks Success removing /projects/_90__project_smokepresident.lock
```

We shouldn't need to address deletion while a project update is still running, because those cases should return a 400.

Obviously, we'll also gate this on @ryanpetrello work https://github.com/ansible/awx/pull/2266, but everything I remember from that points to a final implementation that supports the broadcast_all functionality.