### PR TITLE
Include migration middleware in timings and profiling

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -250,8 +250,8 @@ TEMPLATES = [
 ]
 
 MIDDLEWARE_CLASSES = (  # NOQA
-    'awx.main.middleware.MigrationRanCheckMiddleware',
     'awx.main.middleware.TimingMiddleware',
+    'awx.main.middleware.MigrationRanCheckMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
##### SUMMARY
We have a header that gives our best estimate of total time server-side to produce the request (we have another header that gives timings without middleware), but this middleware was not being counted, giving times lower than actual.

If we don't want to do this, we should remove the timing middlware.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
