### PR TITLE
Add execution node field to job details panel

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -481,6 +481,19 @@ function getLimitDetails () {
     return { label, value };
 }
 
+function getExecutionNodeDetails () {
+    const executionNode = resource.model.get('execution_node');
+
+    if (!executionNode) {
+        return null;
+    }
+
+    const label = strings.get('labels.EXECUTION_NODE');
+    const value = $filter('sanitize')(executionNode);
+
+    return { label, value };
+}
+
 function getInstanceGroupDetails () {
     const instanceGroup = resource.model.get('summary_fields.instance_group');
 
@@ -761,6 +774,7 @@ function JobDetailsController (
         vm.credentials = getCredentialDetails();
         vm.forks = getForkDetails();
         vm.limit = getLimitDetails();
+        vm.executionNode = getExecutionNodeDetails();
         vm.instanceGroup = getInstanceGroupDetails();
         vm.jobTags = getJobTagDetails();
         vm.skipTags = getSkipTagDetails();

--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -481,8 +481,8 @@ function getLimitDetails () {
     return { label, value };
 }
 
-function getExecutionNodeDetails () {
-    const executionNode = resource.model.get('execution_node');
+function getExecutionNodeDetails (node) {
+    const executionNode = node || resource.model.get('execution_node');
 
     if (!executionNode) {
         return null;
@@ -796,12 +796,21 @@ function JobDetailsController (
         vm.toggleLabels = toggleLabels;
         vm.showLabels = showLabels;
 
-        unsubscribe = subscribe(({ status, started, finished, scm, inventoryScm, environment }) => {
+        unsubscribe = subscribe(({
+            status,
+            started,
+            finished,
+            scm,
+            inventoryScm,
+            environment,
+            executionNode
+        }) => {
             vm.started = getStartDetails(started);
             vm.finished = getFinishDetails(finished);
             vm.projectUpdate = getProjectUpdateDetails(scm.id);
             vm.projectStatus = getProjectStatusDetails(scm.status);
             vm.environment = getEnvironmentDetails(environment);
+            vm.executionNode = getExecutionNodeDetails(executionNode);
             vm.inventoryScm = getInventoryScmDetails(inventoryScm.id, inventoryScm.status);
             vm.status = getStatusDetails(status);
             vm.job.status = status;

--- a/awx/ui/client/features/output/details.partial.html
+++ b/awx/ui/client/features/output/details.partial.html
@@ -295,6 +295,12 @@
     <div class="JobResults-resultRowText">{{ vm.environment.value }}</div>
 </div>
 
+<!-- EXECUTION Node DETAIL -->
+<div class="JobResults-resultRow" ng-if="vm.executionNode">
+  <label class="JobResults-resultRowLabel">{{ vm.executionNode.label }}</label>
+  <div class="JobResults-resultRowText">{{ vm.executionNode.value }}</div>
+</div>
+
 <!-- IG DETAIL -->
 <div class="JobResults-resultRow" ng-if="vm.instanceGroup">
     <label class="JobResults-resultRowLabel">{{ vm.instanceGroup.label }}</label>
@@ -319,7 +325,6 @@
         </a>
     </div>
 </div>
-
 
 <!-- EXTRA VARIABLES DETAIL -->
 <at-code-mirror

--- a/awx/ui/client/features/output/output.strings.js
+++ b/awx/ui/client/features/output/output.strings.js
@@ -51,6 +51,7 @@ function OutputStrings (BaseString) {
     ns.labels = {
         CREDENTIAL: t.s('Credential'),
         ENVIRONMENT: t.s('Environment'),
+        EXECUTION_NODE: t.s('Execution Node'),
         EXTRA_VARS: t.s('Extra Variables'),
         FINISHED: t.s('Finished'),
         FORKS: t.s('Forks'),

--- a/awx/ui/client/features/output/status.service.js
+++ b/awx/ui/client/features/output/status.service.js
@@ -279,6 +279,12 @@ function JobStatusService (moment, message) {
         this.state.environment = env;
     };
 
+    this.setExecutionNode = node => {
+        if (!node) return;
+
+        this.state.executionNode = node;
+    };
+
     this.setStatsEvent = data => {
         if (!data) return;
 
@@ -321,6 +327,7 @@ function JobStatusService (moment, message) {
                 this.setStarted(model.get('started'));
                 this.setJobStatus(model.get('status'));
                 this.setEnvironment(model.get('custom_virtualenv'));
+                this.setExecutionNode(model.get('execution_node'));
 
                 this.initHostStatusCounts({ model });
                 this.initPlaybookCounts({ model });


### PR DESCRIPTION
##### SUMMARY
Link: https://github.com/ansible/awx/issues/2330
* Add the node that executed the job to the job output details panel.

<img width="769" alt="screen shot 2019-01-28 at 1 45 05 pm" src="https://user-images.githubusercontent.com/15881645/51858863-b9c3c600-2303-11e9-9420-415a32df2e3f.png">

##### ISSUE TYPE
 - Enhancement Pull Request

##### COMPONENT NAME
 - UI
