### PR TITLE
Ensure workflow graph width is 100% of container

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.block.less
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.block.less
@@ -66,6 +66,7 @@
 
 .WorkflowChart-svg {
     border-bottom-left-radius: 5px;
+    width: 100%;
 }
 
 .WorkflowResults-rightSide .WorkflowChart-svg {


### PR DESCRIPTION
##### SUMMARY
related #2316 

Tested out this change in both Chrome and FF (latest).  Here's what the editor looks like after applying the change:

<img width="1437" alt="screen shot 2018-09-30 at 5 16 18 am" src="https://user-images.githubusercontent.com/9889020/46255821-27ec9f00-c470-11e8-902e-93658724331e.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI