### PR TITLE
Adds error message handling when launching deleted job template.

### DIFF
--- a/awx/ui/client/features/templates/templates.strings.js
+++ b/awx/ui/client/features/templates/templates.strings.js
@@ -84,7 +84,9 @@ function TemplatesStrings (BaseString) {
         UNKNOWN: t.s('Unable to determine template type.'),
         SCHEDULE: t.s('Unable to schedule job.'),
         COPY: t.s('Unable to copy template.'),
-        INVALID: t.s('Resources are missing from this template.')
+        INVALID: t.s('Resources are missing from this template.'),
+        WORKFLOW_TEMPLATE_NOT_FOUND: t.s('launch workflow job template'),
+        JOB_TEMPLATE_NOT_FOUND: t.s('launch job template'),
     };
 
     ns.warnings = {

--- a/awx/ui/client/lib/components/launchTemplateButton/launchTemplateButton.component.js
+++ b/awx/ui/client/lib/components/launchTemplateButton/launchTemplateButton.component.js
@@ -38,9 +38,10 @@ function atLaunchTemplateCtrl (
         if (!vm.disabled) {
             if (vm.template.type === 'job_template') {
                 const selectedJobTemplate = jobTemplate.create();
+                const getLaunch = selectedJobTemplate.getLaunch(vm.template.id).catch(createErrorHandler(templatesStrings.get('error.JOB_TEMPLATE_NOT_FOUND'), 'GET'));
+                const optionsLaunch = selectedJobTemplate.optionsLaunch(vm.template.id).catch(createErrorHandler(templatesStrings.get('error.JOB_TEMPLATE_NOT_FOUND'), 'GET'));
                 const preLaunchPromises = [
-                    selectedJobTemplate.getLaunch(vm.template.id),
-                    selectedJobTemplate.optionsLaunch(vm.template.id),
+                    getLaunch, optionsLaunch
                 ];
 
                 Promise.all(preLaunchPromises)
@@ -86,10 +87,12 @@ function atLaunchTemplateCtrl (
                     });
             } else if (vm.template.type === 'workflow_job_template') {
                 const selectedWorkflowJobTemplate = workflowTemplate.create();
+                const getLaunch = selectedWorkflowJobTemplate.getLaunch(vm.template.id).catch(createErrorHandler(templatesStrings.get('error.WORKFLOW_TEMPLATE_NOT_FOUND'), 'GET'));
+                const optionsLaunch = selectedWorkflowJobTemplate.optionsLaunch(vm.template.id).catch(createErrorHandler(templatesStrings.get('error.WORKFLOW_TEMPLATE_NOT_FOUND'), 'GET'));
                 const preLaunchPromises = [
                     selectedWorkflowJobTemplate.request('get', vm.template.id),
-                    selectedWorkflowJobTemplate.getLaunch(vm.template.id),
-                    selectedWorkflowJobTemplate.optionsLaunch(vm.template.id),
+                    getLaunch,
+                    optionsLaunch
                 ];
 
                 Promise.all(preLaunchPromises)
@@ -163,14 +166,14 @@ function atLaunchTemplateCtrl (
                 } else {
                     $state.go('output', { id: launchRes.data.job, type: 'playbook' }, { reload: true });
                 }
-            }).catch(createErrorHandler('launch job template', 'POST'));
+            }).catch(createErrorHandler(templatesStrings.get('error.JOB_TEMPLATE_NOT_FOUND'), 'POST'));
         } else if (vm.promptData.templateType === 'workflow_job_template') {
             workflowTemplate.create().postLaunch({
                 id: vm.promptData.template,
                 launchData: jobLaunchData
             }).then((launchRes) => {
                 $state.go('workflowResults', { id: launchRes.data.workflow_job }, { reload: true });
-            }).catch(createErrorHandler('launch workflow job template', 'POST'));
+            }).catch(createErrorHandler(templatesStrings.get('error.JOB_TEMPLATE_NOT_FOUND'), 'POST'));
         }
     };
 }


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/3290
When user-A deletes a job in a session, and user-B also in session as the same time, then goes to try to run that job user-B did not receive an error message.  This fix creates an error message for this user case.was in a session and deleted a job, another user, in the same org. in session.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
<img width="1053" alt="screen shot 2019-02-27 at 11 21 49 am" src="https://user-images.githubusercontent.com/39280967/53505800-9c108a80-3a82-11e9-85eb-789a2294d675.png">
<img width="773" alt="screen shot 2019-02-27 at 11 23 34 am" src="https://user-images.githubusercontent.com/39280967/53505799-9c108a80-3a82-11e9-945c-ba4795d099b7.png">
<img width="1443" alt="screen shot 2019-02-27 at 11 24 38 am" src="https://user-images.githubusercontent.com/39280967/53505797-9c108a80-3a82-11e9-8e22-e39c63f13790.png">



