### PR TITLE
Clean up unwanted data in activity stream of nodes

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -963,6 +963,9 @@ class LaunchTimeConfigBase(BaseModel):
         else:
             return self.extra_vars
 
+    def display_extra_data(self):
+        return self.display_extra_vars()
+
     @property
     def _credential(self):
         '''

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -506,7 +506,7 @@ def activity_stream_delete(sender, instance, **kwargs):
     _type = type(instance)
     if getattr(_type, '_deferred', False):
         return
-    changes.update(model_to_dict(instance))
+    changes.update(model_to_dict(instance, model_serializer_mapping))
     object1 = camelcase_to_underscore(instance.__class__.__name__)
     if type(instance) == OAuth2AccessToken:
         changes['token'] = CENSOR_VALUE


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/2820

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```

```


##### ADDITIONAL INFORMATION
There wound up being 2 components to this.

before:

```json
{
 "char_prompts": "{}",
 "created": "2018-11-28 14:20:24.125438+00:00",
 "extra_data": "{\"ffff\": \"hello mom\", \"bbbb\": \"$encrypted$UTF8$AESCBC$Z0FBQUFBQmJfcVFCbEp1NEg3bWd1QWduVFpvaFBDYTQxTExxRjBqdFNWbGt2c1JMdWdPa2tQbjFzVF8xVnZHUUN4RnU1X3d2Z2s4dHZES1ppdlhkaHVZbkZQNEh4MW0zS3c9PQ==\"}",
 "id": 554,
 "inventory": null,
 "modified": "2018-11-28 14:20:24.151095+00:00",
 "survey_passwords": "{\"bbbb\": \"$encrypted$\"}",
 "unified_job_template": "JobTemplate - password survey-36",
 "workflow_job_template": "alan enters a password WFJT@9:20:23 AM-402"
}
```

after:

```json
{
 "extra_data": "{\"bbbb\": \"$encrypted$\", \"ffff\": \"hello mom2\"}",
 "id": 556,
 "inventory": null,
 "unified_job_template": "JobTemplate - password survey-36",
 "workflow_job_template": "alan enters a password WFJT@10:19:36 AM-404"
}
```

Internal fields such as `id` and `survey_passwords` were being returned because the serializer reference was not being passed in the call to `model_to_dict`. This is also a semi-sensitive bug, which I did at the same time as adding in a method such that the corresponding `display_*` method expected by this logic in utils is present.