### PR TITLE
Remove error message for regular logout

### DIFF
--- a/awx/ui/client/src/login/loginModal/loginModal.partial.html
+++ b/awx/ui/client/src/login/loginModal/loginModal.partial.html
@@ -23,7 +23,7 @@
                         Your session timed out due to inactivity. Please sign in.
                     </div>
                 </div>
-                <div class="LoginModal-alert LoginModal-alert--error" ng-show="userLoggedOut && !sessionExpired">
+                <div class="LoginModal-alert LoginModal-alert--error" ng-show="userLoggedOut && !sessionExpired && !attemptFailed && !thirdPartyAttemptFailed && !sessionLimitExpired" translate>
                     <i class="LoginModal-alertIcon fa fa-exclamation-triangle"></i>
                     <div class="LoginModal-alertText" translate>
                         You have been logged out. Please sign in.

--- a/awx/ui/client/src/login/loginModal/loginModal.partial.html
+++ b/awx/ui/client/src/login/loginModal/loginModal.partial.html
@@ -14,19 +14,13 @@
                         ng-src="{{ customLogo }}" >
             </div>
             <div class="LoginModal-body">
-                <div class="LoginModal-alert" ng-show="!sessionExpired && !sessionLimitExpired && !attemptFailed && !thirdPartyAttemptFailed && !userLoggedOut" translate>
+                <div class="LoginModal-alert" ng-show="!sessionExpired && !sessionLimitExpired && !attemptFailed && !thirdPartyAttemptFailed" translate>
                     Welcome to Ansible {{BRAND_NAME}}! &nbsp;Please sign in.
                 </div>
                 <div class="LoginModal-alert LoginModal-alert--error" ng-show="sessionExpired">
                     <i class="LoginModal-alertIcon fa fa-exclamation-triangle"></i>
                     <div class="LoginModal-alertText" translate>
                         Your session timed out due to inactivity. Please sign in.
-                    </div>
-                </div>
-                <div class="LoginModal-alert LoginModal-alert--error" ng-show="userLoggedOut">
-                    <i class="LoginModal-alertIcon fa fa-exclamation-triangle"></i>
-                    <div class="LoginModal-alertText" translate>
-                        You have been logged out. Please sign in.
                     </div>
                 </div>
                 <div class="LoginModal-alert LoginModal-alert--error" ng-show="sessionLimitExpired">

--- a/awx/ui/client/src/login/loginModal/loginModal.partial.html
+++ b/awx/ui/client/src/login/loginModal/loginModal.partial.html
@@ -14,13 +14,19 @@
                         ng-src="{{ customLogo }}" >
             </div>
             <div class="LoginModal-body">
-                <div class="LoginModal-alert" ng-show="!sessionExpired && !sessionLimitExpired && !attemptFailed && !thirdPartyAttemptFailed" translate>
+                <div class="LoginModal-alert" ng-show="!sessionExpired && !sessionLimitExpired && !attemptFailed && !thirdPartyAttemptFailed && !userLoggedOut" translate>
                     Welcome to Ansible {{BRAND_NAME}}! &nbsp;Please sign in.
                 </div>
                 <div class="LoginModal-alert LoginModal-alert--error" ng-show="sessionExpired">
                     <i class="LoginModal-alertIcon fa fa-exclamation-triangle"></i>
                     <div class="LoginModal-alertText" translate>
                         Your session timed out due to inactivity. Please sign in.
+                    </div>
+                </div>
+                <div class="LoginModal-alert LoginModal-alert--error" ng-show="userLoggedOut && !sessionExpired">
+                    <i class="LoginModal-alertIcon fa fa-exclamation-triangle"></i>
+                    <div class="LoginModal-alertText" translate>
+                        You have been logged out. Please sign in.
                     </div>
                 </div>
                 <div class="LoginModal-alert LoginModal-alert--error" ng-show="sessionLimitExpired">


### PR DESCRIPTION
##### SUMMARY 
Connected to issue https://github.com/ansible/awx/issues/2837


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The `You have been logged out. Please sign in.` error showed up even when logging out on purpose.  This error message seemed redundant, and was showing up on top of the timeout error:

![timeoutnotification](https://user-images.githubusercontent.com/28930622/51864229-20031580-2311-11e9-9858-828747a226a5.png)

With the change in this PR, this is what the user sees when logging out on purpose:

![noerrormessage](https://user-images.githubusercontent.com/28930622/51864333-7a9c7180-2311-11e9-93e2-feb34d548c36.png)

...and this is what shows up when the session times out (only one error message vs two):

![nomoredoubleerror](https://user-images.githubusercontent.com/28930622/51864337-7e2ff880-2311-11e9-8b47-0f913d6e2843.png)

