### PR TITLE
Use arrow instead of 'to' in workflow edit link title

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-link-form.partial.html
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-link-form.partial.html
@@ -1,4 +1,6 @@
-<div class="WorkflowMaker-formTitle">{{readOnly ? strings.get('workflow_maker.VIEW_LINK') : (linkConfig.mode === 'add' ? strings.get('workflow_maker.ADD_LINK') : strings.get('workflow_maker.EDIT_LINK')) }} | {{linkConfig.source.name}} {{linkConfig.target ? 'to ' + linkConfig.target.name : ''}}</div>
+<div class="WorkflowMaker-formTitle">
+    {{readOnly ? strings.get('workflow_maker.VIEW_LINK') : (linkConfig.mode === 'add' ? strings.get('workflow_maker.ADD_LINK') : strings.get('workflow_maker.EDIT_LINK')) }} | {{linkConfig.source.name}} {{linkConfig.target ? '&rarr; ' + linkConfig.target.name : ''}}
+</div>
 <div class="WorkflowMaker-form">
     <div class="form-group Form-formGroup Form-formGroup--singleColumn">
         <div ng-show="linkConfig.mode === 'add' && !linkConfig.target">{{:: strings.get('workflow_maker.NEW_LINK')}}</div>

--- a/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.partial.html
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.partial.html
@@ -15,7 +15,7 @@
             <div class="row" ng-show="wf_maker_templates.length === 0 && !(searchTags | isEmpty)">
                 <div class="col-lg-12 List-searchNoResults" translate>No records matched your search.</div>
             </div>
-            <div class="List-noItems" ng-show="wf_maker_templates.length === 0 && (searchTags | isEmpty)">PLEASE ADD ITEMS TO THIS LIST</div>
+            <div class="List-noItems" ng-show="wf_maker_templates.length === 0 && (searchTags | isEmpty)" translate>PLEASE ADD ITEMS TO THIS LIST</div>
             <div class="list-table-container" ng-show="wf_maker_templates.length > 0">
                 <div id="templates_table" class="List-table" is-extended="false">
                     <div class="List-lookupLayout List-tableHeaderRow">

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
@@ -404,7 +404,10 @@ export default ['$scope', 'TemplatesService',
             $scope.graphState.nodeBeingAdded = workflowMakerNodeIdCounter;
 
             $scope.graphState.arrayOfLinksForChart.push({
-                source: {id: parent.id},
+                source: {
+                    id: parent.id,
+                    unifiedJobTemplate: parent.unifiedJobTemplate
+                },
                 target: {id: workflowMakerNodeIdCounter},
                 edgeType: "placeholder"
             });
@@ -439,7 +442,10 @@ export default ['$scope', 'TemplatesService',
             $scope.graphState.nodeBeingAdded = workflowMakerNodeIdCounter;
 
             $scope.graphState.arrayOfLinksForChart.push({
-                source: {id: link.source.id},
+                source: {
+                    id: link.source.id,
+                    unifiedJobTemplate: link.source.unifiedJobTemplate
+                },
                 target: {id: workflowMakerNodeIdCounter},
                 edgeType: "placeholder"
             });
@@ -480,6 +486,7 @@ export default ['$scope', 'TemplatesService',
                     $scope.graphState.arrayOfLinksForChart.map( (link) => {
                         if (link.target.id === nodeId) {
                             link.edgeType = edgeType.value;
+                            link.target.unifiedJobTemplate = selectedTemplate;
                         }
                     });
                 }
@@ -489,6 +496,15 @@ export default ['$scope', 'TemplatesService',
                     nodeRef[$scope.nodeConfig.nodeId].promptData = _.cloneDeep(promptData);
                     nodeRef[$scope.nodeConfig.nodeId].isEdited = true;
                     $scope.graphState.nodeBeingEdited = null;
+
+                    $scope.graphState.arrayOfLinksForChart.map( (link) => {
+                        if (link.target.id === nodeId) {
+                            link.target.unifiedJobTemplate = selectedTemplate;
+                        }
+                        if (link.source.id === nodeId) {
+                            link.source.unifiedJobTemplate = selectedTemplate;
+                        }
+                    });
                 }
             }
 


### PR DESCRIPTION
##### SUMMARY
Screenshot:

<img width="1669" alt="screen shot 2019-02-07 at 1 47 20 pm" src="https://user-images.githubusercontent.com/9889020/52435104-f0a59300-2ade-11e9-8d6b-4196d054e56b.png">

This change makes the title easier to understand in all languages.

I also came across a small bug while making this change.  Editing a link between two brand new nodes showed the incorrect title:

<img width="1411" alt="screen shot 2019-02-07 at 1 32 44 pm" src="https://user-images.githubusercontent.com/9889020/52435161-1cc11400-2adf-11e9-9eb1-d10962734a4e.png">

This PR addresses that bug by making sure that the unifiedJobTemplate attribute is kept up to date on each link whenever a change is made to a node (new or edit).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Tested locally by creating a new workflow with two serial nodes and clicking on the link to edit.  The title should use an arrow between node names instead of `to`.  It was deemed that this would be a better solution for internationalization.

The small bug that I found was tested locally by adding two new nodes in serial and before saving, clicking on the link between the two.  The title should correctly display the names of the resources for each node.
