### PR TITLE
Fix credential kind translation

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/main.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/main.js
@@ -135,7 +135,7 @@ angular.module('inventory', [
                                     if(_.has(resourceData, 'data.summary_fields.insights_credential')){
                                         return credentialTypesLookup()
                                             .then(kinds => {
-                                                let insightsKind = kinds.Insights;
+                                                let insightsKind = kinds.insights;
                                                 let path = `${GetBasePath('projects')}?credential__credential_type=${insightsKind}&role_level=use_role`;
                                                 Rest.setUrl(path);
                                                 return Rest.get().then(({data}) => {

--- a/awx/ui/client/src/job-submission/job-submission-factories/check-passwords.factory.js
+++ b/awx/ui/client/src/job-submission/job-submission-factories/check-passwords.factory.js
@@ -12,7 +12,7 @@ export default
                 .then(({data}) => {
                     credentialTypesLookup()
                         .then(kinds => {
-                            if(data.credential_type === kinds.Machine && data.inputs){
+                            if(data.credential_type === kinds.ssh && data.inputs){
                                 if(data.inputs.password === "ASK" ){
                                     passwords.push("ssh_password");
                                 }

--- a/awx/ui/client/src/job-submission/job-submission.directive.js
+++ b/awx/ui/client/src/job-submission/job-submission.directive.js
@@ -28,7 +28,7 @@ export default [ 'templateUrl', 'CreateDialog', 'Wait', 'CreateSelect2', 'ParseT
                     credentialTypesLookup()
                         .then(kinds => {
                             if(scope.ask_credential_on_launch) {
-                                scope.credentialKind = "" + kinds.Machine;
+                                scope.credentialKind = "" + kinds.ssh;
                                 scope.includeCredentialList = true;
                             }
                         });

--- a/awx/ui/client/src/job-submission/lists/credential/job-sub-cred-list.controller.js
+++ b/awx/ui/client/src/job-submission/lists/credential/job-sub-cred-list.controller.js
@@ -71,9 +71,9 @@ export default
 
                 $scope.$watchCollection('selectedCredentials.extra', () => {
                     if($scope.credentials && $scope.credentials.length > 0) {
-                        if($scope.selectedCredentials.extra && $scope.selectedCredentials.extra.length > 0 && parseInt($scope.credentialKind) !== credentialKinds.Machine) {
+                        if($scope.selectedCredentials.extra && $scope.selectedCredentials.extra.length > 0 && parseInt($scope.credentialKind) !== credentialKinds.ssh) {
                             updateExtraCredentialsList();
-                        } else if (parseInt($scope.credentialKind) !== credentialKinds.Machine) {
+                        } else if (parseInt($scope.credentialKind) !== credentialKinds.ssh) {
                             uncheckAllCredentials();
                         }
                     }
@@ -81,7 +81,7 @@ export default
 
                 $scope.$watch('selectedCredentials.machine', () => {
                     if($scope.credentials && $scope.credentials.length > 0) {
-                        if($scope.selectedCredentials.machine && parseInt($scope.credentialKind) === credentialKinds.Machine) {
+                        if($scope.selectedCredentials.machine && parseInt($scope.credentialKind) === credentialKinds.ssh) {
                             updateMachineCredentialList();
                         }
                         else {
@@ -92,10 +92,10 @@ export default
 
                 $scope.$watchGroup(['credentials', 'selectedCredentials.machine'], () => {
                     if($scope.credentials && $scope.credentials.length > 0) {
-                        if($scope.selectedCredentials.machine && parseInt($scope.credentialKind) === credentialKinds.Machine) {
+                        if($scope.selectedCredentials.machine && parseInt($scope.credentialKind) === credentialKinds.ssh) {
                             updateMachineCredentialList();
                         }
-                        else if($scope.selectedCredentials.extra && $scope.selectedCredentials.extra.length > 0 && parseInt($scope.credentialKind) !== credentialKinds.Machine) {
+                        else if($scope.selectedCredentials.extra && $scope.selectedCredentials.extra.length > 0 && parseInt($scope.credentialKind) !== credentialKinds.ssh) {
                             updateExtraCredentialsList();
                         }
                         else {
@@ -106,7 +106,7 @@ export default
             };
 
             $scope.toggle_row = function(selectedRow) {
-                if(parseInt($scope.credentialKind) === credentialKinds.Machine) {
+                if(parseInt($scope.credentialKind) === credentialKinds.ssh) {
                     $scope.selectedCredentials.machine = _.cloneDeep(selectedRow);
                 }
                 else {

--- a/awx/ui/client/src/shared/credentialTypesLookup.factory.js
+++ b/awx/ui/client/src/shared/credentialTypesLookup.factory.js
@@ -6,7 +6,7 @@ function(Rest, GetBasePath, ProcessErrors) {
             .then(({data}) => {
                 var val = {};
                 data.results.forEach(type => {
-                    val[type.name] = type.id;
+                    val[type.kind] = type.id;
                 });
                 return val;
             })

--- a/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
+++ b/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
@@ -96,7 +96,7 @@ function multiCredentialModalController(GetBasePath, qs, MultiCredentialService)
         scope = _scope_;
         scope.modalSelectedCredentials = _.cloneDeep(scope.selectedCredentials);
 
-        scope.credentialTypes.forEach(({ name, id }) => types[name] = id);
+        scope.credentialTypes.forEach(({ kind, id }) => types[kind] = id);
 
         scope.toggle_row = vm.toggle_row;
         scope.toggle_credential = vm.toggle_credential;
@@ -152,13 +152,13 @@ function multiCredentialModalController(GetBasePath, qs, MultiCredentialService)
 
     function getInitialCredentialType () {
         const selectedMachineCredential = scope.modalSelectedCredentials
-            .find(c => c.id === types.Machine);
+            .find(c => c.id === types.ssh);
 
         if (selectedMachineCredential) {
-            return `${types.Vault}`;
+            return `${types.vault}`;
         }
 
-        return `${types.Machine}`;
+        return `${types.ssh}`;
     }
 
     function fetchCredentials (credentialType) {
@@ -175,7 +175,7 @@ function multiCredentialModalController(GetBasePath, qs, MultiCredentialService)
 
                 scope.destroyList();
 
-                if (credentialType === types.Vault) {
+                if (credentialType === types.vault) {
                     scope.createVaultList();
                 } else {
                     scope.createList();
@@ -215,11 +215,11 @@ function multiCredentialModalController(GetBasePath, qs, MultiCredentialService)
 
         const credentialTypeId = credential.credential_type || credential.credential_type_id;
 
-        if (credentialTypeId === types.Vault) {
+        if (credentialTypeId === types.vault) {
             const vaultId = _.get(credential, 'inputs.vault_id');
 
             scope.modalSelectedCredentials = scope.modalSelectedCredentials
-                .filter(c => (c.credential_type !== types.Vault) || (c.inputs.vault_id !== vaultId))
+                .filter(c => (c.credential_type !== types.vault) || (c.inputs.vault_id !== vaultId))
                 .concat([credential]);
         } else {
             scope.modalSelectedCredentials = scope.modalSelectedCredentials


### PR DESCRIPTION
This fixes an issue where the credential modal would not work when awx was translated.

Went ahead and looked for other instances of where we looking for name keys of credential kinds and updated those.

I tested and when things are not translated, i18n._("foo") would just return foo, so we should be good there.