### PR TITLE
[WIP] Produce ansible_version related to venv

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -954,7 +954,8 @@ class BaseTask(object):
                 self.update_model(pk, custom_virtualenv=getattr(instance, 'ansible_virtualenv_path', settings.ANSIBLE_VENV_PATH))
 
             # Fetch ansible version once here to support version-dependent features.
-            kwargs['ansible_version'] = get_ansible_version()
+            kwargs['ansible_version'] = get_ansible_version(
+                ansible_path=self.get_path_to_ansible(instance, executable='ansible'))
             kwargs['private_data_dir'] = self.build_private_data_dir(instance, **kwargs)
 
             # Fetch "cached" fact data from prior runs and put on the disk

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -168,18 +168,23 @@ def memoize_delete(function_name):
     return cache.delete(function_name)
 
 
-@memoize()
-def get_ansible_version():
+def _get_ansible_version(ansible_path):
     '''
     Return Ansible version installed.
+    Ansible path needs to be provided to account for custom virtual environments
     '''
     try:
-        proc = subprocess.Popen(['ansible', '--version'],
+        proc = subprocess.Popen([ansible_path, '--version'],
                                 stdout=subprocess.PIPE)
         result = smart_str(proc.communicate()[0])
         return result.split('\n')[0].replace('ansible', '').strip()
     except Exception:
         return 'unknown'
+
+
+@memoize()
+def get_ansible_version(ansible_path='ansible'):
+    return _get_ansible_version(ansible_path)
 
 
 @memoize()


### PR DESCRIPTION
This intentionally introduces a conflict with https://github.com/ansible/awx/pull/3041, because this logic is central to the implementation of inventory plugins, and I would rather get ahead of the conflicts.

We were previously producing this parameter that was passed around tasks.py that gave the Ansible version, it just wasn't really the version that particular job run used. Inventory plugins will have to use the version over and over again, because not all plugins works in all Ansible versions.