### PR TITLE
Fix host_filter smart search bug when searching by "or" operator

### DIFF
--- a/awx/ui/client/src/shared/smart-search/queryset.service.js
+++ b/awx/ui/client/src/shared/smart-search/queryset.service.js
@@ -1,5 +1,7 @@
 function searchWithoutKey (term, singleSearchParam = null) {
-    if (singleSearchParam) {
+    if (singleSearchParam === 'host_filter') {
+        return { [singleSearchParam]: `${encodeURIComponent(term)}` };
+    } else if (singleSearchParam) {
         return { [singleSearchParam]: `search=${encodeURIComponent(term)}` };
     }
     return { search: encodeURIComponent(term) };
@@ -370,7 +372,8 @@ function QuerysetService ($q, Rest, ProcessErrors, $rootScope, Wait, DjangoSearc
         },
         getSearchInputQueryset (searchInput, isFilterableBaseField = null, isRelatedField = null, isAnsibleFactField = null, singleSearchParam = null) {
             // XXX Should find a better approach than passing in the two 'is...Field' callbacks XXX
-            const space = '%20and%20';
+            const encodedAnd = '%20and%20';
+            const encodedOr = '%20or%20';
             let params = {};
 
             // Remove leading/trailing whitespace if there is any
@@ -398,7 +401,13 @@ function QuerysetService ($q, Rest, ProcessErrors, $rootScope, Wait, DjangoSearc
                 }
 
                 if (singleSearchParam) {
-                    return `${a}${space}${b}`;
+                    if (b === 'or') {
+                        return `${a}${encodedOr}`;
+                    } else if (a.match(/%20or%20$/g)) {
+                        return `${a}${b}`;
+                    } else {
+                        return `${a}${encodedAnd}${b}`;
+                    }
                 }
 
                 return [a, b];


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/950

This PR partially fixes searching by "or" in the host modal smart search.  

I approached this issue with reservations because of the complexity and fragility of the smart search and queryset service code; applying a change here oftentimes introduces new bugs. To properly address this issue would mean either a "rewrite" of this portion of smart search, patching the existing code (which is difficult due to how tightly coupled it is), writing a separate search component for the smart host filter; all of which is not in the scope of this issue. 

This PR does not fix the tags generated by smart search or single tag deletion. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Example: Searching for group1_host1 or group2_host1 or group3_host1
![hosts](https://user-images.githubusercontent.com/15881645/49307637-c498e080-f4a3-11e8-8639-12a62293c70d.gif)

`name__icontains=group1_host1 or name__icontains=group2_host1 or name__contains=group3_host1`

```yaml
:method: GET
:path: /api/v2/hosts/?order_by=name&page_size=5&inventory__organization=1&host_filter=name__icontains=group1_host1%20or%20name__icontains=group2_host1%20or%20name__contains=group3_host1
```

------------

Example: Searching for (name=group1_host1 or name=group2_host1 or name=group3_host1) and (groups__name=GROUP1 or groups__name=GROUP2)

<img width="689" alt="screen shot 2018-11-30 at 12 14 35 pm" src="https://user-images.githubusercontent.com/15881645/49307893-9a93ee00-f4a4-11e8-9687-fa4fea5395dc.png">

`(name=group1_host1 or name=group2_host1 or name=group3_host1) (groups__name=GROUP1 or groups__name=GROUP2)`

```yaml
:method: GET
:path: /api/v2/hosts/?order_by=name&page_size=5&inventory__organization=1&host_filter=(name=group1_host1%20or%20name=group2_host1%20or%20name=group3_host1)%20and%20(groups__name=GROUP1%20or%20groups__name=GROUP2)
```