### PR TITLE
Fix installer volume definitions

### DIFF
--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -82,9 +82,11 @@
     state: started
     restart_policy: unless-stopped
     image: "{{ awx_web_docker_actual_image }}"
-    volumes:
-      - "{{ project_data_dir + ':/var/lib/awx/projects:z' if project_data_dir is defined else [] }}"
-      - "{{ ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro' if ca_trust_dir is defined else [] }}"
+    volumes: >
+      {{
+        [project_data_dir + ':/var/lib/awx/projects:z'] if project_data_dir is defined else []
+        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
+      }}
     user: root
     ports:
       - "{{ host_port }}:8052"

--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -84,8 +84,8 @@
     image: "{{ awx_web_docker_actual_image }}"
     volumes: >
       {{
-        [project_data_dir + ':/var/lib/awx/projects:z'] if project_data_dir is defined else []
-        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
+        ([project_data_dir + ':/var/lib/awx/projects:z'] if project_data_dir is defined else [])
+        + ([ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else [])
       }}
     user: root
     ports:
@@ -127,8 +127,8 @@
     image: "{{ awx_task_docker_actual_image }}"
     volumes: >
       {{
-        [project_data_dir + ':/var/lib/awx/projects:z'] if project_data_dir is defined else []
-        + [ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else []
+        ([project_data_dir + ':/var/lib/awx/projects:z'] if project_data_dir is defined else [])
+        + ([ca_trust_dir + ':/etc/pki/ca-trust/source/anchors:ro'] if ca_trust_dir is defined else [])
       }}
     links: "{{ awx_task_container_links|list }}"
     user: root


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Should fix https://github.com/ansible/awx/issues/2418

Based on feedback in #2418 I fixed the volume definition to not drop the CA directory, if defined.

(The definition for volumes is still weird:
https://groups.google.com/forum/#!msg/ansible-project/tjBFAN1Qc7w/6IHtXOqktUUJ)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
