### PR TITLE
Remove some obsolete requirements.

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,6 @@
 appdirs==1.4.2
 asgi-amqp==1.1.2
 asgiref==1.1.2
-backports.ssl-match-hostname==3.5.0.1
 boto==2.47.0
 channels==1.1.8
 celery==4.2.1
@@ -23,15 +22,11 @@ djangorestframework==3.7.7
 djangorestframework-yaml==1.0.3
 irc==16.2
 jsonschema==2.6.0
-M2Crypto==0.29.0
-Markdown==2.6.11
 ordereddict==1.1
 pexpect==4.6.0
 psutil==5.4.3
 psycopg2==2.7.3.2   # problems with Segmentation faults / wheels on upgrade
-pycrypto==2.6.1
 pygerduty==0.37.0
-pyOpenSSL==17.5.0
 pyparsing==2.2.0
 python-dateutil==2.7.2  # contains support for TZINFO= parsing
 python-logstash==0.4.6
@@ -49,6 +44,5 @@ tacacs_plus==1.0
 twilio==6.10.4
 uWSGI==2.0.17
 uwsgitop==0.10.0
-xmltodict==0.11.0
 pip==9.0.1
 setuptools==36.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,7 +14,6 @@ attrs==17.4.0             # via automat, service-identity
 autobahn==18.3.1          # via daphne
 automat==0.6.0            # via twisted
 backports.functools-lru-cache==1.5  # via jaraco.functools
-backports.ssl-match-hostname==3.5.0.1
 baron==0.6.6              # via redbaron
 billiard==3.5.0.4         # via celery
 boto==2.47.0
@@ -22,7 +21,7 @@ celery==4.2.1
 cffi==1.11.5              # via cryptography
 channels==1.1.8
 constantly==15.1.0        # via twisted
-cryptography==2.1.4       # via pyopenssl, requests
+cryptography==2.3.1       # via requests
 daphne==1.3.0
 decorator==4.2.1
 defusedxml==0.4.1         # via python-saml
@@ -62,8 +61,6 @@ jsonpickle==0.9.6         # via asgi-amqp
 jsonschema==2.6.0
 kombu==4.2.1              # via asgi-amqp, celery
 lxml==4.2.3
-m2crypto==0.29.0
-markdown==2.6.11
 more-itertools==4.1.0     # via irc, jaraco.functools, jaraco.itertools
 msgpack-python==0.5.5     # via asgi-amqp
 netaddr==0.7.19           # via pyrad
@@ -76,10 +73,8 @@ ptyprocess==0.5.2         # via pexpect
 pyasn1-modules==0.2.1     # via service-identity
 pyasn1==0.4.2             # via pyasn1-modules, service-identity
 pycparser==2.18           # via cffi
-pycrypto==2.6.1
 pygerduty==0.37.0
 pyjwt==1.6.0              # via social-auth-core, twilio
-pyopenssl==17.5.0
 pyparsing==2.2.0
 pyrad==1.2                # via django-radius
 python-dateutil==2.7.2
@@ -98,7 +93,7 @@ requests[security]==2.15.1
 rply==0.7.5               # via baron
 service-identity==17.0.0
 simplejson==3.13.2        # via uwsgitop
-six==1.11.0               # via asgi-amqp, asgiref, autobahn, automat, cryptography, django-extensions, irc, isodate, jaraco.classes, jaraco.collections, jaraco.itertools, jaraco.logging, jaraco.stream, more-itertools, pygerduty, pyopenssl, pyrad, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, tempora, twilio, txaio, websocket-client
+six==1.11.0               # via asgi-amqp, asgiref, autobahn, automat, cryptography, django-extensions, irc, isodate, jaraco.classes, jaraco.collections, jaraco.itertools, jaraco.logging, jaraco.stream, more-itertools, pygerduty, pyrad, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, tempora, twilio, txaio, websocket-client
 slackclient==1.1.2
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
@@ -107,11 +102,10 @@ tempora==1.10             # via irc, jaraco.logging
 twilio==6.10.4
 twisted==17.9.0           # via daphne
 txaio==2.9.0              # via autobahn
-typing==3.6.4             # via django-extensions, m2crypto
+typing==3.6.4             # via django-extensions
 uwsgi==2.0.17
 uwsgitop==0.10.0
 websocket-client==0.47.0  # via slackclient
-xmltodict==0.11.0
 zope.interface==4.4.3     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Bump cryptography to latest.

Obsolete requirements mostly all date back to the day when we pip-ified ansible core requirements rather than using system-installed ones.
