### PR TITLE
fix a py3 bug that breaks the SSO complete endpoint

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -90,7 +90,7 @@ class LoggedLoginView(auth_views.LoginView):
             logger.info(smart_text(u"User {} logged in.".format(self.request.user.username)))
             ret.set_cookie('userLoggedIn', 'true')
             current_user = UserSerializer(self.request.user)
-            current_user = JSONRenderer().render(current_user.data)
+            current_user = smart_text(JSONRenderer().render(current_user.data))
             current_user = urllib.parse.quote('%s' % current_user, '')
             ret.set_cookie('current_user', current_user, secure=settings.SESSION_COOKIE_SECURE or None)
 

--- a/awx/sso/views.py
+++ b/awx/sso/views.py
@@ -44,7 +44,7 @@ class CompleteView(BaseRedirectView):
             logger.info(smart_text(u"User {} logged in".format(self.request.user.username)))
             response.set_cookie('userLoggedIn', 'true')
             current_user = UserSerializer(self.request.user)
-            current_user = JSONRenderer().render(current_user.data)
+            current_user = smart_text(JSONRenderer().render(current_user.data))
             current_user = urllib.parse.quote('%s' % current_user, '')
             response.set_cookie('current_user', current_user, secure=settings.SESSION_COOKIE_SECURE or None)
         return response


### PR DESCRIPTION
This fixes a bug in the `/sso/complete` endpoint in python3:

<img width="354" alt="image" src="https://user-images.githubusercontent.com/214912/51500861-a5307c80-1d9d-11e9-8ab5-e830511a4d7f.png">
