### PR TITLE
don't conditionally hide workflow viz templates list button

### DIFF
--- a/awx/ui/client/features/templates/templatesList.view.html
+++ b/awx/ui/client/features/templates/templatesList.view.html
@@ -94,7 +94,7 @@
                     tooltip="{{:: vm.strings.get('listActions.COPY', vm.getType(template)) }}">
                 </at-row-action>
                 <at-row-action icon="fa-sitemap" ng-click="vm.openWorkflowVisualizer(template)"
-                    ng-show="!vm.isPortalMode && template.summary_fields.user_capabilities.edit"
+                    ng-show="!vm.isPortalMode"
                     ng-if="template.type === 'workflow_job_template'"
                     tooltip="{{:: vm.strings.get('list.OPEN_WORKFLOW_VISUALIZER') }}">
                 </at-row-action>


### PR DESCRIPTION
##### SUMMARY
We shouldn't be hiding this based on the `edit` capability (or any `user_capabilitiy`). Removing this condition will make this button visible to read-only WFJT users, which is expected.

resolves https://github.com/ansible/awx/issues/2800
