### PR TITLE
fix websocket issue

### DIFF
--- a/installer/roles/image_build/templates/nginx.conf
+++ b/installer/roles/image_build/templates/nginx.conf
@@ -65,6 +65,7 @@ http {
             proxy_http_version 1.1;
             # We want proxy_buffering off for proxying to websockets.
             proxy_buffering off;
+            proxy_request_buffering off;
             # http://en.wikipedia.org/wiki/X-Forwarded-For
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             # enable this if you use HTTPS:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
From the Ansible Tower support team.  The customer faced the issue about websocket live events.

I found that the setting of proxying to websockets should be set not only `proxy_buffering off` but also `proxy_request_buffering off`.  The customer satisfied after this setting turned off.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

When Ansible Tower at /var/log/nginx/error.log, the live event doesn't show and the warning is found like this;

```
2018/11/15 18:09:33 [warn] 39967#0: *48 an upstream response is buffered to a temporary file /var/lib/nginx/tmp/uwsgi/1/00/0000000001 while reading upstream, client: 10.47.60.xxx, server: _, request: "GET /api/v2/jobs/10413/job_events/?order_by=-counter&page=1&page_size=50 HTTP/1.1", upstream: "uwsgi://127.0.0.1:8050", host: "ansible.example.org", referrer: "https://ansible.example.org/"
```

