### PR TITLE
Fixed issue where admin_user and password change are not reflected

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -59,8 +59,8 @@ services:
       RABBITMQ_VHOST: awx
       MEMCACHED_HOST: memcached
       MEMCACHED_PORT: 11211
-      AWX_ADMIN_USER: {{ default_admin_user|default('admin') }}
-      AWX_ADMIN_PASSWORD: {{ default_admin_password|default('password') }}
+      AWX_ADMIN_USER: {{ admin_user|default('admin') }}
+      AWX_ADMIN_PASSWORD: {{ admin_password|default('password') }}
 
   task:
     image: {{ awx_task_docker_actual_image }}
@@ -118,8 +118,8 @@ services:
       RABBITMQ_VHOST: awx
       MEMCACHED_HOST: memcached
       MEMCACHED_PORT: 11211
-      AWX_ADMIN_USER: {{ default_admin_user|default('admin') }}
-      AWX_ADMIN_PASSWORD: {{ default_admin_password|default('password') }}
+      AWX_ADMIN_USER: {{ admin_user|default('admin') }}
+      AWX_ADMIN_PASSWORD: {{ admin_password|default('password') }}
 
   rabbitmq:
     image: {{ rabbitmq_image }}


### PR DESCRIPTION
##### SUMMARY

This PR will fix the following issue #2666
- No effect of changing admin_user and admin_password when using docker-compose #2666

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
2.1.0 and devel
```
##### ADDITIONAL INFORMATION

None