### PR TITLE
Add verify_ssl to OpenStack credential type

### DIFF
--- a/awx/main/migrations/0061_v350_add_openstack_cedential_verify_ssl.py
+++ b/awx/main/migrations/0061_v350_add_openstack_cedential_verify_ssl.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+# AWX
+from awx.main.migrations import _credentialtypes as credentialtypes
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0060_v350_update_schedule_uniqueness_constraint'),
+    ]
+
+    operations = [
+        migrations.RunPython(credentialtypes.add_openstack_verify_field),
+    ]

--- a/awx/main/migrations/_credentialtypes.py
+++ b/awx/main/migrations/_credentialtypes.py
@@ -214,3 +214,11 @@ def remove_become_methods(apps, schema_editor):
     become_credtype = CredentialType.objects.filter(kind='ssh', managed_by_tower=True).first()
     become_credtype.inputs = CredentialType.defaults.get('ssh')().inputs
     become_credtype.save()
+
+
+def add_openstack_verify_field(apps, schema_editor):
+    openstack_credtype = CredentialType.objects.get(
+        kind='cloud', name='OpenStack', managed_by_tower=True
+    )
+    openstack_credtype.inputs = CredentialType.defaults.get('openstack')().inputs
+    openstack_credtype.save()

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -933,6 +933,10 @@ def openstack(cls):
                                            'It is only needed for Keystone v3 authentication '
                                            'URLs. Refer to Ansible Tower documentation for '
                                            'common scenarios.')
+            }, {
+                'id': 'verify_ssl',
+                'label': ugettext_noop('Verify SSL'),
+                'type': 'boolean'
             }],
             'required': ['username', 'password', 'host', 'project']
         }

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1139,10 +1139,12 @@ class RunJob(BaseTask):
                                       project_name=credential.get_input('project', default=''))
                 if credential.has_input('domain'):
                     openstack_auth['domain_name'] = credential.get_input('domain', default='')
+                verify_state = credential.get_input('verify_ssl', default=True)
                 openstack_data = {
                     'clouds': {
                         'devstack': {
                             'auth': openstack_auth,
+                            'verify': verify_state,
                         },
                     },
                 }
@@ -1847,6 +1849,7 @@ class RunInventoryUpdate(BaseTask):
                 openstack_auth['domain_name'] = credential.get_input('domain', default='')
 
             private_state = inventory_update.source_vars_dict.get('private', True)
+            verify_state = credential.get_input('verify_ssl', default=True)
             # Retrieve cache path from inventory update vars if available,
             # otherwise create a temporary cache path only for this update.
             cache = inventory_update.source_vars_dict.get('cache', {})
@@ -1859,6 +1862,7 @@ class RunInventoryUpdate(BaseTask):
                 'clouds': {
                     'devstack': {
                         'private': private_state,
+                        'verify': verify_state,
                         'auth': openstack_auth,
                     },
                 },

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -105,7 +105,10 @@ def test_safe_env_returns_new_copy():
     assert build_safe_env(env) is not env
 
 
-def test_openstack_client_config_generation(mocker):
+@pytest.mark.parametrize("source,expected", [
+    (False, False), (True, True)
+])
+def test_openstack_client_config_generation(mocker, source, expected):
     update = tasks.RunInventoryUpdate()
     credential_type = CredentialType.defaults['openstack']()
     inputs = {
@@ -114,6 +117,7 @@ def test_openstack_client_config_generation(mocker):
         'password': 'secrete',
         'project': 'demo-project',
         'domain': 'my-demo-domain',
+        'verify_ssl': source,
     }
     credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
 
@@ -136,7 +140,8 @@ def test_openstack_client_config_generation(mocker):
                 'username': 'demo',
                 'domain_name': 'my-demo-domain',
             },
-            'private': True
+            'verify': expected,
+            'private': True,
         }
     }
 
@@ -153,6 +158,7 @@ def test_openstack_client_config_generation_with_private_source_vars(mocker, sou
         'password': 'secrete',
         'project': 'demo-project',
         'domain': None,
+        'verify_ssl': True,
     }
     credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
 
@@ -174,6 +180,7 @@ def test_openstack_client_config_generation_with_private_source_vars(mocker, sou
                 'project_name': 'demo-project',
                 'username': 'demo'
             },
+            'verify': True,
             'private': expected
         }
     }
@@ -1145,6 +1152,7 @@ class TestJobCredentials(TestJobExecution):
                 '      password: secret',
                 '      project_name: tenant-name',
                 '      username: bob',
+                '    verify: true',
                 ''
             ])
             return ['successful', 0]


### PR DESCRIPTION
##### SUMMARY

This PR adds "Disable SSL Verification" checkbox to the credential edit page with openstack credential type.
If users turned it on, AWX/Tower can access the Keystone API ignoring verification failure that occur when using self-signed certificates.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

 - UI

##### AWX VERSION

```
- devel
```

##### ADDITIONAL INFORMATION

- This is related on the issue #941 (RFE: OpenStack Credential Expantion)
- Re-created for #3132