### PR TITLE
always resolve spinner on template label association attempt

### DIFF
--- a/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
+++ b/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
@@ -588,7 +588,8 @@ export default
                             .then(function() {
                                 Wait('stop');
                                 saveCompleted();
-                            });
+                            })
+                            .finally(() => Wait('stop'));
                     });
                 });
             });


### PR DESCRIPTION
##### SUMMARY
always resolve spinner on label association attempt

fixes #2598 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```
