### PR TITLE
Removed unnecessary adding privileged service account

### DIFF
--- a/installer/roles/kubernetes/tasks/openshift.yml
+++ b/installer/roles/kubernetes/tasks/openshift.yml
@@ -28,7 +28,3 @@
   set_fact:
     postgresql_service_name: "postgresql"
   when: "pg_hostname is not defined or pg_hostname == ''"
-
-- name: Add privileged SCC to service account
-  shell: |
-    {{ openshift_oc_bin }} adm policy add-scc-to-user privileged system:serviceaccount:{{ openshift_project }}:awx


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
AWX should not require cluster admin privileges to install on Openshift, nor should it add a privileged service account during install
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Issue #3115 should be tackled to instead ensure the AWX container does not require root.

related #3114
related #3115

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
