### PR TITLE
fixes dispatcher test that inadvertently access db

### DIFF
--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -8,6 +8,7 @@ import tempfile
 import shutil
 from datetime import timedelta
 from six.moves import xrange
+from mock import PropertyMock
 
 # Django
 from django.core.urlresolvers import resolve
@@ -752,3 +753,8 @@ def sqlite_copy_expert(request):
     request.addfinalizer(lambda: delattr(SQLiteCursorWrapper, 'copy_expert'))
     return path
 
+
+@pytest.fixture
+def disable_database_settings(mocker):
+    m = mocker.patch('awx.conf.settings.SettingsWrapper.all_supported_settings', new_callable=PropertyMock)
+    m.return_value = []

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -55,6 +55,7 @@ class SlowResultWriter(BaseWorker):
         super(SlowResultWriter, self).perform_work(body, result_queue)
 
 
+@pytest.mark.usefixtures("disable_database_settings")
 class TestPoolWorker:
 
     def setup_method(self, test_method):
@@ -247,6 +248,7 @@ class TestAutoScaling:
         assert len(self.pool) == 2
 
 
+@pytest.mark.usefixtures("disable_database_settings")
 class TestTaskDispatcher:
 
     @property


### PR DESCRIPTION
* Logger inadvertently triggered by dispatcher tests that do not need DB
access. Mock settings to sidestep DB access.

Fixes errors of the below form:
```
________________________________________________ TestTaskDispatcher.test_method_dispatch _________________________________________________
[gw6] linux2 -- Python 2.7.5 /venv/awx/bin/python2
Traceback (most recent call last):
  File "/awx_devel/awx/main/tests/functional/test_dispatch.py", line 267, in test_method_dispatch
    'args': [2, 2]
  File "/awx_devel/awx/main/dispatch/worker/task.py", line 79, in perform_work
    result = self.run_callable(body)
  File "/awx_devel/awx/main/dispatch/worker/task.py", line 54, in run_callable
    logger.debug('task {} starting {}(*{})'.format(uuid, task, args))
  File "/usr/lib64/python2.7/logging/__init__.py", line 1137, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1268, in _log
    self.handle(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1278, in handle
    self.callHandlers(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 1318, in callHandlers
    hdlr.handle(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 745, in handle
    rv = self.filter(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 608, in filter
    if not f.filter(record):
  File "/awx_devel/awx/main/utils/filters.py", line 90, in filter
    if not self.enabled_flag:
  File "/awx_devel/awx/main/utils/filters.py", line 37, in __get__
    return getattr(settings, self.setting_name, None)
  File "/awx_devel/awx/conf/settings.py", line 531, in __getattr_without_cache__
    return getattr(self._wrapped, name)
  File "/awx_devel/awx/conf/settings.py", line 444, in __getattr__
    value = self._get_local(name)
  File "/awx_devel/awx/conf/settings.py", line 387, in _get_local
    setting = Setting.objects.filter(key=name, user__isnull=True).order_by('pk').first()
  File "/venv/awx/lib/python2.7/site-packages/django/db/models/query.py", line 564, in first
    objects = list((self if self.ordered else self.order_by('pk'))[:1])
  File "/venv/awx/lib/python2.7/site-packages/django/db/models/query.py", line 250, in __iter__
    self._fetch_all()
  File "/venv/awx/lib/python2.7/site-packages/django/db/models/query.py", line 1118, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/venv/awx/lib/python2.7/site-packages/django/db/models/query.py", line 53, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch)
  File "/venv/awx/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 887, in execute_sql
    cursor = self.connection.cursor()
  File "/venv/awx/lib/python2.7/site-packages/django/db/backends/base/base.py", line 254, in cursor
    return self._cursor()
  File "/venv/awx/lib/python2.7/site-packages/django/db/backends/base/base.py", line 229, in _cursor
    self.ensure_connection()
  File "/venv/awx/lib/python2.7/site-packages/pytest_django/plugin.py", line 665, in _blocking_wrapper
    pytest.fail('Database access not allowed, '
  File "/venv/awx/lib/python2.7/site-packages/_pytest/outcomes.py", line 92, in fail
    raise Failed(msg=msg, pytrace=pytrace)
Failed: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```