### PR TITLE
Fix bug with non-sliced JT job spawn

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -338,6 +338,9 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
             kwargs['_parent_field_name'] = "job_template"
             kwargs.setdefault('_eager_fields', {})
             kwargs['_eager_fields']['is_sliced_job'] = True
+        elif prevent_slicing:
+            kwargs.setdefault('_eager_fields', {})
+            kwargs['_eager_fields'].setdefault('job_slice_count', 1)
         job = super(JobTemplate, self).create_unified_job(**kwargs)
         if slice_event:
             try:

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -561,11 +561,12 @@ def test_callback_accept_prompted_extra_var(mocker, survey_spec_factory, job_tem
                         dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
                         admin_user, expect=201, format='json')
                     assert UnifiedJobTemplate.create_unified_job.called
-                    assert UnifiedJobTemplate.create_unified_job.call_args == ({
+                    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
+                    call_args.pop('_eager_fields', None)  # internal purposes
+                    assert call_args == {
                         'extra_vars': {'survey_var': 4, 'job_launch_var': 3},
-                        '_eager_fields': {'launch_type': 'callback'},
-                        'limit': 'single-host'},
-                    )
+                        'limit': 'single-host'
+                    }
 
     mock_job.signal_start.assert_called_once()
 
@@ -587,10 +588,11 @@ def test_callback_ignore_unprompted_extra_var(mocker, survey_spec_factory, job_t
                         dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
                         admin_user, expect=201, format='json')
                     assert UnifiedJobTemplate.create_unified_job.called
-                    assert UnifiedJobTemplate.create_unified_job.call_args == ({
-                        '_eager_fields': {'launch_type': 'callback'},
-                        'limit': 'single-host'},
-                    )
+                    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
+                    call_args.pop('_eager_fields', None)  # internal purposes
+                    assert call_args == {
+                        'limit': 'single-host'
+                    }
 
     mock_job.signal_start.assert_called_once()
 

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -19,6 +19,18 @@ def test_awx_virtualenv_from_settings(inventory, project, machine_credential):
 
 
 @pytest.mark.django_db
+def test_prevent_slicing():
+    jt = JobTemplate.objects.create(
+        name='foo',
+        job_slice_count=4
+    )
+    job = jt.create_unified_job(_prevent_slicing=True)
+    assert job.job_slice_count == 1
+    assert job.job_slice_number == 0
+    assert isinstance(job, Job)
+
+
+@pytest.mark.django_db
 def test_awx_custom_virtualenv(inventory, project, machine_credential):
     jt = JobTemplate.objects.create(
         name='my-jt',


### PR DESCRIPTION
This fixes a bug where callbacks had a job error.