### PR TITLE
pg_password should be random 10 character alphanumeric string, when p…

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -64,7 +64,8 @@ docker_compose_dir=/var/lib/awx
 # a new postgres service will be created
 # pg_hostname=postgresql
 pg_username=awx
-# password should be random 10 character alphanumeric string, when postgresql is running on kubernetes
+# pg_password should be random 10 character alphanumeric string, when postgresql is running on kubernetes
+# NB: it's a limitation of the "official" postgres helm chart
 pg_password=awxpass
 pg_database=awx
 pg_port=5432

--- a/installer/inventory
+++ b/installer/inventory
@@ -64,6 +64,7 @@ docker_compose_dir=/var/lib/awx
 # a new postgres service will be created
 # pg_hostname=postgresql
 pg_username=awx
+# password should be random 10 character alphanumeric string, when postgresql is running on kubernetes
 pg_password=awxpass
 pg_database=awx
 pg_port=5432


### PR DESCRIPTION
…ostgresql is running on kubernetes

Signed-off-by: Fabrice Flore-Thebault <themr0c@users.noreply.github.com>

##### SUMMARY

As stated in https://github.com/helm/charts/tree/master/stable/postgresql: 
postgresqlPassword | PostgreSQL admin password | random 10 character alphanumeric string

The 10 character limit for `pg_password` (when using kubernetes) should be documented at least in the inventory file.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

```
devel
```


##### ADDITIONAL INFORMATION

When `pg_password` is set with a longer password, helm does not complain but the database is not created.

Depends-on: https://github.com/ansible/awx/pull/2999