### PR TITLE
move from GCE_PEM_FILE_PATH to GCE_CREDENTIALS_FILE_PATH

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -580,7 +580,7 @@ class CredentialType(CommonModelNameNotUnique):
         if not self.injectors:
             if self.managed_by_tower and credential.kind in dir(builtin_injectors):
                 injected_env = {}
-                getattr(builtin_injectors, credential.kind)(credential, injected_env)
+                getattr(builtin_injectors, credential.kind)(credential, injected_env, private_data_dir)
                 env.update(injected_env)
                 safe_env.update(build_safe_env(injected_env))
             return

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -1,20 +1,37 @@
+import json
+import os
+import stat
+import tempfile
+
 from awx.main.utils import decrypt_field
 from django.conf import settings
 
 
-def aws(cred, env):
+def aws(cred, env, private_data_dir):
     env['AWS_ACCESS_KEY_ID'] = cred.username
     env['AWS_SECRET_ACCESS_KEY'] = decrypt_field(cred, 'password')
     if len(cred.security_token) > 0:
         env['AWS_SECURITY_TOKEN'] = decrypt_field(cred, 'security_token')
 
 
-def gce(cred, env):
+def gce(cred, env, private_data_dir):
     env['GCE_EMAIL'] = cred.username
     env['GCE_PROJECT'] = cred.project
+    json_cred = {
+        'type': 'service_account',
+        'private_key': decrypt_field(cred, 'ssh_key_data'),
+        'client_email': cred.username,
+        'project_id': cred.project
+    }
+    handle, path = tempfile.mkstemp(dir=private_data_dir)
+    f = os.fdopen(handle, 'w')
+    json.dump(json_cred, f)
+    f.close()
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    env['GCE_CREDENTIALS_FILE_PATH'] = path
 
 
-def azure_rm(cred, env):
+def azure_rm(cred, env, private_data_dir):
     if len(cred.client) and len(cred.tenant):
         env['AZURE_CLIENT_ID'] = cred.client
         env['AZURE_SECRET'] = decrypt_field(cred, 'secret')
@@ -28,7 +45,7 @@ def azure_rm(cred, env):
         env['AZURE_CLOUD_ENVIRONMENT'] = cred.inputs['cloud_environment']
 
 
-def vmware(cred, env):
+def vmware(cred, env, private_data_dir):
     env['VMWARE_USER'] = cred.username
     env['VMWARE_PASSWORD'] = decrypt_field(cred, 'password')
     env['VMWARE_HOST'] = cred.host

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1232,9 +1232,7 @@ class RunJob(BaseTask):
         # Set environment variables for cloud credentials.
         cred_files = kwargs.get('private_data_files', {}).get('credentials', {})
         for cloud_cred in job.cloud_credentials:
-            if cloud_cred and cloud_cred.kind == 'gce':
-                env['GCE_PEM_FILE_PATH'] = cred_files.get(cloud_cred, '')
-            elif cloud_cred and cloud_cred.kind == 'openstack':
+            if cloud_cred and cloud_cred.kind == 'openstack':
                 env['OS_CLIENT_CONFIG_FILE'] = cred_files.get(cloud_cred, '')
 
         for network_cred in job.network_credentials:
@@ -1805,10 +1803,6 @@ class RunInventoryUpdate(BaseTask):
         """
         private_data = {'credentials': {}}
         credential = inventory_update.get_cloud_credential()
-        # If this is GCE, return the RSA key
-        if inventory_update.source == 'gce':
-            private_data['credentials'][credential] = decrypt_field(credential, 'ssh_key_data')
-            return private_data
 
         if inventory_update.source == 'openstack':
             openstack_auth = dict(auth_url=credential.host,
@@ -2041,7 +2035,6 @@ class RunInventoryUpdate(BaseTask):
             'ec2': 'EC2_INI_PATH',
             'vmware': 'VMWARE_INI_PATH',
             'azure_rm': 'AZURE_INI_PATH',
-            'gce': 'GCE_PEM_FILE_PATH',
             'openstack': 'OS_CLIENT_CONFIG_FILE',
             'satellite6': 'FOREMAN_INI_PATH',
             'cloudforms': 'CLOUDFORMS_INI_PATH'

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1032,10 +1032,11 @@ class TestJobCredentials(TestJobExecution):
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
-            assert env['GCE_EMAIL'] == 'bob'
-            assert env['GCE_PROJECT'] == 'some-project'
-            ssh_key_data = env['GCE_PEM_FILE_PATH']
-            assert open(ssh_key_data, 'rb').read() == self.EXAMPLE_PRIVATE_KEY
+            json_data = json.load(open(env['GCE_CREDENTIALS_FILE_PATH'], 'rb'))
+            assert json_data['type'] == 'service_account'
+            assert json_data['private_key'] == self.EXAMPLE_PRIVATE_KEY
+            assert json_data['client_email'] == 'bob'
+            assert json_data['project_id'] == 'some-project'
             return ['successful', 0]
 
         self.run_pexpect.side_effect = run_pexpect_side_effect
@@ -2048,11 +2049,12 @@ class TestInventoryUpdateCredentials(TestJobExecution):
 
         def run_pexpect_side_effect(*args, **kwargs):
             args, cwd, env, stdout = args
-            assert env['GCE_EMAIL'] == 'bob'
-            assert env['GCE_PROJECT'] == 'some-project'
             assert env['GCE_ZONE'] == expected_gce_zone
-            ssh_key_data = env['GCE_PEM_FILE_PATH']
-            assert open(ssh_key_data, 'rb').read() == self.EXAMPLE_PRIVATE_KEY
+            json_data = json.load(open(env['GCE_CREDENTIALS_FILE_PATH'], 'rb'))
+            assert json_data['type'] == 'service_account'
+            assert json_data['private_key'] == self.EXAMPLE_PRIVATE_KEY
+            assert json_data['client_email'] == 'bob'
+            assert json_data['project_id'] == 'some-project'
 
             config = ConfigParser.ConfigParser()
             config.read(env['GCE_INI_PATH'])


### PR DESCRIPTION
`GCE_PEM_FILE_PATH` was deprecated in 2.5 and removed in 2.7; this moves to the new format and fixes GCE auth

see: https://github.com/ansible/awx/issues/351