### PR TITLE
Show elapsed timer while job is running

### DIFF
--- a/awx/ui/client/features/output/stats.partial.html
+++ b/awx/ui/client/features/output/stats.partial.html
@@ -13,8 +13,7 @@
     <span ng-show="!vm.hideCounts && !vm.running" class="at-Panel-headingTitleBadge at-Panel-headingTitleBadge--inline">{{ vm.hosts || 1 }}</span>
 
     <span class="at-Panel-label">{{:: vm.strings.get('stats.ELAPSED') }}</span>
-    <span ng-show="vm.running" class="at-Panel-headingTitleBadge at-Panel-headingTitleBadge--inline">...</span>
-    <span ng-show="!vm.running" class="at-Panel-headingTitleBadge at-Panel-headingTitleBadge--inline">
+    <span class="at-Panel-headingTitleBadge at-Panel-headingTitleBadge--inline">
         {{ (vm.elapsed * 1000 || 0) | duration: "hh:mm:ss"}}
     </span>
 


### PR DESCRIPTION
##### SUMMARY
OK so here's how this works: As a job is running and the UI receives events over websockets we use the start time of the job and the execution time of the event to fudge the elapsed time.  This only occurs while the job is running.  Once the job completes running we make a GET request to the job endpoint to get the real elapsed time and display that (https://github.com/ansible/awx/pull/3264 should ensure that).  @wenottingham is this acceptable behavior?  While the job is running the UI shows an elapsed time based on the greatest difference between job start time and event time.  We then correct that elapsed time with the real deal from the api when the job completes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Tested using a bevy of playbooks from https://github.com/ansible/test-playbooks.  Particularly useful was chatty tasks which allowed me to vary the execution time of the job template quite a bit.  What I was looking for was situations where the displayed elapsed field was different after refreshing the job results page.  To do this, I let a job run (elapsed incrementally updated) to completion.  Noting the currently displayed elapsed string I refreshed the page.  If everything is working as expected, the elapsed string should be the same after refresh.

