### PR TITLE
Fix Organizations TemplateList websockets

### DIFF
--- a/awx/ui/client/features/templates/routes/organizationsTemplatesList.route.js
+++ b/awx/ui/client/features/templates/routes/organizationsTemplatesList.route.js
@@ -8,6 +8,15 @@ const templatesListTemplate = require('~features/templates/templatesList.view.ht
 export default {
     url: "/:organization_id/job_templates",
     name: 'organizations.job_templates',
+    data: {
+        activityStream: true,
+        activityStreamTarget: 'template',
+        socket: {
+            "groups": {
+                "jobs": ["status_changed"]
+            }
+        }
+    },
     params: {
         template_search: {
             dynamic: true,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #2552 

It appears that we were not adding a websocket "listener" for job-status changes to the Org > TemplateList page, thus causing the smart status indicators to not update in real-time.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```
