### PR TITLE
fix instance group lookup in orgs scrolling behavior

### DIFF
--- a/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
+++ b/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
@@ -12,7 +12,7 @@
             <at-tag tag="tag.name" remove-tag="deleteTag(tag)"></at-tag>
         </div>
         <div ng-if="fieldIsDisabled" class="LabelList-tag" ng-repeat="tag in instanceGroupsTags">
-            <span class="LabelList-name">{{tag.name}}</span>
+            <span class="LabelList-name">{{tag.name | sanitize}}</span>
         </div>
     </span>
 </div>

--- a/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
+++ b/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
@@ -1,14 +1,18 @@
 <div class="input-group Form-mixedInputGroup">
-    <span class="input-group-btn">
-        <button type="button" class="Form-lookupButton btn btn-default" ng-click="openInstanceGroupsModal()"
+    <span class="input-group-btn Form-variableHeightButtonGroup">
+        <button type="button" class="Form-lookupButton Form-lookupButton--variableHeight btn btn-default" ng-click="openInstanceGroupsModal()"
             ng-disabled="fieldIsDisabled">
             <i class="fa fa-search"></i>
         </button>
     </span>
     <span id="InstanceGroups" class="form-control Form-textInput Form-textInput--variableHeight input-medium lookup LabelList-lookupTags"
-        ng-disabled="fieldIsDisabled">
-        <div class="LabelList-tagContainer" ng-repeat="tag in instanceGroupsTags">
+        ng-disabled="fieldIsDisabled"
+        ng-class="{'LabelList-lookupTags--disabled' : fieldIsDisabled}">
+        <div ng-if="!fieldIsDisabled" class="LabelList-tagContainer" ng-repeat="tag in instanceGroupsTags">
             <at-tag tag="tag.name" remove-tag="deleteTag(tag)"></at-tag>
+        </div>
+        <div ng-if="fieldIsDisabled" class="LabelList-tag" ng-repeat="tag in instanceGroupsTags">
+            <span class="LabelList-name">{{tag.name}}</span>
         </div>
     </span>
 </div>

--- a/awx/ui/client/src/templates/labels/labelsList.block.less
+++ b/awx/ui/client/src/templates/labels/labelsList.block.less
@@ -92,11 +92,6 @@
 .LabelList-lookupTags {
     display: flex;
     padding: 0 12px;
-    overflow-y: hidden;
-}
-
-.LabelList-lookupTags[disabled] {
-    pointer-events: none;
 }
 
 .LabelList-lookupTags--disabled {


### PR DESCRIPTION
Now, instance groups scrolls when enabled

<img width="567" alt="screen shot 2018-11-19 at 3 33 24 pm" src="https://user-images.githubusercontent.com/1342624/48733680-5cc7d780-ec11-11e8-8adb-ad0972b2105b.png">
<img width="547" alt="screen shot 2018-11-19 at 3 33 29 pm" src="https://user-images.githubusercontent.com/1342624/48733681-5cc7d780-ec11-11e8-9f00-ec4564518da0.png">

as well as when disabled

<img width="589" alt="screen shot 2018-11-19 at 3 32 59 pm" src="https://user-images.githubusercontent.com/1342624/48733689-65201280-ec11-11e8-86e8-35bc71f1ca97.png">
<img width="576" alt="screen shot 2018-11-19 at 3 33 04 pm" src="https://user-images.githubusercontent.com/1342624/48733691-65201280-ec11-11e8-9d2f-d31ff39eacee.png">


I was able to get rid of the `pointer-events: none` css rule (which breaks scrolling), when the form is disabled.  I show just the non-removable tag, exactly the way the smart host filter, which also uses these classes, does it:

<img width="559" alt="screen shot 2018-11-19 at 3 18 35 pm" src="https://user-images.githubusercontent.com/1342624/48733769-900a6680-ec11-11e8-91de-4cb732bcfda5.png">
<img width="550" alt="screen shot 2018-11-19 at 3 18 44 pm" src="https://user-images.githubusercontent.com/1342624/48733770-900a6680-ec11-11e8-8ecb-07ee80be5e46.png">
