### PR TITLE
Let users disable create_preload_data if it isn't necessary

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -88,6 +88,9 @@ rabbitmq_erlang_cookie=cookiemonster
 admin_user=admin
 admin_password=password
 
+# Whether or not to create preload data for demonstration purposes
+create_preload_data=True
+
 # AWX Secret key
 # It's *very* important that this stay the same between upgrades or you will lose the ability to decrypt
 # your credentials

--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 dockerhub_version: "{{ lookup('file', playbook_dir + '/../VERSION') }}"
+create_preload_data: True
 
 admin_user: 'admin'
 admin_email: 'root@localhost'

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -192,6 +192,7 @@
       bash -c "awx-manage create_preload_data"
   register: cdo
   changed_when: "'added' in cdo.stdout"
+  when: create_preload_data | bool
 
 - name: Delete management pod
   shell: |


### PR DESCRIPTION
##### SUMMARY
The demo things might not be desirable in a production environment.
Let users disable create_preload_data.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
devel

##### ADDITIONAL INFORMATION
This aligns with the current implementation in Tower -- it is mentioned here:
https://docs.ansible.com/ansible-tower/3.2.0/html/upgrade-migration-guide/release_notes.html#ansible-tower-version-3-2-0