### PR TITLE
don't reap jobs that aren't running

### DIFF
--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -11,6 +11,9 @@ logger = logging.getLogger('awx.main.dispatch')
 
 
 def reap_job(j, status):
+    if UnifiedJob.objects.get(id=j.id).status not in ('running', 'waiting'):
+        # just in case, don't reap jobs that aren't running
+        return
     j.status = status
     j.start_args = ''  # blank field to remove encrypted passwords
     j.job_explanation += ' '.join((


### PR DESCRIPTION
this is a simple sanity check, but it should help us avoid shooting
ourselves in the foot in complicated scenarios, such as:

1.  A dispatcher worker is running a job, and it's killed with `kill -9`
2.  The dispatcher pool detects the missing worker and attempts to reap any jobs with a matching celery_task_id: https://github.com/ansible/awx/blob/7330102961f4704257bceea6575d995a1b09d059/awx/main/dispatch/pool.py#L342
3.  The associated sync project update has the **same** celery_task_id
    (an implementation detail of how we implemented that), and it ends
    up getting reaped _even though_ it's already finished and has
    status=successful