### PR TITLE
Update UJT with inv summary field and update schedule base route to include object to be scheduled

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4614,6 +4614,22 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
             res['inventory'] = obj.unified_job_template.inventory.get_absolute_url(self.context.get('request'))
         return res
 
+    def get_summary_fields(self, obj):
+        summary_fields = super(ScheduleSerializer, self).get_summary_fields(obj)
+        inventory = None
+        if obj.inventory:
+            inventory = obj.inventory
+        elif obj.unified_job_template and getattr(obj.unified_job_template, 'inventory', None):
+            inventory = obj.unified_job_template.inventory
+        else:
+            return summary_fields
+
+        summary_fields['inventory'] = dict()
+        for field in SUMMARIZABLE_FK_FIELDS['inventory']:
+            summary_fields['inventory'][field] = getattr(inventory, field, None)
+
+        return summary_fields
+
     def validate_unified_job_template(self, value):
         if type(value) == InventorySource and value.source not in SCHEDULEABLE_PROVIDERS:
             raise serializers.ValidationError(_('Inventory Source must be a cloud resource.'))

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4616,10 +4616,11 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
 
     def get_summary_fields(self, obj):
         summary_fields = super(ScheduleSerializer, self).get_summary_fields(obj)
+        if 'inventory' in summary_fields:
+            return summary_fields
+
         inventory = None
-        if obj.inventory:
-            inventory = obj.inventory
-        elif obj.unified_job_template and getattr(obj.unified_job_template, 'inventory', None):
+        if obj.unified_job_template and getattr(obj.unified_job_template, 'inventory', None):
             inventory = obj.unified_job_template.inventory
         else:
             return summary_fields

--- a/awx/ui/client/src/scheduler/scheduled-jobs.list.js
+++ b/awx/ui/client/src/scheduler/scheduled-jobs.list.js
@@ -33,7 +33,7 @@ export default ['i18n', function(i18n) {
                 sourceModel: 'unified_job_template',
                 sourceField: 'name',
                 // ngBind: 'schedule.summary_fields.unified_job_template.name',
-                ngClick: "editSchedule(schedule)",
+                uiSref: "{{schedule.linkToDetails}}",
                 awToolTip: "{{ schedule.nameTip | sanitize}}",
                 dataTipWatch: 'schedule.nameTip',
                 dataPlacement: "top",

--- a/awx/ui/client/src/scheduler/schedulerList.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerList.controller.js
@@ -115,7 +115,7 @@ export default [
                         stateParams.workflow_job_template_id = item.summary_fields.unified_job_template.id;
                     } else if (item.summary_fields.unified_job_template.unified_job_type === 'inventory_update') {
                         route = 'inventories.edit.inventory_sources.edit.schedules.edit';
-                        stateParams.inventory_id = parseInt(item.related.inventory.split("/").slice(-2, -1)[0]);
+                        stateParams.inventory_id = item.summary_fields.inventory.id;
                         stateParams.inventory_source_id = item.summary_fields.unified_job_template.id;
                     } else if (item.summary_fields.unified_job_template.unified_job_type === 'system_job') {
                         route = 'managementJobsList.schedule';

--- a/awx/ui/client/src/scheduler/schedulerList.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerList.controller.js
@@ -101,18 +101,30 @@ export default [
                 }
                 buildTooltips(itm);
 
-                if (!$state.is('schedules')){
-                    if($state.current.name.endsWith('.add')) {
-                        itm.linkToDetails = `^.edit({schedule_id:schedule.id})`;
-                    }
-                    else if($state.current.name.endsWith('.edit')) {
-                        itm.linkToDetails = `.({schedule_id:schedule.id})`;
-                    }
-                    else {
-                        itm.linkToDetails = `.edit({schedule_id:schedule.id})`;
+                let stateParams = { schedule_id: item.id };
+                let route = '';
+                if (item.summary_fields.unified_job_template) {
+                    if (item.summary_fields.unified_job_template.unified_job_type === 'job') {
+                        route = 'templates.editJobTemplate.schedules.edit';
+                        stateParams.job_template_id = item.summary_fields.unified_job_template.id;
+                    } else if (item.summary_fields.unified_job_template.unified_job_type === 'project_update') {
+                        route = 'projects.edit.schedules.edit';
+                        stateParams.project_id = item.summary_fields.unified_job_template.id;
+                    } else if (item.summary_fields.unified_job_template.unified_job_type === 'workflow_job') {
+                        route = 'templates.editWorkflowJobTemplate.schedules.edit';
+                        stateParams.workflow_job_template_id = item.summary_fields.unified_job_template.id;
+                    } else if (item.summary_fields.unified_job_template.unified_job_type === 'inventory_update') {
+                        route = 'inventories.edit.inventory_sources.edit.schedules.edit';
+                        stateParams.inventory_id = parseInt(item.related.inventory.split("/").slice(-2, -1)[0]);
+                        stateParams.inventory_source_id = item.summary_fields.unified_job_template.id;
+                    } else if (item.summary_fields.unified_job_template.unified_job_type === 'system_job') {
+                        route = 'managementJobsList.schedule';
+                        stateParams.id = item.summary_fields.unified_job_template.id;
                     }
                 }
-
+                itm.route = route;
+                itm.stateParams = stateParams;
+                itm.linkToDetails = `${route}(${JSON.stringify(stateParams)})`;
             });
         }
 
@@ -157,20 +169,7 @@ export default [
         };
 
         $scope.editSchedule = function(schedule) {
-            if ($state.is('schedules')){
-                $state.go('schedules.edit', {schedule_id: schedule.id});
-            }
-            else {
-                if($state.current.name.endsWith('.add')) {
-                    $state.go('^.edit', { schedule_id: schedule.id });
-                }
-                else if($state.current.name.endsWith('.edit')) {
-                    $state.go('.', { schedule_id: schedule.id });
-                }
-                else {
-                    $state.go('.edit', { schedule_id: schedule.id });
-                }
-            }
+            $state.go(schedule.route, schedule.stateParams);
         };
 
         $scope.toggleSchedule = function(event, id) {


### PR DESCRIPTION
API: Add inventory summary to schedules resource

UI: previously, schedule edit would go to its own page, which would make it so that the user could not easily get to the resource to be scheduled.

---

Issue filed for issue where error modal pops up when user navigates to inv sync schedule edit and they don't have access to the project the inventory source inventory file is from.  https://github.com/ansible/awx/issues/2641