### PR TITLE
correct authorization code expiration help-text

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -43,7 +43,7 @@ register(
     help_text=_('Dictionary for customizing OAuth 2 timeouts, available items are '
                 '`ACCESS_TOKEN_EXPIRE_SECONDS`, the duration of access tokens in the number '
                 'of seconds, and `AUTHORIZATION_CODE_EXPIRE_SECONDS`, the duration of '
-                'authorization grants in the number of seconds.'),
+                'authorization codes in the number of seconds.'),
     category=_('Authentication'),
     category_slug='authentication',
 )


### PR DESCRIPTION
##### SUMMARY

The `AUTHORIZATION_CODE_EXPIRE_SECONDS` setting refers to the expiration of the authorization code, not the grant.  No migrations are needed.  