### PR TITLE
use npm ci to install ui dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ $(UI_RELEASE_FLAG_FILE): $(I18N_FLAG_FILE) $(UI_RELEASE_DEPS_FLAG_FILE)
 	touch $(UI_RELEASE_FLAG_FILE)
 
 $(UI_RELEASE_DEPS_FLAG_FILE):
-	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 $(NPM_BIN) --unsafe-perm --prefix awx/ui install --no-save awx/ui
+	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 $(NPM_BIN) --unsafe-perm --prefix awx/ui ci --no-save awx/ui
 	touch $(UI_RELEASE_DEPS_FLAG_FILE)
 
 # END UI RELEASE TASKS
@@ -498,7 +498,7 @@ $(UI_DEPS_FLAG_FILE):
 		rm -rf awx/ui/node_modules; \
 		rm -f ${UI_RELEASE_DEPS_FLAG_FILE}; \
 	fi; \
-	$(NPM_BIN) --unsafe-perm --prefix awx/ui install --no-save awx/ui
+	$(NPM_BIN) --unsafe-perm --prefix awx/ui ci --no-save awx/ui
 	touch $(UI_DEPS_FLAG_FILE)
 
 ui-docker-machine: $(UI_DEPS_FLAG_FILE)

--- a/awx/ui/README.md
+++ b/awx/ui/README.md
@@ -57,22 +57,13 @@ npm --prefix awx/ui run e2e
 
 ## Adding dependencies
 ```shell
-# add a development or build dependency
-npm install --prefix awx/ui --save-dev dev-package@1.2.3
-
-# add a production dependency
-npm install --prefix awx/ui --save prod-package@1.23
-
-# add the updated package.json and lock files to scm
-git add awx/ui/package.json awx/ui/package-lock.json
-```
-
-## Adding exact dependencies
-```shell
 # add an exact development or build dependency
 npm install --prefix awx/ui --save-dev --save-exact dev-package@1.2.3
 # add an exact production dependency
 npm install --prefix awx/ui --save --save-exact prod-package@1.23
+
+# add the updated package.json and package-lock.json files to scm
+git add awx/ui/package.json awx/ui/package-lock.json
 ```
 
 ## Removing dependencies

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -260,6 +260,7 @@
       "from": "git+https://git@github.com/ansible/angular-scheduler.git#v0.3.3",
       "requires": {
         "angular": "~1.6.6",
+        "angular-tz-extensions": "github:ansible/angular-tz-extensions#fc60660f43ee9ff84da94ca71ab27ef0c20fd77d",
         "jquery": "*",
         "jquery-ui": "*",
         "lodash": "~3.8.0",
@@ -303,7 +304,8 @@
         "angular": "~1.6.6",
         "angular-filters": "^1.1.2",
         "jquery": "^3.1.0",
-        "jstimezonedetect": "1.0.5"
+        "jstimezonedetect": "1.0.5",
+        "timezone-js": "github:ansible/timezone-js#6937de14ce0c193961538bb5b3b12b7ef62a358f"
       },
       "dependencies": {
         "jquery": {
@@ -5405,15 +5407,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5430,22 +5430,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5576,8 +5573,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5591,7 +5587,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5608,7 +5603,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5617,15 +5611,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5646,7 +5638,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5735,8 +5726,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5750,7 +5740,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5888,7 +5877,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13266,6 +13254,10 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "timezone-js": {
+      "version": "github:ansible/timezone-js#6937de14ce0c193961538bb5b3b12b7ef62a358f",
+      "from": "github:ansible/timezone-js#0.4.14"
     },
     "tiny-emitter": {
       "version": "2.0.2",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -136,6 +136,7 @@
     "rrule": "git+https://git@github.com/jkbrzt/rrule#4ff63b2f8524fd6d5ba6e80db770953b5cd08a0c",
     "select2": "^4.0.2",
     "sprintf-js": "^1.0.3",
+    "timezone-js": "github:ansible/timezone-js#0.4.14",
     "titlecase": "^1.1.2"
   }
 }

--- a/docs/licenses/ui/timezone-js.txt
+++ b/docs/licenses/ui/timezone-js.txt
@@ -1,0 +1,20 @@
+
+
+
+Copyright 2010 Matthew Eernisse (mde@fleegix.org) and Open Source Applications Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+Credits: Ideas included from incomplete JS implementation of Olson parser, "XMLDAte" by Philippe Goetz (philippe.goetz@wanadoo.fr)
+
+Contributions:
+
+- Jan Niehusmann
+- Ricky Romero
+- Preston Hunt (prestonhunt@gmail.com)
+- Dov. B Katz (dov.katz@morganstanley.com)
+- Peter Bergström (pbergstr@mac.com)
+- Long Ho (@longlho)
+- Eugeny Loy (eugeny.loy@gmail.com)


### PR DESCRIPTION
##### SUMMARY
Handling of lock files by npm5 [changed](https://github.com/npm/npm/issues/18103) [slightly](https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json) with one of the minor release versions. From what I can gather, the net result of these changes means that `package.json` can _sometimes_ override `package-lock` if the `package.json` version for a dependency is higher and for other nuanced situations that one might not expect.

In our workflow, it's been my observation that we like for `package-lock` to be sourced exclusively for dependency installation and `package.json` to serve only as a top-level manifest of project dependencies used to generate the lock file. A new(er) command introduced in 5.7, `npm ci`, should let us accomplish this.

---
Some highlights worth pointing out about this command, [directly from the documentation](https://docs.npmjs.com/cli/ci.html#description):

- The project must have an existing package-lock.json or npm-shrinkwrap.json.
- If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.
- npm ci can only install entire projects at a time: individual dependencies cannot be added with this command.

---
##### What does this mean?
- `make ui-devel` and `make ui-release` should now _only_ source the lock file in _all_ cases. If the two aren't in sync, the `make` target will fail. (I view this as a good thing)
- When adding or removing dependencies, you _must_ use [the steps outlined in the readme](https://github.com/jakemcdermott/awx/blob/npm-ci/awx/ui/README.md#adding-dependencies). Updating the `package.json` manually and re-running `make ui-devel` / `make ui-release` _won't_ be enough ensure the right dependencies get added nor will it re-generate the lock file like it once did.
