### PR TITLE
[WIP] Remove trailing slash in custom venvs

### DIFF
--- a/awx/lib/awx_display_callback/events.py
+++ b/awx/lib/awx_display_callback/events.py
@@ -31,8 +31,8 @@ import uuid
 try:
     import memcache
 except ImportError:
-    raise ImportError('python-memcached is missing; {}bin/pip install python-memcached'.format(
-        os.environ['VIRTUAL_ENV']
+    raise ImportError('python-memcached is missing; {}/bin/pip install python-memcached'.format(
+        os.environ['VIRTUAL_ENV'].rstrip(os.path.sep)
     ))
 
 __all__ = ['event_context']

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -584,7 +584,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
             self.project.organization.custom_virtualenv if self.project.organization else None
         ):
             if virtualenv:
-                return virtualenv
+                return virtualenv.rstrip('/')
         return settings.ANSIBLE_VENV_PATH
 
     @property


### PR DESCRIPTION
##### SUMMARY
This removes the trailing slash from custom virtualenv values.




##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
There are a few reasons we should do this. One is that the default venv does it this way.

Another reason is that the API browser makes these into links, so here's how it looks currently:

![screen shot 2019-01-18 at 9 50 40 am](https://user-images.githubusercontent.com/1385596/51403520-aacc5f00-1b1e-11e9-8c8f-3dd2ace2e4fa.png)

post-change:

![screen shot 2019-01-18 at 9 58 30 am](https://user-images.githubusercontent.com/1385596/51403805-89b83e00-1b1f-11e9-8367-db8d7d40597d.png)
