### PR TITLE
[WIP] Pass verbosity flag to ansible-inventory

### DIFF
--- a/awx/main/tests/unit/utils/test_ansible.py
+++ b/awx/main/tests/unit/utils/test_ansible.py
@@ -1,10 +1,11 @@
 import os
 import os.path
+import json
 
 import pytest
 
 from awx.main.tests import data
-from awx.main.utils.ansible import could_be_playbook, could_be_inventory
+from awx.main.utils.ansible import could_be_playbook, could_be_inventory, filter_non_json_lines
 
 DATA = os.path.join(os.path.dirname(data.__file__), 'ansible_utils')
 
@@ -31,3 +32,13 @@ def test_could_be_inventory(filename):
 def test_is_not_inventory(filename):
     path = os.path.join(DATA, 'inventories', 'invalid')
     assert could_be_inventory(DATA, path, filename) is None
+
+
+def test_filter_non_json_lines():
+    data = {'foo': 'bar', 'bar': 'foo'}
+    dumped_data = json.dumps(data, indent=2)
+    output = 'Openstack does this\nOh why oh why\n{}\ntrailing lines\nneed testing too'.format(dumped_data)
+    filtered_data, warnings = filter_non_json_lines(output)
+    assert filtered_data == dumped_data
+    assert 'Openstack does this' in warnings
+    assert 'need testing too' in warnings

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -11,7 +11,7 @@ from itertools import islice
 from django.utils.encoding import smart_str
 
 
-__all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory']
+__all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory', 'filter_non_json_lines']
 
 
 valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$')
@@ -97,3 +97,72 @@ def could_be_inventory(project_path, dir_path, filename):
     except IOError:
         return None
     return inventory_rel_path
+
+
+# This method is copied directly from Ansible core code base
+# lib/ansible/module_utils/json_utils.py
+# For purpose, see: https://github.com/ansible/ansible/issues/50100
+# Any patches to this method should sync from that version
+# NB: a copy of this function exists in ../../modules/core/async_wrapper.py. Ensure any
+# changes are propagated there.
+def _filter_non_json_lines(data):
+    '''
+    Used to filter unrelated output around module JSON output, like messages from
+    tcagetattr, or where dropbear spews MOTD on every single command (which is nuts).
+    Filters leading lines before first line-starting occurrence of '{' or '[', and filter all
+    trailing lines after matching close character (working from the bottom of output).
+    '''
+    warnings = []
+
+    # Filter initial junk
+    lines = data.splitlines()
+
+    for start, line in enumerate(lines):
+        line = line.strip()
+        if line.startswith(u'{'):
+            endchar = u'}'
+            break
+        elif line.startswith(u'['):
+            endchar = u']'
+            break
+    else:
+        raise ValueError('No start of json char found')
+
+    # Filter trailing junk
+    leading_junk = lines[:start]
+    for line in leading_junk:
+        if line.strip():
+            warnings.append('Module invocation had junk before the JSON data: %s' % '\n'.join(leading_junk))
+            break
+    lines = lines[start:]
+
+    for reverse_end_offset, line in enumerate(reversed(lines)):
+        if line.strip().endswith(endchar):
+            break
+    else:
+        raise ValueError('No end of json char found')
+
+    if reverse_end_offset > 0:
+        # Trailing junk is uncommon and can point to things the user might
+        # want to change.  So print a warning if we find any
+        trailing_junk = lines[len(lines) - reverse_end_offset:]
+        for line in trailing_junk:
+            if line.strip():
+                warnings.append('Module invocation had junk after the JSON data: %s' % '\n'.join(trailing_junk))
+                break
+
+    lines = lines[:(len(lines) - reverse_end_offset)]
+
+    # NOTE: warnings are undesired (would prevent JSON parsing)
+    # so this change diverges from the source by not using the warnings
+    # original:
+    # return ('\n'.join(lines), warnings)
+    return '\n'.join(lines), '\n'.join(warnings)
+
+
+def filter_non_json_lines(data):
+    # Optimization on top of Ansible's method to avoid operations on large
+    # strings when it is given in standard ansible-inventory form
+    if data.startswith(u'{') and data.endswith(u'}'):
+        return (data, '')
+    return _filter_non_json_lines(data)


### PR DESCRIPTION
Connect https://github.com/ansible/awx/issues/2105

See discussion at https://github.com/ansible/ansible/issues/50100

Let me recap the important point - either we need acceptance of this workaround on our side, or this issue needs to be punted back to the Ansible core side. One of these things needs to happen in order for the OpenStack plugin transition to happen.

It just happens to be that this verbosity issue can easily be resolved by the same workaround. So we get a nice extra little enhancement out of it too.