### PR TITLE
Set port from env variables in launch_awx scipts

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -47,6 +47,7 @@ dockerhub_base=ansible
 # memcached_mem_limit=2
 # management_cpu_limit=2000
 # management_mem_limit=2
+memcached_port=11211
 
 # Common Docker parameters
 awx_task_hostname=awx
@@ -90,6 +91,7 @@ pg_port=5432
 # RabbitMQ Configuration
 rabbitmq_password=awxpass
 rabbitmq_erlang_cookie=cookiemonster
+rabbitmq_port=5672
 
 # Use a local distribution build container image for building the AWX package
 # This is helpful if you don't want to bother installing the build-time dependencies as

--- a/installer/roles/image_build/files/launch_awx.sh
+++ b/installer/roles/image_build/files/launch_awx.sh
@@ -6,8 +6,8 @@ if [ `id -u` -ge 500 ]; then
 fi
 
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=11211" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=5672" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=$MEMCACHED_PORT" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=$RABBITMQ_PORT" all
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user $DATABASE_USER -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
 
 awx-manage collectstatic --noinput --clear

--- a/installer/roles/image_build/files/launch_awx_task.sh
+++ b/installer/roles/image_build/files/launch_awx_task.sh
@@ -6,8 +6,8 @@ if [ `id -u` -ge 500 ]; then
 fi
 
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=11211" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=5672" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=$MEMCACHED_PORT" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=$RABBITMQ_PORT" all
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user $DATABASE_USER -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
 
 if [ -z "$AWX_SKIP_MIGRATIONS" ]; then

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -157,6 +157,10 @@ spec:
               value: {{ pg_hostname|default('postgresql') }}
             - name: DATABASE_PORT
               value: "{{ pg_port|default('5432') }}"
+            - name: RABBIT_PORT
+              value: "{{ rabbitmq_port|default('5672') }}"
+            - name: MEMCACHED_PORT
+              value: "{{ memcached_port|default('11211') }}"
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -205,6 +209,10 @@ spec:
               value: {{ pg_hostname|default('postgresql') }}
             - name: DATABASE_PORT
               value: "{{ pg_port|default('5432') }}"
+            - name: RABBIT_PORT
+              value: "{{ rabbitmq_port|default('5672') }}"
+            - name: MEMCACHED_PORT
+              value: "{{ memcached_port|default('11211') }}"
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I've replaced static ports in `launch_awx.sh` and `launch_awx_task.sh` with environment variables.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.0
```

