### PR TITLE
remove admin and member roles from team->organizations role assignment options

### DIFF
--- a/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.controller.js
+++ b/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.controller.js
@@ -77,8 +77,17 @@ function(scope, $state, i18n, CreateSelect2, Rest, $q, Wait, ProcessErrors) {
 
     // aggregate name/descriptions for each available role, based on resource type
     // reasoning:
-    function aggregateKey(item, type){
-        _.merge(scope.keys[type], item.summary_fields.object_roles);
+    function aggregateKey(item, type) {
+        const ownerType = _.get(scope, ['owner', 'type']);
+        const { object_roles } = item.summary_fields;
+
+        if (ownerType === 'team' && type === 'organizations') {
+            // some organization object_roles aren't allowed for teams
+            delete object_roles.admin_role;
+            delete object_roles.member_role;
+        }
+
+        _.merge(scope.keys[type], object_roles);
     }
 
     scope.closeModal = function() {


### PR DESCRIPTION
##### SUMMARY
see: https://github.com/ansible/awx/issues/2563#issuecomment-435741153

We disallow  organization `admin_role` and `member_role` assignment to teams in the API. This PR is to remove these options from the team->organizations permissions view.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

