### PR TITLE
Prevent key error, fix mismatched event numbers

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -120,7 +120,8 @@ class PoolWorker(object):
         # this worker
         for uuid in finished:
             self.messages_finished += 1
-            del self.managed_tasks[uuid]
+            if uuid in self.managed_tasks:
+                del self.managed_tasks[uuid]
 
     @property
     def current_task(self):


### PR DESCRIPTION
##### SUMMARY
This fixes the traceback

```
awx_1        | 15:41:00 receiver.1   | 2019-02-22 15:41:00,018 WARNING  awx.main.dispatch detail: Traceback (most recent call last):
awx_1        | 15:41:00 receiver.1   |   File "/awx_devel/awx/main/dispatch/pool.py", line 259, in write
awx_1        | 15:41:00 receiver.1   |     self.workers[queue_actual].put(body)
awx_1        | 15:41:00 receiver.1   |   File "/awx_devel/awx/main/dispatch/pool.py", line 77, in put
awx_1        | 15:41:00 receiver.1   |     self.calculate_managed_tasks()
awx_1        | 15:41:00 receiver.1   |   File "/awx_devel/awx/main/dispatch/pool.py", line 123, in calculate_managed_tasks
awx_1        | 15:41:00 receiver.1   |     del self.managed_tasks[uuid]
awx_1        | 15:41:00 receiver.1   | KeyError: '0242ac12-0005-3f4f-e198-00000000000b'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
This error only happens when using serial strategy. It's weird, I don't fully understand it.

However, I can say that before this change, some events could be duplicated strangely, and after this change, that doesn't happen.

Again, can't totally tell you why, but maybe this code isn't expected to throw errors? I don't know, it sounds complicated.
