### PR TITLE
Optimize dashboard using Django annotation for sum

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -18,7 +18,7 @@ import six
 # Django
 from django.conf import settings
 from django.core.exceptions import FieldError, ObjectDoesNotExist
-from django.db.models import Q
+from django.db.models import Q, Sum
 from django.db import IntegrityError, transaction, connection
 from django.shortcuts import get_object_or_404
 from django.utils.safestring import mark_safe
@@ -173,7 +173,7 @@ class DashboardView(APIView):
         user_inventory = get_user_queryset(request.user, Inventory)
         inventory_with_failed_hosts = user_inventory.filter(hosts_with_active_failures__gt=0)
         user_inventory_external = user_inventory.filter(has_inventory_sources=True)
-        failed_inventory = sum(i.inventory_sources_with_failures for i in user_inventory)
+        failed_inventory = user_inventory.aggregate(Sum('inventory_sources_with_failures'))['inventory_sources_with_failures__sum']
         data['inventories'] = {'url': reverse('api:inventory_list', request=request),
                                'total': user_inventory.count(),
                                'total_with_inventory_source': user_inventory_external.count(),


### PR DESCRIPTION
##### SUMMARY
Previously, this was loading all inventory sources with active failures into memory, and because of that, it was the slowest query shown by Django debug toolbar. This is not at all necessary, but may have been written before Django annotations were available?

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Tested that count is the same. New query:

```sql
SELECT
   SUM("main_inventory"."inventory_sources_with_failures") AS "inventory_sources_with_failures__sum" 
FROM
   "main_inventory"
```

old query:

```sql
SELECT
   "main_inventory"."id",
   "main_inventory"."created",
   "main_inventory"."modified",
   "main_inventory"."description",
   "main_inventory"."created_by_id",
   "main_inventory"."modified_by_id",
   "main_inventory"."name",
   "main_inventory"."organization_id",
   "main_inventory"."variables",
   "main_inventory"."has_active_failures",
   "main_inventory"."total_hosts",
   "main_inventory"."hosts_with_active_failures",
   "main_inventory"."total_groups",
   "main_inventory"."groups_with_active_failures",
   "main_inventory"."has_inventory_sources",
   "main_inventory"."total_inventory_sources",
   "main_inventory"."inventory_sources_with_failures",
   "main_inventory"."kind",
   "main_inventory"."host_filter",
   "main_inventory"."admin_role_id",
   "main_inventory"."update_role_id",
   "main_inventory"."adhoc_role_id",
   "main_inventory"."use_role_id",
   "main_inventory"."read_role_id",
   "main_inventory"."insights_credential_id",
   "main_inventory"."pending_deletion",
   "auth_user"."id",
   "auth_user"."password",
   "auth_user"."last_login",
   "auth_user"."is_superuser",
   "auth_user"."username",
   "auth_user"."first_name",
   "auth_user"."last_name",
   "auth_user"."email",
   "auth_user"."is_staff",
   "auth_user"."is_active",
   "auth_user"."date_joined",
   T3."id",
   T3."password",
   T3."last_login",
   T3."is_superuser",
   T3."username",
   T3."first_name",
   T3."last_name",
   T3."email",
   T3."is_staff",
   T3."is_active",
   T3."date_joined",
   "main_organization"."id",
   "main_organization"."created",
   "main_organization"."modified",
   "main_organization"."description",
   "main_organization"."created_by_id",
   "main_organization"."modified_by_id",
   "main_organization"."name",
   "main_organization"."custom_virtualenv",
   "main_organization"."admin_role_id",
   "main_organization"."execute_role_id",
   "main_organization"."project_admin_role_id",
   "main_organization"."inventory_admin_role_id",
   "main_organization"."credential_admin_role_id",
   "main_organization"."workflow_admin_role_id",
   "main_organization"."notification_admin_role_id",
   "main_organization"."job_template_admin_role_id",
   "main_organization"."auditor_role_id",
   "main_organization"."member_role_id",
   "main_organization"."read_role_id" 
FROM
   "main_inventory" 
   LEFT OUTER JOIN
      "auth_user" 
      ON ("main_inventory"."created_by_id" = "auth_user"."id") 
   LEFT OUTER JOIN
      "auth_user" T3 
      ON ("main_inventory"."modified_by_id" = T3."id") 
   LEFT OUTER JOIN
      "main_organization" 
      ON ("main_inventory"."organization_id" = "main_organization"."id") 
ORDER BY
   "main_inventory"."name" ASC
```
