### PR TITLE
Modify main.yml file to deploy AWX pod after DB migration complete #2345

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -127,12 +127,11 @@
     - 'secret'
   no_log: yes
 
-- name: Apply Deployment
+- name: Apply Configmap and Secrets
   shell: |
     echo {{ item | quote }} | {{ kubectl_or_oc }} apply -f -
   with_items:
     - "{{ configmap }}"
-    - "{{ deployment }}"
     - "{{ secret }}"
   no_log: yes
 
@@ -196,6 +195,13 @@
   shell: |
     {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
       delete pod ansible-tower-management --grace-period=0 --ignore-not-found
+
+- name: Apply Deployment
+  shell: |
+    echo {{ item | quote }} | {{ kubectl_or_oc }} apply -f -
+  with_items:
+    - "{{ deployment }}"
+  no_log: yes
 
 - name: Scale up deployment
   shell: |


### PR DESCRIPTION
##### SUMMARY
Modify main.yml file to deploy AWX pod once DB migration is complete #2345

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 1.0.7.12

```


##### ADDITIONAL INFORMATION

The deployment without this change works i.e. the AWX pod deploys however there are many python errors in the AWX_Web and AWX_Celery containers due to the migration process not completing before these start when deploying into Openshift Container platform.

This change simply delays the deployment of the AWX pod until the AWX Tower Management pod has completed its DB migration.