### PR TITLE
dont render blank output lines for some event types + adjust line wrapping

### DIFF
--- a/awx/ui/client/features/output/_index.less
+++ b/awx/ui/client/features/output/_index.less
@@ -72,9 +72,17 @@
     &-row {
         display: flex;
 
+        &:hover {
+            background-color: white;
+        }
+
         &:hover div {
             background-color: white;
         }
+    }
+
+    &-row--clickable {
+        cursor: pointer;
     }
 
     &-toggle {
@@ -110,12 +118,6 @@
 
     &-event {
         .at-mixin-event();
-    }
-
-    &-event--host {
-        .at-mixin-event();
-
-        cursor: pointer;
     }
 
     &-time {

--- a/awx/ui/client/features/output/_index.less
+++ b/awx/ui/client/features/output/_index.less
@@ -175,7 +175,6 @@
 }
 
 .at-mixin-event() {
-    flex: 1;
     padding: 0 10px;
     white-space: pre-wrap;
     word-break: break-all;

--- a/awx/ui/client/features/output/constants.js
+++ b/awx/ui/client/features/output/constants.js
@@ -1,8 +1,6 @@
 export const API_MAX_PAGE_SIZE = 200;
 export const API_ROOT = '/api/v2/';
 
-export const EVENT_NOTIFY_PLAYBOOK = 'playbook_on_notify';
-export const EVENT_RUNNER_OK = 'runner_on_ok';
 export const EVENT_START_TASK = 'playbook_on_task_start';
 export const EVENT_START_PLAY = 'playbook_on_play_start';
 export const EVENT_START_PLAYBOOK = 'playbook_on_start';

--- a/awx/ui/client/features/output/constants.js
+++ b/awx/ui/client/features/output/constants.js
@@ -1,6 +1,8 @@
 export const API_MAX_PAGE_SIZE = 200;
 export const API_ROOT = '/api/v2/';
 
+export const EVENT_NOTIFY_PLAYBOOK = 'playbook_on_notify';
+export const EVENT_RUNNER_OK = 'runner_on_ok';
 export const EVENT_START_TASK = 'playbook_on_task_start';
 export const EVENT_START_PLAY = 'playbook_on_play_start';
 export const EVENT_START_PLAYBOOK = 'playbook_on_start';

--- a/awx/ui/client/features/output/index.controller.js
+++ b/awx/ui/client/features/output/index.controller.js
@@ -6,7 +6,6 @@ import {
     OUTPUT_PAGE_SIZE,
 } from './constants';
 
-let $compile;
 let $q;
 let $scope;
 let $state;
@@ -97,6 +96,7 @@ function firstRange () {
                 .then(() => render.pushFront(results));
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
             lockFollow = false;
         });
@@ -124,6 +124,7 @@ function nextRange () {
                 .then(() => render.pushFront(results));
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
             lockFrames = false;
 
@@ -162,6 +163,7 @@ function previousRange () {
             return $q.resolve();
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
             lockFrames = false;
 
@@ -189,6 +191,7 @@ function lastRange () {
             return $q.resolve();
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
 
             return $q.resolve();
@@ -280,6 +283,7 @@ function firstPage () {
                 .then(() => render.pushFront(results));
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
 
             return $q.resolve();
@@ -309,6 +313,7 @@ function lastPage () {
             return $q.resolve();
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
 
             return $q.resolve();
@@ -330,6 +335,7 @@ function nextPage () {
                 .then(() => render.pushFront(results));
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
         });
 }
@@ -363,6 +369,7 @@ function previousPage () {
             return $q.resolve();
         })
         .finally(() => {
+            render.compile();
             scroll.resume();
 
             return $q.resolve();
@@ -546,10 +553,6 @@ function toggleTaskCollapse (uuid) {
     render.records[uuid].isCollapsed = !isCollapsed;
 }
 
-function compile (html) {
-    return $compile(html)($scope);
-}
-
 function showHostDetails (id, uuid) {
     $state.go('output.host-event.json', { eventId: id, taskUuid: uuid });
 }
@@ -599,7 +602,7 @@ function showMissingEvents (uuid) {
                         delete render.records[uuid];
                     }
                 })
-                .then(() => render.compile(elements))
+                .then(() => render.compile())
                 .then(() => lines);
         });
 }
