### PR TITLE
[WIP] Feature for API clients to skip project update on create

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -858,7 +858,7 @@ class OrganizationAdminsList(BaseUsersList):
 class OrganizationProjectsList(SubListCreateAttachDetachAPIView):
 
     model = Project
-    serializer_class = ProjectSerializer
+    serializer_class = ProjectSerializerCreate
     parent_model = Organization
     relationship = 'projects'
     parent_key = 'organization'
@@ -1069,7 +1069,7 @@ class TeamAccessList(ResourceAccessList):
 class ProjectList(ListCreateAPIView):
 
     model = Project
-    serializer_class = ProjectSerializer
+    serializer_class = ProjectSerializerCreate
 
     def get_queryset(self):
         projects_qs = Project.accessible_objects(self.request.user, 'read_role')

--- a/awx/main/tests/functional/api/test_project.py
+++ b/awx/main/tests/functional/api/test_project.py
@@ -5,6 +5,7 @@ from django.conf import settings
 import pytest
 
 from awx.api.versioning import reverse
+from awx.main.models import Project
 
 
 @pytest.mark.django_db
@@ -44,3 +45,20 @@ def test_project_unset_custom_virtualenv(get, patch, project, admin, value):
     url = reverse('api:project_detail', kwargs={'pk': project.id})
     resp = patch(url, {'custom_virtualenv': value}, user=admin, expect=200)
     assert resp.data['custom_virtualenv'] is None
+
+
+@pytest.mark.django_db
+def test_create_project_no_update(post, organization, admin_user):
+    r = post(
+        url=reverse('api:project_list'),
+        user=admin_user,
+        data=dict(
+            name="test-proj",
+            organization=organization.id,
+            scm_url='localhost',
+            scm_type='git',
+            skip_update=True
+        )
+    )
+    project = Project.objects.get(id=r.data['id'])
+    assert project.status == 'never updated'

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,45 @@
+### Distributed project update concepts
+
+Project updates serve an important role in maintaining the audit trail
+of what actions were performed by an AWX server. They also serve the role
+of assuring that the project folder contains the expected content on the local
+file system before running a job in clustered AWX installations.
+
+These two responsibilities are separated in the technical design of
+project updates. The `job_type` field of a project update indicates which
+function that update served.
+
+ - a `job_type` of `check` (denoting Ansible "check mode") updates the
+   last-known revision of the project saved in the database, but does not
+   make persistent changes to the local file system on the instance it runs.
+   This revision is surfaced in the field `scm_revision` in the project API.
+ - a `job_type` of `run` updates the content of the project folder to the
+   `scm_revision` of the project.
+
+A run-type project update is performed on the same instance in the cluster
+before running a job template in order to obtain the right playbook and
+associated files. This type of update is denoted by a `launch_type` of `sync`.
+
+Check-type project updates, on the other hand, can be ran from any instance
+in the cluster. If a project is set to update on launch, this results in
+_both_ a check-type project update and then a run-type project update before
+the job template runs.
+
+#### Delayed initial update for direct API clients
+
+By default, the action of creating a project will launch a check type project
+update, so that an initial value of `scm_revision` can be filled in.
+
+There is a feature to skip this update, designed specifically for API clients
+that wish to avoid bottlenecks.
+
+ - provide field `skip_update=true` on project creation
+ - on creation of subsequent job templates, validation of the `playbook` field
+   is bypassed, so the client does not need to wait for project update
+   completion before proceeding with the rest of its work
+ - whenever a job template using the project runs, the revision discovered
+   by the `run` type update will subsequently be used as the
+   `scm_revision` of the project
+
+This allows the client to reliably create resources sufficient to launch a job
+without doing any polling.


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/208

I have become well-familiar with a particular kind of pain for people writing clients for AWX / Tower, which can be seen in almost every attempt to write code to create data in-bulk. Some examples of bulk data creators:

https://github.com/AlanCoding/tower-cli-bulk-data-faker

https://github.com/ansible/tower-cli/tree/master/tower_cli/cli/transfer

Most issues people have are related to projects, and even if they get it right, the result is extremely non-performant, due to waiting for a project update to finish before moving to the next step.

What's more, github is very often where the destination code lives. Connectivity to such a service can never be 100%, particularly when it's free. By forcing the project update, we demand that retry logic lives in 2 places, if someone is trying to write a resilient tool. After all, even if the project is updated, that doesn't guarantee connection projects _won't_ happen in the subsequent job runs.

This feature is for API clients that want to create resources in Tower and then run jobs. In that case, you already know what your playbook is, and there's no value in the server forcing you to select from a list (strictly UX value).

Thus, if you set this flag, the server lets you create a JT with whatever playbook you want to give. (cannot be used in the UI, and I have no intention to address this ever)

Using this flag puts _your_ project in a similar state to the "Demo Project" that the `create_demo_data` command creates. Additionally, I have touched up the task logic such that the first run of this type of project will save the SCM revision, so that _after_ that, it behaves as all other projects do, being more consistent with our audibility standards.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
1.0.8-13
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
