### PR TITLE
Fix default Postgresql version to 9.6

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -69,7 +69,7 @@
           -e POSTGRESQL_PASSWORD={{ pg_password }} \
           -e POSTGRESQL_ADMIN_PASSWORD={{ pg_password }} \
           -e POSTGRESQL_DATABASE={{ pg_database }} \
-          -e POSTGRESQL_VERSION=9.5 \
+          -e POSTGRESQL_VERSION=9.6 \
           -n {{ kubernetes_namespace }}
       register: openshift_pg_activate
       no_log: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Postgresql have been updated to 9.6 image by default installation. When running install.yml on existing installation postgresql fails to start when trying to migrate from 9.5 but finds 9.6 data.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
