### PR TITLE
Allow additional awx_task volumes

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -141,3 +141,7 @@ secret_key=awxsecret
 # which makes include "optional" - i.e. not fail
 # if file is absent
 #extra_nginx_include="/etc/nginx/awx_extra[.]conf"
+
+# Additional volumes to mount into awx_task container (local_docker only)
+# e.g., to make NFS shares accessible for jobs via named docker volume
+#additional_task_volumes=['mynamedvolume:/mnt/mynamedvolume:z', '/tmp/foo:/mnt/foo:z']

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -72,6 +72,11 @@ services:
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
     {% endif %}
+    {% if additional_task_volumes is defined %}
+    {% for additional_task_volume in additional_task_volumes %}
+      - "{{ additional_task_volume }}"
+    {% endfor %}
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
@@ -123,3 +128,14 @@ services:
       POSTGRES_DB: {{ pg_database }}
       PGDATA: /var/lib/postgresql/data/pgdata
   {% endif %}
+
+{% if additional_task_volumes is defined %}
+{% set named_volumes = additional_task_volumes | reject("match", "^[^:]*/[^:]*:[^:]*(:.*)?") | list %}
+{% if named_volumes %}
+volumes:
+{% for named_volume in named_volumes %}
+  {{ named_volume.split(':')[0] }}:
+    external: true
+{% endfor %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
for local docker installations. Implements #3252

##### SUMMARY
All the background can be found in the related issue. It's all about allowing (bind) mounts into the awx_task container for local docker installations.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.1.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
Feel free to ask for changes in naming etc. I'm not familiar with your conventions.