### PR TITLE
tower-cli config: host value needs to be URL

### DIFF
--- a/DATA_MIGRATION.md
+++ b/DATA_MIGRATION.md
@@ -18,7 +18,7 @@ $ pip install --upgrade ansible-tower-cli
 
 The AWX host URL, user, and password must be set for the AWX instance to be exported:
 ```
-$ tower-cli config host <old-awx-host.example.com>
+$ tower-cli config host http://<old-awx-host.example.com>
 $ tower-cli config username <user>
 $ tower-cli config password <pass>
 ```
@@ -62,7 +62,7 @@ For other install methods, refer to the [Install.md](https://github.com/ansible/
 Configure tower-cli for your new AWX host as shown earlier.  Import from a JSON file named assets.json
 
 ```
-$ tower-cli config host <new-awx-host.example.com>
+$ tower-cli config host http://<new-awx-host.example.com>
 $ tower-cli config username <user>
 $ tower-cli config password <pass>
 $ tower-cli send assets.json


### PR DESCRIPTION
Since the key name "host" is slightly misleading, it would help to point out in this documentation, that in fact an URL is required for that key/value pair "host" in the tower-cli config. 

Failing to do so drops the follwing error:

```
Error: There was a network error of some kind trying to connect to Tower.
The most common  reason for this is a settings issue; is your "host" value in `tower-cli config` correct?
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
tower-cli documentation

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
2.1.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
