### PR TITLE
Fix chrome can not be started with unit-tests due to missing shared libraries

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -17,9 +17,11 @@ RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
   xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 \
   xmlsec1-openssl-devel libtool-ltdl-devel rabbitmq-server bubblewrap \
   zanata-python-client gettext gcc-c++ libcurl-devel bzip2 rsync \
-  libXcomposite libXcursor libXdamage libXext libXfixes libXi libXrender \
-  libXtst cups-libs libXScrnSaver libXrandr alsa-lib pango cairo \
-  atk at-spi2-atk gtk3 gdk-pixbuf2
+  pango libXcomposite libXcursor libXdamage \
+  libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 alsa-lib atk \
+  gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi \
+  xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 \
+  xorg-x11-fonts-misc
 
 RUN ln -s /usr/bin/python36 /usr/bin/python3
 

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -16,8 +16,10 @@ RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
   libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel \
   xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 \
   xmlsec1-openssl-devel libtool-ltdl-devel rabbitmq-server bubblewrap \
-  zanata-python-client gettext gcc-c++ libcurl-devel bzip2 \
-  rsync
+  zanata-python-client gettext gcc-c++ libcurl-devel bzip2 rsync \
+  libXcomposite libXcursor libXdamage libXext libXfixes libXi libXrender \
+  libXtst cups-libs libXScrnSaver libXrandr alsa-lib pango cairo \
+  atk at-spi2-atk gtk3 gdk-pixbuf2
 
 RUN ln -s /usr/bin/python36 /usr/bin/python3
 


### PR DESCRIPTION
##### SUMMARY

Chrome can not be started with unit-tests(`make ui-test-ci`) due to missing shared libraries.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
 
- Unit tests

##### AWX VERSION

```
- devel
```

##### ADDITIONAL INFORMATION

I have got the following error message when I executed `make ui-test-ci`:

~~~~
bash-4.2$ make ui-test-ci
npm --prefix awx/ui run test:ci

> awx@1.0.0 test:ci /awx_devel/awx/ui
> npm run test -- --single-run --reporter junit,dots --browsers=chromeHeadless


> awx@1.0.0 test /awx_devel/awx/ui
> karma start test/spec/karma.spec.js "--single-run" "--reporter" "junit,dots" "--browsers=chromeHeadless"

30 01 2019 23:51:33.926:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
30 01 2019 23:51:33.928:INFO [launcher]: Launching browser chromeHeadless with unlimited concurrency
30 01 2019 23:51:34.194:INFO [launcher]: Starting browser Chrome
30 01 2019 23:51:34.261:ERROR [launcher]: Cannot start Chrome
	/awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.262:ERROR [launcher]: Chrome stdout: 
30 01 2019 23:51:34.262:ERROR [launcher]: Chrome stderr: /awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.272:INFO [launcher]: Trying to start Chrome again (1/2).
30 01 2019 23:51:34.305:ERROR [launcher]: Cannot start Chrome
	/awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.305:ERROR [launcher]: Chrome stdout: 
30 01 2019 23:51:34.305:ERROR [launcher]: Chrome stderr: /awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.316:INFO [launcher]: Trying to start Chrome again (2/2).
30 01 2019 23:51:34.350:ERROR [launcher]: Cannot start Chrome
	/awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.350:ERROR [launcher]: Chrome stdout: 
30 01 2019 23:51:34.350:ERROR [launcher]: Chrome stderr: /awx_devel/awx/ui/node_modules/puppeteer/.local-chromium/linux-588429/chrome-linux/chrome: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory

