### PR TITLE
Fixes bug where jobs list search was lost on socket message

### DIFF
--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -39,7 +39,6 @@ function ListJobsController (
     vm.list = { iterator, name };
     vm.job_dataset = Dataset.data;
     vm.jobs = Dataset.data.results;
-    vm.querySet = $state.params.job_search;
 
     $scope.$watch('vm.job_dataset.count', () => {
         $scope.$emit('updateCount', vm.job_dataset.count, 'jobs');
@@ -237,6 +236,8 @@ function ListJobsController (
     };
 
     function refreshJobs () {
+        console.log(SearchBasePath, $state.params.job_search);
+        console.log(vm.querySet);
         qs.search(SearchBasePath, $state.params.job_search, { 'X-WS-Session-Quiet': true })
             .then(({ data }) => {
                 vm.jobs = data.results;

--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -236,8 +236,6 @@ function ListJobsController (
     };
 
     function refreshJobs () {
-        console.log(SearchBasePath, $state.params.job_search);
-        console.log(vm.querySet);
         qs.search(SearchBasePath, $state.params.job_search, { 'X-WS-Session-Quiet': true })
             .then(({ data }) => {
                 vm.jobs = data.results;

--- a/awx/ui/client/features/jobs/jobsList.view.html
+++ b/awx/ui/client/features/jobs/jobsList.view.html
@@ -9,7 +9,6 @@
             dataset="vm.job_dataset"
             collection="vm.jobs"
             search-tags="searchTags"
-            query-set="vm.querySet"
             search-bar-full-width="vm.isPortalMode">
         </smart-search>
     </div>
@@ -106,7 +105,6 @@
         collection="vm.jobs"
         dataset="vm.job_dataset"
         iterator="job"
-        base-path="{{vm.searchBasePath}}"
-        query-set="vm.querySet">
+        base-path="{{vm.searchBasePath}}">
     </paginate>
 </at-panel-body>


### PR DESCRIPTION
##### SUMMARY
When a socket message came in on the jobs list for a status update any search params would be lost.  This PR fixes that issue by ensuring that the state params (url) is updated whenever a search is performed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI