### PR TITLE
Implement deprecation of groups_with_active_failures

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1499,6 +1499,12 @@ class InventorySerializer(BaseSerializerWithVariables):
         'admin', 'adhoc',
         {'copy': 'organization.inventory_admin'}
     ]
+    groups_with_active_failures = serializers.IntegerField(
+        read_only=True,
+        min_value=0,
+        help_text=_('This field has been deprecated and will be removed in a future release')
+    )
+
 
     class Meta:
         model = Inventory
@@ -1720,6 +1726,11 @@ class AnsibleFactsSerializer(BaseSerializer):
 
 class GroupSerializer(BaseSerializerWithVariables):
     capabilities_prefetch = ['inventory.admin', 'inventory.adhoc']
+    groups_with_active_failures = serializers.IntegerField(
+        read_only=True,
+        min_value=0,
+        help_text=_('This field has been deprecated and will be removed in a future release')
+    )
 
     class Meta:
         model = Group


### PR DESCRIPTION
##### SUMMARY
Searching for this field in code base:

https://github.com/ansible/awx/search?q=groups_with_active_failures&unscoped_q=groups_with_active_failures

No javascript results. The UI is not using this field at all.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
2.1.0
```


##### ADDITIONAL INFORMATION
Follows same pattern as: https://github.com/ansible/awx/pull/2591

Prior attempts to deal with computed fields issues:

Applying a lock for de-duplication, iffy https://github.com/ansible/awx/pull/2715

Avoid recursion in logic to reduce combinatorial runtimes, https://github.com/ansible/awx/pull/1642, needs significant algorithmic testing

on-the-fly calculations https://github.com/ansible/awx/pull/1628, generally favored, but actually not viable

Whenever I ever dug into an algorithmic option, it was clear that this exact field _kills_ our options. To clarify "Groups with active failures" means groups that have either hosts with failures _or_ any sub-groups that have hosts with active failures, which could be of any depth. You could have `group1`->`group2`->`group3`->`host1`, and if host1 had a failed job last job, then group1 has active failures.

This is a complex concept, and apparently no one uses it.

By opening up the option of removing this field, we dramatically increase our available options for replacement or abatement of computed fields.

OPTIONS before:

```json
"groups_with_active_failures": {
    "type": "integer",
    "label": "Groups with active failures",
    "help_text": "Number of groups in this inventory with active failures.",
    "min_value": 0,
    "filterable": true
},
```

OPTIONS after:

```json
"groups_with_active_failures": {
    "type": "integer",
    "label": "Groups with active failures",
    "help_text": "This field has been deprecated and will be removed in a future release",
    "min_value": 0,
    "filterable": true
},
```