### PR TITLE
Add prompt for extra vars to wfjt

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4495,8 +4495,8 @@ class WorkflowJobLaunchSerializer(BaseSerializer):
         fields = ('ask_inventory_on_launch', 'can_start_without_user_input', 'defaults', 'extra_vars',
                   'inventory', 'survey_enabled', 'variables_needed_to_start',
                   'node_templates_missing', 'node_prompts_rejected',
-                  'workflow_job_template_data', 'survey_enabled')
-        read_only_fields = ('ask_inventory_on_launch',)
+                  'workflow_job_template_data', 'survey_enabled', 'ask_variables_on_launch')
+        read_only_fields = ('ask_inventory_on_launch', 'ask_variables_on_launch')
 
     def get_survey_enabled(self, obj):
         if obj:

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -52,12 +52,10 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings',
                     .then( (response) => {
                         vm.promptDataClone.prompts.credentials.credentialTypes = {};
                         vm.promptDataClone.prompts.credentials.credentialTypeOptions = [];
-                        let machineCredTypeId = null;
                         response.data.results.forEach((credentialTypeRow => {
                             vm.promptDataClone.prompts.credentials.credentialTypes[credentialTypeRow.id] = credentialTypeRow.kind;
                             if(credentialTypeRow.kind.match(/^(cloud|net|ssh|vault)$/)) {
                                 if(credentialTypeRow.kind === 'ssh') {
-                                    machineCredTypeId = credentialTypeRow.id;
                                     vm.promptDataClone.prompts.credentials.credentialKind = credentialTypeRow.id.toString();
                                 }
                                 vm.promptDataClone.prompts.credentials.credentialTypeOptions.push({

--- a/awx/ui/client/src/templates/workflows.form.js
+++ b/awx/ui/client/src/templates/workflows.form.js
@@ -115,6 +115,10 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                     dataTitle: i18n._('Extra Variables'),
                     dataPlacement: 'right',
                     dataContainer: "body",
+                    subCheckbox: {
+                        variable: 'ask_variables_on_launch',
+                        text: i18n._('Prompt on launch')
+                    },
                     ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)' // TODO: get working
                 },
                 checkbox_group: {

--- a/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
+++ b/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
@@ -69,7 +69,9 @@ export default [
                          data[fld] = $scope[fld];
                      }
                  }
+                 
                  data.ask_inventory_on_launch = Boolean($scope.ask_inventory_on_launch);
+                 data.ask_variables_on_launch = Boolean($scope.ask_variables_on_launch);
 
                  data.extra_vars = ToJSON($scope.parseType,
                      $scope.variables, true);

--- a/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
+++ b/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
@@ -56,6 +56,7 @@ export default [
         $scope.parseType = 'yaml';
         $scope.includeWorkflowMaker = false;
         $scope.ask_inventory_on_launch = workflowJobTemplateData.ask_inventory_on_launch;
+        $scope.ask_variables_on_launch = (workflowJobTemplateData.ask_variables_on_launch) ? true : false;
 
         if (Inventory){
             $scope.inventory = Inventory.id;
@@ -92,6 +93,7 @@ export default [
                 }
 
                 data.ask_inventory_on_launch = Boolean($scope.ask_inventory_on_launch);
+                data.ask_variables_on_launch = Boolean($scope.ask_variables_on_launch);
 
                 data.extra_vars = ToJSON($scope.parseType,
                     $scope.variables, true);

--- a/awx/ui/test/spec/workflows/workflow-add.controller-test.js
+++ b/awx/ui/test/spec/workflows/workflow-add.controller-test.js
@@ -148,6 +148,7 @@ describe('Controller: WorkflowAdd', () => {
                 variables: undefined,
                 allow_simultaneous: undefined,
                 ask_inventory_on_launch: false,
+                ask_variables_on_launch: false,
                 extra_vars: undefined
             });
         });


### PR DESCRIPTION
##### SUMMARY
This option has been available in the api for some time.  This PR exposes prompting for extra vars on wfjt's in the UI.  Ping @AlanCoding - I implemented your suggested change to the serializer which results in the `ask_variables_on_launch` flag being exposed in the wfjt launch endpoint response.  Let me know if there's something else that I need to do there.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
This flag behaves exactly the same as the corresponding flag in the JT form.  The launching user will be presented with the extra vars textarea (prefilled with the value(s) from the wfjt extra vars).  These extra vars can be modified before launch.  If a particular variable is present in a survey (in addition to extra vars prompt) then the survey answer will take precedence.  This behavior is consistent with JT extra var prompting.

Local testing performed:

1) Create a WFJT with prompt checkbox unchecked
2) Create a WFJT with prompt checkbox checked
3) Edit WFJT to ensure that prompt checkbox can be toggled on/off
4) Launch a WFJT without prompt for extra vars
5) Launch a WFJT with prompt for extra vars
6) Launch a WFJT with prompt for extra vars and survey (ensured that survey answers took precedence)
