### PR TITLE
Removes top left border radius on lists

### DIFF
--- a/awx/ui/client/lib/components/list/_index.less
+++ b/awx/ui/client/lib/components/list/_index.less
@@ -99,12 +99,22 @@
 .at-List-container {
     border: @at-border-default-width solid @at-color-list-border;
     border-radius: @at-border-radius;
+
+    & > div:last-of-type {
+        border-bottom-left-radius:@at-border-radius;
+    }
 }
 
 // Remove top left and right rounded corners of a list if there is a toolbar above it
 .at-List-toolbar--attached + .at-List > .at-List-container {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+}
+
+.at-List-toolbar--attached + .at-List > .at-List-container{
+    .at-Row--active {
+        border-top-left-radius: 0;
+    }
 }
 
 .at-List-toolbar--attached + .at-List {


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/3283
Fixes a border issue with lists in several situations:
1) Removes top left border radius on lists with a tool bar for the first item in the list
2) Adds bottom left border radius on lists with a tool bar for the first item in the list
3) Makes the correct border radius for lists without a tool bar.

This makes a better looking UI for the user.

##### ISSUE TYPE
 - Bug

##### COMPONENT NAME
 - UI
![screen shot 2019-02-25 at 2 27 04 pm](https://user-images.githubusercontent.com/39280967/53363153-cc80e900-3909-11e9-97cf-bcd45116fb3b.png)
![screen shot 2019-02-25 at 2 27 39 pm](https://user-images.githubusercontent.com/39280967/53363168-d4408d80-3909-11e9-8aba-e859dc0a50c2.png)
![screen shot 2019-02-25 at 2 28 27 pm](https://user-images.githubusercontent.com/39280967/53363192-da366e80-3909-11e9-9832-996420823957.png)
![screen shot 2019-02-25 at 2 29 02 pm](https://user-images.githubusercontent.com/39280967/53363200-defb2280-3909-11e9-9806-79561331bf89.png)


##### ADDITIONAL INFORMATION


