### PR TITLE
more sane default log handlers

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1116,11 +1116,11 @@ LOGGING = {
             'handlers': ['console'],
         },
         'django.request': {
-            'handlers': ['mail_admins', 'console', 'file', 'tower_warnings'],
+            'handlers': ['console', 'file', 'tower_warnings'],
             'level': 'WARNING',
         },
         'rest_framework.request': {
-            'handlers': ['mail_admins', 'console', 'file', 'tower_warnings'],
+            'handlers': ['console', 'file', 'tower_warnings'],
             'level': 'WARNING',
             'propagate': False,
         },


### PR DESCRIPTION
* Removed the emailing of admins on request error. When turned on, the
handler will include all django settings in the email. This is not
desirable from a security standpoint.
