### PR TITLE
Make docker environment interoperable with supervisorctl commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ supervisor:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	supervisord --configuration /supervisor.conf --pidfile=/tmp/supervisor_pid
+	supervisord --pidfile=/tmp/supervisor_pid
 
 # Alternate approach to tmux to run all development tasks specified in
 # Procfile.

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -63,6 +63,6 @@ CMD /start_development.sh
 RUN for dir in /var/lib/awx/ /projects /.ansible /var/log/nginx /var/lib/nginx /.local; \
   do mkdir -p $dir; chmod -R g+rwx $dir; chgrp -R root $dir; done
 
-RUN for file in /etc/passwd /supervisor.conf \
+RUN for file in /etc/passwd /etc/supervisord.conf \
   /venv/awx/lib/python2.7/site-packages/awx.egg-link /var/run/nginx.pid; \
   do touch $file; chmod -R g+rwx $file; chgrp -R root $file; done

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -28,7 +28,7 @@ else
 fi
 
 make awx-link
-yes | cp -rf /awx_devel/tools/docker-compose/supervisor.conf /supervisor.conf
+yes | cp -rf /awx_devel/tools/docker-compose/supervisor.conf /etc/supervisord.conf
 
 # AWX bootstrapping
 make version_file

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -3,7 +3,7 @@ umask = 022
 minfds = 4096
 nodaemon=true
 
-[program:dispatcher]
+[program:awx-dispatcher]
 command = awx-manage run_dispatcher
 autostart = true
 autorestart = true
@@ -11,7 +11,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:receiver]
+[program:awx-receiver]
 command = python manage.py run_callback_receiver
 autostart = true
 autorestart = true
@@ -19,7 +19,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:runworker]
+[program:awx-runworker]
 command = python manage.py runworker
 autostart = true
 autorestart = true
@@ -27,7 +27,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:uwsgi]
+[program:awx-uwsgi]
 command = make uwsgi
 autostart = true
 autorestart = true
@@ -35,7 +35,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:daphne]
+[program:awx-daphne]
 command = daphne -b 0.0.0.0 -p 8051 awx.asgi:channel_layer
 autostart = true
 autorestart = true
@@ -43,7 +43,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:nginx]
+[program:awx-nginx]
 command = nginx -g "daemon off;"
 autostart = true
 autorestart = true
@@ -51,7 +51,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[program:jupyter]
+[program:awx-jupyter]
 command = make jupyter
 autostart = true
 autorestart = true
@@ -59,8 +59,8 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
-[group:awx-processes]
-programs=dispatcher,receiver,runworker,uwsgi,daphne,nginx
+[group:tower-processes]
+programs=awx-dispatcher,awx-receiver,awx-runworker,awx-uwsgi,awx-daphne,awx-nginx
 priority=5
 
 [unix_http_server]


### PR DESCRIPTION
##### SUMMARY
This makes it so that `supervisorctl` commands that work in other environments will also work inside of the docker container environment.

```
supervisorctl start tower-processes:awx-dispatcher
```

I'm not particular about the names, I just want to use the same names that other environments use.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
I have tested this. The dev environment generally runs, for one.

I did not fully rebuild the container images, but I manually took the steps in the Dockerfile as root in the tools_awx_1 container. And also:

```
docker exec -it tools_awx_1 /bin/bash
bash-4.2$ supervisorctl status
awx-jupyter                      RUNNING   pid 258, uptime 0:00:18
tower-processes:awx-daphne       RUNNING   pid 252, uptime 0:00:18
tower-processes:awx-dispatcher   RUNNING   pid 257, uptime 0:00:18
tower-processes:awx-nginx        RUNNING   pid 251, uptime 0:00:18
tower-processes:awx-receiver     RUNNING   pid 255, uptime 0:00:18
tower-processes:awx-runworker    RUNNING   pid 253, uptime 0:00:18
tower-processes:awx-uwsgi        RUNNING   pid 250, uptime 0:00:18
```

The need to specify a config file location has been a major pain in the rear end, and I'm very happy to axe it. I don't know if this was only newly possible with the users in the containers?? not sure why I couldn't ever manager to get this to work before.

Anyway, this is needed to test restarting services and such in the docker environment.
