### PR TITLE
Updating e2e tests to match change in order layout

### DIFF
--- a/awx/ui/test/e2e/tests/test-templates-list-actions.js
+++ b/awx/ui/test/e2e/tests/test-templates-list-actions.js
@@ -176,8 +176,8 @@ module.exports = {
         client.expect.element('#node-1 text').text.not.equal('').after(5000);
         client.expect.element('#node-2 text').text.not.equal('').after(5000);
         client.expect.element('#node-3 text').text.not.equal('').after(5000);
-        client.expect.element('#node-4 text').text.not.equal('').after(5000);        
-
+        client.expect.element('#node-4 text').text.not.equal('').after(5000);
+        
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-job")]/..');
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-project")]/..');
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-inventory")]/..');

--- a/awx/ui/test/e2e/tests/test-templates-list-actions.js
+++ b/awx/ui/test/e2e/tests/test-templates-list-actions.js
@@ -177,7 +177,7 @@ module.exports = {
         client.expect.element('#node-2 text').text.not.equal('').after(5000);
         client.expect.element('#node-3 text').text.not.equal('').after(5000);
         client.expect.element('#node-4 text').text.not.equal('').after(5000);
-        
+
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-job")]/..');
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-project")]/..');
         client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-inventory")]/..');

--- a/awx/ui/test/e2e/tests/test-templates-list-actions.js
+++ b/awx/ui/test/e2e/tests/test-templates-list-actions.js
@@ -176,16 +176,11 @@ module.exports = {
         client.expect.element('#node-1 text').text.not.equal('').after(5000);
         client.expect.element('#node-2 text').text.not.equal('').after(5000);
         client.expect.element('#node-3 text').text.not.equal('').after(5000);
-        client.expect.element('#node-4 text').text.not.equal('').after(5000);
+        client.expect.element('#node-4 text').text.not.equal('').after(5000);        
 
-        const checkNodeText = (selector, text) => client.getText(selector, ({ value }) => {
-            client.assert.equal(text.indexOf(value.replace('...', '')) >= 0, true);
-        });
-
-        checkNodeText('#node-1 text', 'START');
-        checkNodeText('#node-3 text', data.project.name);
-        checkNodeText('#node-4 text', data.template.name);
-        checkNodeText('#node-2 text', data.source.name);
+        client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-job")]/..');
+        client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-project")]/..');
+        client.useXpath().waitForElementVisible('//*[contains(@class, "WorkflowChart-nameText") and contains(text(), "test-actions-inventory")]/..');
 
         templates.expect.element('@save').visible;
         templates.expect.element('@save').enabled;


### PR DESCRIPTION
##### SUMMARY
In the workflow-convergence branch, we changed the identifying element for workflow nodes on the visualizer. This test now just looks for the nodename instead of the associated node element-id.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION
When running the testsuite against two deployments:
``` OK. 61 assertions passed. (20.532s) OK. 91  total assertions passed. (41.696s)```