### PR TITLE
Adds proper error handling to workflow save related promises

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
@@ -221,6 +221,7 @@ export default ['$scope', 'TemplatesService', 'JobTemplateModel', 'PromptService
                             $scope.promptModalMissingReqFields = false;
                         }
                     }
+                    watchForPromptChanges();
                     $scope.nodeFormDataLoaded = true;
                 } else if (
                     _.get($scope, 'nodeConfig.node.fullUnifiedJobTemplateObject.unified_job_type') === 'job_template' ||

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
@@ -5,12 +5,12 @@
  *************************************************/
 
 export default ['$scope', 'TemplatesService',
-    'ProcessErrors', 'CreateSelect2', '$q', 'JobTemplateModel',
-    'Empty', 'PromptService', 'Rest', 'TemplatesStrings', 'WorkflowChartService',
+    'ProcessErrors', '$q',
+    'PromptService', 'TemplatesStrings', 'WorkflowChartService',
     'Wait', '$state',
     function ($scope, TemplatesService,
-        ProcessErrors, CreateSelect2, $q, JobTemplate,
-        Empty, PromptService, Rest, TemplatesStrings, WorkflowChartService,
+        ProcessErrors, $q,
+        PromptService, TemplatesStrings, WorkflowChartService,
         Wait, $state
     ) {
 
@@ -159,6 +159,11 @@ export default ['$scope', 'TemplatesService',
                                     });
                                 });
                             }
+                        }).catch(({ data, status }) => {
+                            Wait('stop');
+                            ProcessErrors($scope, data, status, null, {
+                                hdr: $scope.strings.get('error.HEADER')
+                            });
                         }));
                     } else if (nodeRef[workflowMakerNodeId].isEdited) {
                         editPromises.push(TemplatesService.editWorkflowNode({
@@ -360,14 +365,26 @@ export default ['$scope', 'TemplatesService',
                                     .then(() => {
                                         Wait('stop');
                                         $scope.closeDialog();
+                                    }).catch(({ data, status }) => {
+                                        Wait('stop');
+                                        ProcessErrors($scope, data, status, null, {
+                                            hdr: $scope.strings.get('error.HEADER')
+                                        });
                                     });
                             }).catch(({
                                 data,
                                 status
                             }) => {
                                 Wait('stop');
-                                ProcessErrors($scope, data, status, null, {});
+                                ProcessErrors($scope, data, status, null, {
+                                    hdr: $scope.strings.get('error.HEADER')
+                                });
                             });
+                    }).catch(({ data, status }) => {
+                        Wait('stop');
+                        ProcessErrors($scope, data, status, null, {
+                            hdr: $scope.strings.get('error.HEADER')
+                        });
                     });
 
             } else {
@@ -381,6 +398,11 @@ export default ['$scope', 'TemplatesService',
                         Wait('stop');
                         $scope.closeDialog();
                         $state.transitionTo('templates');
+                    }).catch(({ data, status }) => {
+                        Wait('stop');
+                        ProcessErrors($scope, data, status, null, {
+                            hdr: $scope.strings.get('error.HEADER')
+                        });
                     });
             }
         };


### PR DESCRIPTION
##### SUMMARY

Also fixes bug watching for prompt changes after the node has been edited once.  This was something else that I came across while fixing the initial issue.  If a user edited a node with a prompted inventory (didn't have to actually change anything about the node, just had to click the node and then hit select) and then edited the node _again_, they could remove the inventory and attempt to save the workflow.  This threw an error to the console.  https://github.com/ansible/awx/compare/devel...mabashian:workflow-403?expand=1#diff-2b17e09a52ead2d6aa91ff513154252dR224 addresses this issue.

Everything else is related to error handling in the workflow maker.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

To test this locally I followed these steps:

* Have a job template with promptable inventory
* As admin, create a workflow that uses that job template. Set it to use inventory "ABC"
* Delegate admin on the workflow to user "foo" who does not have access to inventory "ABC".
* Log in as "foo"
* Configure workflow node. Deselect inventory "ABC", and select some other inventory.
* Attempt to save workflow

and made sure that the error message passed back to us from the api is now displayed and the waiting... spinner is hidden.  These changes _shouldn't_ impact normal workflow actions and are specific to error handling.