### PR TITLE
Adds environment to output details for jts and inv syncs

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -113,8 +113,8 @@ function getVerbosityDetails () {
     return { label, value };
 }
 
-function getEnvironmentDetails (custom_virtualenv) {
-    const value = custom_virtualenv || resource.model.get('custom_virtualenv');
+function getEnvironmentDetails (virtualenv) {
+    const value = virtualenv || resource.model.get('custom_virtualenv');
 
     if (!value || value === '') {
         return null;

--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -113,8 +113,8 @@ function getVerbosityDetails () {
     return { label, value };
 }
 
-function getEnvironmentDetails () {
-    const value = resource.model.get('custom_virtualenv');
+function getEnvironmentDetails (custom_virtualenv) {
+    const value = custom_virtualenv || resource.model.get('custom_virtualenv');
 
     if (!value || value === '') {
         return null;

--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -113,6 +113,18 @@ function getVerbosityDetails () {
     return { label, value };
 }
 
+function getEnvironmentDetails () {
+    const value = resource.model.get('custom_virtualenv');
+
+    if (!value || value === '') {
+        return null;
+    }
+
+    const label = strings.get('labels.ENVIRONMENT');
+
+    return { label, value };
+}
+
 function getSourceWorkflowJobDetails () {
     const sourceWorkflowJob = resource.model.get('summary_fields.source_workflow_job');
 
@@ -711,6 +723,7 @@ function JobDetailsController (
         vm.launchedBy = getLaunchedByDetails();
         vm.jobExplanation = getJobExplanationDetails();
         vm.verbosity = getVerbosityDetails();
+        vm.environment = getEnvironmentDetails();
         vm.credentials = getCredentialDetails();
         vm.forks = getForkDetails();
         vm.limit = getLimitDetails();
@@ -735,11 +748,12 @@ function JobDetailsController (
         vm.toggleLabels = toggleLabels;
         vm.showLabels = showLabels;
 
-        unsubscribe = subscribe(({ status, started, finished, scm }) => {
+        unsubscribe = subscribe(({ status, started, finished, scm, environment }) => {
             vm.started = getStartDetails(started);
             vm.finished = getFinishDetails(finished);
             vm.projectUpdate = getProjectUpdateDetails(scm.id);
             vm.projectStatus = getProjectStatusDetails(scm.status);
+            vm.environment = getEnvironmentDetails(environment);
             vm.status = getStatusDetails(status);
             vm.job.status = status;
         });

--- a/awx/ui/client/features/output/details.partial.html
+++ b/awx/ui/client/features/output/details.partial.html
@@ -268,6 +268,12 @@
     <div class="JobResults-resultRowText">{{ vm.verbosity.value }}</div>
 </div>
 
+<!-- ENVIRONMENT DETAIL -->
+<div class="JobResults-resultRow" ng-if="vm.environment">
+    <label class="JobResults-resultRowLabel">{{ vm.environment.label }}</label>
+    <div class="JobResults-resultRowText">{{ vm.environment.value }}</div>
+</div>
+
 <!-- IG DETAIL -->
 <div class="JobResults-resultRow" ng-if="vm.instanceGroup">
     <label class="JobResults-resultRowLabel">{{ vm.instanceGroup.label }}</label>

--- a/awx/ui/client/features/output/output.strings.js
+++ b/awx/ui/client/features/output/output.strings.js
@@ -48,6 +48,7 @@ function OutputStrings (BaseString) {
 
     ns.labels = {
         CREDENTIAL: t.s('Credential'),
+        ENVIRONMENT: t.s('Environment'),
         EXTRA_VARS: t.s('Extra Variables'),
         FINISHED: t.s('Finished'),
         FORKS: t.s('Forks'),

--- a/awx/ui/client/features/output/status.service.js
+++ b/awx/ui/client/features/output/status.service.js
@@ -39,6 +39,7 @@ function JobStatusService (moment, message) {
             elapsed: model.get('elapsed'),
             started: model.get('started'),
             finished: model.get('finished'),
+            environment: model.get('custom_virtualenv'),
             scm: {
                 id: model.get('summary_fields.project_update.id'),
                 status: model.get('summary_fields.project_update.status')
@@ -255,6 +256,12 @@ function JobStatusService (moment, message) {
         this.updateRunningState();
     };
 
+    this.setEnvironment = env => {
+        if (!env) return;
+
+        this.state.environment = env;
+    };
+
     this.setStatsEvent = data => {
         if (!data) return;
 
@@ -296,6 +303,7 @@ function JobStatusService (moment, message) {
                 this.setElapsed(model.get('elapsed'));
                 this.setStarted(model.get('started'));
                 this.setJobStatus(model.get('status'));
+                this.setEnvironment(model.get('custom_virtualenv'));
 
                 this.initHostStatusCounts({ model });
                 this.initPlaybookCounts({ model });


### PR DESCRIPTION
##### SUMMARY
link #2264 

API portion was completed here: #3051 

Mockup:
<img width="1501" alt="screen shot 2019-01-24 at 12 21 11 pm" src="https://user-images.githubusercontent.com/9889020/51696074-a39bca00-1fd2-11e9-99c4-6d8a4e0742f5.png">

JT results:
<img width="1493" alt="screen shot 2019-01-24 at 12 23 12 pm" src="https://user-images.githubusercontent.com/9889020/51696197-e198ee00-1fd2-11e9-9d12-b035ddfa7b91.png">

Inventory Sync results:
<img width="1487" alt="screen shot 2019-01-24 at 12 22 18 pm" src="https://user-images.githubusercontent.com/9889020/51696156-c8903d00-1fd2-11e9-964d-09d40580eee3.png">

This field is shown only _when there's a value provided via the api_.  We've only just now started tracking this field so for jobs that ran before this logic was added the field will not be present.  This will should also not be present for jobs other than playbook/inventory sync.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
