### PR TITLE
fix busted notification tests

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -19,7 +19,7 @@ import six
 from django.conf import settings
 from django.core.exceptions import FieldError, ObjectDoesNotExist
 from django.db.models import Q, Count
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, transaction, connection
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
```python
14:17:46 uwsgi.1     | 2018-10-05 14:17:46,823 ERROR    django.request Internal Server Error: /api/v2/notification_templates/33/test/
14:17:46 uwsgi.1     | Traceback (most recent call last):
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
14:17:46 uwsgi.1     |     response = get_response(request)
14:17:46 uwsgi.1     |   File "./awx/wsgi.py", line 71, in _legacy_get_response
14:17:46 uwsgi.1     |     return super(AWXWSGIHandler, self)._legacy_get_response(request)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
14:17:46 uwsgi.1     |     response = self._get_response(request)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
14:17:46 uwsgi.1     |     response = self.process_exception_by_middleware(e, request)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
14:17:46 uwsgi.1     |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
14:17:46 uwsgi.1     |     return func(*args, **kwargs)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
14:17:46 uwsgi.1     |     return view_func(*args, **kwargs)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
14:17:46 uwsgi.1     |     return self.dispatch(request, *args, **kwargs)
14:17:46 uwsgi.1     |   File "./awx/api/generics.py", line 328, in dispatch
14:17:46 uwsgi.1     |     return super(APIView, self).dispatch(request, *args, **kwargs)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 494, in dispatch
14:17:46 uwsgi.1     |     response = self.handle_exception(exc)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 454, in handle_exception
14:17:46 uwsgi.1     |     self.raise_uncaught_exception(exc)
14:17:46 uwsgi.1     |   File "/venv/awx/lib/python2.7/site-packages/rest_framework/views.py", line 491, in dispatch
14:17:46 uwsgi.1     |     response = handler(request, *args, **kwargs)
14:17:46 uwsgi.1     |   File "./awx/api/views/__init__.py", line 4734, in post
14:17:46 uwsgi.1     |     connection.on_commit(lambda: send_notifications.delay([notification.id]))
14:17:46 uwsgi.1     | NameError: global name 'connection' is not defined
```