### PR TITLE
Fixes bug launching jt where first survey question is optional and empty

### DIFF
--- a/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
@@ -49,11 +49,11 @@ export default
 
                 if (scope.promptData.launchConf.survey_enabled){
                     scope.promptData.surveyQuestions.forEach(surveyQuestion => {
+                        if (!scope.promptData.extraVars) {
+                            scope.promptData.extraVars = {};
+                        }
                         // grab all survey questions that have answers
                         if (surveyQuestion.required || (surveyQuestion.required === false && surveyQuestion.model.toString()!=="")) {
-                            if (!scope.promptData.extraVars) {
-                                scope.promptData.extraVars = {};
-                            }
                             scope.promptData.extraVars[surveyQuestion.variable] = surveyQuestion.model;
                         }
 


### PR DESCRIPTION
##### SUMMARY
This fixes a bug where configuring and then launching a JT with an optional first question would throw JS error and launch without any extra vars.  We need to initialize `extraVars` regardless of whether or not the first question is required.  This PR addresses that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
2.1.1
