### PR TITLE
remove over-eager survey choices validation

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3073,11 +3073,6 @@ class JobTemplateSurveySpec(GenericAPIView):
                         return Response(dict(error=_(
                             "The {min_or_max} limit in survey question {idx} expected to be integer."
                         ).format(min_or_max=key, **context)))
-            if 'choices' in survey_item:
-                if not isinstance(survey_item['choices'], six.string_types):
-                    return Response(dict(error=_(
-                        "Choices in survey question {idx} expected to be string."
-                    ).format(**context)))
             if qtype in ['multiplechoice', 'multiselect'] and 'choices' not in survey_item:
                 return Response(dict(error=_(
                     "Survey question {idx} of type {survey_item[type]} must specify choices.".format(**context)

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -383,7 +383,6 @@ class TestSurveySpecValidation:
         ({'type': 'foo'}, 'allowed question types'),
         ({'type': u'🐉'}, 'allowed question types'),
         ({'type': 'multiplechoice'}, 'multiplechoice must specify choices'),
-        ({'type': 'multiplechoice', 'choices': 45}, 'Choices in survey question 0 expected to be string'),
         ({'type': 'integer', 'min': 'foo'}, 'min limit in survey question 0 expected to be integer'),
         ({'question_name': 42}, "'question_name' in survey question 0 expected to be string.")
     ])


### PR DESCRIPTION
it looks like choices can also be a list and _maybe_ comma delimited;
clearly there's a lot of history here; let's verify and test what's _really_ supported and _then_ add any necessary validation