### PR TITLE
Set fixed container names

### DIFF
--- a/tools/docker-compose-cluster.yml
+++ b/tools/docker-compose-cluster.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ./docker-compose
       dockerfile: Dockerfile-haproxy
+    container_name: tools_haproxy_1
     depends_on:
       - "awx_1"
       - "awx_2"
@@ -15,6 +16,7 @@ services:
       - "15672:15672"
   awx_1:
     user: ${CURRENT_UID}
+    container_name: tools_awx_1_1
     privileged: true
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     hostname: awx_1
@@ -32,6 +34,7 @@ services:
       - "5899-5999:5899-5999"
   awx_2:
     user: ${CURRENT_UID}
+    container_name: tools_awx_2_1
     privileged: true
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     hostname: awx_2
@@ -49,6 +52,7 @@ services:
       - "6899-6999:6899-6999"
   awx_3:
     user: ${CURRENT_UID}
+    container_name: tools_awx_3_1
     privileged: true
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     hostname: awx_3
@@ -67,19 +71,24 @@ services:
   rabbitmq_1:
     image: ${DEV_DOCKER_TAG_BASE}/rabbit_cluster_node:latest
     hostname: rabbitmq_1
+    container_name: tools_rabbitmq_1_1
   rabbitmq_2:
     image: ${DEV_DOCKER_TAG_BASE}/rabbit_cluster_node:latest
     hostname: rabbitmq_2
+    container_name: tools_rabbitmq_2_1
     environment: 
       - CLUSTERED=true
       - CLUSTER_WITH=rabbitmq_1
   rabbitmq_3:
     image: ${DEV_DOCKER_TAG_BASE}/rabbit_cluster_node:latest
     hostname: rabbitmq_3
+    container_name: tools_rabbitmq_3_1
     environment: 
       - CLUSTERED=true
       - CLUSTER_WITH=rabbitmq_1
   postgres:
     image: postgres:9.6
+    container_name: tools_postgres_1
   memcached:
     image: memcached:alpine
+    container_name: tools_memcached_1

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   awx:
     user: ${CURRENT_UID}
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
+    container_name: tools_awx_1
     hostname: awx
     environment:
       RABBITMQ_HOST: rabbitmq
@@ -37,13 +38,16 @@ services:
   # Postgres Database Container
   postgres:
     image: postgres:9.6
+    container_name: tools_postgres_1
     ports:
         - "5432:5432"
   memcached:
     image: memcached:alpine
+    container_name: tools_memcached_1
     ports:
       - "11211:11211"
   rabbitmq:
     image: rabbitmq:3-management
+    container_name: tools_rabbitmq_1
     ports:
       - "15672:15672"

--- a/tools/docker-isolated-override.yml
+++ b/tools/docker-isolated-override.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   # Primary Tower Development Container link
   awx:
@@ -9,6 +9,7 @@ services:
   # Isolated Rampart Container
   isolated:
     image: ${DEV_DOCKER_TAG_BASE}/awx_isolated:${TAG}
+    container_name: tools_isolated_1
     hostname: isolated
     volumes:
       - "../awx/main/expect:/awx_devel"


### PR DESCRIPTION
##### SUMMARY
I have some associated tooling where I use a static inventory file for docker-compose-cluster inventory, it looks like:

```
[local]
127.0.0.1 ansible_connection=local ansible_python_interpreter="/usr/bin/env python"

[tower]
tools_awx_1_1 ansible_connection=docker ansible_user=awx
tools_awx_2_1 ansible_connection=docker ansible_user=awx
tools_awx_3_1 ansible_connection=docker ansible_user=awx
```

This was broken with the last upgrade of Docker for Mac because it started creating names like `tools_awx_1_7d5d1ac4ffa9`

While these are not the nicest possible names, this obtains the same behavior that we have always had, after the upgrade.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Also, bumped version in the isolated override file because it was changed in the primary file here:

https://github.com/ansible/awx/commit/5c400cdf799642327b6795edabb90a29986de563#diff-0da361373f3517322c1b79b1e0288a12

So, obviously, it just hasn't been used since that change was made, and different versions docker files are not compatible with each other.
