### PR TITLE
Copy WFJT created_by to jobs it spawns

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1374,14 +1374,13 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
 
         created_by = getattr_dne(self, 'created_by')
 
-        if not created_by:
-            wj = self.get_workflow_job()
-            if wj:
-                for name in ('awx', 'tower'):
-                    r['{}_workflow_job_id'.format(name)] = wj.pk
-                    r['{}_workflow_job_name'.format(name)] = wj.name
-                created_by = getattr_dne(wj, 'created_by')
+        wj = self.get_workflow_job()
+        if wj:
+            for name in ('awx', 'tower'):
+                r['{}_workflow_job_id'.format(name)] = wj.pk
+                r['{}_workflow_job_name'.format(name)] = wj.name
 
+        if not created_by:
             schedule = getattr_dne(self, 'schedule')
             if schedule:
                 for name in ('awx', 'tower'):

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -276,6 +276,8 @@ class WorkflowJobNode(WorkflowNodeBase):
             data['extra_vars'] = extra_vars
         # ensure that unified jobs created by WorkflowJobs are marked
         data['_eager_fields'] = {'launch_type': 'workflow'}
+        if self.workflow_job and self.workflow_job.created_by:
+            data['_eager_fields']['created_by'] = self.workflow_job.created_by
         # Extra processing in the case that this is a slice job
         if 'job_slice' in self.ancestor_artifacts and is_root_node:
             data['_eager_fields']['allow_simultaneous'] = True

--- a/awx/main/tests/functional/models/test_unified_job.py
+++ b/awx/main/tests/functional/models/test_unified_job.py
@@ -112,15 +112,15 @@ class TestMetaVars:
         for key in user_vars:
             assert key not in job.awx_meta_vars()
 
-    def test_workflow_job_metavars(self, admin_user):
+    def test_workflow_job_metavars(self, admin_user, job_template):
         workflow_job = WorkflowJob.objects.create(
             name='workflow-job',
             created_by=admin_user
         )
-        job = Job.objects.create(
-            name='fake-job',
-            launch_type='workflow'
-        )
+        node = workflow_job.workflow_nodes.create(unified_job_template=job_template)
+        job_kv = node.get_job_kwargs()
+        job = node.unified_job_template.create_unified_job(**job_kv)
+
         workflow_job.workflow_nodes.create(job=job)
         data = job.awx_meta_vars()
         assert data['awx_user_id'] == admin_user.id


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/2896

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Before this change, and then relaunched after this change

<img width="1185" alt="screen shot 2018-12-10 at 11 26 41 am" src="https://user-images.githubusercontent.com/1385596/49746348-fdd50b80-fc6e-11e8-83a8-d4a71f14e786.png">

you can see the launched by field is copied after this change.
