### PR TITLE
Pass tiller namespace down to helm task

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -85,6 +85,7 @@
       --set postgresPassword={{ pg_password }} \
       --set postgresDatabase={{ pg_database }} \
       --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
+      --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
       stable/postgresql
   when:
     - pg_hostname is not defined or pg_hostname == ''


### PR DESCRIPTION
Fixes #2484

This has been tested with the value set, and not set. When not set, it defaults to the kube-system namespace, which is the default for a `helm init`.