### PR TITLE
Catch python error when unable to find user

### DIFF
--- a/awx/settings/local_settings.py.docker_compose
+++ b/awx/settings/local_settings.py.docker_compose
@@ -267,7 +267,10 @@ TEST_SVN_PRIVATE_HTTPS = 'https://github.com/ansible/product-docs'
 
 # To test repo access via SSH login to localhost.
 import getpass
-TEST_SSH_LOOPBACK_USERNAME = getpass.getuser()
+try:
+    TEST_SSH_LOOPBACK_USERNAME = getpass.getuser()
+except KeyError:
+    TEST_SSH_LOOPBACK_USERNAME = 'root'
 TEST_SSH_LOOPBACK_PASSWORD = ''
 
 ###############################################################################


### PR DESCRIPTION
##### SUMMARY
I need to be able to run commands in containers as root, and with the recent container permission changes this was failing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Shell into node in cluster as root

```
docker exec --user=0 -it tools_awx_1_1 /bin/bash
```

then management commands don't work

```
bash-4.2# awx-manage
Traceback (most recent call last):
  File "/usr/local/bin/awx-manage", line 9, in <module>
    load_entry_point('awx', 'console_scripts', 'awx-manage')()
  File "/awx_devel/awx/__init__.py", line 134, in manage
    prepare_env()
  File "/awx_devel/awx/__init__.py", line 89, in prepare_env
    if not settings.DEBUG: # pragma: no cover
  File "/venv/awx/lib/python2.7/site-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/venv/awx/lib/python2.7/site-packages/django/conf/__init__.py", line 41, in _setup
    self._wrapped = Settings(settings_module)
  File "/venv/awx/lib/python2.7/site-packages/django/conf/__init__.py", line 110, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/awx_devel/awx/settings/development.py", line 138, in <module>
    include(optional('local_*.py'), scope=locals())
  File "/venv/awx/lib/python2.7/site-packages/split_settings/tools.py", line 102, in include
    exec(compile(to_compile.read(), included_file, 'exec'), scope)
  File "/awx_devel/awx/settings/local_settings.py", line 274, in <module>
    TEST_SSH_LOOPBACK_USERNAME = getpass.getuser()
  File "/usr/lib64/python2.7/getpass.py", line 158, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 0'
```

The use of this setting is for tests

https://github.com/ansible/awx/commit/acc974289fe74804967e772ccd88ae246992dd39

Those tests no longer exist, we could delete the entire section of the settings, but right now I just want it to not error.

The root appears to be that there is no entry for the root user in `/etc/passwd`, https://github.com/cms-dev/isolate/issues/25... I don't really want to dive into that either.
