### PR TITLE
Fix links to some resources that lack v1 pages

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4934,10 +4934,6 @@ class ActivityStreamSerializer(BaseSerializer):
 
     def get_related(self, obj):
         rel = {}
-        VIEW_NAME_EXCEPTIONS = {
-            'custom_inventory_script': 'inventory_script_detail',
-            'o_auth2_access_token': 'o_auth2_token_detail'
-        }
         if obj.actor is not None:
             rel['actor'] = self.reverse('api:user_detail', kwargs={'pk': obj.actor.pk})
         for fk, __ in self._local_summarizable_fk_fields:
@@ -4951,11 +4947,12 @@ class ActivityStreamSerializer(BaseSerializer):
                     if getattr(thisItem, 'id', None) in id_list:
                         continue
                     id_list.append(getattr(thisItem, 'id', None))
-                    if fk in VIEW_NAME_EXCEPTIONS:
-                        view_name = VIEW_NAME_EXCEPTIONS[fk]
+                    if hasattr(thisItem, 'get_absolute_url'):
+                        rel_url = thisItem.get_absolute_url(self.context.get('request'))
                     else:
                         view_name = fk + '_detail'
-                    rel[fk].append(self.reverse('api:' + view_name, kwargs={'pk': thisItem.id}))
+                        rel_url = self.reverse('api:' + view_name, kwargs={'pk': thisItem.id})
+                    rel[fk].append(rel_url)
 
                     if fk == 'schedule':
                         rel['unified_job_template'] = thisItem.unified_job_template.get_absolute_url(self.context.get('request'))

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -134,6 +134,9 @@ User.add_to_class('is_in_enterprise_category', user_is_in_enterprise_category)
 
 
 def o_auth2_application_get_absolute_url(self, request=None):
+    # this page does not exist in v1
+    if request.version == 'v1':
+        return reverse('api:o_auth2_application_detail', kwargs={'pk': self.pk})  # use default version
     return reverse('api:o_auth2_application_detail', kwargs={'pk': self.pk}, request=request)
 
 
@@ -141,6 +144,9 @@ OAuth2Application.add_to_class('get_absolute_url', o_auth2_application_get_absol
 
 
 def o_auth2_token_get_absolute_url(self, request=None):
+    # this page does not exist in v1
+    if request.version == 'v1':
+        return reverse('api:o_auth2_token_detail', kwargs={'pk': self.pk})  # use default version
     return reverse('api:o_auth2_token_detail', kwargs={'pk': self.pk}, request=request)
 
 

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -479,6 +479,9 @@ class CredentialType(CommonModelNameNotUnique):
     )
 
     def get_absolute_url(self, request=None):
+        # Page does not exist in API v1
+        if request.version == 'v1':
+            return reverse('api:credential_type_detail', kwargs={'pk': self.pk})
         return reverse('api:credential_type_detail', kwargs={'pk': self.pk}, request=request)
 
     @property


### PR DESCRIPTION
##### SUMMARY
Tokens and applications don't have v1 pages. So we cannot link to them

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
I did test custom inventory scripts with this

also note the disconnect v1 / v2:

```json
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 25166,
            "type": "activity_stream",
            "url": "/api/v1/activity_stream/25166/",
            "related": {
                "o_auth2_application": [
                    "/api/v2/applications/1/"
                ],
                "actor": "/api/v1/users/1/"
            },
            "summary_fields": {
                "o_auth2_application": [
                    {
                        "description": "",
                        "id": 1,
                        "name": "fefefe"
                    }
                ],
                "actor": {
                    "username": "admin",
                    "first_name": "",
                    "last_name": "",
                    "id": 1
                }
            },
            "timestamp": "2018-12-06T13:25:15.772347Z",
            "operation": "create",
            "changes": {
                "redirect_uris": "",
                "description": "",
                "name": "fefefe",
                "client_type": "public",
                "organization": "Organization - AbuseTeach燁-52",
                "skip_authorization": false,
                "id": 1,
                "authorization_grant_type": "password"
            },
            "object1": "o_auth2_application",
            "object2": "",
            "object_association": ""
        }
    ]
}
```
