### PR TITLE
skip chromium download when using ui-release make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ __pycache__
 # UI build flag files
 awx/ui/.deps_built
 awx/ui/.release_built
+awx/ui/.release_deps_built
 
 # Testing
 .cache


### PR DESCRIPTION
##### SUMMARY
We use puppeteer to run unit tests and puppeteer depends on chromium. Since we generally don't run unit tests in the same environment we build releases, we can skip the ~100mb download for the `ui-release` make target.