### PR TITLE
Prevent jobs/templates lists from refreshing list data more than once every 5 seconds

### DIFF
--- a/awx/ui/client/features/jobs/routes/hostCompletedJobs.route.js
+++ b/awx/ui/client/features/jobs/routes/hostCompletedJobs.route.js
@@ -16,6 +16,13 @@ export default {
             squash: ''
         }
     },
+    data: {
+        socket: {
+            groups: {
+                jobs: ['status_changed']
+            }
+        }
+    },
     ncyBreadcrumb: {
         label: N_('COMPLETED JOBS')
     },

--- a/awx/ui/client/features/jobs/routes/inventoryCompletedJobs.route.js
+++ b/awx/ui/client/features/jobs/routes/inventoryCompletedJobs.route.js
@@ -18,6 +18,13 @@ export default {
             squash: ''
         }
     },
+    data: {
+        socket: {
+            groups: {
+                jobs: ['status_changed']
+            }
+        }
+    },
     ncyBreadcrumb: {
         label: N_('JOBS')
     },

--- a/awx/ui/client/features/jobs/routes/templateCompletedJobs.route.js
+++ b/awx/ui/client/features/jobs/routes/templateCompletedJobs.route.js
@@ -17,6 +17,13 @@ export default {
             squash: ''
         }
     },
+    data: {
+        socket: {
+            groups: {
+                jobs: ['status_changed']
+            }
+        }
+    },
     ncyBreadcrumb: {
         label: N_('COMPLETED JOBS')
     },

--- a/awx/ui/client/features/jobs/routes/workflowJobTemplateCompletedJobs.route.js
+++ b/awx/ui/client/features/jobs/routes/workflowJobTemplateCompletedJobs.route.js
@@ -17,6 +17,13 @@ export default {
             squash: ''
         }
     },
+    data: {
+        socket: {
+            groups: {
+                jobs: ['status_changed']
+            }
+        }
+    },
     ncyBreadcrumb: {
         label: N_('COMPLETED JOBS')
     },

--- a/awx/ui/client/features/templates/routes/projectsTemplatesList.route.js
+++ b/awx/ui/client/features/templates/routes/projectsTemplatesList.route.js
@@ -14,6 +14,13 @@ export default {
             },
         }
     },
+    data: {
+        socket: {
+            groups: {
+                jobs: ['status_changed']
+            }
+        }
+    },
     ncyBreadcrumb: {
         label: N_("JOB TEMPLATES")
     },

--- a/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
+++ b/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
@@ -48,10 +48,6 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
                         });
                 }
 
-                scope.$on('jobStatusChange', function(event, status){
-                    recreateGraph(scope.period, scope.jobType, status);
-                });
-
                 function createGraph(period, jobtype, data, status){
                     scope.period = period;
                     scope.jobType = jobtype;
@@ -171,7 +167,7 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
                                     <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
                                 </a>`);
 
-                        scope.$broadcast("jobStatusChange", job_status);
+                        recreateGraph(scope.period, scope.jobType, job_status);
                     });
 
                     adjustGraphSize(job_status_chart, element);

--- a/awx/ui/client/src/home/home.controller.js
+++ b/awx/ui/client/src/home/home.controller.js
@@ -4,18 +4,24 @@
  * All Rights Reserved
  *************************************************/
 
-export default ['$scope', '$rootScope','Wait',
+export default ['$scope', '$rootScope','Wait', '$timeout',
     'Rest', 'GetBasePath', 'ProcessErrors', 'graphData',
-    function($scope, $rootScope, Wait,
+    function($scope, $rootScope, Wait, $timeout,
     Rest, GetBasePath, ProcessErrors, graphData) {
 
         var dataCount = 0;
         let launchModalOpen = false;
         let refreshAfterLaunchClose = false;
+        let pendingRefresh = false;
+        let refreshTimerRunning = false;
 
         $scope.$on('ws-jobs', function () {
             if (!launchModalOpen) {
-                refreshLists();
+                if (!refreshTimerRunning) {
+                    refreshLists();
+                } else {
+                    pendingRefresh = true;
+                }
             } else {
                 refreshAfterLaunchClose = true;
             }
@@ -137,6 +143,15 @@ export default ['$scope', '$rootScope','Wait',
             .catch(({data, status}) => {
                 ProcessErrors($scope, data, status, null, { hdr: 'Error!', msg: 'Failed to get dashboard jobs list: ' + status });
             });
+            pendingRefresh = false;
+            refreshTimerRunning = true;
+            $timeout(() => {
+                if (pendingRefresh) {
+                    refreshLists();
+                } else {
+                    refreshTimerRunning = false;
+                }
+            }, 5000);
         }
 
     }


### PR DESCRIPTION
##### SUMMARY
When you launch something like a really large workflow that spawns tons of jobs and generates a significant number of status updates the UI can bomb the api with requests on any page that displays jobs/templates (dashboard, my view, jobs list, templates list, etc).  Before this change, we'd fire off requests to refresh the list data on _every_ status update socket message.  With these changes, we now "hang on" to status updates that come in on a 5 second interval after a previous request was made to refresh the list data.  If a status update does come in during that time, we refresh the list at the end of those 5 seconds and start a new timer.  This continues until no status updates come in during the 5 second timer.  At that point the list is in a resting state until the next status update comes in which would start the process up again.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

Impacted pages:

Dashboard
Templates List
Jobs List
 My View
Org Templates

To test this, I created a large workflow with many root nodes and many branches.  The nodes were configured to use a simple playbook that runs quite quickly (something like the hello_world.yml playbook).  Launching this WF will generate a large number of status updates in quick succession.  To verify the fix, I monitored the network tab on the above pages to ensure that the handful of requests that we make to refresh the lists were only made once every 5 seconds or so.  Note that the dashboard makes a number of requests to refresh both the recently used templates and jobs list but also the graph data.
