### PR TITLE
Fixes bug where all instances were preselected when modal was initially opened

### DIFF
--- a/awx/ui/client/src/instance-groups/instances/instance-modal.controller.js
+++ b/awx/ui/client/src/instance-groups/instances/instance-modal.controller.js
@@ -36,7 +36,7 @@ function InstanceModalController ($scope, $state, Dataset, models, strings, Proc
 
         $scope.$watch('vm.instances', function() {
             angular.forEach(vm.instances, function(instance) {
-                instance.isSelected = _.filter(vm.selectedRows, 'id', instance.id).length > 0;
+                instance.isSelected = _.filter(vm.selectedRows, { 'id': instance.id }).length > 0;
             });
         });
     }


### PR DESCRIPTION
##### SUMMARY
I think this was a syntax change from lodash 3 -> 4.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
![instances](https://user-images.githubusercontent.com/9889020/53520600-fb32c700-3aa3-11e9-8038-84e0aab05223.gif)

Tested by adding a number of instances to my local AWX.  When I created a new instance group and opened up the modal (before the fix) all of the instances were checked even though none belonged to the IG group yet.  After the fix, only the instances that belong to the group in question are selected.
