### PR TITLE
update-ca-trust: Ensure CA trust is updated in awx_task container

### DIFF
--- a/installer/roles/local_docker/tasks/standalone.yml
+++ b/installer/roles/local_docker/tasks/standalone.yml
@@ -156,3 +156,8 @@
       MEMCACHED_PORT: "11211"
       AWX_ADMIN_USER: "{{ admin_user|default('admin') }}"
       AWX_ADMIN_PASSWORD: "{{ admin_password|default('password') }}"
+  register: awx_task_container
+
+- name: Update CA trust in awx_task container
+  command: docker exec awx_task '/usr/bin/update-ca-trust'
+  when: awx_task_container.changed


### PR DESCRIPTION
Related #3010

Both awx_web and awx_task containers can have a volume mounted in
specified by the ca_trust_dir variable. Unfortunately only the
awx_web container's trust is updated. This patch makes sure the
awx_task container's trust is updated as well

##### SUMMARY
Both awx_web and awx_task containers can have a volume mounted in
specified by the ca_trust_dir variable. Unfortunately only the
awx_web container's trust is updated. This patch makes sure the
awx_task container's trust is updated as well

Related #3010 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 3.0.0
```