### PR TITLE
Prevent extra fetch of cred list as cred modal is closing

### DIFF
--- a/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
+++ b/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.directive.js
@@ -117,7 +117,7 @@ function multiCredentialModalController(GetBasePath, qs, MultiCredentialService)
         }));
 
         const watchType = scope.$watch('credentialType', (newValue, oldValue) => {
-            if (newValue !== oldValue) {
+            if (newValue && newValue !== oldValue) {
                 fetchCredentials(parseInt(newValue));
             }
         });


### PR DESCRIPTION
##### SUMMARY
On the JT form if you click outside the credential modal to navigate away from it you would be presented with a 400 error.  This was due to an errant request that was being made as the modal was closing and the request was missing a credential type.  These changes should prevent that request from being made.

Tested locally by opening the credential modal on the JT form and then clicking outside the modal to close it.  Expected behavior is no error to be shown.  I also double checked that the functionality of the modal itself was not negatively impacted since the change is around the logic which controls loading the list each time the credential type changes.

![cred_400](https://user-images.githubusercontent.com/9889020/52666587-afe1bb80-2edc-11e9-9bce-80d9a876aa6b.gif)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
