### PR TITLE
Job timeout in ui

### DIFF
--- a/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
+++ b/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
@@ -282,7 +282,7 @@ export default
                 $scope.breadcrumb.job_template_name = jobTemplateData.name;
                 var fld, i;
                 for (fld in form.fields) {
-                    if (fld !== 'extra_vars' && fld !== 'survey' && fld !== 'forks' && jobTemplateData[fld] !== null && jobTemplateData[fld] !== undefined) {
+                    if (fld !== 'extra_vars' && fld !== 'survey' && jobTemplateData[fld] !== null && jobTemplateData[fld] !== undefined) {
                         if (form.fields[fld].type === 'select') {
                             if ($scope[fld + '_options'] && $scope[fld + '_options'].length > 0) {
                                 for (i = 0; i < $scope[fld + '_options'].length; i++) {
@@ -300,12 +300,6 @@ export default
                             }
                         }
                         master[fld] = $scope[fld];
-                    }
-                    if (fld === 'forks') {
-                        if (jobTemplateData[fld] !== 0) {
-                            $scope[fld] = jobTemplateData[fld];
-                            master[fld] = $scope[fld];
-                        }
                     }
                     if (fld === 'extra_vars') {
                         // Parse extra_vars, converting to YAML.

--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -141,18 +141,15 @@ function(NotificationsList, i18n) {
                 },
                 forks: {
                     label: i18n._('Forks'),
-                    id: 'forks-number',
                     type: 'number',
                     integer: true,
-                    min: 1,
+                    min: 0,
+                    default: 0,
                     spinner: true,
-                    'class': "input-small",
-                    column: 1,
-                    awPopOver: i18n._('The number of parallel or simultaneous processes to use while executing the playbook. Value defaults to 0. Refer to the Ansible documentation for details about the configuration file.'),
-                    placeholder: 'DEFAULT',
                     dataTitle: i18n._('Forks'),
                     dataPlacement: 'right',
-                    dataContainer: "body",
+                    dataContainer: 'body',
+                    awPopOver: "<p>" + i18n._("The number of parallel or simultaneous processes to use while executing the playbook. Value defaults to 0. Refer to the Ansible documentation for details about the configuration file.") + "</p>",
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
                 },
                 limit: {
@@ -268,6 +265,19 @@ function(NotificationsList, i18n) {
                     dataPlacement: 'right',
                     dataContainer: 'body',
                     awPopOver: "<p>" + i18n._("Divide the work done by this job template into the specified number of job slices, each running the same tasks against a portion of the inventory.") + "</p>",
+                    ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
+                },
+                timeout: {
+                    label: i18n._('Timeout'),
+                    type: 'number',
+                    integer: true,
+                    min: 0,
+                    default: 0,
+                    spinner: true,
+                    dataTitle: i18n._('Timeout'),
+                    dataPlacement: 'right',
+                    dataContainer: 'body',
+                    awPopOver: "<p>" + i18n._("The amount of time (in seconds) to run before the task is canceled.  Defaults to 0, which means the job will not timeout.") + "</p>",
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
                 },
                 diff_mode: {

--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -277,7 +277,7 @@ function(NotificationsList, i18n) {
                     dataTitle: i18n._('Timeout'),
                     dataPlacement: 'right',
                     dataContainer: 'body',
-                    awPopOver: "<p>" + i18n._("The amount of time (in seconds) to run before the task is canceled.  Defaults to 0, which means the job will not timeout.") + "</p>",
+                    awPopOver: "<p>" + i18n._("The amount of time (in seconds) to run before the task is canceled. Defaults to 0 for no job timeout.") + "</p>",
                     ngDisabled: '!(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
                 },
                 diff_mode: {


### PR DESCRIPTION
link #1932 

- add timeout field to ui
- update help text of timeout field in ui (checked with @docschick)
- updated forks to behave similarly to job slice (defaults to 0 value instead of a "DEFAULT" placeholder), so now all number fields work similarly
- updated forks to populate when 0 value is present on edit