### PR TITLE
optimize a slow query in inventory script generation

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -239,7 +239,7 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
         hosts_kw = dict()
         if not show_all:
             hosts_kw['enabled'] = True
-        fetch_fields = ['name', 'id', 'variables']
+        fetch_fields = ['name', 'id', 'variables', 'inventory_id']
         if towervars:
             fetch_fields.append('enabled')
         hosts = self.hosts.filter(**hosts_kw).order_by('name').only(*fetch_fields)

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -805,7 +805,10 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
     def get_notification_friendly_name(self):
         return "Job"
 
-    def _get_inventory_hosts(self, only=['name', 'ansible_facts', 'ansible_facts_modified', 'modified',]):
+    def _get_inventory_hosts(
+        self,
+        only=['name', 'ansible_facts', 'ansible_facts_modified', 'modified', 'inventory_id']
+    ):
         if not self.inventory:
             return []
         return self.inventory.hosts.only(*only)


### PR DESCRIPTION
if we don't preload this column, Django needs it, and so it generates
one query per-host (!!!) to get it.  For large (10k+ host) inventories,
this is incredibly slow.

see: https://github.com/ansible/awx/issues/3214