### PR TITLE
cache dynamic input fields

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -284,10 +284,6 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
         'admin_role',
     ])
 
-    def __init__(self, *args, **kwargs):
-        super(Credential, self).__init__(*args, **kwargs)
-        self.dynamic_input_fields = self._get_dynamic_input_field_names()
-
     def __getattr__(self, item):
         if item != 'inputs':
             if item in V1Credential.FIELDS:
@@ -376,6 +372,14 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
             else:
                 needed.append('vault_password')
         return needed
+    
+    @property
+    def dynamic_input_fields(self):
+        dynamic_input_fields = getattr(self, '_dynamic_input_fields', None)
+        if dynamic_input_fields is None:
+            self._dynamic_input_fields = self._get_dynamic_input_field_names()
+            return self._dynamic_input_fields
+        return dynamic_input_fields
 
     def _password_field_allows_ask(self, field):
         return field in self.credential_type.askable_fields


### PR DESCRIPTION
Only query dynamic input fields the first time they're used. Store the results for later after the first time

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
