### PR TITLE
Fix task scheduling bugs discovered by testing

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -339,6 +339,7 @@ class InstanceDetail(RetrieveUpdateAPIView):
             obj = self.get_object()
             if obj.enabled:
                 obj.refresh_capacity()
+                schedule_task_manager()
             else:
                 obj.capacity = 0
             obj.save()

--- a/awx/api/views/mixin.py
+++ b/awx/api/views/mixin.py
@@ -22,6 +22,7 @@ from awx.main.constants import ACTIVE_STATES
 from awx.main.utils import (
     get_object_or_400,
     parse_yaml_or_json,
+    schedule_task_manager
 )
 from awx.main.models.ha import (
     Instance,
@@ -131,6 +132,9 @@ class InstanceGroupMembershipMixin(object):
                 if inst_name not in ig_obj.policy_instance_list:
                     ig_obj.policy_instance_list.append(inst_name)
                     ig_obj.save(update_fields=['policy_instance_list'])
+            # the prior action may turn a dead IG into a live IG
+            # so process jobs as soon as the outermost transaction completes
+            schedule_task_manager()
         return response
 
     def is_valid_relation(self, parent, sub, created=False):

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -884,7 +884,7 @@ class Group(CommonModelNameNotUnique, RelatedJobsMixin):
                 marked_groups.append(group)
             Group.objects.filter(id__in=marked_groups).delete()
             Host.objects.filter(id__in=marked_hosts).delete()
-            update_inventory_computed_fields.delay(self.inventory.id)
+            connection.on_commit(lambda: update_inventory_computed_fields.delay(self.inventory.id))
         with ignore_inventory_computed_fields():
             with disable_activity_stream():
                 mark_actual()

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -151,6 +151,7 @@ class TaskManager():
                     job.status = 'failed'
                     job.save(update_fields=['status', 'job_explanation'])
                     job.websocket_emit_status('failed')
+                    schedule_task_manager()
 
                 # TODO: should we emit a status on the socket here similar to tasks.py awx_periodic_scheduler() ?
                 #emit_websocket_notification('/socket.io/jobs', '', dict(id=))
@@ -229,6 +230,7 @@ class TaskManager():
                 task.job_explanation += ' '
             task.job_explanation += 'Task failed pre-start check.'
             task.save()
+            schedule_task_manager()
             # TODO: run error handler to fail sub-tasks and send notifications
         else:
             if type(task) is WorkflowJob:

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -11,6 +11,7 @@ import sys
 
 # Django
 from django.conf import settings
+from django.db import connection
 from django.db.models.signals import (
     pre_save,
     post_save,
@@ -141,7 +142,7 @@ def emit_update_inventory_computed_fields(sender, **kwargs):
     except Inventory.DoesNotExist:
         pass
     else:
-        update_inventory_computed_fields.delay(inventory.id, True)
+        connection.on_commit(lambda: update_inventory_computed_fields.delay(inventory.id))
 
 
 def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
@@ -162,7 +163,7 @@ def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
         pass
     else:
         if inventory is not None:
-            update_inventory_computed_fields.delay(inventory.id, True)
+            connection.on_commit(lambda: update_inventory_computed_fields.delay(inventory.id))
 
 
 def rebuild_role_ancestor_list(reverse, model, instance, pk_set, action, **kwargs):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -245,6 +245,10 @@ def apply_cluster_membership_policies():
                 if instances_to_remove:
                     logger.info('Removing instances {} from group {}'.format(list(instances_to_remove), g.obj.name))
                     g.obj.instances.remove(*instances_to_remove)
+
+        # This was not a no-op, meaning that some jobs may go from pending to waiting
+        schedule_task_manager()
+
         logger.info('Cluster policy computation finished in {} seconds'.format(time.time() - started_compute))
 
 


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/2766

This resolves bugs related to how and when we schedule idempotent tasks discovered by a new means of testing, which specifically enforces that:

- no .delay is done inside an active transaction
- that run_task_manager period task can be turned off

This does not include any of the supporting tooling that was necessary to obtain these discoveries, so this is strictly implementing the bug fixes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
