### PR TITLE
Fix styling on related groups labels after bootstrap upgrade

### DIFF
--- a/awx/ui/client/src/templates/labels/labelsList.block.less
+++ b/awx/ui/client/src/templates/labels/labelsList.block.less
@@ -7,7 +7,8 @@
 }
 
 .LabelList-tagContainer {
-    display: inline-block;
+    display: flex;
+    padding-bottom: 5px;
 }
 
 .LabelList-tagContainer {
@@ -56,7 +57,6 @@
     border-bottom-right-radius: 5px;
     color: @default-bg;
     padding: 0 5px;
-    margin: 3px 0px;
     align-items: center;
     display: flex;
     cursor: pointer;


### PR DESCRIPTION
##### SUMMARY
link #3158 

Style changes to display related groups labels properly

<img width="1026" alt="screen shot 2019-02-12 at 11 10 55 am" src="https://user-images.githubusercontent.com/9889020/52650409-3637d680-2eb8-11e9-9e6f-be14033d16c7.png">
<img width="1000" alt="screen shot 2019-02-12 at 11 10 50 am" src="https://user-images.githubusercontent.com/9889020/52650410-3637d680-2eb8-11e9-9d07-acd726d51d6e.png">

I verified the fix locally in both Chrome and FF.  I attempted to locate other places where these classes are used and ensure that these changes don't have any inadvertent side effects.  Those areas included the job output details view (labels, tags, etc) and the instance groups lookup modal.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
