### PR TITLE
prevent field lookups on Host.ansible_facts keys (it doesn't work)

### DIFF
--- a/awx/main/tests/unit/utils/test_filters.py
+++ b/awx/main/tests/unit/utils/test_filters.py
@@ -105,6 +105,7 @@ class TestSmartFilterQueryFromString():
         ('a__b__c=false', Q(**{u"a__b__c": False})),
         ('a__b__c=null', Q(**{u"a__b__c": None})),
         ('ansible_facts__a="true"', Q(**{u"ansible_facts__contains": {u"a": u"true"}})),
+        ('ansible_facts__a__exact="true"', Q(**{u"ansible_facts__contains": {u"a": u"true"}})),
         #('"a__b\"__c"="true"', Q(**{u"a__b\"__c": "true"})),
         #('a__b\"__c="true"', Q(**{u"a__b\"__c": "true"})),
     ])


### PR DESCRIPTION
under the hood, `Host.ansible_facts` is a postgres `jsonb` field which
performs match operations using the JSON containment operator (`@>`)

this operator _only_ works on **exact** matches of containment (i.e.,
"does the `ansible_facts` `jsonb` value contain _this exact_ JSON
sub-object"):

https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSONB-OP-TABLE

```sql
SELECT ...
FROM main_host
WHERE ansible_facts @> '{"ansible_distribution": "centos"}'

SELECT ...
FROM main_host
WHERE ansible_facts @> '{"packages": {"dnsmasq": [{"version": 2}]}}'
```

postgres does _not_ expose any operator for fuzzy or lookup-based
matches with this operator, so host filter values like these don't
really make sense (postgres can't _filter_ in the way intended in these
examples):

```
ansible_distribution__startswith=\"Cent\"
ansible_distribution__icontains=\"CentOS\"
ansible_facts__packages__dnsmasq[]__version__startswith=\"2\"
```