### PR TITLE
UI WF results relaunch: handle any relaunch errors.

### DIFF
--- a/awx/ui/client/src/workflow-results/workflow-results.service.js
+++ b/awx/ui/client/src/workflow-results/workflow-results.service.js
@@ -5,7 +5,7 @@
 *************************************************/
 
 
-export default ['$q', 'Prompt', '$filter', 'Wait', 'Rest', '$state', 'ProcessErrors', 'WorkflowJobModel', '$interval', 'moment', function ($q, Prompt, $filter, Wait, Rest, $state, ProcessErrors, WorkflowJob, $interval, moment) {
+export default ['$q', 'Prompt', '$filter', 'Wait', 'Rest', '$state', 'ProcessErrors', 'WorkflowJobModel', '$interval', 'moment', 'ComponentsStrings', function ($q, Prompt, $filter, Wait, Rest, $state, ProcessErrors, WorkflowJob, $interval, moment, strings) {
     var val = {
         getCounts: function(workflowNodes){
             var nodeArr = [];
@@ -113,6 +113,11 @@ export default ['$q', 'Prompt', '$filter', 'Wait', 'Rest', '$state', 'ProcessErr
                 id: scope.workflow.id
             }).then((launchRes) => {
                 $state.go('workflowResults', { id: launchRes.data.id }, { reload: true });
+            }).catch(({ data, status, config }) => {
+                ProcessErrors(scope, data, status, null, {
+                    hdr: strings.get('error.HEADER'),
+                    msg: strings.get('error.CALL', { path: `${config.url}`, status })
+                });
             });
         },
         createOneSecondTimer: function(startTime, fn) {

--- a/awx/ui/test/spec/workflow--results/workflow-results.controller-test.js
+++ b/awx/ui/test/spec/workflow--results/workflow-results.controller-test.js
@@ -18,7 +18,7 @@ describe('Controller: workflowResults', () => {
 
     beforeEach(angular.mock.module('workflowResults', ($provide) => {
         ['PromptDialog', 'Prompt', 'Wait', 'Rest', '$state', 'ProcessErrors',
-         'jobLabels', 'workflowNodes', 'count', 'WorkflowJobModel',
+         'jobLabels', 'workflowNodes', 'count', 'WorkflowJobModel', 'ComponentsStrings'
         ].forEach((item) => {
             $provide.value(item, {});
         });

--- a/awx/ui/test/spec/workflow--results/workflow-results.service-test.js
+++ b/awx/ui/test/spec/workflow--results/workflow-results.service-test.js
@@ -6,7 +6,7 @@ describe('workflowResultsService', () => {
     let $interval;
 
     beforeEach(angular.mock.module('workflowResults', ($provide) => {
-        ['PromptDialog', 'Prompt', 'Wait', 'Rest', 'ProcessErrors', '$state', 'WorkflowJobModel']
+        ['PromptDialog', 'Prompt', 'Wait', 'Rest', 'ProcessErrors', '$state', 'WorkflowJobModel', 'ComponentsStrings']
             .forEach(function(item) {
                 $provide.value(item, {});
             });


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #2554 

We now handle errors on the WF results page if a job is relaunched and the API returns an error.
![relaunch_error](https://user-images.githubusercontent.com/2293210/48788294-84be4600-ecb8-11e8-8ece-09a615c9bb3d.gif)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.0
```

