### PR TITLE
add verify_ssl to OpenStack credential type

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -671,6 +671,7 @@ class CredentialTypeInputField(JSONSchemaField):
                             'multiline': {'type': 'boolean'},
                             'secret': {'type': 'boolean'},
                             'ask_at_runtime': {'type': 'boolean'},
+                            'default': {},
                         },
                         'additionalProperties': False,
                         'required': ['id', 'label'],
@@ -713,6 +714,14 @@ class CredentialTypeInputField(JSONSchemaField):
             if 'type' not in field:
                 # If no type is specified, default to string
                 field['type'] = 'string'
+
+            if 'default' in field:
+                default = field['default']
+                _type = {'string': str, 'boolean': bool}[field['type']]
+                if type(default) != _type:
+                    raise django_exceptions.ValidationError(
+                        _('{} is not a {}').format(default, field['type'])
+                    )
 
             for key in ('choices', 'multiline', 'format', 'secret',):
                 if key in field and field['type'] != 'string':

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -445,6 +445,9 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
             try:
                 return decrypt_field(self, field_name)
             except AttributeError:
+                for field in self.credential_type.inputs.get('fields', []):
+                    if field['id'] == field_name and 'default' in field:
+                        return field['default']
                 if 'default' in kwargs:
                     return kwargs['default']
                 raise AttributeError
@@ -452,6 +455,9 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
             return self.inputs[field_name]
         if 'default' in kwargs:
             return kwargs['default']
+        for field in self.credential_type.inputs.get('fields', []):
+            if field['id'] == field_name and 'default' in field:
+                return field['default']
         raise AttributeError(field_name)
 
     def has_input(self, field_name):
@@ -973,7 +979,8 @@ ManagedCredentialType(
         }, {
             'id': 'verify_ssl',
             'label': ugettext_noop('Verify SSL'),
-            'type': 'boolean'
+            'type': 'boolean',
+            'default': True,
         }],
         'required': ['username', 'password', 'host', 'project']
     }

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -970,6 +970,10 @@ ManagedCredentialType(
                                        'It is only needed for Keystone v3 authentication '
                                        'URLs. Refer to Ansible Tower documentation for '
                                        'common scenarios.')
+        }, {
+            'id': 'verify_ssl',
+            'label': ugettext_noop('Verify SSL'),
+            'type': 'boolean'
         }],
         'required': ['username', 'password', 'host', 'project']
     }

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1167,10 +1167,12 @@ class RunJob(BaseTask):
                                       project_name=credential.get_input('project', default=''))
                 if credential.has_input('domain'):
                     openstack_auth['domain_name'] = credential.get_input('domain', default='')
+                verify_state = credential.get_input('verify_ssl', default=True)
                 openstack_data = {
                     'clouds': {
                         'devstack': {
                             'auth': openstack_auth,
+                            'verify': verify_state,
                         },
                     },
                 }
@@ -1875,6 +1877,7 @@ class RunInventoryUpdate(BaseTask):
                 openstack_auth['domain_name'] = credential.get_input('domain', default='')
 
             private_state = inventory_update.source_vars_dict.get('private', True)
+            verify_state = credential.get_input('verify_ssl', default=True)
             # Retrieve cache path from inventory update vars if available,
             # otherwise create a temporary cache path only for this update.
             cache = inventory_update.source_vars_dict.get('cache', {})
@@ -1887,6 +1890,7 @@ class RunInventoryUpdate(BaseTask):
                 'clouds': {
                     'devstack': {
                         'private': private_state,
+                        'verify': verify_state,
                         'auth': openstack_auth,
                     },
                 },

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -105,7 +105,10 @@ def test_safe_env_returns_new_copy():
     assert build_safe_env(env) is not env
 
 
-def test_openstack_client_config_generation(mocker):
+@pytest.mark.parametrize("source,expected", [
+    (False, False), (True, True)
+])
+def test_openstack_client_config_generation(mocker, source, expected):
     update = tasks.RunInventoryUpdate()
     credential_type = CredentialType.defaults['openstack']()
     inputs = {
@@ -114,6 +117,7 @@ def test_openstack_client_config_generation(mocker):
         'password': 'secrete',
         'project': 'demo-project',
         'domain': 'my-demo-domain',
+        'verify_ssl': source,
     }
     credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
 
@@ -136,7 +140,8 @@ def test_openstack_client_config_generation(mocker):
                 'username': 'demo',
                 'domain_name': 'my-demo-domain',
             },
-            'private': True
+            'verify': expected,
+            'private': True,
         }
     }
 
@@ -153,6 +158,7 @@ def test_openstack_client_config_generation_with_private_source_vars(mocker, sou
         'password': 'secrete',
         'project': 'demo-project',
         'domain': None,
+        'verify_ssl': True,
     }
     credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
 
@@ -174,6 +180,7 @@ def test_openstack_client_config_generation_with_private_source_vars(mocker, sou
                 'project_name': 'demo-project',
                 'username': 'demo'
             },
+            'verify': True,
             'private': expected
         }
     }
@@ -1145,6 +1152,7 @@ class TestJobCredentials(TestJobExecution):
                 '      password: secret',
                 '      project_name: tenant-name',
                 '      username: bob',
+                '    verify: true',
                 ''
             ])
             return ['successful', 0]

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -106,7 +106,7 @@ def test_safe_env_returns_new_copy():
 
 
 @pytest.mark.parametrize("source,expected", [
-    (False, False), (True, True)
+    (None, True), (False, False), (True, True)
 ])
 def test_openstack_client_config_generation(mocker, source, expected):
     update = tasks.RunInventoryUpdate()
@@ -116,9 +116,10 @@ def test_openstack_client_config_generation(mocker, source, expected):
         'username': 'demo',
         'password': 'secrete',
         'project': 'demo-project',
-        'domain': 'my-demo-domain',
-        'verify_ssl': source,
+        'domain': 'my-demo-domain'
     }
+    if source is not None:
+        inputs['verify_ssl'] = source
     credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
 
     cred_method = mocker.Mock(return_value=credential)

--- a/awx/ui/client/lib/components/input/base.controller.js
+++ b/awx/ui/client/lib/components/input/base.controller.js
@@ -20,7 +20,7 @@ function BaseInputController (strings) {
             scope.state._displayPromptOnLaunch = true;
         }
 
-        if (scope.state._value) {
+        if (typeof scope.state._value !== 'undefined') {
             scope.state._edit = true;
             scope.state._preEditValue = scope.state._value;
 
@@ -37,6 +37,8 @@ function BaseInputController (strings) {
                 scope.state._isBeingReplaced = false;
                 scope.state._activeModel = '_displayValue';
             }
+        } else if (typeof scope.state.default !== 'undefined') {
+            scope.state._value = scope.state.default;
         }
 
         form.register(type, scope);

--- a/docs/custom_credential_types.md
+++ b/docs/custom_credential_types.md
@@ -136,6 +136,12 @@ ordered fields for that type:
             "multiline": false               # if true, the field should be rendered
                                              # as multi-line for input entry
                                              # (only applicable to `type=string`)
+            "default": "default value"       # optional, can be used to provide a
+                                             # default value if the field is left empty
+                                             # when creating a credential of this type
+                                             # credential forms will use this value
+                                             # as a prefill when making credentials of
+                                             # this type
         },{
             # field 2...
         },{


### PR DESCRIPTION
To avoid verification failures when using a self-signed certificate file,
 Added "Verify SSL" check box to the openstack credential type edit page.

Signed-off-by: Hideki Saito <saito@fgrep.org>