### PR TITLE
Update variable names for local Docker daemon installation

### DIFF
--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -109,8 +109,8 @@
       RABBITMQ_VHOST: "{{ rabbitmq_default_vhost }}"
       MEMCACHED_HOST: "memcached"
       MEMCACHED_PORT: "11211"
-      AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
-      AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+      AWX_ADMIN_USER: "{{ admin_user|default('admin') }}"
+      AWX_ADMIN_PASSWORD: "{{ admin_password|default('password') }}"
   register: awx_web_container
 
 - name: Update CA trust in awx_web container
@@ -150,5 +150,5 @@
       RABBITMQ_VHOST: "{{ rabbitmq_default_vhost }}"
       MEMCACHED_HOST: "memcached"
       MEMCACHED_PORT: "11211"
-      AWX_ADMIN_USER: "{{ default_admin_user|default('admin') }}"
-      AWX_ADMIN_PASSWORD: "{{ default_admin_password|default('password') }}"
+      AWX_ADMIN_USER: "{{ admin_user|default('admin') }}"
+      AWX_ADMIN_PASSWORD: "{{ admin_password|default('password') }}"


### PR DESCRIPTION
Signed-off-by: Igor Vuk <parcijala@gmail.com>

##### SUMMARY
Since commit ee1d5e43b9102df6f477cda4beb61c7185f729ef, `inventory` file uses `admin_user` and `admin_password` variables; the local Docker daemon installation wasn't updated for this, so it still looks for old variables (`default_admin_user` and `default_admin_password`), making it impossible to override the default user and password that are created. This fixes the variable names in the corresponding Ansible tasks.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 2.0.1
```


##### ADDITIONAL INFORMATION
To reproduce, try a local Docker installation with changed `admin_user` and `admin_password` values, with and without this commit.