### PR TITLE
Some sidebar nav fixes.

### DIFF
--- a/awx/ui/client/lib/components/layout/_index.less
+++ b/awx/ui/client/lib/components/layout/_index.less
@@ -49,6 +49,7 @@
                     width: @main-menu-width;
                     margin: @main-menu-margin;
                     flex: initial;
+                    pointer-events: none;
                 }
             }
 

--- a/awx/ui/client/lib/components/layout/side-nav.directive.js
+++ b/awx/ui/client/lib/components/layout/side-nav.directive.js
@@ -44,6 +44,14 @@ function AtSideNavController ($scope, $window) {
             vm.isExpanded = false;
         }
     });
+
+    $(window).resize(() => {
+        if ($window.innerWidth <= breakpoint) {
+            vm.isExpanded = false;
+        } else {
+            vm.isExpanded = true;
+        }
+    });
 }
 
 AtSideNavController.$inject = ['$scope', '$window'];


### PR DESCRIPTION
- Set isExpanded state to false when window width is < 700px.
- Set `pointer-events` to `none` for logo to allow users to easily click on hamburger icon.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #3082 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.0
```