30 01 2019 23:51:34.366:ERROR [launcher]: Chrome failed 2 times (cannot start). Giving up.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! awx@1.0.0 test: `karma start test/spec/karma.spec.js "--single-run" "--reporter" "junit,dots" "--browsers=chromeHeadless"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the awx@1.0.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/.npm/_logs/2019-01-30T23_51_34_452Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! awx@1.0.0 test:ci: `npm run test -- --single-run --reporter junit,dots --browsers=chromeHeadless`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the awx@1.0.0 test:ci script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/.npm/_logs/2019-01-30T23_51_34_463Z-debug.log
~~~~

It seems that the following libraries for Chrome are missing:

~~~~
	linux-vdso.so.1 =>  (0x00007ffd743fe000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fc02df8f000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fc02dd73000)
	librt.so.1 => /lib64/librt.so.1 (0x00007fc02db6b000)
	libX11.so.6 => /lib64/libX11.so.6 (0x00007fc02d82d000)
	libX11-xcb.so.1 => /lib64/libX11-xcb.so.1 (0x00007fc02d62b000)
	libxcb.so.1 => /lib64/libxcb.so.1 (0x00007fc02d403000)
	libXcomposite.so.1 => not found
	libXcursor.so.1 => not found
	libXdamage.so.1 => not found
	libXext.so.6 => not found
	libXfixes.so.3 => not found
	libXi.so.6 => not found
	libXrender.so.1 => not found
	libXtst.so.6 => not found
	libgobject-2.0.so.0 => /lib64/libgobject-2.0.so.0 (0x00007fc02d1b3000)
	libglib-2.0.so.0 => /lib64/libglib-2.0.so.0 (0x00007fc02ce9d000)
	libnss3.so => /lib64/libnss3.so (0x00007fc02cb70000)
	libnssutil3.so => /lib64/libnssutil3.so (0x00007fc02c941000)
	libsmime3.so => /lib64/libsmime3.so (0x00007fc02c71a000)
	libnspr4.so => /lib64/libnspr4.so (0x00007fc02c4dc000)
	libcups.so.2 => not found
	libexpat.so.1 => /lib64/libexpat.so.1 (0x00007fc02c2b2000)
	libdbus-1.so.3 => /lib64/libdbus-1.so.3 (0x00007fc02c062000)
	libXss.so.1 => not found
	libuuid.so.1 => /lib64/libuuid.so.1 (0x00007fc02be5d000)
	libXrandr.so.2 => not found
	libgio-2.0.so.0 => /lib64/libgio-2.0.so.0 (0x00007fc02babe000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fc02b7bc000)
	libasound.so.2 => not found
	libpangocairo-1.0.so.0 => not found
	libpango-1.0.so.0 => not found
	libcairo.so.2 => not found
	libatk-1.0.so.0 => not found
	libatk-bridge-2.0.so.0 => not found
	libgtk-3.so.0 => not found
	libgdk-3.so.0 => not found
	libgdk_pixbuf-2.0.so.0 => not found
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fc02b5a6000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc02b1d9000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc03709c000)
	libXau.so.6 => /lib64/libXau.so.6 (0x00007fc02afd5000)
	libpcre.so.1 => /lib64/libpcre.so.1 (0x00007fc02ad73000)
	libffi.so.6 => /lib64/libffi.so.6 (0x00007fc02ab6b000)
	libplc4.so => /lib64/libplc4.so (0x00007fc02a966000)
	libplds4.so => /lib64/libplds4.so (0x00007fc02a762000)
	libsystemd.so.0 => /lib64/libsystemd.so.0 (0x00007fc02a531000)
	libgmodule-2.0.so.0 => /lib64/libgmodule-2.0.so.0 (0x00007fc02a32d000)
	libz.so.1 => /lib64/libz.so.1 (0x00007fc02a117000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007fc029ef0000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007fc029cd7000)
	libmount.so.1 => /lib64/libmount.so.1 (0x00007fc029a94000)
	libcap.so.2 => /lib64/libcap.so.2 (0x00007fc02988f000)
	liblzma.so.5 => /lib64/liblzma.so.5 (0x00007fc029669000)
	liblz4.so.1 => /lib64/liblz4.so.1 (0x00007fc029454000)
	libgcrypt.so.11 => /lib64/libgcrypt.so.11 (0x00007fc0291d3000)
	libgpg-error.so.0 => /lib64/libgpg-error.so.0 (0x00007fc028fce000)
	libdw.so.1 => /lib64/libdw.so.1 (0x00007fc028d7f000)
	libblkid.so.1 => /lib64/libblkid.so.1 (0x00007fc028b3f000)
	libattr.so.1 => /lib64/libattr.so.1 (0x00007fc02893a000)
	libelf.so.1 => /lib64/libelf.so.1 (0x00007fc028722000)
	libbz2.so.1 => /lib64/libbz2.so.1 (0x00007fc028512000)
~~~~