### PR TITLE
Call `this.sync` when we receive a ws complete message.

### DIFF
--- a/awx/ui/client/features/output/index.controller.js
+++ b/awx/ui/client/features/output/index.controller.js
@@ -810,7 +810,6 @@ function OutputIndexController (
             onStop () {
                 lockFollow = true;
                 stopFollowing();
-                stopListening();
                 status.updateStats();
                 status.dispatch();
                 status.sync();

--- a/awx/ui/client/features/output/status.service.js
+++ b/awx/ui/client/features/output/status.service.js
@@ -95,6 +95,9 @@ function JobStatusService (moment, message) {
 
         if (isJobStatusEvent) {
             this.setJobStatus(data.status);
+            if (JOB_STATUS_FINISHED.includes(data.status)) {
+                this.sync();
+            }
             this.dispatch();
         } else if (isProjectStatusEvent) {
             this.setProjectStatus(data.status);


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #3193

- There can be a race condition where a job run finishes event processing before sending off a "successful/failed" websocket message. In this instance, we would miss gathering known artifacts for a job. The proposed fix is to do a manual detection of when a job status updates to "successful/failed/unknown" and perform a GET request to the job endpoint.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```