### PR TITLE
Job Artifacts: check for empty object rather than string value.

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -579,7 +579,8 @@ function getExtraVarsDetails () {
 
 function getArtifactsDetails (val) {
     const artifacts = val || resource.model.get('artifacts');
-    if (!artifacts || (Object.entries(artifacts).length === 0 && artifacts.constructor === Object)) {
+    if (!artifacts || (Object.entries(artifacts).length === 0 &&
+        artifacts.constructor === Object)) {
         return null;
     }
 

--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -579,8 +579,7 @@ function getExtraVarsDetails () {
 
 function getArtifactsDetails (val) {
     const artifacts = val || resource.model.get('artifacts');
-
-    if (!artifacts || artifacts === '{}') {
+    if (!artifacts || (Object.entries(artifacts).length === 0 && artifacts.constructor === Object)) {
         return null;
     }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes how we check for jobs that have empty `artifacts` field and conditionally renders it. Before we were checking for a string value when we should be checking whether or not the value returned is an empty object.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.0
```

