### PR TITLE
resolve a nuanced traceback for JTs that run w/ a failed project

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1413,6 +1413,11 @@ class RunJob(BaseTask):
 
     def final_run_hook(self, job, status, **kwargs):
         super(RunJob, self).final_run_hook(job, status, **kwargs)
+        if 'private_data_dir' not in kwargs:
+            # If there's no private data dir, that means we didn't get into the
+            # actual `run()` call; this _usually_ means something failed in
+            # the pre_run_hook method
+            return
         if job.use_fact_cache:
             job.finish_job_fact_cache(
                 kwargs['private_data_dir'],


### PR DESCRIPTION
related: https://github.com/ansible/awx/pull/2719

![image](https://user-images.githubusercontent.com/214912/49251132-ba68da80-f3ee-11e8-89c4-c70d83e8144d.png)
