### PR TITLE
create_preload_data: log no-op operation, remove unnecessary credential

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -15,6 +15,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         # Sanity check: Is there already an organization in the system?
         if Organization.objects.count():
+            print('An organization is already in the system, exiting.')
+            print('(changed: False)')
             return
 
         # Create a default organization as the first superuser found.
@@ -54,3 +56,4 @@ class Command(BaseCommand):
                 jt.credentials.add(c)
         print('Default organization added.')
         print('Demo Credential, Inventory, and Job Template added.')
+        print('(changed: True)')


### PR DESCRIPTION
##### SUMMARY
It's frustrating to run a command, get no output, and have nothing happen, so I add a statement for when nothing is added.

In other commands, we write changed status so that something else can detect if something changed, so I wanted this to follow suit.

Also, we don't need a credential to run this JT, so I think it's more clear if we don't make one.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
1.0.8-11
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
