### PR TITLE
Use block: to remove redundant when: ansible_os_family != or == "Wind…

### DIFF
--- a/awx/playbooks/scan_facts.yml
+++ b/awx/playbooks/scan_facts.yml
@@ -4,33 +4,34 @@
     scan_use_recursive: false
   tasks:
 
-    - name: "Scan packages (Unix/Linux)"
-      scan_packages:
-        os_family: '{{ ansible_os_family }}'
-      when: ansible_os_family != "Windows"
-    - name: "Scan services (Unix/Linux)"
-      scan_services:
-      when: ansible_os_family != "Windows"
-    - name: "Scan files (Unix/Linux)"
-      scan_files:
-        paths: '{{ scan_file_paths }}'
-        get_checksum: '{{ scan_use_checksum }}'
-        recursive: '{{ scan_use_recursive }}'
-      when: scan_file_paths is defined and ansible_os_family != "Windows"
-    - name: "Scan Insights for Machine ID (Unix/Linux)"
-      scan_insights:
+    - name: Unix/Linux
+      block:
+        - name: "Scan packages (Unix/Linux)"
+          scan_packages:
+            os_family: '{{ ansible_os_family }}'
+        - name: "Scan services (Unix/Linux)"
+          scan_services:
+        - name: "Scan files (Unix/Linux)"
+          scan_files:
+            paths: '{{ scan_file_paths }}'
+            get_checksum: '{{ scan_use_checksum }}'
+            recursive: '{{ scan_use_recursive }}'
+          when: scan_file_paths is defined
+        - name: "Scan Insights for Machine ID (Unix/Linux)"
+          scan_insights:
       when: ansible_os_family != "Windows"
 
-    - name: "Scan packages (Windows)"
-      win_scan_packages:
+    - name: "Windows"
+      block:
+        - name: "Scan packages (Windows)"
+          win_scan_packages:
+        - name: "Scan services (Windows)"
+          win_scan_services:
+        - name: "Scan files (Windows)"
+          win_scan_files:
+            paths: '{{ scan_file_paths }}'
+            get_checksum: '{{ scan_use_checksum }}'
+            recursive: '{{ scan_use_recursive }}'
+          when: scan_file_paths is defined
       when: ansible_os_family == "Windows"
-    - name: "Scan services (Windows)"
-      win_scan_services:
-      when: ansible_os_family == "Windows"
-    - name: "Scan files (Windows)"
-      win_scan_files:
-        paths: '{{ scan_file_paths }}'
-        get_checksum: '{{ scan_use_checksum }}'
-        recursive: '{{ scan_use_recursive }}'
-      when: scan_file_paths is defined and ansible_os_family == "Windows"
 


### PR DESCRIPTION
…ows"



##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the original playbook, ansible_os_family was compared to "Windows" seven times. Using block: around the two sets of plays, this can be reduced to two times, and make the play a bit more readable, and more defined as to what is happening and where / when.
<!---

-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx/playbooks

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.

This was just an inefficiency I noticed while looking at the awx code to better understand Tower and how it worked. I don't know if the mod is appropriate or will be accepted, but thought I'd contribute the suggestion. Feel free to change / update / reject, as you see fit.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
