### PR TITLE
Fixed role download typo in help text

### DIFF
--- a/awx/locale/django.pot
+++ b/awx/locale/django.pot
@@ -2020,7 +2020,7 @@ msgstr ""
 
 #: awx/main/conf.py:286
 msgid ""
-"Allows roles to be dynamically downlaoded from a requirements.yml file for "
+"Allows roles to be dynamically downloaded from a requirements.yml file for "
 "SCM projects."
 msgstr ""
 

--- a/awx/locale/en-us/LC_MESSAGES/django.po
+++ b/awx/locale/en-us/LC_MESSAGES/django.po
@@ -2020,7 +2020,7 @@ msgstr ""
 
 #: awx/main/conf.py:286
 msgid ""
-"Allows roles to be dynamically downlaoded from a requirements.yml file for "
+"Allows roles to be dynamically downloaded from a requirements.yml file for "
 "SCM projects."
 msgstr ""
 

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -295,7 +295,7 @@ register(
     field_class=fields.BooleanField,
     default=True,
     label=_('Enable Role Download'),
-    help_text=_('Allows roles to be dynamically downlaoded from a requirements.yml file for SCM projects.'),
+    help_text=_('Allows roles to be dynamically downloaded from a requirements.yml file for SCM projects.'),
     category=_('Jobs'),
     category_slug='jobs',
 )


### PR DESCRIPTION
##### SUMMARY
Fixed a couple of typos I noticed in the help text for role downloads

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
3.0.0
```


##### ADDITIONAL INFORMATION
```
None
```
