### PR TITLE
Fixed requirements.yml role installation to avoid concurrent job's fa…

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -118,7 +118,6 @@
         when: results is defined
       when: scm_type == 'insights'
 
-
     - name: Repository Version
       debug: msg="Repository Version {{ scm_version }}"
       when: scm_version is defined
@@ -128,29 +127,20 @@
         dest: "{{ scm_revision_output }}"
         content: "{{ scm_version }}"
       when: scm_version is defined and scm_revision_output is defined
-
-- hosts: all
-  connection: local
-  gather_facts: false
-  tasks:
-
+    
     - block:
       - name: detect requirements.yml
         stat: path={{project_path|quote}}/roles/requirements.yml
         register: doesRequirementsExist
 
       - name: fetch galaxy roles from requirements.yml
-        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/
+        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/ {{ scm_clean|ternary('--force','') }}
         args:
           chdir: "{{project_path|quote}}/roles"
         register: galaxy_result
-        when: doesRequirementsExist.stat.exists and scm_result is undefined
+        when: doesRequirementsExist.stat.exists
         changed_when: "'was installed successfully' in galaxy_result.stdout"
+      
+      when: roles_enabled|bool
 
-      - name: fetch galaxy roles from requirements.yml (forced update)
-        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/ --force
-        args:
-          chdir: "{{project_path|quote}}/roles"
-        when: doesRequirementsExist.stat.exists and scm_result is defined
 
-      when: scm_full_checkout|bool and roles_enabled|bool


### PR DESCRIPTION
##### SUMMARY
Fixed requirements.yml role installation to avoid concurrent job's failures
    
When performing a project update roles were not downloaded and were downloaded at job execution time, this caused problems accessing and decrypting files updated by other concurrent jobs.

The behavior now is:
- update roles during scm_update
-  perform galaxy-install --force only when scm_clean option is true

##### ISSUE TYPE
 - Bugfix Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```