### PR TITLE
Disable hosts toggle in smart inventory hosts tab

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-hosts.route.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-hosts.route.js
@@ -38,7 +38,8 @@ export default {
             delete list.fieldActions.delete;
             delete list.fieldActions.edit;
             delete list.fieldActions.view.ngShow;
-            list.fields.toggleHost.ngDisabled = true;
+            let toggleHost = list.staticColumns.find((el) => { return el.field === 'toggleHost'; });
+            toggleHost.content.ngDisabled = true;
             list.fields.name.columnClass = 'col-lg-8 col-md-11 col-sm-8 col-xs-7';
             return list;
         }],


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/3135

Related to structural changes within `related-host.list.js` during the jQuery / Bootstrap upgrade: https://github.com/ansible/awx/commit/9c20e1b4946f05cbb63a616f297dc7da62071385#diff-7d045d6d353712d07c6c18adcd09575cR21

`list.fields.toggleHost.ngDisabled` does not exist causing the resolve to fail. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
![demo inv host](https://user-images.githubusercontent.com/15881645/52133819-21ce2100-2610-11e9-988d-01b7be94e84b.gif)
