### PR TITLE
properly detect ansible-playbook vs ansible runs in bwrap arg building

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -882,7 +882,7 @@ def wrap_args_with_proot(args, cwd, **kwargs):
         path = os.path.realpath(path)
         new_args.extend(['--bind', '%s' % (path,), '%s' % (path,)])
     if kwargs.get('isolated'):
-        if 'ansible-playbook' in args:
+        if '/bin/ansible-playbook' in ' '.join(args):
             # playbook runs should cwd to the SCM checkout dir
             new_args.extend(['--chdir', os.path.join(kwargs['private_data_dir'], 'project')])
         else:


### PR DESCRIPTION
a recent change (65641c7) made it so that we call
ansible-playbook using its _absolute path_ (i.e.,
/usr/bin/ansible-playbook, /var/lib/venv/xyz/bin/ansible-playbook), so
this logic is no longer correct