### PR TITLE
Added support for aarch64

### DIFF
--- a/tools/docker-compose/Dockerfile-aarch64
+++ b/tools/docker-compose/Dockerfile-aarch64
@@ -1,0 +1,66 @@
+FROM centos:7
+
+ARG UID=0
+
+ADD Makefile /tmp/Makefile
+
+RUN mkdir /tmp/requirements
+
+RUN yum -y update && yum -y install curl epel-release 
+
+RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
+  mercurial subversion python-devel python-psycopg2 make postgresql \
+  postgresql-devel nginx nodejs python-psutil libxml2-devel libxslt-devel \
+  libstdc++ gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel \
+  zeromq-devel python-pip xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 \
+  xmlsec1-openssl-devel libtool-ltdl-devel rabbitmq-server bubblewrap \
+  zanata-python-client gettext gcc-c++ libcurl-devel python-pycurl bzip2 \
+  python-crypto rsync git freetype freetype-devel libpng libpng-devel
+
+RUN pip install virtualenv
+RUN /usr/bin/ssh-keygen -q -t rsa -N "" -f /root/.ssh/id_rsa
+RUN mkdir -p /data/db
+RUN pip2 install honcho
+RUN pip2 install supervisor
+
+ADD requirements/requirements.txt \
+  requirements/requirements_git.txt \
+  requirements/requirements_ansible.txt \
+  requirements/requirements_ansible_git.txt \
+  requirements/requirements_dev.txt \
+  requirements/requirements_ansible_uninstall.txt \
+  requirements/requirements_tower_uninstall.txt \
+  /tmp/requirements/
+
+ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
+ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
+ADD tools/docker-compose/awx.egg-info /tmp/awx.egg-info
+ADD tools/docker-compose/start_development.sh /start_development.sh
+ADD tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
+ADD tools/docker-compose/start_tests.sh /start_tests.sh
+ADD tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
+ADD tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
+RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/nginx/nginx.csr -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/OU=AWX Development/CN=awx.localhost"
+RUN openssl x509 -req -days 365 -in /etc/nginx/nginx.csr -signkey /etc/nginx/nginx.key -out /etc/nginx/nginx.crt
+WORKDIR /tmp
+
+RUN mkdir -p /venv && chmod g+w /venv
+RUN CFLAGS="-DXMLSEC_NO_SIZE_T" SWIG_FEATURES="-cpperraswarn -includeall -D__`uname -m`__ -I/usr/include/openssl" VENV_BASE="/venv" make requirements_dev
+RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini-arm64 /tini
+RUN chmod +x /tini
+WORKDIR /
+EXPOSE 8043 8013 8080 22
+ENTRYPOINT ["/tini", "--"]
+CMD /start_development.sh
+
+RUN touch /venv/awx/lib/python2.7/site-packages/awx.egg-link
+RUN chmod g+rwx /venv/awx/lib/python2.7/site-packages/awx.egg-link
+
+RUN chmod g+w /etc/passwd
+RUN mkdir -p /projects && chmod g+w /projects
+
+USER ${UID}


### PR DESCRIPTION
##### SUMMARY

Dockerfile changed to work on aarch64 platform

```
> tini-arm64 
> git2u-core -> git
> NodeJS -> Epel Repo
> YUM INSTALL ADD freetype freetype-devel libpng libpng-devel
```
##### ISSUE TYPE
I was not working on arm64

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: devel
```

##### ADDITIONAL INFORMATION
Added support for arm64 platform
