### PR TITLE
Add serviceName to Kubernetes StatefulSet spec

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -115,6 +115,7 @@ metadata:
   name: {{ kubernetes_deployment_name }}
   namespace: {{ kubernetes_namespace }}
 spec:
+  serviceName: {{ kubernetes_deployment_name }}
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
Signed-off-by: Ashley Nelson <fantashley@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The apiVersion of the StatefulSet was recently changed to apps/v1beta1, which requires that the serviceName attribute be set in StatefulSet.spec. My kubernetes deployment was failing with the message "error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1beta1.StatefulSetSpec". After this fix, the deployment completes successfully.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer - Kubernetes

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
2.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
