### PR TITLE
Add pod limits. Related #2488 

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -162,6 +162,9 @@ spec:
             requests:
               memory: "{{ web_mem_request }}Gi"
               cpu: "{{ web_cpu_request }}m"
+            limits:
+              memory: "{{ web_mem_limit | default(web_mem_request) }}Gi"
+              cpu: "{{ web_cpu_limit | default(web_cpu_request) }}m"
         - name: {{ kubernetes_deployment_name }}-celery
           securityContext:
             privileged: true
@@ -208,6 +211,9 @@ spec:
             requests:
               memory: "{{ task_mem_request }}Gi"
               cpu: "{{ task_cpu_request }}m"
+            limits:
+              memory: "{{ task_mem_limit | default(task_mem_request) }}Gi"
+              cpu: "{{ task_cpu_limit | default(task_cpu_request) }}m"
         - name: {{ kubernetes_deployment_name }}-rabbit
           image: "{{ kubernetes_rabbitmq_image }}:{{ kubernetes_rabbitmq_version }}"
           imagePullPolicy: Always
@@ -251,6 +257,9 @@ spec:
             requests:
               memory: "{{ rabbitmq_mem_request }}Gi"
               cpu: "{{ rabbitmq_cpu_request }}m"
+            limits:
+              memory: "{{ rabbitmq_mem_limit | default(rabbitmq_mem_request) }}Gi"
+              cpu: "{{ rabbitmq_cpu_limit | default(rabbitmq_cpu_request) }}m"
         - name: {{ kubernetes_deployment_name }}-memcached
           image: "{{ kubernetes_memcached_image }}:{{ kubernetes_memcached_version }}"
           imagePullPolicy: Always
@@ -258,6 +267,9 @@ spec:
             requests:
               memory: "{{ memcached_mem_request }}Gi"
               cpu: "{{ memcached_cpu_request }}m"
+            limits:
+              memory: "{{ memcached_mem_limit | default(memcached_mem_request) }}Gi"
+              cpu: "{{ memcached_cpu_limit | default(memcached_cpu_request) }}m"
       volumes:
         - name: {{ kubernetes_deployment_name }}-application-config
           configMap:

--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -17,6 +17,9 @@ spec:
         - name: "{{ kubernetes_deployment_name }}-confd"
           mountPath: "/etc/tower/conf.d/"
           readOnly: true
+      resources:
+        limits:
+          memory: 2Gi
   volumes:
     - name: {{ kubernetes_deployment_name }}-application-config
       configMap:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

We enforce having limits and requests on all containers in our environment, and set the LimitRange very low to require them to be set. This change adds new variables to control the limits, and defaults them to the requests.

Without these limits set, the database migration fails due to the migration process running out of memory, and the awx-0 pod fails to start.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