@@ -709,7 +712,6 @@ function clear () {
 }
 
 function OutputIndexController (
-    _$compile_,
     _$q_,
     _$scope_,
     _$state_,
@@ -727,7 +729,6 @@ function OutputIndexController (
     const { isPanelExpanded, _debug } = $stateParams;
     const isProcessingFinished = !_debug && _resource_.model.get('event_processing_finished');
 
-    $compile = _$compile_;
     $q = _$q_;
     $scope = _$scope_;
     $state = _$state_;
@@ -765,7 +766,7 @@ function OutputIndexController (
     vm.debug = _debug;
 
     render.requestAnimationFrame(() => {
-        render.init({ compile, toggles: vm.toggleLineEnabled });
+        render.init($scope, { toggles: vm.toggleLineEnabled });
 
         status.init(resource);
         page.init(resource.events);
@@ -815,6 +816,7 @@ function OutputIndexController (
                 status.sync();
                 scroll.unlock();
                 scroll.unhide();
+                render.compile();
             }
         });
 
@@ -850,7 +852,6 @@ function OutputIndexController (
 }
 
 OutputIndexController.$inject = [
-    '$compile',
     '$q',
     '$scope',
     '$state',

--- a/awx/ui/client/features/output/render.service.js
+++ b/awx/ui/client/features/output/render.service.js
@@ -347,6 +347,7 @@ function JobRenderService ($q, $compile, $sce, $window) {
         let tdToggle = '';
         let tdEvent = '';
         let classList = '';
+        let directives = '';
 
         if (record.isMissing) {
             return `<div id="${record.uuid}" class="at-Stdout-row">
@@ -371,10 +372,6 @@ function JobRenderService ($q, $compile, $sce, $window) {
                 }
 
                 tdToggle = `<div class="at-Stdout-toggle" ng-click="vm.toggleCollapse('${id}')"><i class="fa ${icon} can-toggle"></i></div>`;
-            }
-
-            if (record.isClickable) {
-                tdEvent = `<div class="at-Stdout-event--host" ng-click="vm.showHostDetails('${record.id}', '${record.uuid}')"><span ng-non-bindable>${content}</span></div>`;
             }
 
             if (record.time && record.line === ln) {
@@ -404,11 +401,16 @@ function JobRenderService ($q, $compile, $sce, $window) {
             }
         }
 
+        if (record && record.isClickable) {
+            classList += ' at-Stdout-row--clickable';
+            directives = `ng-click="vm.showHostDetails('${record.id}', '${record.uuid}')"`;
+        }
+
         return `
-            <div id="${id}" class="at-Stdout-row ${classList}">
+            <div id="${id}" class="at-Stdout-row ${classList}" ${directives}>
                 ${tdToggle}
                 <div class="at-Stdout-line">${ln}</div>
-                ${tdEvent}
+                <div class="at-Stdout-event"><span ng-non-bindable>${content}</span></div>
                 <div class="at-Stdout-time">${timestamp}</div>
             </div>`;
     };

--- a/awx/ui/client/features/output/render.service.js
+++ b/awx/ui/client/features/output/render.service.js
@@ -2,6 +2,8 @@ import Ansi from 'ansi-to-html';
 import Entities from 'html-entities';
 
 import {
+    EVENT_NOTIFY_PLAYBOOK,
+    EVENT_RUNNER_OK,
     EVENT_START_PLAY,
     EVENT_START_PLAYBOOK,
     EVENT_STATS_PLAY,
@@ -210,6 +212,14 @@ function JobRenderService ($q, $sce, $window) {
         const record = this.createRecord(event, lines);
 
         if (event.event === EVENT_START_PLAYBOOK) {
+            return { html: '', count: 0 };
+        }
+
+        if (event.stdout === '' && event.event === EVENT_NOTIFY_PLAYBOOK) {
+            return { html: '', count: 0 };
+        }
+
+        if (event.stdout === '' && event.event === EVENT_RUNNER_OK) {
             return { html: '', count: 0 };
         }
 

--- a/awx/ui/client/features/output/render.service.js
+++ b/awx/ui/client/features/output/render.service.js
@@ -259,17 +259,17 @@ function JobRenderService ($q, $sce, $window) {
             return this.records[event.counter];
         }
 
-        let isHost = false;
-        if (typeof event.host === 'number') {
-            isHost = true;
+        let isClickable = false;
+        if (typeof event.host === 'number' || event.event_data && event.event_data.res) {
+            isClickable = true;
         } else if (event.type === 'project_update_event' &&
             event.event !== 'runner_on_skipped' &&
             event.event_data.host) {
-            isHost = true;
+            isClickable = true;
         }
 
         const record = {
-            isHost,
+            isClickable,
             id: event.id,
             line: event.start_line + 1,
             name: event.event,
@@ -369,7 +369,7 @@ function JobRenderService ($q, $sce, $window) {
                 tdToggle = `<div class="at-Stdout-toggle" ng-click="vm.toggleCollapse('${id}')"><i class="fa ${icon} can-toggle"></i></div>`;
             }
 
-            if (record.isHost) {
+            if (record.isClickable) {
                 tdEvent = `<div class="at-Stdout-event--host" ng-click="vm.showHostDetails('${record.id}', '${record.uuid}')"><span ng-non-bindable>${content}</span></div>`;
             }
 

--- a/awx/ui/client/features/output/render.service.js
+++ b/awx/ui/client/features/output/render.service.js
@@ -2,10 +2,7 @@ import Ansi from 'ansi-to-html';
 import Entities from 'html-entities';
 
 import {
-    EVENT_NOTIFY_PLAYBOOK,
-    EVENT_RUNNER_OK,
     EVENT_START_PLAY,
-    EVENT_START_PLAYBOOK,
     EVENT_STATS_PLAY,
     EVENT_START_TASK,
     OUTPUT_ANSI_COLORMAP,
@@ -211,15 +208,7 @@ function JobRenderService ($q, $sce, $window) {
         const lines = stdout.split('\r\n');
         const record = this.createRecord(event, lines);
 
-        if (event.event === EVENT_START_PLAYBOOK) {
-            return { html: '', count: 0 };
-        }
-
-        if (event.stdout === '' && event.event === EVENT_NOTIFY_PLAYBOOK) {
-            return { html: '', count: 0 };
-        }
-
-        if (event.stdout === '' && event.event === EVENT_RUNNER_OK) {
+        if (lines.length === 1 && lines[0] === '') {
             return { html: '', count: 0 };
         }
 

--- a/awx/ui/client/features/output/slide.service.js
+++ b/awx/ui/client/features/output/slide.service.js
@@ -114,6 +114,9 @@ function SlidingWindowService ($q) {
             }
         }
 
+        this.buffer.events.length = 0;
+        delete this.buffer.events;
+
         this.buffer.events = frames;
         this.buffer.min = min;
         this.buffer.max = max;


### PR DESCRIPTION
##### SUMMARY
- don't render events if they have zero-length string values for their `stdout` field.
- adjust line wrapping for output lines to make the behavior more ansible-like
- don't compile html in real time

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
![output_terminal](https://user-images.githubusercontent.com/9753817/47034306-fc8ed300-d144-11e8-8073-6babe0a6b205.gif)
![output_ui](https://user-images.githubusercontent.com/9753817/47034311-00225a00-d145-11e8-9334-fbc2f4178396.gif)

