### PR TITLE
Update compose configuration

### DIFF
--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -12,3 +12,6 @@
 - name: Start the containers
   docker_service:
     project_src: "{{ docker_compose_dir }}"
+    
+- name: Update CA trust in awx_web container
+  command: docker exec awx_web_1 '/usr/bin/update-ca-trust'

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -8,10 +8,17 @@
   template:
     src: docker-compose.yml.j2
     dest: "{{ docker_compose_dir }}/docker-compose.yml"
+  register: awx_compose_config
 
 - name: Start the containers
   docker_service:
     project_src: "{{ docker_compose_dir }}"
+  register: awx_compose_start
     
 - name: Update CA trust in awx_web container
   command: docker exec awx_web_1 '/usr/bin/update-ca-trust'
+  when: awx_compose_config.changed or awx_compose_start.changed
+
+- name: Update CA trust in awx_task container
+  command: docker exec awx_task_1 '/usr/bin/update-ca-trust'
+  when: awx_compose_config.changed or awx_compose_start.changed


### PR DESCRIPTION

##### SUMMARY
Fix custom certificates not working in docker-compose configuration.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
3.0.1
```

##### ADDITIONAL INFORMATION
When running awx via docker-compose and using custom certificates (for LDAP auth or whatever else...), update-ca-trust has to be called afer starting the container to actually use new certificates (just as it is called when using docker to run - https://github.com/ansible/awx/blob/devel/installer/roles/local_docker/tasks/standalone.yml#L119-L120 ). Withou this, LDAP auth with custom certs will fail even though certs are mounted correctly.
