### PR TITLE
CORS Support

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -252,6 +252,7 @@ TEMPLATES = [
 MIDDLEWARE_CLASSES = (  # NOQA
     'awx.main.middleware.TimingMiddleware',
     'awx.main.middleware.MigrationRanCheckMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -284,6 +285,7 @@ INSTALLED_APPS = (
     'polymorphic',
     'taggit',
     'social_django',
+    'corsheaders',
     'awx.conf',
     'awx.main',
     'awx.api',

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,6 +7,7 @@ celery==4.2.1
 daphne==1.3.0   # Last before backwards-incompatible channels 2 upgrade
 Django==1.11.16
 django-auth-ldap==1.2.8
+django-cors-headers==2.4.0
 django-crum==0.7.2
 django-extensions==2.0.0
 django-jsonfield==1.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -79,6 +79,7 @@ pyparsing==2.2.0
 pyrad==1.2                # via django-radius
 python-dateutil==2.7.2
 python-ldap==2.5.2        # via django-auth-ldap
+django-cors-headers==2.4.0
 python-logstash==0.4.6
 python-memcached==1.59
 python-openid==2.2.5      # via social-auth-core


### PR DESCRIPTION
##### SUMMARY
AWX does not support CORS at the application level. Modifying NGINX config to enable CORS works for the API, but breaks the UI.

This change adds the [`django-cors-headers`](https://github.com/ottoyiu/django-cors-headers/) app and middleware to the AWX project to enable CORS support.

No configuration of `django-cors-headers` is added to the `settings/defaults.py` file. The defaults are sane and [block all cross origin requests](https://github.com/ottoyiu/django-cors-headers/#cors_origin_whitelist).

related #1519 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 2.1.0
```

##### ADDITIONAL INFORMATION
