### PR TITLE
enforce required credential fields at job start time rather than on save

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -655,13 +655,7 @@ class CredentialInputField(JSONSchemaField):
                 )
             errors[error.schema['id']] = [error.message]
 
-        inputs = model_instance.credential_type.inputs
         defined_fields = model_instance.credential_type.defined_fields
-        for field in inputs.get('required', []):
-            if field in defined_fields and not value.get(field, None):
-                errors[field] = [_('required for %s') % (
-                    model_instance.credential_type.name
-                )]
 
         # `ssh_key_unlock` requirements are very specific and can't be
         # represented without complicated JSON schema

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1229,6 +1229,23 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
             self.save(update_fields=['job_explanation'])
             return (False, None)
 
+        # verify that any associated credentials aren't missing required field data
+        missing_credential_inputs = []
+        for credential in self.credentials.all():
+            defined_fields = credential.credential_type.defined_fields
+            for required in credential.credential_type.inputs.get('required', []):
+                if required in defined_fields and not credential.has_input(required):
+                    missing_credential_inputs.append(required)
+
+        if missing_credential_inputs:
+            self.job_explanation = '{} cannot start because Credential {} does not provide one or more required fields ({}).'.format(
+                self._meta.verbose_name.title(),
+                credential.name,
+                ', '.join(sorted(missing_credential_inputs))
+            )
+            self.save(update_fields=['job_explanation'])
+            return (False, None)
+
         needed = self.get_passwords_needed_to_start()
         try:
             start_args = json.loads(decrypt_field(self, 'start_args'))

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1020,7 +1020,7 @@ class BaseTask(object):
             # handle custom injectors specified on the CredentialType
             credentials = []
             if isinstance(instance, Job):
-                credentials = instance.credentials.all()
+                credentials = instance.credentials.prefetch_related('input_sources__source_credential').all()
             elif isinstance(instance, InventoryUpdate):
                 # TODO: allow multiple custom creds for inv updates
                 credentials = [instance.get_cloud_credential()]
@@ -1170,7 +1170,7 @@ class RunJob(BaseTask):
         }
         '''
         private_data = {'credentials': {}}
-        for credential in job.credentials.all():
+        for credential in job.credentials.prefetch_related('input_sources__source_credential').all():
             # If we were sent SSH credentials, decrypt them and send them
             # back (they will be written to a temporary file).
             if credential.has_input('ssh_key_data'):

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -184,7 +184,7 @@ def test_ssh_key_data_validation(organization, kind, ssh_key_data, ssh_key_unloc
 @pytest.mark.django_db
 @pytest.mark.parametrize('inputs, valid', [
     ({'vault_password': 'some-pass'}, True),
-    ({}, False),
+    ({}, True),
     ({'vault_password': 'dev-pass', 'vault_id': 'dev'}, True),
     ({'vault_password': 'dev-pass', 'vault_id': 'dev@prompt'}, False),  # @ not allowed
 ])

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -291,15 +291,17 @@ class TestJobExecution(object):
 
         # mock the job.credentials M2M relation so we can avoid DB access
         job._credentials = []
-        patch = mock.patch.object(UnifiedJob, 'credentials', mock.Mock(**{
+        mocked = mock.Mock(**{
             'all': lambda: job._credentials,
             'add': job._credentials.append,
             'filter.return_value': mock.Mock(
                 __iter__ = lambda *args: iter(job._credentials),
                 first = lambda: job._credentials[0]
             ),
-            'spec_set': ['all', 'add', 'filter']
-        }))
+            'prefetch_related': lambda _: mocked,
+            'spec_set': ['all', 'add', 'filter', 'prefetch_related']
+        })
+        patch = mock.patch.object(UnifiedJob, 'credentials', mocked)
         self.patches.append(patch)
         patch.start()
 


### PR DESCRIPTION
this is necessary for credential plugins support so that you can (in two
requests):

1.  Save a Credential with _no_ input values defined
2.  Create/associate one (or more) CredentialInputSource records to the
    new Credential