### PR TITLE
include M2M labels and credentials in Job creation activity stream

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -425,6 +425,11 @@ def activity_stream_create(sender, instance, created, **kwargs):
         changes = model_to_dict(instance, model_serializer_mapping)
         # Special case where Job survey password variables need to be hidden
         if type(instance) == Job:
+            changes['credentials'] = [
+                six.text_type('{} ({})').format(c.name, c.id)
+                for c in instance.credentials.iterator()
+            ]
+            changes['labels'] = [l.name for l in instance.labels.iterator()]
             if 'extra_vars' in changes:
                 changes['extra_vars'] = instance.display_extra_vars()
         if type(instance) == OAuth2AccessToken:


### PR DESCRIPTION
@AlanCoding I don't love that I ended up special-casing this, but it's fairly important, and I can't think of a less complicated way to do it.