### PR TITLE
Fix slack "not_in_channel" error when using colors

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -37,7 +37,6 @@ class SlackBackend(AWXBaseEmailBackend):
                     if self.color:
                         ret = connection.api_call("chat.postMessage",
                                                   channel=r,
-                                                  as_user=True,
                                                   attachments=[{
                                                       "color": self.color,
                                                       "text": m.subject


### PR DESCRIPTION
When using colors in the slack notifications, the API was returning a "not_in_channel" error. The "as_user" option is meant to allow authoring of messages as a non-bot user. However, the way the slack notification works is explicitly with a bot user, so the "as_user" flag was causing the "not_in_channel" error.

##### SUMMARY
When trying to use slack notifications, if "color" is defined, the API would error with "not_in_channel". This is due to the "as_user" flag being passed when using a slack bot account.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
slack notifications
 - UI

##### AWX VERSION
```2.7.4```