### PR TITLE
collect isolated capacity using a cache plugin, not stdout parsing

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -198,6 +198,18 @@ register(
 )
 
 register(
+    'AWX_ISOLATED_VERBOSITY',
+    field_class=fields.IntegerField,
+    min_value=0,
+    max_value=5,
+    label=_('Verbosity level for isolated node management tasks'),
+    help_text=_('This can be raised to aid in debugging connection issues for isolated task execution'),
+    category=_('Jobs'),
+    category_slug='jobs',
+    default=0
+)
+
+register(
     'AWX_ISOLATED_CHECK_INTERVAL',
     field_class=fields.IntegerField,
     min_value=0,

--- a/awx/plugins/isolated/awx_capacity.py
+++ b/awx/plugins/isolated/awx_capacity.py
@@ -62,7 +62,12 @@ def main():
 
     # Module never results in a change
     module.exit_json(changed=False, capacity_cpu=capacity_cpu,
-                     capacity_mem=capacity_mem, version=version)
+                     capacity_mem=capacity_mem, version=version,
+                     ansible_facts=dict(
+                         awx_capacity_cpu=capacity_cpu,
+                         awx_capacity_mem=capacity_mem,
+                         awx_capacity_version=version
+                     ))
 
 
 if __name__ == '__main__':

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -430,6 +430,9 @@ AWX_ISOLATED_CONNECTION_TIMEOUT = 10
 # The time (in seconds) between the periodic isolated heartbeat status check
 AWX_ISOLATED_PERIODIC_CHECK = 600
 
+# Verbosity level for isolated node management tasks
+AWX_ISOLATED_VERBOSITY = 0
+
 # Memcached django cache configuration
 # CACHES = {
 #     'default': {


### PR DESCRIPTION
reading capacity values using the jsonfile cache plugin is more robust in scenarios where ansible-playbook may print non-JSON output (such as -vvv or when a custom callback plugin like timer is
enabled)