### PR TITLE
update expected color vals of active tab in smoke test

### DIFF
--- a/awx/ui/test/e2e/tests/smoke.js
+++ b/awx/ui/test/e2e/tests/smoke.js
@@ -146,7 +146,7 @@ module.exports = {
         client.waitForElementVisible('div.spinny');
         client.waitForElementNotVisible('div.spinny');
 
-        client.expect.element('#hosts_tab').css('background-color').contain('132, 137, 146');
+        client.expect.element('#hosts_tab').css('background-color').contain('100, 105, 114');
 
         client.useCss();
         client.waitForElementVisible(addHost);


### PR DESCRIPTION
##### SUMMARY
we use color to detect an activated tab in the smoke test so we need to update these values
