### PR TITLE
Using new Helm parameters for PostgreSQL access.

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -81,9 +81,9 @@
 - name: Deploy and Activate Postgres (Kubernetes)
   shell: |
     helm install --name {{ kubernetes_deployment_name }} --namespace {{ kubernetes_namespace }} \
-      --set postgresUser={{ pg_username }} \
-      --set postgresPassword={{ pg_password }} \
-      --set postgresDatabase={{ pg_database }} \
+      --set postgresqlUsername={{ pg_username }} \
+      --set postgresqlPassword={{ pg_password }} \
+      --set postgresqlDatabase={{ pg_database }} \
       --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
       --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
       stable/postgresql


### PR DESCRIPTION
##### SUMMARY
Deploy to Kubernetes failed because credentials to PgSQL did not match. Installer use helm chart for PostgreSQL deployment but name parameters for customizing credentials has been changed. I changed them according to latest [README.md](https://github.com/helm/charts/tree/master/stable/postgresql) and deployment succeed. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.0.1
```