### PR TITLE
fix project and adhoc command form lookups when many credential types exist

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.controller.js
@@ -12,7 +12,7 @@
 function adhocController($q, $scope, $stateParams,
     $state, CheckPasswords, PromptForPasswords, CreateLaunchDialog, CreateSelect2, adhocForm,
     GenerateForm, Rest, ProcessErrors, GetBasePath, GetChoices,
-    KindChange, Wait, ParseTypeChange, credentialTypes) {
+    KindChange, Wait, ParseTypeChange, machineCredentialType) {
 
     // this is done so that we can access private functions for testing, but
     // we don't want to populate the "public" scope with these internal
@@ -302,12 +302,9 @@ function adhocController($q, $scope, $stateParams,
     };
 
     $scope.lookupCredential = function(){
-        let credType = _.filter(credentialTypes, function(credType){
-            return credType.kind === "ssh";
-        });
         $state.go('.credential', {
             credential_search: {
-                credential_type: credType[0].id,
+                credential_type: machineCredentialType,
                 page_size: '5',
                 page: '1'
             }
@@ -319,5 +316,5 @@ function adhocController($q, $scope, $stateParams,
 export default ['$q', '$scope', '$stateParams',
     '$state', 'CheckPasswords', 'PromptForPasswords', 'CreateLaunchDialog', 'CreateSelect2',
      'adhocForm', 'GenerateForm', 'Rest', 'ProcessErrors', 'GetBasePath',
-    'GetChoices', 'KindChange', 'Wait', 'ParseTypeChange', 'credentialTypes',
+    'GetChoices', 'KindChange', 'Wait', 'ParseTypeChange', 'machineCredentialType',
     adhocController];

--- a/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.route.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/adhoc/adhoc.route.js
@@ -7,6 +7,23 @@
  import {templateUrl} from '../../../shared/template-url/template-url.factory';
  import { N_ } from '../../../i18n';
 
+ function ResolveMachineCredentialType (GetBasePath, Rest, ProcessErrors) {
+    Rest.setUrl(GetBasePath('credential_types') + '?kind=ssh');
+
+    return Rest.get()
+        .then(({ data }) => {
+            return data.results[0].id;
+        })
+        .catch(({ data, status }) => {
+            ProcessErrors(null, data, status, null, {
+                hdr: 'Error!',
+                msg: 'Failed to get credential type data: ' + status
+            });
+        });
+}
+
+ResolveMachineCredentialType.$inject = ['GetBasePath', 'Rest', 'ProcessErrors'];
+
 export default {
     url: '/adhoc',
     params:{
@@ -28,12 +45,6 @@ export default {
         label: N_("RUN COMMAND")
     },
     resolve: {
-        credentialTypes: ['CredentialTypeModel', (CredentialType) =>
-            new CredentialType('get')
-                .then((model) => {
-                    const credentialTypeRes = model.get();
-                    return credentialTypeRes.results;
-                })
-        ]
+        machineCredentialType: ResolveMachineCredentialType,
     }
 };

--- a/awx/ui/client/src/projects/add/projects-add.controller.js
+++ b/awx/ui/client/src/projects/add/projects-add.controller.js
@@ -7,10 +7,10 @@
 export default ['$scope', '$location', '$stateParams', 'GenerateForm',
     'ProjectsForm', 'Rest', 'Alert', 'ProcessErrors', 'GetBasePath',
     'GetProjectPath', 'GetChoices', 'Wait', '$state', 'CreateSelect2', 'i18n',
-    'CredentialTypes', 'ConfigData', 'resolvedModels',
+    'ConfigData', 'resolvedModels', 'scmCredentialType',
     function($scope, $location, $stateParams, GenerateForm, ProjectsForm, Rest,
     Alert, ProcessErrors, GetBasePath, GetProjectPath, GetChoices, Wait, $state,
-    CreateSelect2, i18n, CredentialTypes, ConfigData, resolvedModels) {
+    CreateSelect2, i18n, ConfigData, resolvedModels, scmCredentialType) {
 
         let form = ProjectsForm(),
             base = $location.path().replace(/^\//, '').split('/')[0],
@@ -191,13 +191,9 @@ export default ['$scope', '$location', '$stateParams', 'GenerateForm',
         $scope.lookupCredential = function(){
             // Perform a lookup on the credential_type. Git, Mercurial, and Subversion
             // all use SCM as their credential type.
-            let credType = _.filter(CredentialTypes, function(credType){
-                return ($scope.scm_type.value !== "insights" && credType.kind === "scm" ||
-                    $scope.scm_type.value === "insights" && credType.kind === "insights");
-            });
             $state.go('.credential', {
                 credential_search: {
-                    credential_type: credType[0].id,
+                    credential_type: scmCredentialType,
                     page_size: '5',
                     page: '1'
                 }

--- a/awx/ui/client/src/projects/edit/projects-edit.controller.js
+++ b/awx/ui/client/src/projects/edit/projects-edit.controller.js
@@ -8,12 +8,12 @@ export default ['$scope', '$rootScope', '$stateParams', 'ProjectsForm', 'Rest',
     'Alert', 'ProcessErrors', 'GenerateForm', 'Prompt',
     'GetBasePath', 'GetProjectPath', 'Authorization', 'GetChoices', 'Empty',
     'Wait', 'ProjectUpdate', '$state', 'CreateSelect2', 'ToggleNotification',
-    'i18n', 'CredentialTypes', 'OrgAdminLookup', 'ConfigData',
+    'i18n', 'OrgAdminLookup', 'ConfigData', 'scmCredentialType',
     function($scope, $rootScope, $stateParams, ProjectsForm, Rest, Alert,
     ProcessErrors, GenerateForm, Prompt, GetBasePath,
     GetProjectPath, Authorization, GetChoices, Empty, Wait, ProjectUpdate,
-    $state, CreateSelect2, ToggleNotification, i18n, CredentialTypes,
-    OrgAdminLookup, ConfigData) {
+    $state, CreateSelect2, ToggleNotification, i18n, OrgAdminLookup,
+    ConfigData, scmCredentialType) {
 
         let form = ProjectsForm(),
             defaultUrl = GetBasePath('projects') + $stateParams.project_id + '/',
@@ -321,13 +321,10 @@ export default ['$scope', '$rootScope', '$stateParams', 'ProjectsForm', 'Rest',
         $scope.lookupCredential = function(){
             // Perform a lookup on the credential_type. Git, Mercurial, and Subversion
             // all use SCM as their credential type.
-            let credType = _.filter(CredentialTypes, function(credType){
-                return ($scope.scm_type.value !== "insights" && credType.kind === "scm" ||
-                    $scope.scm_type.value === "insights" && credType.kind === "insights");
-            });
+
             $state.go('.credential', {
                 credential_search: {
-                    credential_type: credType[0].id,
+                    credential_type: scmCredentialType,
                     page_size: '5',
                     page: '1'
                 }


### PR DESCRIPTION
##### SUMMARY
When more than 25 credential types exist, the credential lookups on the adhoc command and project forms fail to initialize. This occurs because the primary key of the credential type needed for the lookup is extracted from the first page of unfiltered api results from the credential type endpoint - if more than a page of credential types exist, the credential type may not be found.

This PR updates the routes and forms for these views to query and use the needed credential types directly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### AWX VERSION
```
awx: 2.1.0
```