### PR TITLE
Add helper text to the limit field prompt modal

### DIFF
--- a/awx/ui/client/features/templates/templates.strings.js
+++ b/awx/ui/client/features/templates/templates.strings.js
@@ -48,6 +48,7 @@ function TemplatesStrings (BaseString) {
         SKIP_TAGS: t.s('Skip Tags'),
         JOB_TAGS: t.s('Job Tags'),
         LIMIT: t.s('Limit'),
+        LIMIT_HELP: t.s('Provide a host pattern to further constrain the list of hosts that will be managed or affected by the playbook. Multiple patterns are allowed. Refer to Ansible documentation for more information and examples on patterns.'),
         JOB_TYPE: t.s('Job Type'),
         VERBOSITY: t.s('Verbosity'),
         CHOOSE_JOB_TYPE: t.s('Choose a job type'),

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.partial.html
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.partial.html
@@ -22,6 +22,9 @@
     <div class="form-group Form-formGroup Form-formGroup--singleColumn" ng-if="promptData.launchConf.ask_limit_on_launch">
         <label for="limit">
             <span class="Form-inputLabel">{{:: vm.strings.get('prompt.LIMIT') }}</span>
+            <a id="awp-limit" href="" aw-pop-over="{{:: vm.strings.get('prompt.LIMIT_HELP') }}" data-placement="right" data-container="body" over-title="{{:: vm.strings.get('prompt.LIMIT') }}" class="help-link" data-original-title="" title="" tabindex="-1">
+                <i class="fa fa-question-circle"></i>
+            </a>
         </label>
         <div>
             <input


### PR DESCRIPTION
##### SUMMARY
Related to #2261 
Add helper text to prompt modal limit field. Also tags limit helper text for translation.

##### ISSUE TYPE
- Enhancement

##### COMPONENT NAME
 - UI

<img width="1386" alt="screen shot 2019-02-21 at 3 48 35 pm" src="https://user-images.githubusercontent.com/39280967/53200708-363e8180-35f0-11e9-9540-906f8ba9ec74.png">
