### PR TITLE
Resize window to avoid breaking the UI

### DIFF
--- a/awx/ui/test/e2e/tests/test-jobs-portal-list-actions.js
+++ b/awx/ui/test/e2e/tests/test-jobs-portal-list-actions.js
@@ -17,6 +17,7 @@ module.exports = {
                 data = { admin, job };
 
                 client.login(data.admin.username);
+                client.resizeWindow(1200, 800);
                 client.waitForAngular();
 
                 done();


### PR DESCRIPTION
##### SUMMARY
Update test-jobs-portal-list-actions to resize the browser window and
avoid a flake test because of broken layout. See the additional information for the screenshot when the window is not resized.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
 - E2E Tests

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```


##### ADDITIONAL INFORMATION

![relaunch-a-job-from-the-all-jobs-list_failed_feb-19-2019-163213-gmt 0000](https://user-images.githubusercontent.com/48132/53032816-5df5e400-344e-11e9-9142-46fbed4580fc.png)
