### PR TITLE
Show type in related_jobs, link based on type

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2983,12 +2983,13 @@ class JobTemplateMixin(object):
     '''
 
     def _recent_jobs(self, obj):
-        if hasattr(obj, 'workflow_jobs'):
-            job_mgr = obj.workflow_jobs
-        else:
-            job_mgr = obj.jobs
-        return [{'id': x.id, 'status': x.status, 'finished': x.finished}
-                for x in job_mgr.all().order_by('-created')[:10]]
+        job_mgr = obj.unifiedjob_unified_jobs.non_polymorphic().exclude(job__job_slice_count__gt=1).only(
+            'id', 'status', 'finished', 'polymorphic_ctype_id')
+        type_mapping = {}
+        for model, ct in ContentType.objects.get_for_models(*UnifiedJob.__subclasses__()).iteritems():
+            type_mapping[ct.pk] = model._meta.verbose_name
+        return [{'id': x.id, 'status': x.status, 'finished': x.finished, 'type': type_mapping[x.polymorphic_ctype_id]}
+                for x in job_mgr.order_by('-created')[:10]]
 
     def get_summary_fields(self, obj):
         d = super(JobTemplateMixin, self).get_summary_fields(obj)

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1276,6 +1276,7 @@ class JobTemplateAccess(BaseAccess):
         'instance_groups',
         'credentials__credential_type',
         Prefetch('labels', queryset=Label.objects.all().order_by('name')),
+        Prefetch('last_job', queryset=UnifiedJob.objects.non_polymorphic()),
     )
 
     def filtered_queryset(self):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -697,9 +697,9 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
     )
 
     def get_absolute_url(self, request=None):
-        real_instance = self.get_real_instance()
-        if real_instance != self:
-            return real_instance.get_absolute_url(request=request)
+        RealClass = self.get_real_instance_class()
+        if RealClass != UnifiedJob:
+            return RealClass.get_absolute_url(RealClass(pk=self.pk), request=request)
         else:
             return ''
 

--- a/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
@@ -71,11 +71,19 @@ class TestJobTemplateSerializerGetRelated():
 class TestJobTemplateSerializerGetSummaryFields():
     def test__recent_jobs(self, mocker, job_template, jobs):
 
-        job_template.jobs.all = mocker.MagicMock(**{'order_by.return_value': jobs})
-        job_template.jobs.all.return_value = job_template.jobs.all
+        job_template.unifiedjob_unified_jobs = mocker.MagicMock(**{
+            'non_polymorphic.return_value': mocker.MagicMock(**{
+                'only.return_value': mocker.MagicMock(**{
+                    'order_by.return_value': jobs
+                })
+            })
+        })
 
         serializer = JobTemplateSerializer()
         recent_jobs = serializer._recent_jobs(job_template)
+
+        job_template.unifiedjob_unified_jobs.non_polymorphic.assert_called_once_with()
+        job_template.unifiedjob_unified_jobs.non_polymorphic().only().order_by.assert_called_once_with('-created')
 
         job_template.jobs.all.assert_called_once_with()
         job_template.jobs.all.order_by.assert_called_once_with('-created')

--- a/awx/ui/client/src/smart-status/smart-status.controller.js
+++ b/awx/ui/client/src/smart-status/smart-status.controller.js
@@ -21,19 +21,16 @@ export default ['$scope', '$filter', 'i18n',
                 return;
             }
 
-            // unless we explicitly define a value for the template-type attribute when invoking the
-            // directive, assume the status icons are for a regular (non-workflow) job when building
-            // the details url path
-            if (typeof $scope.templateType !== 'undefined' && $scope.templateType === 'workflow_job_template') {
-                detailsBaseUrl = '/#/workflows/';
-            } else {
-                detailsBaseUrl = '/#/jobs/playbook/';
-            }
-
             var sparkData =
             _.sortBy(recentJobs.map(function(job) {
-
                 const finished = $filter('longDate')(job.finished) || job.status+"";
+
+                // We now get the job type of recent jobs associated with a JT
+                if (job.type === 'workflow job') {
+                    detailsBaseUrl = '/#/workflows/';
+                } else if (job.type === 'job') {
+                    detailsBaseUrl = '/#/jobs/playbook/';
+                }
 
                 const data = {
                     status: job.status,

--- a/awx/ui/client/src/smart-status/smart-status.controller.js
+++ b/awx/ui/client/src/smart-status/smart-status.controller.js
@@ -26,7 +26,7 @@ export default ['$scope', '$filter', 'i18n',
                 const finished = $filter('longDate')(job.finished) || job.status+"";
 
                 // We now get the job type of recent jobs associated with a JT
-                if (job.type === 'workflow job') {
+                if (job.type === 'workflow_job') {
                     detailsBaseUrl = '/#/workflows/';
                 } else if (job.type === 'job') {
                     detailsBaseUrl = '/#/jobs/playbook/';


### PR DESCRIPTION
##### SUMMARY
This filters out joblets in the recent jobs of a job template

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
The new SQL for generating the recent jobs list:

```sql
SELECT "main_unifiedjob"."id", 
       "main_unifiedjob"."polymorphic_ctype_id", 
       "main_unifiedjob"."created", 
       "main_unifiedjob"."modified", 
       "main_unifiedjob"."description", 
       "main_unifiedjob"."created_by_id", 
       "main_unifiedjob"."modified_by_id", 
       "main_unifiedjob"."name", 
       "main_unifiedjob"."old_pk", 
       "main_unifiedjob"."emitted_events", 
       "main_unifiedjob"."unified_job_template_id", 
       "main_unifiedjob"."launch_type", 
       "main_unifiedjob"."schedule_id", 
       "main_unifiedjob"."execution_node", 
       "main_unifiedjob"."controller_node", 
       "main_unifiedjob"."cancel_flag", 
       "main_unifiedjob"."status", 
       "main_unifiedjob"."failed", 
       "main_unifiedjob"."started", 
       "main_unifiedjob"."finished", 
       "main_unifiedjob"."elapsed", 
       "main_unifiedjob"."job_args", 
       "main_unifiedjob"."job_cwd", 
       "main_unifiedjob"."job_env", 
       "main_unifiedjob"."job_explanation", 
       "main_unifiedjob"."start_args", 
       "main_unifiedjob"."result_traceback", 
       "main_unifiedjob"."celery_task_id", 
       "main_unifiedjob"."instance_group_id" 
FROM   "main_unifiedjob" 
       LEFT OUTER JOIN "main_job" 
                    ON ( "main_unifiedjob"."id" = 
                       "main_job"."unifiedjob_ptr_id" ) 
WHERE  ( "main_unifiedjob"."unified_job_template_id" = 350 
         AND NOT ( "main_job"."job_slice_count" > 1 
                   AND "main_job"."job_slice_count" IS NOT NULL ) ) 
ORDER  BY "main_unifiedjob"."created" DESC 
LIMIT  10 
```

We did lose something due to a weird polymorphic issue - it won't let me use `.only` in combination with the `.exclude` filter (without grabbing real instances again). I think this is _probably_ a Django polymorphic bug.

Anyway, we didn't used to have the only, so I guess this is probably okay. It doesn't affect the indexing.

Also, since this hits on the same logic, I used the same trick to get the model from the unified model for the `last_job`. This brings the query count down to around 40 for my dataset (25 are unavoidable due to recent jobs not being prefetchable).

One recent_jobs fetching:

https://explain.depesz.com/s/AQS