### PR TITLE
close the persistent shelve when we're done checking it

### DIFF
--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -87,6 +87,11 @@ class Command(BaseCommand):
         except Exception:
             logger.exception('{} is corrupted, removing.'.format(sched_file))
             sched._remove_db()
+        finally:
+            try:
+                sched.close()
+            except Exception:
+                logger.exception('{} failed to sync/close'.format(sched_file))
 
         beat.Beat(
             30,


### PR DESCRIPTION
this code was added to detect celerybeat shelve .db corruption, but it caused a different issue; opening the shelve in this way puts a write lock on it, which means that when we attempt to open it _again_ moments later, we can't.

when we're done checking the validity of the file, we need to close it