### PR TITLE
upgrade social-auth-core to v3.0.0

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -36,7 +36,7 @@ python-logstash==0.4.6
 python-memcached==1.59
 python-radius==1.0
 python3-saml==1.4.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 social-auth-app-django==2.1.0
 redbaron==0.6.3
 requests<2.16  # Older versions rely on certify

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -96,7 +96,7 @@ simplejson==3.13.2        # via uwsgitop
 six==1.11.0               # via asgi-amqp, asgiref, autobahn, automat, cryptography, django-extensions, irc, isodate, jaraco.classes, jaraco.collections, jaraco.itertools, jaraco.logging, jaraco.stream, more-itertools, pygerduty, pyrad, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, tempora, twilio, txaio, websocket-client
 slackclient==1.1.2
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 tacacs_plus==1.0
 tempora==1.10             # via irc, jaraco.logging
 twilio==6.10.4


### PR DESCRIPTION
##### SUMMARY
Related: https://github.com/ansible/tower/issues/3238

Upgrade social-auth-core to v3.0.0 to pick up support for new Google SSO API

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


