### PR TITLE
explicitly handle .inputs in decrypt_field, encrypt_field

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -32,9 +32,6 @@ from rest_framework.permissions import AllowAny
 from rest_framework.renderers import StaticHTMLRenderer, JSONRenderer
 from rest_framework.negotiation import DefaultContentNegotiation
 
-# cryptography
-from cryptography.fernet import InvalidToken
-
 # AWX
 from awx.api.filters import FieldLookupBackend
 from awx.main.models import *  # noqa
@@ -858,11 +855,14 @@ class CopyAPIView(GenericAPIView):
                         and isinstance(field_val[sub_field], six.string_types):
                     try:
                         field_val[sub_field] = decrypt_field(obj, field_name, sub_field)
-                    except InvalidToken:
+                    except AttributeError:
                         # Catching the corner case with v1 credential fields
                         field_val[sub_field] = decrypt_field(obj, sub_field)
         elif isinstance(field_val, six.string_types):
-            field_val = decrypt_field(obj, field_name)
+            try:
+                field_val = decrypt_field(obj, field_name)
+            except AttributeError:
+                return field_val
         return field_val
 
     def _build_create_dict(self, obj):

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -345,6 +345,10 @@ def test_credential_get_input(organization_factory):
                 'id': 'vault_id',
                 'type': 'string',
                 'secret': False
+            }, {
+                'id': 'secret',
+                'type': 'string',
+                'secret': True,
             }]
         }
     )
@@ -372,6 +376,12 @@ def test_credential_get_input(organization_factory):
         cred.get_input('field_not_on_credential_type')
     # verify that the provided default is used for undefined inputs
     assert cred.get_input('field_not_on_credential_type', default='bar') == 'bar'
+    # verify expected exception is raised when attempting to access an unset secret
+    # input without providing a default
+    with pytest.raises(AttributeError):
+        cred.get_input('secret')
+    # verify that the provided default is used for undefined inputs
+    assert cred.get_input('secret', default='fiz') == 'fiz'
     # verify return values for encrypted secret fields are decrypted
     assert cred.inputs['vault_password'].startswith('$encrypted$')
     assert cred.get_input('vault_password') == 'testing321'

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1656,6 +1656,7 @@ class TestJobCredentials(TestJobExecution):
                 'password': 'secret'
             }
         )
+        azure_rm_credential.inputs['secret'] = ''
         azure_rm_credential.inputs['secret'] = encrypt_field(azure_rm_credential, 'secret')
         self.instance.credentials.add(azure_rm_credential)
 
@@ -2089,6 +2090,7 @@ class TestInventoryUpdateCredentials(TestJobExecution):
                     'host': 'https://keystone.example.org'
                 }
             )
+            cred.inputs['ssh_key_data'] = ''
             cred.inputs['ssh_key_data'] = encrypt_field(
                 cred, 'ssh_key_data'
             )

--- a/awx/main/tests/unit/utils/test_encryption.py
+++ b/awx/main/tests/unit/utils/test_encryption.py
@@ -2,6 +2,8 @@
 
 # Copyright (c) 2017 Ansible, Inc.
 # All Rights Reserved.
+import pytest
+
 from awx.conf.models import Setting
 from awx.main.utils import encryption
 
@@ -43,6 +45,16 @@ def test_encrypt_field_with_ask():
 def test_encrypt_field_with_empty_value():
     encrypted = encryption.encrypt_field(Setting(value=None), 'value')
     assert encrypted is None
+
+
+def test_encrypt_field_with_undefined_attr_raises_expected_exception():
+    with pytest.raises(AttributeError):
+        encryption.encrypt_field({}, 'undefined_attr')
+
+
+def test_decrypt_field_with_undefined_attr_raises_expected_exception():
+    with pytest.raises(AttributeError):
+        encryption.decrypt_field({}, 'undefined_attr')
 
 
 class TestSurveyReversibilityValue:

--- a/awx/main/utils/encryption.py
+++ b/awx/main/utils/encryption.py
@@ -63,7 +63,13 @@ def encrypt_field(instance, field_name, ask=False, subfield=None):
     '''
     Return content of the given instance and field name encrypted.
     '''
-    value = getattr(instance, field_name)
+    try:
+        value = instance.inputs[field_name]
+    except (TypeError, AttributeError):
+        value = getattr(instance, field_name)
+    except KeyError:
+        raise AttributeError(field_name)
+
     if isinstance(value, dict) and subfield is not None:
         value = value[subfield]
     if value is None:
@@ -98,7 +104,13 @@ def decrypt_field(instance, field_name, subfield=None):
     '''
     Return content of the given instance and field name decrypted.
     '''
-    value = getattr(instance, field_name)
+    try:
+        value = instance.inputs[field_name]
+    except (TypeError, AttributeError):
+        value = getattr(instance, field_name)
+    except KeyError:
+        raise AttributeError(field_name)
+
     if isinstance(value, dict) and subfield is not None:
         value = value[subfield]
     value = smart_str(value)


### PR DESCRIPTION
- [x] update unit tests
- [x] new unit tests
- [x] full run of other tests / tooling (including e2e)  ✅
- [x] manual testing and verification (see PR comments)

##### SUMMARY
When using decrypt_field on credentials, we implicitly rely on the model's `__getattr__` behavior. This means our input access methods for credential plugins, tasks.py, etc. silently ignore the provided defaults for some input fields but not others, which is unexpected. The `__getattr__` is also [going away with v1](https://github.com/ansible/awx/pull/3021#pullrequestreview-194106785). 

This PR finishes the remaining groundwork for https://github.com/ansible/awx/issues/2238 by handling the exceptional credential input case explicitly inside the utility functions themselves. 

- This makes it so we don't silently ignore the `default` param passed to the access method for _some_ input fields and not others.
- Though not the main objective of this PR, this also leaves us in a better place for `api/v1` removal (whenever we get to it in the future) as the `__getattr__` can now be removed along with its dependent serializers, etc.  [without breaking the access methods](https://github.com/ansible/awx/pull/3021#issuecomment-456075608) used by credential plugins and tasks.py

**No functionality should change by merging this pr.**