### PR TITLE
Fix openshift auth broken by undefined vars

### DIFF
--- a/installer/roles/kubernetes/tasks/openshift_auth.yml
+++ b/installer/roles/kubernetes/tasks/openshift_auth.yml
@@ -29,11 +29,16 @@
 
 - name: OpenShift authentication failed on TLS verification
   fail:
-    msg: "Failed to verify TLS, consider settings openshift_skip_tls_verify=True {{ openshift_auth_result.stderr }}"
+    msg: "Failed to verify TLS, consider settings openshift_skip_tls_verify=True {{ openshift_auth_result.stderr  | default('certificate does not match hostname') }}"
   when:
     - openshift_skip_tls_verify is not defined or not openshift_skip_tls_verify
-    - openshift_auth_result.rc != 0
-    - openshift_auth_result.stderr | search("certificate that does not match its hostname")
+    - openshift_auth_result.rc is defined and openshift_auth_result.rc != 0
+    - openshift_auth_result.stderr is defined and (openshift_auth_result.stderr | search("certificate that does not match its hostname"))
+
+- name: OpenShift authentication failed
+  fail:
+    msg: "{{ openshift_auth_result.stderr | default('Invalid credentials') }}"
+  when: openshift_auth_result.rc is defined and openshift_auth_result.rc != 0
 
 - name: Authenticate with OpenShift via token
   shell: |
@@ -47,5 +52,6 @@
 
 - name: OpenShift authentication failed
   fail:
-    msg: "{{ openshift_auth_result.stderr }}"
-  when: openshift_auth_result.rc != 0
+    msg: "{{ openshift_auth_result.stderr | default('Invalid token') }}"
+  when: openshift_auth_result.rc is defined and openshift_auth_result.rc != 0
+


### PR DESCRIPTION
Signed-off-by: Ashley Nelson <fantashley@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The recent merge of https://github.com/ansible/awx/pull/2164 caused username and password authentication to no longer work for me due to undefined variables. I've added a bunch of tests to see that variables/keys exist before attempting to use them. This has been tested with both username/password auth as well as token auth on OpenShift 3.9 using ansible 2.7.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
2.0.1
```



<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
