### PR TITLE
Minor cleanup of task environment vars

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1208,8 +1208,6 @@ class RunJob(BaseTask):
         if job.project:
             env['PROJECT_REVISION'] = job.project.scm_revision
         env['ANSIBLE_RETRY_FILES_ENABLED'] = "False"
-        env['ANSIBLE_INVENTORY_ENABLED'] = 'script'
-        env['ANSIBLE_INVENTORY_UNPARSED_FAILED'] = 'True'
         env['MAX_EVENT_RES'] = str(settings.MAX_EVENT_RES_DATA)
         if not kwargs.get('isolated'):
             env['ANSIBLE_CALLBACK_PLUGINS'] = plugin_path
@@ -1223,9 +1221,6 @@ class RunJob(BaseTask):
         if not os.path.exists(cp_dir):
             os.mkdir(cp_dir, 0o700)
         env['ANSIBLE_SSH_CONTROL_PATH_DIR'] = cp_dir
-
-        # Allow the inventory script to include host variables inline via ['_meta']['hostvars'].
-        env['INVENTORY_HOSTVARS'] = str(True)
 
         # Set environment variables for cloud credentials.
         cred_files = kwargs.get('private_data_files', {}).get('credentials', {})

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -606,6 +606,9 @@ ANSIBLE_PARAMIKO_RECORD_HOST_KEYS = False
 # output
 ANSIBLE_FORCE_COLOR = True
 
+# If tmp generated inventory parsing fails (error state), fail playbook fast
+ANSIBLE_INVENTORY_UNPARSED_FAILED = True
+
 # Additional environment variables to be passed to the ansible subprocesses
 AWX_TASK_ENV = {}
 


### PR DESCRIPTION
##### SUMMARY
For one, this is doing some basic modernization of our handling of certain playbook-affecting env vars.

Another thing, we had negative user feedback about the script setting here, so that is getting reverted.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Disposition on things:

`ANSIBLE_INVENTORY_ENABLED` - this _should_ be set in inventory imports (that is done elsewhere, not affected by this change), but it was apparently a headache for people who used their playbooks to call other playbooks.

We don't _need_ this setting, it just made the error reporting more clear. In the case of playbook runs, however, it should _never ever error_, so having that extremely rare system-level error look bad is small potatoes.

`ANSIBLE_INVENTORY_UNPARSED_FAILED` - by default, this runs your playbook to the end with localhost if your inventory was not parsed. This is nonsense behavior, but it was previously not configurable. If you want this nonsense behavior, there are no adverse system consequences, so you should be able to define in it file-based settings.

`ANSIBLE_RETRY_FILES_ENABLED` - not touching this, because it depends on _where_ the retry files are placed. Since I'm not 100% sure that would go in the tmp directory, there could be unforeseen consequences, I'm leaving it the same, where we _force_ the value to False, and the user has no override options.

`INVENTORY_HOSTVARS` - this doesn't appear to be a thing. I believe it's ancient and no longer used. The stated reason for its use is default Ansible behavior. If you Google it, you only get job results from Ansible Tower / AWX.