### PR TITLE
Empties /tmp in awx_web Dockerfile

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -45,6 +45,7 @@ RUN chmod -R g+w /var/log/tower
 RUN mkdir -p /etc/tower
 COPY {{ awx_sdist_file }} /tmp/{{ awx_sdist_file }}
 RUN OFFICIAL=yes pip install /tmp/{{ awx_sdist_file }}
+RUN rm -rf /tmp/*
 
 RUN echo "{{ awx_version }}" > /var/lib/awx/.tower_version
 ADD nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Deletes the files in /tmp after the usage.
This reduces the image size with at least a whopping 11MB 🐋 

I couldn't find if these files are also used for the image on Docker Hub, if not they should be updated too.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```
