### PR TITLE
Use patch instead of put when updating a wfjt

### DIFF
--- a/awx/ui/client/src/templates/templates.service.js
+++ b/awx/ui/client/src/templates/templates.service.js
@@ -151,7 +151,7 @@ export default ['Rest', 'GetBasePath', '$q', 'NextPage', function(Rest, GetBaseP
           url = url + params.id;
 
           Rest.setUrl(url);
-          return Rest.put(params.data);
+          return Rest.patch(params.data);
       },
       getWorkflowJobTemplate: function(id) {
           var url = GetBasePath('workflow_job_templates');


### PR DESCRIPTION
##### SUMMARY
PUT will set attributes that are not included in the payload back to their default values and as a result ask_variables_on_launch is being set back to `false` any time a user saves the WFJT form in the UI.  PATCH will only update the provided attributes.

related https://github.com/ansible/awx/issues/2428

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
