### PR TITLE
don't explicitly set `ANSIBLE_INVENTORY_ENABLED`

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1269,14 +1269,6 @@ class InventorySourceOptions(BaseModel):
             )
         return None
 
-    def get_inventory_plugin_name(self):
-        if self.source in CLOUD_PROVIDERS or self.source == 'custom':
-            # TODO: today, all vendored sources are scripts
-            # in future release inventory plugins will replace these
-            return 'script'
-        # in other cases we do not specify which plugin to use
-        return None
-
     def get_deprecated_credential(self, kind):
         for cred in self.credentials.all():
             if cred.credential_type.kind == kind:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1229,7 +1229,6 @@ class RunJob(BaseTask):
         if job.project:
             env['PROJECT_REVISION'] = job.project.scm_revision
         env['ANSIBLE_RETRY_FILES_ENABLED'] = "False"
-        env['ANSIBLE_INVENTORY_ENABLED'] = 'script'
         env['ANSIBLE_INVENTORY_UNPARSED_FAILED'] = 'True'
         env['MAX_EVENT_RES'] = str(settings.MAX_EVENT_RES_DATA)
         if not kwargs.get('isolated'):
@@ -2052,9 +2051,6 @@ class RunInventoryUpdate(BaseTask):
         env['INVENTORY_SOURCE_ID'] = str(inventory_update.inventory_source_id)
         env['INVENTORY_UPDATE_ID'] = str(inventory_update.pk)
         env.update(STANDARD_INVENTORY_UPDATE_ENV)
-        plugin_name = inventory_update.get_inventory_plugin_name()
-        if plugin_name is not None:
-            env['ANSIBLE_INVENTORY_ENABLED'] = plugin_name
 
         # Set environment variables specific to each source.
         #


### PR DESCRIPTION
Specifying `ANSIBLE_INVENTORY_ENABLED='script'` ends up causing issues for playbooks that _themselves_ invoke `-m shell -a 'ansible-playbook ...'`