### PR TITLE
Updating e2e tests to match new settings nav

### DIFF
--- a/awx/ui/test/e2e/objects/configuration.js
+++ b/awx/ui/test/e2e/objects/configuration.js
@@ -15,6 +15,17 @@ const commands = [{
     },
     selectSubcategory (name) {
         const spinny = 'div.spinny';
+        const categoryName = `//*[text() = '${name}']`;
+        
+        this.api.useXpath();
+        this.api.waitForElementVisible(categoryName);
+        this.api.click(categoryName);
+        this.api.useCss();
+
+        return this;
+    },
+    selectDropDownContainer (name) {
+        const spinny = 'div.spinny';
         const select = '#configure-dropdown-nav';
         const arrow = `${select} + span span[class$="arrow"]`;
         const option = `//li[contains(text(), "${name}")]`;

--- a/awx/ui/test/e2e/tests/test-configuration-ldap-fields.js
+++ b/awx/ui/test/e2e/tests/test-configuration-ldap-fields.js
@@ -1,9 +1,7 @@
 module.exports = {
     'expected LDAP codemirror fields are rendered when returning from another tab': client => {
-        const authTab = '#auth_tab';
         const authView = 'div[ui-view="auth"]';
         const ldapForm = '#configuration_ldap_template_form';
-        const systemTab = '#system_tab';
         const systemView = 'div[ui-view="system"]';
 
         const { navigation } = client.page.dashboard().section;
@@ -14,20 +12,22 @@ module.exports = {
 
         navigation
             .waitForElementVisible('@settings')
-            .click('@settings');
+            .moveToElement('@settings',0,0)
+            .waitForElementVisible('@settingsSubPaneSystem')
+            .click('@settingsSubPaneSystem');
 
-        configuration.waitForElementVisible(authView);
-
-        configuration.waitForElementVisible(systemTab);
-        configuration.click(systemTab);
-        configuration.waitForElementNotVisible(authView);
         configuration.waitForElementVisible(systemView);
 
-        configuration.waitForElementVisible(authTab);
-        configuration.click(authTab);
-        configuration.waitForElementNotVisible(systemView);
-        configuration.waitForElementVisible(authView);
+        navigation
+            .waitForElementVisible('@settings')
+            .moveToElement('@settings',0,0)
+            .waitForElementVisible('@settingsSubPane')
+            .waitForElementVisible('@settingsSubPaneAuth')
+            .click('@settingsSubPaneAuth');
 
+        configuration.waitForElementVisible(authView);    
+        
+        // works as xpath const categoryName = `//*[@id="configuration_edit"]/div[1]/div/div/div[4]`;
         configuration.selectSubcategory('LDAP');
         configuration.waitForElementVisible(ldapForm);
 
@@ -41,7 +41,7 @@ module.exports = {
             'AUTH_LDAP_TEAM_MAP',
         ];
 
-        const ldapCodeMirrors = `${ldapForm} div[class^="CodeMirror"] textarea`;
+        const ldapCodeMirrors = `${ldapForm}  div[class^="CodeMirror"] textarea`;
 
         client.elements('css selector', ldapCodeMirrors, ({ value }) => {
             client.assert.equal(value.length, expectedCodemirrorFields.length);


### PR DESCRIPTION
##### SUMMARY
Updating e2e tests to match new settings nav. There was some test drift due to the layout changes in the application.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### Test output

Test Configuration Ldap Fields Test Suite

Running:  expected LDAP codemirror fields are rendered when returning from another tab
 ✔ Element <#login-button> was visible after 26 milliseconds.
 ✔ Element <div.spinny> was not visible after 26 milliseconds.
 ✔ Element <div.spinny> was visible after 16 milliseconds.
 ✔ Element <div.spinny> was not visible after 1558 milliseconds.
 ✔ Element <Section[name=navigation],Element[name=@settings]> was visible after 1405 milliseconds.
 ✔ Element <Section[name=navigation],Element[name=@settingsSubPaneSystem]> was visible after 1267 milliseconds.
 ✔ Element <div[ui-view="system"]> was visible after 2068 milliseconds.
 ✔ Element <Section[name=navigation],Element[name=@settings]> was visible after 232 milliseconds.
 ✔ Element <Section[name=navigation],Element[name=@settingsSubPane]> was visible after 139 milliseconds.
 ✔ Element <Section[name=navigation],Element[name=@settingsSubPaneAuth]> was visible after 3592 milliseconds.
 ✔ Element <div[ui-view="auth"]> was visible after 54 milliseconds.
 ✔ Element <//*[text() = 'LDAP']> was visible after 30 milliseconds.
 ✔ Element <#configuration_ldap_template_form> was visible after 25 milliseconds.
 ✔ Passed [equal]: 7 == 7
 ✔ Expected element <#cm-AUTH_LDAP_USER_SEARCH-container div[class^="CodeMirror"]> to be visible - condition was met in 33ms
 ✔ Expected element <#cm-AUTH_LDAP_USER_SEARCH-container div[class^="CodeMirror"]> to be enabled - condition was met in 27ms
 ✔ Expected element <#cm-AUTH_LDAP_GROUP_SEARCH-container div[class^="CodeMirror"]> to be visible - condition was met in 41ms
 ✔ Expected element <#cm-AUTH_LDAP_GROUP_SEARCH-container div[class^="CodeMirror"]> to be enabled - condition was met in 19ms
 ✔ Expected element <#cm-AUTH_LDAP_USER_ATTR_MAP-container div[class^="CodeMirror"]> to be visible - condition was met in 26ms
 ✔ Expected element <#cm-AUTH_LDAP_USER_ATTR_MAP-container div[class^="CodeMirror"]> to be enabled - condition was met in 24ms
 ✔ Expected element <#cm-AUTH_LDAP_GROUP_TYPE_PARAMS-container div[class^="CodeMirror"]> to be visible - condition was met in 26ms
 ✔ Expected element <#cm-AUTH_LDAP_GROUP_TYPE_PARAMS-container div[class^="CodeMirror"]> to be enabled - condition was met in 14ms
 ✔ Expected element <#cm-AUTH_LDAP_USER_FLAGS_BY_GROUP-container div[class^="CodeMirror"]> to be visible - condition was met in 29ms
 ✔ Expected element <#cm-AUTH_LDAP_USER_FLAGS_BY_GROUP-container div[class^="CodeMirror"]> to be enabled - condition was met in 17ms
 ✔ Expected element <#cm-AUTH_LDAP_ORGANIZATION_MAP-container div[class^="CodeMirror"]> to be visible - condition was met in 23ms
 ✔ Expected element <#cm-AUTH_LDAP_ORGANIZATION_MAP-container div[class^="CodeMirror"]> to be enabled - condition was met in 17ms
 ✔ Expected element <#cm-AUTH_LDAP_TEAM_MAP-container div[class^="CodeMirror"]> to be visible - condition was met in 27ms
 ✔ Expected element <#cm-AUTH_LDAP_TEAM_MAP-container div[class^="CodeMirror"]> to be enabled - condition was met in 15ms

OK. 28 assertions passed. (21.478s)