### PR TITLE
Fix typo in ca_trust_dir

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -120,7 +120,7 @@ secret_key=awxsecret
 # this variable causes this directory on the host to be bind mounted over
 # /etc/pki/ca-trust in the awx_task and awx_web containers.
 # NOTE: only obeyed in local_docker install
-#ca_trust_dir=/etc/pki/ca-trust/source/anchor
+#ca_trust_dir=/etc/pki/ca-trust/source/anchors
 
 # Include /etc/nginx/awx_extra.conf
 # Note the use of glob pattern for nginx


### PR DESCRIPTION
The correct path is used in docker-compose template:
- "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"

##### SUMMARY
Small typo fix, it's anchors, not anchor

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 2.1.2
```