### PR TITLE
Fixes cred form checkbox input styling

### DIFF
--- a/awx/ui/client/lib/components/input/_index.less
+++ b/awx/ui/client/lib/components/input/_index.less
@@ -27,12 +27,17 @@
 .at-InputCheckbox {
     margin: 0;
     padding: 0;
+    display: block;
+    min-height: 20px;
 
     & > label {
+        font-weight: normal;
+
         & > input[type=checkbox] {
             height: @at-height-input;
             margin: 0;
             padding: 0;
+            float: left;
         }
 
         & > p {


### PR DESCRIPTION
##### SUMMARY
#3164 

I looked at the styles that _used_ to be applied with bootstrap v3 and copied what was needed.

<img width="1517" alt="screen shot 2019-02-12 at 11 50 53 am" src="https://user-images.githubusercontent.com/9889020/52652836-d2fc7300-2ebc-11e9-9b68-0a6305936507.png">
<img width="1475" alt="screen shot 2019-02-12 at 11 50 38 am" src="https://user-images.githubusercontent.com/9889020/52652837-d2fc7300-2ebc-11e9-95e8-f73bec9054f2.png">

Tested in both Chrome and FF.  I _think_ the only form that uses the checkbox input component is the cred form.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
