### PR TITLE
Fixed typo Ansbile->Ansible

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.form.js
@@ -68,7 +68,7 @@ export default ['i18n', function(i18n) {
                 awPopOver: '<p>Select the credential you want to use when ' +
                     'accessing the remote hosts to run the command. ' +
                     'Choose the credential containing ' +
-                    'the username and SSH key or password that Ansbile ' +
+                    'the username and SSH key or password that Ansible ' +
                     'will need to log into the remote hosts.</p>',
                 dataTitle: i18n._('Credential'),
                 dataPlacement: 'right',


### PR DESCRIPTION
##### SUMMARY
Fixing a typo in the UI, one of the help boxes says Ansbile instead of Ansible

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

 - UI

