### PR TITLE
Avoid pg password ending up in syslog/shell output

### DIFF
--- a/installer/roles/kubernetes/tasks/backup.yml
+++ b/installer/roles/kubernetes/tasks/backup.yml
@@ -55,6 +55,7 @@
           --port={{ pg_port | default('5432') }} \
           --username='{{ pg_username }}' \
           --dbname='{{ pg_database }}'" > {{ playbook_dir }}/tower-openshift-backup-{{ now }}/tower.db
+  no_log: yes
 
 - name: Copy inventory into backup directory
   copy:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently if an error occurs the pgpassword would be exposed to syslog / shell during playbook backup.yml
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
...

TASK [kubernetes : Dump database] *******************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc --config=/tmp/awx-config/.kube/config -n awx exec ansible-tower-management -- bash -c \"PGPASSWORD=secretstring \\\npg_dump --clean --create \\\n--host='postgresql' \\\n--port=5432 \\\n--username='awx' \\\n--dbname='awx'\" > /root/awx/installer/tower-openshift-backup-2019-02-15-15:56:03/tower.db", "delta": "0:00:00.401827", "end": "2019-02-15 15:56:30.201543", "msg": "non-zero return code", "rc": 1, "start": "2019-02-15 15:56:29.799716", "stderr": "pg_dump: unrecognized option '--dbname=awx'\nTry \"pg_dump --help\" for more information.\ncommand terminated with exit code 1", "stderr_lines": ["pg_dump: unrecognized option '--dbname=awx'", "Try \"pg_dump --help\" for more information.", "command terminated with exit code 1"], "stdout": "", "stdout_lines": []}

```
After:
```
TASK [kubernetes : Dump database] *******************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
```