### PR TITLE
Extract translations from ejs files

### DIFF
--- a/awx/ui/grunt-tasks/nggettext_extract.js
+++ b/awx/ui/grunt-tasks/nggettext_extract.js
@@ -4,7 +4,8 @@ let source = [
     'client/lib/**/*.js',
     'client/lib/**/*.html',
     'client/src/**/*.js',
-    'client/src/**/*.html'
+    'client/src/**/*.html',
+    'client/*.ejs'
 ];
 
 module.exports = {


### PR DESCRIPTION
##### SUMMARY
This grunt task wasn't pulling in strings marked in `client/index.template.ejs` and `client/installing.template.ejs`.  This PR addresses that issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
