### PR TITLE
Don't skip schema migrations on kubernetes

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -195,8 +195,6 @@ spec:
               mountPath: "/etc/tower/conf.d/"
               readOnly: true
           env:
-            - name: AWX_SKIP_MIGRATIONS
-              value: "1"
             - name: DATABASE_USER
               value: {{ pg_username }}
             - name: DATABASE_NAME


### PR DESCRIPTION
Database schema is inconsistent without the migration and prevent to have a
working installation of awx.

related #2482

##### SUMMARY
Fix the kubernetes installer configuration to let the data migration happen.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
2.1.2

##### ADDITIONAL INFORMATION
To be double-checked as I don't understand why the data migration was disabled at start.