### PR TITLE
prevent the dispatcher from using a nonsensical max_workers value

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -296,6 +296,10 @@ class AutoscalePool(WorkerPool):
             # 5 workers per GB of total memory
             self.max_workers = (total_memory_gb * 5)
 
+        # max workers can't be less than min_workers
+        self.max_workers = max(self.min_workers, self.max_workers)
+        logger.warning(self.debug_meta)
+
     @property
     def should_grow(self):
         if len(self.workers) < self.min_workers:


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/2705