### PR TITLE
Nginx: Specify X-Frame-Options "DENY" header

### DIFF
--- a/installer/roles/image_build/templates/nginx.conf
+++ b/installer/roles/image_build/templates/nginx.conf
@@ -44,6 +44,9 @@ http {
 
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
+
+        # Protect against click-jacking https://www.owasp.org/index.php/Testing_for_Clickjacking_(OTG-CLIENT-009)
+        add_header X-Frame-Options "DENY";
         
         location /nginx_status {
           stub_status on;


### PR DESCRIPTION
##### SUMMARY

Adding the X-Frame-Options "DENY"; header to avoid possible clickjacking
attack.

More info of the why available here:
https://www.owasp.org/index.php/Testing_for_Clickjacking_(OTG-CLIENT-009)

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

 - devel


##### ADDITIONAL INFORMATION

 - N/A