### PR TITLE
add additional DB retry logic to the callback receiver

### DIFF
--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -1,7 +1,5 @@
 import logging
 import time
-import os
-import signal
 import traceback
 
 from django.conf import settings
@@ -110,8 +108,7 @@ class CallbackBrokerWorker(BaseWorker):
                     break
                 except (OperationalError, InterfaceError, InternalError):
                     if retries >= self.MAX_RETRIES:
-                        logger.exception('Worker could not re-establish database connectivity, shutting down gracefully: Job {}'.format(job_identifier))
-                        os.kill(os.getppid(), signal.SIGINT)
+                        logger.exception('Worker could not re-establish database connectivity, giving up on event for Job {}'.format(job_identifier))
                         return
                     delay = 60 * retries
                     logger.exception('Database Error Saving Job Event, retry #{i} in {delay} seconds:'.format(

--- a/awx/main/dispatch/worker/task.py
+++ b/awx/main/dispatch/worker/task.py
@@ -5,7 +5,6 @@ import sys
 import traceback
 
 import six
-from django import db
 
 from awx.main.tasks import dispatch_startup, inform_cluster_of_shutdown
 
@@ -75,10 +74,6 @@ class TaskWorker(BaseWorker):
             'task': u'awx.main.tasks.RunProjectUpdate'
         }
         '''
-        for conn in db.connections.all():
-            # If the database connection has a hiccup during at task, close it
-            # so we can establish a new connection
-            conn.close_if_unusable_or_obsolete()
         result = None
         try:
             result = self.run_callable(body)


### PR DESCRIPTION
initially, I implemented this for _only_ the task worker, but it's
probably needed for callback event workers, too