### PR TITLE
add input access methods to credentials

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4334,7 +4334,7 @@ class JobLaunchSerializer(BaseSerializer):
                             passwords_needed=cred.passwords_needed
                         )
                         if cred.credential_type.managed_by_tower and 'vault_id' in cred.credential_type.defined_fields:
-                            cred_dict['vault_id'] = cred.inputs.get('vault_id') or None
+                            cred_dict['vault_id'] = cred.get_input('vault_id', default=None)
                         defaults_dict.setdefault(field_name, []).append(cred_dict)
             else:
                 defaults_dict[field_name] = getattr(obj, field_name)

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -70,7 +70,6 @@ from awx.main.models import * # noqa
 from awx.main.utils import * # noqa
 from awx.main.utils import (
     extract_ansible_vars,
-    decrypt_field,
 )
 from awx.main.utils.encryption import encrypt_value
 from awx.main.utils.filters import SmartFilter
@@ -1592,7 +1591,7 @@ class HostInsights(GenericAPIView):
     serializer_class = EmptySerializer
 
     def _extract_insights_creds(self, credential):
-        return (credential.inputs['username'], decrypt_field(credential, 'password'))
+        return (credential.get_input('username', default=''), credential.get_input('password', default=''))
 
     def _get_insights(self, url, username, password):
         session = requests.Session()

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -166,8 +166,8 @@ class ProjectOptions(models.Model):
                                          check_special_cases=False)
                 scm_url_parts = urlparse.urlsplit(scm_url)
                 # Prefer the username/password in the URL, if provided.
-                scm_username = scm_url_parts.username or cred.username or ''
-                if scm_url_parts.password or cred.password:
+                scm_username = scm_url_parts.username or cred.get_input('username', default='')
+                if scm_url_parts.password or cred.has_input('password'):
                     scm_password = '********'
                 else:
                     scm_password = ''

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -108,13 +108,16 @@ def test_safe_env_returns_new_copy():
 
 def test_openstack_client_config_generation(mocker):
     update = tasks.RunInventoryUpdate()
-    credential = mocker.Mock(**{
+    credential_type = CredentialType.defaults['openstack']()
+    inputs = {
         'host': 'https://keystone.openstack.example.org',
         'username': 'demo',
         'password': 'secrete',
         'project': 'demo-project',
         'domain': 'my-demo-domain',
-    })
+    }
+    credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
+
     cred_method = mocker.Mock(return_value=credential)
     inventory_update = mocker.Mock(**{
         'source': 'openstack',
@@ -144,13 +147,16 @@ def test_openstack_client_config_generation(mocker):
 ])
 def test_openstack_client_config_generation_with_private_source_vars(mocker, source, expected):
     update = tasks.RunInventoryUpdate()
-    credential = mocker.Mock(**{
+    credential_type = CredentialType.defaults['openstack']()
+    inputs = {
         'host': 'https://keystone.openstack.example.org',
         'username': 'demo',
         'password': 'secrete',
         'project': 'demo-project',
         'domain': None,
-    })
+    }
+    credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
+
     cred_method = mocker.Mock(return_value=credential)
     inventory_update = mocker.Mock(**{
         'source': 'openstack',


### PR DESCRIPTION
- [x] update unit tests
- [x] add unit tests
- [x] run other tooling ✅ 

##### SUMMARY
This PR lays some groundwork for https://github.com/ansible/awx/issues/2238 by centralizing credential input access that potentially decrypts a field or could result in a call to an external service.

We want to reduce the possibility of corner cases and bugs that might expose information as much as possible, so we're leaving our extended `__getattr__` (added previously for backwards-compatibility reasons) alone for now and going with a pair of accessor methods on the credential model.

**No functionality should change by merging this pr.**

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

