### PR TITLE
always recompile multicredential lists

### DIFF
--- a/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
+++ b/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
@@ -44,17 +44,24 @@ function MultiCredentialModal(
             selectedCredentials: '=',
         },
         link: (scope, element, attrs, controllers) => {
-            const compiledList = $compile(listHtml)(scope);
-            const compiledVaultList = $compile(vaultHtml)(scope);
-
             const modalBodyElement = $('#multi-credential-modal-body');
             const modalElement = $('#multi-credential-modal');
 
             scope.showModal = () => modalElement.modal('show');
             scope.hideModal = () => modalElement.modal('hide');
 
-            scope.createList = () => modalBodyElement.append(compiledList);
-            scope.createVaultList = () => modalBodyElement.append(compiledVaultList);
+            scope.createList = () => {
+                const compiledList = $compile(listHtml)(scope);
+
+                modalBodyElement.append(compiledList);
+            };
+
+            scope.createVaultList = () => {
+                const compiledVaultList = $compile(vaultHtml)(scope);
+
+                modalBodyElement.append(compiledVaultList);
+            };
+
             scope.destroyList = () => modalBodyElement.empty();
 
             modalElement.on('hidden.bs.modal', () => {


### PR DESCRIPTION
##### SUMMARY
This fixes a bug with multi-credential select where using the pagination controls would, in some cases, result in an unexpected trip to the dashboard.

**before**:
![fix_multicred_before](https://user-images.githubusercontent.com/9753817/48105954-7c213680-e207-11e8-92e3-9814d4630053.gif)

**after**:
![fix_multicred_after](https://user-images.githubusercontent.com/9753817/48105967-83e0db00-e207-11e8-8782-339be25d275e.gif)

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```

