### PR TITLE
Fix instance group modal selection

### DIFF
--- a/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups-modal/instance-groups-modal.directive.js
+++ b/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups-modal/instance-groups-modal.directive.js
@@ -65,8 +65,13 @@ export default ['templateUrl', '$window', function(templateUrl, $window) {
                             $('#instance-groups-modal-body').append($compile(html)($scope));
 
                             if ($scope.instanceGroups) {
-                                $scope.instance_groups.map( (item) => {
-                                    isSelected(item);
+                                $scope.instanceGroups = $scope.instanceGroups.map( (item) => {
+                                    item.isSelected = true;
+                                    if (!$scope.igTags) {
+                                        $scope.igTags = [];
+                                    }
+                                    $scope.igTags.push(item);
+                                    return item;
                                 });
                             }
 
@@ -82,21 +87,9 @@ export default ['templateUrl', '$window', function(templateUrl, $window) {
                             });
                         });
                     });
-
             }
 
             init();
-
-            function isSelected(item) {
-                if(_.find($scope.instanceGroups, {id: item.id})){
-                    item.isSelected = true;
-                    if (!$scope.igTags) {
-                        $scope.igTags = [];
-                    }
-                    $scope.igTags.push(item);
-                }
-                return item;
-            }
 
             $scope.$on("selectedOrDeselected", function(e, value) {
                 let item = value.value;


### PR DESCRIPTION
##### SUMMARY
This PR addresses an issue where only instance groups on the first page of the instance group modal are "selected".

Default Organization has 15 instance groups, but only the groups on the first page of the lookup modal are selected. We were checking the resource's instance groups against the results returned from `/api/v2/instance_groups/?order_by=name&page=2&page_size=5`.

###### Bug
![ig br](https://user-images.githubusercontent.com/15881645/49298225-d0c47400-f48a-11e8-8892-29c7d125c511.gif)

###### Fixed Bug
![ig](https://user-images.githubusercontent.com/15881645/49301025-ab873400-f491-11e8-9fe0-d1f0d2af1dda.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
I verified this fixed the instance groups lookup modal for job templates, inventories, and organizations.
