### PR TITLE
Show the proper tooltip on workflow results inventory

### DIFF
--- a/awx/ui/client/src/workflow-results/workflow-results.controller.js
+++ b/awx/ui/client/src/workflow-results/workflow-results.controller.js
@@ -54,6 +54,7 @@ export default ['workflowData', 'workflowResultsService', 'workflowDataOptions',
                     EDIT_WORKFLOW: i18n._('Edit the workflow job template'),
                     EDIT_SLICE_TEMPLATE: i18n._('Edit the slice job template'),
                     EDIT_SCHEDULE: i18n._('Edit the schedule'),
+                    EDIT_INVENTORY: i18n._('Edit the inventory'),
                     SOURCE_WORKFLOW_JOB: i18n._('View the source Workflow Job'),
                     TOGGLE_STDOUT_FULLSCREEN: i18n._('Expand Output'),
                     STATUS: '' // re-assigned elsewhere

--- a/awx/ui/client/src/workflow-results/workflow-results.partial.html
+++ b/awx/ui/client/src/workflow-results/workflow-results.partial.html
@@ -133,7 +133,7 @@
                         </label>
                         <div class="WorkflowResults-resultRowText">
                             <a href="{{ inventory_link }}"
-                                aw-tool-tip="{{ strings.tooltips.EDIT_WORKFLOW }}"
+                                aw-tool-tip="{{ strings.tooltips.EDIT_INVENTORY }}"
                                 data-placement="top">
                                 {{ workflow.summary_fields.inventory.name }}
                             </a>


### PR DESCRIPTION
##### SUMMARY
Tooltip was displaying `Edit the workflow job template`.  Now it displays `Edit the inventory`:

<img width="578" alt="screen shot 2019-02-12 at 3 50 28 pm" src="https://user-images.githubusercontent.com/9889020/52667165-1fa47600-2ede-11e9-8361-c0ac20c3ebbd.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
