### PR TITLE
Pre-delete bulk delete related, fix parallel request conflicts

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -552,9 +552,8 @@ class SubListDestroyAPIView(DestroyAPIView, SubListAPIView):
 
     def perform_list_destroy(self, instance_list):
         if self.check_sub_obj_permission:
-            # Check permissions for all before deleting, avoiding half-deleted lists
             for instance in instance_list:
-                if self.has_delete_permission(instance):
+                if not self.has_delete_permission(instance):
                     raise PermissionDenied()
         for instance in instance_list:
             self.perform_destroy(instance, check_permission=False)

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2056,6 +2056,14 @@ class InventorySourceHostsList(HostRelatedSearchMixin, SubListDestroyAPIView):
     relationship = 'hosts'
     check_sub_obj_permission = False
 
+    def perform_list_destroy(self, instance_list):
+        # Activity stream doesn't record disassociation here anyway
+        # no signals-related reason to not bulk-delete
+        Host.groups.through.objects.filter(
+            host__inventory_sources=self.get_parent_object()
+        ).delete()
+        return super(InventorySourceHostsList, self).perform_list_destroy(instance_list)
+
 
 class InventorySourceGroupsList(SubListDestroyAPIView):
 
@@ -2064,6 +2072,13 @@ class InventorySourceGroupsList(SubListDestroyAPIView):
     parent_model = InventorySource
     relationship = 'groups'
     check_sub_obj_permission = False
+
+    def perform_list_destroy(self, instance_list):
+        # Same arguments for bulk delete as with host list
+        Group.hosts.through.objects.filter(
+            group__inventory_sources=self.get_parent_object()
+        ).delete()
+        return super(InventorySourceGroupsList, self).perform_list_destroy(instance_list)
 
 
 class InventorySourceUpdatesList(SubListAPIView):


### PR DESCRIPTION
##### SUMMARY
There was an issue involving the following steps:
 - sync a large ec2 inventory
 - delete the inventory source in the UI

Problem was that the transactions created a deadlock situation.

Testing shows that this fixes that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```


##### ADDITIONAL INFORMATION
This is modeled after the fix

https://github.com/ansible/awx/commit/91a24666501c437aa37c4448709931932892ad67

Thanks @wwitzel3 

I can't fully get into why bulk deleting would be expected to _not_ cause deadlocks, whereas the Django behavior of walking related `on_delete` fields does, but the reasons may be self-obvious to the reader.

In the process of debugging, I kept getting some 504 timeouts, because of HARAKIRI. After I turned off the Django Debug Toolbar this stopped happening. Because of that, I tried uwsgi top with memory reports, this diff is needed:

```diff
diff --git a/Makefile b/Makefile
index 4337c13c22..91247e2a61 100644
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ uwsgi: collectstatic
        @if [ "$(VENV_BASE)" ]; then \
                . $(VENV_BASE)/awx/bin/activate; \
        fi; \
-    uwsgi -b 32768 --socket 127.0.0.1:8050 --module=awx.wsgi:application --home=/venv/awx --chdir=/awx_devel/ --vacuum --processes=5 --harakiri=120 --master --no-orphans --py-autoreload 1 --max-requests=1000 --stats /tmp/stats.socket --lazy-apps --logformat "%(addr) %(method) %(uri) - %(proto) %(status)" --hook-accepting1-once="exec:awx-manage run_dispatcher --reload"
+    uwsgi -b 32768 --socket 127.0.0.1:8050 --module=awx.wsgi:application --home=/venv/awx --chdir=/awx_devel/ --vacuum --processes=5 --harakiri=120 --master --no-orphans --py-autoreload 1 --max-requests=1000 --stats /tmp/stats.socket --memory-report --lazy-apps --logformat "%(addr) %(method) %(uri) - %(proto) %(status)" --hook-accepting1-once="exec:awx-manage run_dispatcher --reload"
 
 daphne:
        @if [ "$(VENV_BASE)" ]; then \
```

So anyway, using _without_ the debug toolbar on would still give fairly long times for highly-connected inventory deletions, but parameters still looked fairly nominal.

![screen shot 2018-11-15 at 10 51 56 am](https://user-images.githubusercontent.com/1385596/48566563-1ef14900-e8c9-11e8-88ed-3deef7a77e3e.png)

