### PR TITLE
Clear the test cache at end of every test

### DIFF
--- a/awx/main/tests/conftest.py
+++ b/awx/main/tests/conftest.py
@@ -14,6 +14,8 @@ from awx.main.tests.factories import (
     create_workflow_job_template,
 )
 
+from django.core.cache import cache
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -129,4 +131,11 @@ def mock_cache():
             del self.cache[key]
 
     return MockCache()
+
+
+def pytest_runtest_teardown(item, nextitem):
+    # clear Django cache at the end of every test ran
+    # NOTE: this should not be memcache, see test_cache in test_env.py
+    # this is a local test cache, so we want every test to start with empty cache
+    cache.clear()
 

--- a/awx/main/tests/functional/api/test_settings.py
+++ b/awx/main/tests/functional/api/test_settings.py
@@ -75,9 +75,11 @@ def test_awx_task_env_validity(get, patch, admin, value, expected):
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'jobs'})
     patch(url, user=admin, data={'AWX_TASK_ENV': value}, expect=expected)
 
+    resp = get(url, user=admin)
     if expected == 200:
-        resp = get(url, user=admin)
         assert resp.data['AWX_TASK_ENV'] == dict((k, str(v)) for k, v in value.items())
+    else:
+        assert resp.data['AWX_TASK_ENV'] == dict()
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -528,10 +528,8 @@ class TestGenericRun(TestJobExecution):
         self.task.run(self.pk)
 
     def test_awx_task_env(self):
-        patch = mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'})
-        patch.start()
-
-        self.task.run(self.pk)
+        with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'}):
+            self.task.run(self.pk)
 
         assert self.run_pexpect.call_count == 1
         call_args, _ = self.run_pexpect.call_args_list[0]
@@ -584,16 +582,11 @@ class TestGenericRun(TestJobExecution):
         [{'ANSIBLE_LIBRARY': '/foo/bar'}, '/foo/bar:/awx_devel/awx/plugins/library'],
     ])
     def test_fact_cache_usage_with_ansible_library(self, task_env, ansible_library_env):
-        patch = mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', task_env)
-        patch.start()
-
         self.instance.use_fact_cache = True
-        start_mock = mock.Mock()
-        patch = mock.patch.object(Job, 'start_job_fact_cache', start_mock)
-        self.patches.append(patch)
-        patch.start()
-
-        self.task.run(self.pk)
+        with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', task_env):
+            start_mock = mock.Mock()
+            with mock.patch.object(Job, 'start_job_fact_cache', start_mock):
+                self.task.run(self.pk)
         call_args, _ = self.run_pexpect.call_args_list[0]
         args, cwd, env, stdout = call_args
         assert env['ANSIBLE_LIBRARY'] == ansible_library_env
@@ -1682,10 +1675,8 @@ class TestJobCredentials(TestJobExecution):
         assert self.instance.job_env['AZURE_PASSWORD'] == tasks.HIDDEN_PASSWORD
 
     def test_awx_task_env(self):
-        patch = mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'})
-        patch.start()
-
-        self.task.run(self.pk)
+        with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'}):
+            self.task.run(self.pk)
 
         assert self.run_pexpect.call_count == 1
         call_args, _ = self.run_pexpect.call_args_list[0]
@@ -1800,10 +1791,8 @@ class TestProjectUpdateCredentials(TestJobExecution):
 
     def test_awx_task_env(self, scm_type):
         self.instance.scm_type = scm_type
-        patch = mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'})
-        patch.start()
-
-        self.task.run(self.pk)
+        with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'}):
+            self.task.run(self.pk)
 
         assert self.run_pexpect.call_count == 1
         call_args, _ = self.run_pexpect.call_args_list[0]
@@ -2274,10 +2263,8 @@ class TestInventoryUpdateCredentials(TestJobExecution):
             return cred
         self.instance.get_cloud_credential = get_cred
 
-        patch = mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'})
-        patch.start()
-
-        self.task.run(self.pk)
+        with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'}):
+            self.task.run(self.pk)
 
         assert self.run_pexpect.call_count == 1
         call_args, _ = self.run_pexpect.call_args_list[0]


### PR DESCRIPTION
I was hitting problems because `AWX_TASK_ENV` would add env vars in a task run. Those variables came from the cache, which were set by a test that previously ran.

I considered some truly terrible workarounds before I figured this out. Always nuke the cache when running a test.