### PR TITLE
Add timeout & slice count to the job field whitelist.

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1389,7 +1389,7 @@ class JobTemplateAccess(BaseAccess):
             'job_tags', 'force_handlers', 'skip_tags', 'ask_variables_on_launch',
             'ask_tags_on_launch', 'ask_job_type_on_launch', 'ask_skip_tags_on_launch',
             'ask_inventory_on_launch', 'ask_credential_on_launch', 'survey_enabled',
-            'custom_virtualenv', 'diff_mode',
+            'custom_virtualenv', 'diff_mode', 'timeout', 'job_slice_count',
 
             # These fields are ignored, but it is convenient for QA to allow clients to post them
             'last_job_run', 'created', 'modified',


### PR DESCRIPTION
##### SUMMARY

Allow them to be set by JT admins even if they can't access the project/inventory/creds.

