### PR TITLE
Allow SCM overwrite vars in the UI

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/add/sources-add.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/add/sources-add.controller.js
@@ -185,10 +185,6 @@ export default ['$state', '$stateParams', '$scope', 'SourcesFormDefinition',
 
             if (source === 'scm') {
                 $scope.projectBasePath = GetBasePath('projects')  + '?not__status=never updated';
-                $scope.overwrite_vars = true;
-                $scope.inventory_source_form.inventory_file.$setPristine();
-            } else {
-                $scope.overwrite_vars = false;
             }
 
             // reset fields
@@ -201,6 +197,7 @@ export default ['$state', '$stateParams', '$scope', 'SourcesFormDefinition',
             $scope.credential_name = null;
             $scope.group_by = null;
             $scope.group_by_choices = [];
+            $scope.overwrite_vars = false;
             initRegionSelect();
         };
         // region / source options callback

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
@@ -392,13 +392,6 @@ export default ['$state', '$stateParams', '$scope', 'ParseVariableString',
                 });
             }
 
-            if (source === 'scm') {
-              $scope.overwrite_vars = true;
-              $scope.inventory_source_form.inventory_file.$setPristine();
-            } else {
-              $scope.overwrite_vars = false;
-            }
-
             // reset fields
             $scope.group_by_choices = source === 'ec2' ? $scope.ec2_group_by : null;
             // azure_rm regions choices are keyed as "azure" in an OPTIONS request to the inventory_sources endpoint
@@ -409,6 +402,7 @@ export default ['$state', '$stateParams', '$scope', 'ParseVariableString',
             $scope.credential_name = null;
             $scope.group_by = null;
             $scope.group_by_choices = [];
+            $scope.overwrite_vars = false;
 
             initRegionSelect();
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
@@ -367,7 +367,7 @@ return {
                 dataTitle: i18n._('Overwrite Variables'),
                 dataContainer: 'body',
                 dataPlacement: 'right',
-                ngDisabled: "(!(inventory_source_obj.summary_fields.user_capabilities.edit || canAdd) || source.value === 'scm')"
+                ngDisabled: "(!(inventory_source_obj.summary_fields.user_capabilities.edit || canAdd))"
             }, {
                 name: 'update_on_launch',
                 label: i18n._('Update on Launch'),


### PR DESCRIPTION
##### SUMMARY
This implements the UI change to allow users to click the box mentioned in the issue.

https://github.com/ansible/awx/issues/1271

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
![screen shot 2018-12-10 at 7 02 14 am](https://user-images.githubusercontent.com/1385596/49732009-277c3b80-fc4b-11e8-95b5-041bfcb990f2.png)

saved it, re-checked, and it's still checked. Tested adding vs. editing flow.
