### PR TITLE
run the requirements script

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -22,7 +22,7 @@ django-taggit==0.22.2
 djangorestframework==3.7.7
 djangorestframework-yaml==1.0.3
 irc==16.2
-jinja2=2.10
+jinja2==2.10
 jsonschema==2.6.0
 Markdown==2.6.11    # used for formatting API help
 ordereddict==1.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,10 +20,11 @@ celery==4.2.1
 cffi==1.11.5              # via cryptography
 channels==1.1.8
 constantly==15.1.0        # via twisted
-cryptography==2.3.1       # via requests
+cryptography==2.3.1       # via pyopenssl
 daphne==1.3.0
-defusedxml==0.5.0         # via python3-saml
+defusedxml==0.5.0
 django-auth-ldap==1.7.0
+django-cors-headers==2.4.0
 django-crum==0.7.2
 django-extensions==2.0.0
 django-jsonfield==1.0.1
@@ -37,14 +38,13 @@ django-taggit==0.22.2
 django==1.11.16
 djangorestframework-yaml==1.0.3
 djangorestframework==3.7.7
-docutils==0.14            # via botocore
+future==0.16.0            # via django-radius
 hyperlink==18.0.0         # via twisted
-idna==2.6                 # via cryptography, hyperlink, requests
+idna==2.6                 # via cryptography, hyperlink
 incremental==17.5.0       # via twisted
 inflect==0.2.5            # via jaraco.itertools
-ipaddress==1.0.19         # via cryptography
 irc==16.2
-isodate==0.6.0            # via python-saml
+isodate==0.6.0            # via python3-saml
 jaraco.classes==1.4.3     # via jaraco.collections
 jaraco.collections==1.5.3  # via irc, jaraco.text
 jaraco.functools==1.17    # via irc, jaraco.text
@@ -56,33 +56,34 @@ jinja2==2.10
 jsonpickle==0.9.6         # via asgi-amqp
 jsonschema==2.6.0
 kombu==4.2.1              # via asgi-amqp, celery
-lxml==4.2.3
+lxml==4.2.3               # via xmlsec
 markdown==2.6.11
-MarkupSafe==1.0           # via jinja2
+markupsafe==1.0           # via jinja2
 more-itertools==4.1.0     # via irc, jaraco.functools, jaraco.itertools
 msgpack-python==0.5.5     # via asgi-amqp
 netaddr==0.7.19           # via pyrad
 oauthlib==2.0.6           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 ordereddict==1.1
 pexpect==4.6.0
+pkgconfig==1.4.0          # via xmlsec
 psutil==5.4.3
 psycopg2==2.7.3.2
 ptyprocess==0.5.2         # via pexpect
-pyasn1-modules==0.2.1     # via service-identity
-pyasn1==0.4.2             # via pyasn1-modules, service-identity
+pyasn1-modules==0.2.1     # via python-ldap, service-identity
+pyasn1==0.4.2             # via pyasn1-modules, python-ldap, service-identity
 pycparser==2.18           # via cffi
 pygerduty==0.37.0
 pyjwt==1.6.0              # via social-auth-core, twilio
+pyopenssl==19.0.0         # via service-identity
 pyparsing==2.2.0
 pyrad==2.1                # via django-radius
-pysocks==1.6.8
+pysocks==1.6.8            # via twilio
 python-dateutil==2.7.2
 python-ldap==3.1.0        # via django-auth-ldap
-django-cors-headers==2.4.0
 python-logstash==0.4.6
 python-memcached==1.59
-python3-openid>=3.0.10      # via social-auth-core
 python-radius==1.0
+python3-openid==3.1.0     # via social-auth-core
 python3-saml==1.4.0
 pytz==2018.5              # via celery, django, irc, tempora, twilio
 pyyaml==3.12              # via djangorestframework-yaml
@@ -93,7 +94,7 @@ requests[security]==2.15.1
 rply==0.7.5               # via baron
 service-identity==17.0.0
 simplejson==3.13.2        # via uwsgitop
-six==1.11.0               # via asgi-amqp, asgiref, autobahn, automat, cryptography, django-extensions, irc, isodate, jaraco.classes, jaraco.collections, jaraco.itertools, jaraco.logging, jaraco.stream, more-itertools, pygerduty, pyrad, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, tempora, twilio, txaio, websocket-client
+six==1.11.0               # via asgi-amqp, asgiref, autobahn, automat, cryptography, django-extensions, irc, isodate, jaraco.classes, jaraco.collections, jaraco.itertools, jaraco.logging, jaraco.stream, more-itertools, pygerduty, pyopenssl, pyrad, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, tempora, twilio, txaio, websocket-client
 slackclient==1.1.2
 social-auth-app-django==2.1.0
 social-auth-core==3.0.0
@@ -105,7 +106,9 @@ txaio==2.9.0              # via autobahn
 typing==3.6.4             # via django-extensions
 uwsgi==2.0.17
 uwsgitop==0.10.0
+vine==1.2.0               # via amqp
 websocket-client==0.47.0  # via slackclient
+xmlsec==1.3.3             # via python3-saml
 zope.interface==4.4.3     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
##### SUMMARY
I suspect some of these changes aren't necessary. My motivation here is mainly to get this stuff into its own PR, separate from https://github.com/ansible/awx/pull/3098 as I don't think the changes are related, and also to confirm with the team that we're all caught up with whatever (mostly) deterministic process we use to generate the requirements file.

I followed this process to generate the file:

- manually updated the `jinja2` entry in `requirements.in` to fix the version pinning syntax (this may be all we need to do for now?)
- pip installed `pip-tools` to /venv/awx
- added the `git` entries from `requirements_git` to `requirements.in` as the readme instructs
- ran  `pip-compile --output-file requirements/requirements.txt requirements/requirements.in` using /venv/awx
- removed the `git` entries from both files
- changed `requests==2.15.1` back to `requests[security]==2.15.1` per conversation in https://github.com/ansible/awx/pull/3098

