### PR TITLE
related #2991 - Helm creation of postgreql on multiple namespaces

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -80,7 +80,8 @@
 
 - name: Deploy and Activate Postgres (Kubernetes)
   shell: |
-    helm upgrade --install --name {{ postgresql_service_name }} \
+    helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
+    helm upgrade {{ postgresql_service_name }} --install \
       --namespace {{ kubernetes_namespace }} \
       --set postgresqlUsername={{ pg_username }} \
       --set postgresqlPassword={{ pg_password }} \

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -80,7 +80,8 @@
 
 - name: Deploy and Activate Postgres (Kubernetes)
   shell: |
-    helm install --name {{ kubernetes_deployment_name }} --namespace {{ kubernetes_namespace }} \
+    helm upgrade --install --name {{ kubernetes_namespace }}-{{ kubernetes_deployment_name }} \
+      --namespace {{ kubernetes_namespace }} \
       --set postgresqlUsername={{ pg_username }} \
       --set postgresqlPassword={{ pg_password }} \
       --set postgresqlDatabase={{ pg_database }} \

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -53,13 +53,13 @@
 
 - name: Deploy PostgreSQL (OpenShift)
   block:
-    - name: Template PostgreSQL Deployment
+    - name: Template PostgreSQL Deployment (OpenShift)
       template:
         src: postgresql-persistent.yml.j2
         dest: "{{ kubernetes_base_path }}/postgresql-persistent.yml"
         mode: '0600'
 
-    - name: Deploy and Activate Postgres
+    - name: Deploy and Activate Postgres (OpenShift)
       shell: |
         {{ openshift_oc_bin }} new-app --file={{ kubernetes_base_path }}/postgresql-persistent.yml \
           -e MEMORY_LIMIT={{ pg_memory_limit|default('512') }}Mi \
@@ -80,7 +80,7 @@
 
 - name: Deploy and Activate Postgres (Kubernetes)
   shell: |
-    helm upgrade --install --name {{ kubernetes_namespace }}-{{ kubernetes_deployment_name }} \
+    helm upgrade --install --name {{ postgresql_service_name }} \
       --namespace {{ kubernetes_namespace }} \
       --set postgresqlUsername={{ pg_username }} \
       --set postgresqlPassword={{ pg_password }} \
@@ -95,9 +95,9 @@
   register: kubernetes_pg_activate
   no_log: yes
 
-- name: Set postgresql hostname to helm package service
+- name: Set postgresql hostname to helm package service (Kubernetes)
   set_fact:
-    pg_hostname: "{{ kubernetes_deployment_name }}-postgresql"
+    pg_hostname: "{{ postgresql_service_name }}"
   when:
     - pg_hostname is not defined or pg_hostname == ''
     - kubernetes_context is defined

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -98,7 +98,7 @@
 
 - name: Set postgresql hostname to helm package service (Kubernetes)
   set_fact:
-    pg_hostname: "{{ postgresql_service_name }}"
+    pg_hostname: "{{ postgresql_service_name }}-postgresql"
   when:
     - pg_hostname is not defined or pg_hostname == ''
     - kubernetes_context is defined

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -87,6 +87,7 @@
       --set postgresqlPassword={{ pg_password }} \
       --set postgresqlDatabase={{ pg_database }} \
       --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
+      --version="2.0.0" \
       --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
       stable/postgresql
   when:


### PR DESCRIPTION
make Helm creation of postgreql succeed when installing multiple AWX on different namespaces on same kubernetes

Signed-off-by: Fabrice Flore-Thebault <themr0c@users.noreply.github.com>

##### SUMMARY

related #2991

make Helm creation of postgreql succeed when installing multiple AWX on different namespaces on same kubernetes. (Usecase example: setup 2 AWX instances on the same kubernetes to upgrade AWX).

Make sure the name is unique, making it a concatenation of `kubernetes_namespace` and `kubernetes_deployment_name`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION

```
2.1.2
```


##### ADDITIONAL INFORMATION

I additionally replaced `helm install` which can run once an then fails, with the idempotent version of the same action: `helm upgrade --install`