### PR TITLE
Surface empty groups as children of all group

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -289,23 +289,27 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
                 group_children = group_children_map.setdefault(to_group_id, [])
                 group_children.append(from_group_name)
 
-            # Now use in-memory maps to build up group info.
-            for group in self.groups.only('name', 'id', 'variables'):
-                group_info = dict()
-                group_info['hosts'] = group_hosts_map.get(group.id, [])
-                group_info['children'] = group_children_map.get(group.id, [])
-                group_info['vars'] = group.variables_dict
-                data[group.name] = group_info
-
             # Add ungrouped hosts to all group
             all_group['hosts'] = [host.name for host in hosts if host.name not in grouped_hosts]
 
-        # Remove any empty groups
-        for group_name in list(data.keys()):
-            if group_name == 'all':
-                continue
-            if not (data.get(group_name, {}).get('hosts', []) or data.get(group_name, {}).get('children', [])):
-                data.pop(group_name)
+            # Now use in-memory maps to build up group info.
+            all_group_names = []
+            for group in self.groups.only('name', 'id', 'variables'):
+                group_info = dict()
+                if group.id in group_hosts_map:
+                    group_info['hosts'] = group_hosts_map[group.id]
+                if group.id in group_children_map:
+                    group_info['children'] = group_children_map[group.id]
+                group_vars = group.variables_dict
+                if group_vars:
+                    group_info['vars'] = group_vars
+                if group_info:
+                    data[group.name] = group_info
+                all_group_names.append(group.name)
+
+            # add all groups as children of all group, includes empty groups
+            if all_group_names:
+                all_group['children'] = all_group_names
 
         if hostvars:
             data.setdefault('_meta', dict())


### PR DESCRIPTION
##### SUMMARY
This makes empty groups accessible via playbook references.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
There is a good deal of history here, we actually had several related issues lately (see grandparent groups) related to this.

I went back to the fundamentals on this. There is a standard inventory JSON format that we strive to adhere to. If empty groups are placed in the top-level keys, then they can give the error:

>  [WARNING]: Found both group and host with same name: ghost4

and this will break things. Ansible interprets the entry both as a group and as a host, and that's bad. This is why I tried to remove empty groups from the output, but this is because I missed critical detail.

See:

https://github.com/AlanCoding/Ansible-inventory-file-examples/blob/master/scripts/empty_group.py

```
ansible-inventory -i scripts/empty_group.py --list --export
{
    "_meta": {
        "hostvars": {
            "old_host": {}
        }
    }, 
    "all": {
        "children": [
            "ghost", 
            "ghost2", 
            "ghost3", 
            "ungrouped"
        ]
    }, 
    "ghost": {
        "vars": {
            "foobar": "hello_world"
        }
    }, 
    "ungrouped": {
        "hosts": [
            "old_host"
        ]
    }
}
```

The truly empty groups (no vars or children or hosts) are not shown in the top-level keys. However, those are still accounted for by having them listed as children of the all group.

I don't want to go back to the old pattern, because this is a more canonical pattern set by Ansible core. I definitely got this wrong, but I have good confidence this is the right way going forward.