### PR TITLE
fix parameter for helm install stable/postgresql

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -81,9 +81,9 @@
 - name: Deploy and Activate Postgres (Kubernetes)
   shell: |
     helm install --name {{ kubernetes_deployment_name }} --namespace {{ kubernetes_namespace }} \
-      --set postgresUser={{ pg_username }} \
-      --set postgresPassword={{ pg_password }} \
-      --set postgresDatabase={{ pg_database }} \
+      --set postgresqlUsername={{ pg_username }} \
+      --set postgresqlPassword={{ pg_password }} \
+      --set postgresqlDatabase={{ pg_database }} \
       --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
       --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
       stable/postgresql


### PR DESCRIPTION
I have issues right now following the installation path for awx on kubernetes.

When i see it correctly, those parameters are broken as the stable/postgresql does not have postgres* properties. https://github.com/helm/charts/tree/master/stable/postgresql

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
