### PR TITLE
Replace single quote with appropriate entity when generating new attribute

### DIFF
--- a/awx/ui/client/src/shared/generator-helpers.js
+++ b/awx/ui/client/src/shared/generator-helpers.js
@@ -22,7 +22,7 @@ angular.module('GeneratorHelpers', [systemStatus.name])
 .factory('Attr', function () {
     return function (obj, key, fld) {
         var i, s, result,
-            value = (typeof obj[key] === "string") ? obj[key].replace(/[\'\"]/g, '&quot;') : obj[key];
+            value = (typeof obj[key] === "string") ? obj[key].replace(/[\"]/g, '&quot;').replace(/[\']/g, '&apos;') : obj[key];
 
         if (/^ng/.test(key)) {
             result = 'ng-' + key.replace(/^ng/, '').toLowerCase() + "=\"" + value + "\" ";


### PR DESCRIPTION
##### SUMMARY
It was noted that in the form field help text `'` characters were being transformed to `"`.  Looking at the original line of code, both `'` and `"` were being replaced with the `&quot;` entity.  `&quot;` is the entity for `"`.  These changes should appropriately encode single and double quotes.

I tested this by adding both a `"` and a `'` to the popover help text for one of our form fields and confirmed that the UI was displaying them both correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
