### PR TITLE
[WIP] Allow use of vault encrypted variables in job template extra_vars

### DIFF
--- a/awx/main/tests/unit/utils/test_safe_yaml.py
+++ b/awx/main/tests/unit/utils/test_safe_yaml.py
@@ -3,7 +3,8 @@
 from copy import deepcopy
 import pytest
 import yaml
-from awx.main.utils.safe_yaml import safe_dump
+import json
+from awx.main.utils.safe_yaml import safe_dump, VaultDecoder, VaultEncoder, SafeLoader
 
 
 @pytest.mark.parametrize('value', [None, 1, 1.5, []])
@@ -95,3 +96,31 @@ def test_deep_diff_unsafe_marking():
     deep['a'][1][0]['b']['z'] = 'not safe'
     yaml = safe_dump(deep, jt_vars)
     assert "!unsafe 'z'" in yaml
+
+
+def test_mark_variable_as_vault():
+    JSON_DATA = '''
+    {
+        "vars_secret_funky_json": {
+            "__ansible_vault": "$ANSIBLE_VAULT;1.2;AES256;alan_host\\n3535666661663330333731376634656261396131326233353066343239\\n3733\\n"
+        }
+    }
+    '''
+    vars = json.loads(JSON_DATA, cls=VaultDecoder)
+    output = safe_dump(vars)
+    assert "!unsafe 'vars_secret_funky_json': !vault |" in output
+
+
+def test_convert_constructor_to_json_form():
+    YAML_DATA = '''
+    vars_secret_funky_json: !vault |
+        $ANSIBLE_VAULT;1.2;AES256;alan_host
+        35356666616633303337313766346562613961313262333530663432393965303736653334306433
+        6239666265343936343462653836386162343234353961330a306665396665353364613863316362
+        66646663313737393763383565333237316663666339623063646666646261643338616261633330
+        3634313634666264620a383632386661653330326435633861333031643334643237366430313733
+        3733
+    '''
+    vars = yaml.load(YAML_DATA, Loader=SafeLoader)
+    output = json.dumps(vars, cls=VaultEncoder)
+    assert '__ansible_vault' in output


### PR DESCRIPTION
##### SUMMARY
See the bug described in

https://github.com/ansible/awx/issues/223#issuecomment-422457165

Although I had assumed this would work (it works in inventory vars), it turns out that AWX provides no way to put vault encrypted content inside of job template extra vars.

The reasons for this are nuanced, but this PR adds logic inside the same place that the `!unsafe` constructor is handled to also handle `!vault`, more-or-less.

Tested with a JT and it works.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
1.0.8-11
```


##### ADDITIONAL INFORMATION
@sivel, I based this off your suggestions here:

https://gist.github.com/sivel/6991a5abcfc41bb2872d5898213575eb


