### PR TITLE
Update register_queue.py to enable registration of group names with unicode

### DIFF
--- a/awx/main/management/commands/register_queue.py
+++ b/awx/main/management/commands/register_queue.py
@@ -104,7 +104,7 @@ class Command(BaseCommand):
             changed3 = False
             (ig, created, changed1) = self.get_create_update_instance_group(queuename, inst_per, inst_min)
             if created:
-                print(six.text_type("Creating instance group {}".format(ig.name)))
+                print(six.text_type("Creating instance group {}").format(ig.name))
             elif not created:
                 print(six.text_type("Instance Group already registered {}").format(ig.name))
 
@@ -126,4 +126,3 @@ class Command(BaseCommand):
         if instance_not_found_err:
             print(instance_not_found_err.message)
             sys.exit(1)
-

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
-import six
 import random
 from decimal import Decimal
 
-from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models, connection
 from django.db.models.signals import post_save, post_delete

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -31,14 +31,6 @@ from awx.main.models.mixins import RelatedJobsMixin
 __all__ = ('Instance', 'InstanceGroup', 'JobOrigin', 'TowerScheduleState',)
 
 
-def validate_queuename(v):
-    # kombu doesn't play nice with unicode in queue names
-    if v:
-        try:
-            '{}'.format(v.decode('utf-8'))
-        except UnicodeEncodeError:
-            raise ValidationError(_(six.text_type('{} contains unsupported characters')).format(v))
-
 
 class HasPolicyEditsMixin(HasEditsMixin):
 
@@ -163,11 +155,8 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         self.save(update_fields=['capacity', 'version', 'modified', 'cpu',
                                  'memory', 'cpu_capacity', 'mem_capacity'])
 
-    def clean_hostname(self):
-        validate_queuename(self.hostname)
-        return self.hostname
 
-    
+
 
 class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
     """A model representing a Queue/Group of AWX Instances."""
@@ -234,9 +223,7 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
     class Meta:
         app_label = 'main'
 
-    def clean_name(self):
-        validate_queuename(self.name)
-        return self.name
+
 
     def fit_task_to_most_remaining_capacity_instance(self, task):
         instance_most_capacity = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
awx/main/management/commands/register_queue.py

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 2.1.0
```


##### ADDITIONAL INFORMATION

There was a bug that prevented registrations of instance groups that contained unicode.

```
failed: [localhost] (item=[] + [ 'fröbözz' ] + [ 'xyz' ] + [ '🙈🙉🙊' ] + [ 'tower' ]) => {"changed": false,
 "cmd": "awx-manage register_queue --queuename=\"[] + [ 'fröbözz' ] + [ 'xyz' ] + [ '🙈🙉🙊' ] + [ 'tower' ]\" --hostnames=\"localhost\"",
 "delta": "0:00:04.766854",
 "end": "2018-01-23 20:57:58.086117",
 "item": "[] + [ 'fröbözz' ] + [ 'xyz' ] + [ '🙈🙉🙊' ] + [ 'tower' ]",
 "msg": "non-zero return code",
 "rc": 1,
 "start": "2018-01-23 20:57:53.319263",
 "stderr": "Traceback (most recent call last):
  File \"/bin/awx-manage\", line 9, in <module>
    load_entry_point('awx==3.2.2', 'console_scripts', 'awx-manage')()
  File \"/lib/python2.7/site-packages/awx/__init__.py\", line 107, in manage
  File \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/management/__init__.py\", line 354, in execute_from_command_line
    utility.execute()
  File \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/management/__init__.py\", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/management/base.py\", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/django/core/management/base.py\", line 445, in execute
    output = self.handle(*args, **options)
  File \"/lib/python2.7/site-packages/awx/main/management/commands/register_queue.py\", line 28, in handle
  File \"/usr/lib64/python2.7/contextlib.py\", line 17, in __enter__
    return self.gen.next()
  File \"/lib/python2.7/site-packages/awx/main/utils/pglock.py\", line 13, in advisory_lock
  File \"/usr/lib64/python2.7/contextlib.py\", line 17, in __enter__
    return self.gen.next()
  File \"/var/lib/awx/venv/awx/lib/python2.7/site-packages/django_pglocks/__init__.py\", line 47, in advisory_lock
    pos = crc32(lock_id.encode(\"utf-8\"))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 38: ordinal not in range(128)", 
...
```

Showing output error + correct output after change:

![outputfixedafterchange](https://user-images.githubusercontent.com/28930622/48438768-b08a7a80-e752-11e8-9d58-738cc0da79ed.png)

Instances successfully registered:

![instancesapi](https://user-images.githubusercontent.com/28930622/48438801-cd26b280-e752-11e8-85d3-2fff167e24a4.png)
