### PR TITLE
Change default path of postgres_data_dir in inventory

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -49,9 +49,10 @@ dockerhub_base=ansible
 # management_mem_limit=2
 
 # Common Docker parameters
+# A postgres_data_dir defines the directory where the Postgresql database files are stored.
 awx_task_hostname=awx
 awx_web_hostname=awxweb
-postgres_data_dir=/tmp/pgdocker
+postgres_data_dir=/var/lib/awx/pgdocker
 host_port=80
 
 # Docker Compose Install


### PR DESCRIPTION
##### SUMMARY
Currently, the default path of PostgreSQL database is specified `/tmp/pgdocker`.
I think that it would be better to move the default PostgreSQL files path to another path like `/var/lib/awx/pgdocker` to avoid the effect of unexpectedly cleanup under /tmp/.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
None