### PR TITLE
adds wait time for postgres setup as a variable

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -42,3 +42,5 @@ openshift_pg_pvc_name: postgresql
 kubernetes_deployment_name: awx
 
 kubernetes_deployment_replica_size: 1
+
+postgress_activate_wait: 60

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -103,7 +103,7 @@
 
 - name: Wait for Postgres to activate
   pause:
-    seconds: 60
+    seconds: "{{ postgress_activate_wait }}"
   when: openshift_pg_activate.changed or kubernetes_pg_activate.changed
 
 - name: Set image names if using custom registry


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I ran into an issue where on some occasions the setup of the postgress database took longer than 60 seconds to complete. This sets the wait time to be a variable to help in situations where setup time may be more than 60 seconds.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 2.1.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
