### PR TITLE
awx.main.tasks: Remove reference to unimport six

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -468,7 +468,7 @@ def awx_periodic_scheduler():
             try:
                 job_kwargs = schedule.get_job_kwargs()
                 new_unified_job = schedule.unified_job_template.create_unified_job(**job_kwargs)
-                logger.info(six.text_type('Spawned {} from schedule {}-{}.').format(
+                logger.info('Spawned {} from schedule {}-{}.'.format(
                     new_unified_job.log_format, schedule.name, schedule.pk))
 
                 if invalid_license:


### PR DESCRIPTION
d4c3c08 re:introduced the use of six that has been removed by daeeaf4.
This lead to `NameError: name 'six' is not defined`. This commit fixes
the issue.

Signed-off-by: Yanis Guenane <yguenane@redhat.com>
Fixes: https://github.com/ansible/awx/issues/3200