### PR TITLE
Dynamically place link hover tooltip based on its size

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -225,6 +225,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
                             // In order for this to work in FF a height of at least 1 must be present
                             .attr("width", 100)
                             .attr("height", 1)
+                            .style("overflow", "visible")
                             .html(function(){
                                 return `<div class='WorkflowChart-tooltipContents'>
                                         <div>${TemplatesStrings.get('workflow_maker.RUN')}: ${edgeTypeLabel}</div>
@@ -283,8 +284,8 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
                                 return `${arrowPoints.pt1.x},${arrowPoints.pt1.y} ${arrowPoints.pt2.x},${arrowPoints.pt2.y} ${arrowPoints.pt3.x},${arrowPoints.pt3.y}`;
                             });
 
-                        tipRef.attr('height', tipDimensions.height);
-                        tipRef.attr("transform", `translate(${xPos},${yPos})`)
+                        tipRef.attr('height', scaledHeight);
+                        tipRef.attr("transform", `translate(${xPos},${yPos})`);
                     };
 
                     let g = new dagre.graphlib.Graph();

--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -4,8 +4,8 @@
  * All Rights Reserved
  *************************************************/
 
-export default ['$state','moment', '$timeout', '$window', '$filter', 'Rest', 'GetBasePath', 'ProcessErrors', 'TemplatesStrings',
-    function($state, moment, $timeout, $window, $filter, Rest, GetBasePath, ProcessErrors, TemplatesStrings) {
+export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
+    function(moment, $timeout, $window, $filter, TemplatesStrings) {
 
     return {
         scope: {
@@ -206,50 +206,8 @@ export default ['$state','moment', '$timeout', '$window', '$filter', 'Rest', 'Ge
             const updateGraph = () => {
                 if(scope.dimensionsSet) {
                     const buildLinkTooltip = (d) => {
-                        let sourceNode = d3.select(`#node-${d.source.id}`);
-                        const sourceNodeX = d3.transform(sourceNode.attr("transform")).translate[0];
-                        const sourceNodeY = d3.transform(sourceNode.attr("transform")).translate[1];
-                        let targetNode = d3.select(`#node-${d.target.id}`);
-                        const targetNodeX = d3.transform(targetNode.attr("transform")).translate[0];
-                        const targetNodeY = d3.transform(targetNode.attr("transform")).translate[1];
-                        let xPos, yPos, arrowPoints;
-                        if (nodePositionMap[d.source.id].y === nodePositionMap[d.target.id].y) {
-                            xPos = (sourceNodeX + nodeW + targetNodeX)/2 - 50;
-                            yPos = (sourceNodeY + nodeH + targetNodeY)/2 - 70;
-                             arrowPoints = {
-                                pt1: {
-                                    x: xPos + 40,
-                                    y: yPos + 47
-                                },
-                                pt2: {
-                                    x: xPos + 60,
-                                    y: yPos + 47
-                                },
-                                pt3: {
-                                    x: xPos + 50,
-                                    y: yPos + 57
-                                }
-                            };
-                        } else {
-                            xPos = (sourceNodeX + nodeW + targetNodeX)/2 - 120;
-                            yPos = (sourceNodeY + nodeH + targetNodeY)/2 - 30;
-                             arrowPoints = {
-                                pt1: {
-                                    x: xPos + 100,
-                                    y: yPos + 17
-                                },
-                                pt2: {
-                                    x: xPos + 100,
-                                    y: yPos + 33
-                                },
-                                pt3: {
-                                    x: xPos + 110,
-                                    y: yPos + 25
-                                }
-                            };
-                        }
-                         let edgeTypeLabel;
-                         switch(d.edgeType) {
+                        let edgeTypeLabel;
+                        switch(d.edgeType) {
                             case "always":
                                 edgeTypeLabel = TemplatesStrings.get('workflow_maker.ALWAYS');
                                 break;
@@ -260,24 +218,73 @@ export default ['$state','moment', '$timeout', '$window', '$filter', 'Rest', 'Ge
                                 edgeTypeLabel = TemplatesStrings.get('workflow_maker.ON_FAILURE');
                                 break;
                         }
-                         let linkInstructionText = !scope.readOnly ? TemplatesStrings.get('workflow_maker.EDIT_LINK_TOOLTIP') : TemplatesStrings.get('workflow_maker.VIEW_LINK_TOOLTIP');
-                         let linkTooltip = svgGroup.append("g")
-                          .attr("class", "WorkflowChart-tooltip");
-                         linkTooltip.append("foreignObject")
-                            .attr("transform", `translate(${xPos},${yPos})`)
+                        let linkInstructionText = !scope.readOnly ? TemplatesStrings.get('workflow_maker.EDIT_LINK_TOOLTIP') : TemplatesStrings.get('workflow_maker.VIEW_LINK_TOOLTIP');
+                        let linkTooltip = svgGroup.append("g")
+                            .attr("class", "WorkflowChart-tooltip");
+                        const tipRef = linkTooltip.append("foreignObject")
+                            // In order for this to work in FF a height of at least 1 must be present
                             .attr("width", 100)
-                            .attr("height", 50)
+                            .attr("height", 1)
                             .html(function(){
                                 return `<div class='WorkflowChart-tooltipContents'>
-                                          <div>${TemplatesStrings.get('workflow_maker.RUN')}: ${edgeTypeLabel}</div>
-                                          <div>${linkInstructionText}</div>
+                                        <div>${TemplatesStrings.get('workflow_maker.RUN')}: ${edgeTypeLabel}</div>
+                                        <div>${linkInstructionText}</div>
                                         </div>`;
                             });
-                         linkTooltip.append("polygon")
+                        const tipDimensions = tipRef.select('.WorkflowChart-tooltipContents').node().getBoundingClientRect();
+                        let sourceNode = d3.select(`#node-${d.source.id}`);
+                        const sourceNodeX = d3.transform(sourceNode.attr("transform")).translate[0];
+                        const sourceNodeY = d3.transform(sourceNode.attr("transform")).translate[1];
+                        let targetNode = d3.select(`#node-${d.target.id}`);
+                        const targetNodeX = d3.transform(targetNode.attr("transform")).translate[0];
+                        const targetNodeY = d3.transform(targetNode.attr("transform")).translate[1];
+                        let xPos, yPos, arrowPoints;
+                        const scaledHeight = tipDimensions.height/zoomObj.scale();
+
+                        if (nodePositionMap[d.source.id].y === nodePositionMap[d.target.id].y) {
+                            xPos = (sourceNodeX + nodeW + targetNodeX)/2 - 50;
+                            yPos = sourceNodeY + nodeH/2 - scaledHeight - 20;
+                             arrowPoints = {
+                                pt1: {
+                                    x: xPos + 40,
+                                    y: yPos + scaledHeight
+                                },
+                                pt2: {
+                                    x: xPos + 60,
+                                    y: yPos + scaledHeight
+                                },
+                                pt3: {
+                                    x: xPos + 50,
+                                    y: yPos + scaledHeight + 10
+                                }
+                            };
+                        } else {
+                            xPos = (sourceNodeX + nodeW + targetNodeX)/2 - 120;
+                            yPos = (sourceNodeY + (nodeH/2) + targetNodeY + (nodeH/2))/2 - (scaledHeight/2);
+                             arrowPoints = {
+                                pt1: {
+                                    x: xPos + 100,
+                                    y: yPos + (scaledHeight/2) - 10
+                                },
+                                pt2: {
+                                    x: xPos + 100,
+                                    y: yPos + (scaledHeight/2) + 10
+                                },
+                                pt3: {
+                                    x: xPos + 110,
+                                    y: yPos + (scaledHeight/2)
+                                }
+                            };
+                        }
+
+                        linkTooltip.append("polygon")
                             .attr("class", "WorkflowChart-tooltipArrow")
                             .attr("points", function() {
                                 return `${arrowPoints.pt1.x},${arrowPoints.pt1.y} ${arrowPoints.pt2.x},${arrowPoints.pt2.y} ${arrowPoints.pt3.x},${arrowPoints.pt3.y}`;
                             });
+
+                        tipRef.attr('height', tipDimensions.height);
+                        tipRef.attr("transform", `translate(${xPos},${yPos})`)
                     };
 
                     let g = new dagre.graphlib.Graph();


### PR DESCRIPTION
##### SUMMARY
When the contents of the workflow link tooltip are translated they _can_ overflow to a third line.  This caused part of the text to be chopped off since the size of this tooltip was static.  This PR allows the size of the tooltip to be dynamic and handles updating the position of the tooltip appropriately.

Local testing in FF and Chrome:
![link-tooltip](https://user-images.githubusercontent.com/9889020/52508029-3b97d700-2bc1-11e9-9e05-18bd9e5820b5.gif)

It's important to test these changes in FF as well as Chrome because they handle SVG's differently.  All of the relevant changes here were made within the function that handles adding/placing the link tooltip specifically.  That function is not used for anything else so I don't anticipate much regression testing needing to happen for other workflow maker features.  To originally recreate the bug you'll need to view a workflow in french.

Note: the string `Click to edit link` has been marked for translation

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
