### PR TITLE
Restore Date Picker field in Scheduler template.

### DIFF
--- a/awx/ui/client/lib/theme/index.less
+++ b/awx/ui/client/lib/theme/index.less
@@ -92,6 +92,7 @@
 @import '../../src/organizations/orgcards.block.less';
 @import '../../src/scheduler/repeatFrequencyOptions.block.less';
 @import '../../src/scheduler/schedulerForm.block.less';
+@import '../../src/scheduler/schedulerDatePicker.block.less';
 @import '../../src/scheduler/schedulerFormDetail.block.less';
 @import '../../src/scheduler/schedulertime.block.less';
 @import '../../src/scheduler/scheduleToggle.block.less';

--- a/awx/ui/client/src/scheduler/schedulerDatePicker.block.less
+++ b/awx/ui/client/src/scheduler/schedulerDatePicker.block.less
@@ -1,0 +1,37 @@
+.DatePicker {
+    flex: 1 0 auto;
+    display: flex;
+
+    &-icon {
+        flex: initial;
+        padding: 6px 12px;
+        font-size: 14px;
+        border-radius: 4px 0 0 4px;
+        border: 1px solid @b7grey;
+        border-right: 0;
+        background-color: @default-bg;
+    }
+
+    &-icon:hover {
+        background-color: @f6grey;
+    }
+
+    &-icon:focus,
+    &-icon:active {
+        background-color: @f6grey;
+    }
+
+    &-input {
+        flex: 1 0 auto;
+        border-radius: 0 4px 4px 0;
+        border: 1px solid @b7grey;
+        padding: 6px 12px;
+        background-color: @fcgrey;
+    }
+
+    &-input:focus,
+    &-input:active {
+        outline-offset: 0;
+        outline: 0;
+    }
+}

--- a/awx/ui/client/src/scheduler/schedulerDatePicker.directive.js
+++ b/awx/ui/client/src/scheduler/schedulerDatePicker.directive.js
@@ -20,7 +20,7 @@ export default
                     inputClass: '&',
                     disabled: '=?'
                 },
-                templateUrl: templateUrl('system-tracking/date-picker/date-picker'),
+                templateUrl: templateUrl('scheduler/schedulerDatePicker'),
                 link: function(scope, element, attrs) {
                     var lang = window.navigator.languages ?
                         window.navigator.languages[0] :


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Restore Date Picker field in Scheduler template.
Related #2503 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```


##### ADDITIONAL INFORMATION

The Scheduler template was using the System Tracking date-picker template. When we removed the System Tracking assets as part of #2141 , part of the template became broken. This PR restores the Date Picker field by linking the `date-picker` directive to the `date-picker` partial in the `scheduler` directory.
![image 1](https://user-images.githubusercontent.com/2293210/47298118-ed949e80-d5e4-11e8-974d-69794301029c.png)

