### PR TITLE
silence the noisy error that's printed w/ `awx-manage check_migrations`

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -126,7 +126,8 @@ def _ctit_db_wrapper(trans_safe=False):
             bottom_stack.close()
             # Log the combined stack
             if trans_safe:
-                logger.warning('Database settings are not available, using defaults, error:\n{}'.format(tb_string))
+                if 'check_migrations' not in sys.argv:
+                    logger.warning('Database settings are not available, using defaults, error:\n{}'.format(tb_string))
             else:
                 logger.error('Error modifying something related to database settings.\n{}'.format(tb_string))
     finally:


### PR DESCRIPTION
This error occurs because the CI that runs `awx-manage check_migrations` doesn't have an actual postgres container when run in the zuul CI environment, so this warning is logged at `awx` import time when it attempts to evaluate certain `django.conf.settings` values:

<img width="1366" alt="screen shot 2018-10-16 at 8 35 23 am" src="https://user-images.githubusercontent.com/214912/47016698-72cc0f00-d11e-11e8-8374-8ca275105314.png">