### PR TITLE
Remove .cluster.local from service name for rabbitmq

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -44,7 +44,7 @@ data:
 
       ## Clustering
       cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
-      cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+      cluster_formation.k8s.host = kubernetes.default.svc
       cluster_formation.k8s.address_type = ip
       cluster_formation.node_cleanup.interval = 10
       cluster_formation.node_cleanup.only_log_warning = false


### PR DESCRIPTION
FQDNs are not required for service discovery, and having the FQDN in the
name prevents the discovery from working in clusters not named
cluster.local.

This has been tested in docker-for-desktop and a production cluster not named cluster.local.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

In-cluster DNS can use short names, by stopping at the service domain, it will work from any namespace within the cluster. Having cluster.local leads to searching for names such as `kubernetes.default.svc.cluster.local.productioncluster.example.com`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
