### PR TITLE
Show yaml comments when possible on launch prompt

### DIFF
--- a/awx/ui/client/src/templates/prompt/prompt.service.js
+++ b/awx/ui/client/src/templates/prompt/prompt.service.js
@@ -25,14 +25,14 @@ function PromptService (Empty, $filter)  {
               hasDefaultExtraVars = _.get(params, 'launchConf.defaults.extra_vars');
 
         if(hasCurrentExtraVars && hasDefaultExtraVars) {
-            extraVars = _.merge(jsyaml.safeLoad(params.launchConf.defaults.extra_vars), params.currentValues.extra_data);
+            extraVars = jsyaml.safeDump(_.merge(jsyaml.safeLoad(params.launchConf.defaults.extra_vars), params.currentValues.extra_data));
         } else if(hasCurrentExtraVars) {
             extraVars = params.currentValues.extra_data;
         } else if(hasDefaultExtraVars) {
-            extraVars = jsyaml.safeLoad(params.launchConf.defaults.extra_vars);
+            extraVars = params.launchConf.defaults.extra_vars;
         }
 
-        prompts.variables.value = extraVars && extraVars !== '' ? '---\n' + jsyaml.safeDump(extraVars) : '---\n';
+        prompts.variables.value = extraVars && extraVars !== '' ? extraVars : '---\n';
         prompts.verbosity.choices = _.get(params, 'launchOptions.actions.POST.verbosity.choices', []).map(c => ({label: c[1], value: c[0]}));
         prompts.verbosity.value = _.has(params, 'currentValues.verbosity') && params.currentValues.verbosity ? _.find(prompts.verbosity.choices, item => item.value === params.currentValues.verbosity) : _.find(prompts.verbosity.choices, item => item.value === params.launchConf.defaults.verbosity);
         prompts.jobType.choices = _.get(params, 'launchOptions.actions.POST.job_type.choices', []).map(c => ({label: c[1], value: c[0]}));

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
@@ -12,7 +12,7 @@ export default
 
             let scope;
 
-            vm.init = (_scope_, _launch_) => {
+            vm.init = (_scope_) => {
                 scope = _scope_;
 
                 scope.parseType = 'yaml';

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
@@ -11,11 +11,9 @@ export default
             vm.strings = strings;
 
             let scope;
-            let launch;
 
             vm.init = (_scope_, _launch_) => {
                 scope = _scope_;
-                launch = _launch_;
 
                 scope.parseType = 'yaml';
 

--- a/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
@@ -11,7 +11,6 @@ export default
             vm.strings = strings;
 
             let scope;
-            let launch;
 
             let consolidateTags = (tagModel, tagId) => {
                 let tags = angular.copy(tagModel);
@@ -28,14 +27,11 @@ export default
 
             vm.init = (_scope_, _launch_) => {
                 scope = _scope_;
-                launch = _launch_;
 
                 vm.showJobTags = true;
                 vm.showSkipTags = true;
 
                 scope.parseType = 'yaml';
-
-                scope.promptData.extraVars = ToJSON(scope.parseType, scope.promptData.prompts.variables.value, false);
 
                 const surveyPasswords = {};
 
@@ -48,6 +44,7 @@ export default
                 }
 
                 if (scope.promptData.launchConf.survey_enabled){
+                    scope.promptData.extraVars = ToJSON(scope.parseType, scope.promptData.prompts.variables.value, false);
                     scope.promptData.surveyQuestions.forEach(surveyQuestion => {
                         if (!scope.promptData.extraVars) {
                             scope.promptData.extraVars = {};
@@ -76,15 +73,17 @@ export default
                             surveyPasswords[surveyQuestion.variable] = '$encrypted$';
                         }
                     });
+                    // We don't want to modify the extra vars when we merge them with the survey
+                    // password $encrypted$ strings so we clone it
+                    const extraVarsClone = _.cloneDeep(scope.promptData.extraVars);
+                    // Replace the survey passwords with $encrypted$ to display to the user
+                    const cleansedExtraVars = extraVarsClone ? Object.assign(extraVarsClone, surveyPasswords) : {};
+
+                    scope.promptExtraVars = $.isEmptyObject(scope.promptData.extraVars) ? '---' : '---\n' + jsyaml.safeDump(cleansedExtraVars);
+                } else {
+                    scope.promptData.extraVars = scope.promptData.prompts.variables.value;
+                    scope.promptExtraVars = scope.promptData.prompts.variables.value && scope.promptData.prompts.variables.value !== '' ? scope.promptData.prompts.variables.value : '---\n';
                 }
-
-                // We don't want to modify the extra vars when we merge them with the survey
-                // password $encrypted$ strings so we clone it
-                const extraVarsClone = _.cloneDeep(scope.promptData.extraVars);
-                // Replace the survey passwords with $encrypted$ to display to the user
-                const cleansedExtraVars = extraVarsClone ? Object.assign(extraVarsClone, surveyPasswords) : {};
-
-                scope.promptExtraVars = $.isEmptyObject(scope.promptData.extraVars) ? '---' : '---\n' + jsyaml.safeDump(cleansedExtraVars);
 
                 ParseTypeChange({
                     scope: scope,

--- a/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/preview/prompt-preview.controller.js
@@ -25,7 +25,7 @@ export default
                 return [...tags.reduce((map, tag) => map.has(tag.value) ? map : map.set(tag.value, tag), new Map()).values()];
             };
 
-            vm.init = (_scope_, _launch_) => {
+            vm.init = (_scope_) => {
                 scope = _scope_;
 
                 vm.showJobTags = true;


### PR DESCRIPTION
##### SUMMARY
When the JT launch prompt modal was overhauled we added a Preview tab.  When we added this tab, we added some logic to aggregate prompted extra vars and survey questions into a single block of
extra vars to give the user an idea of exactly what extra vars will be used during that JT run.  In order to achieve this we have to convert the existing extra vars from YAML to JSON.  This allows us to merge the two objects easily.  When the extra vars are converted though, the comments are stripped out.  We _could_ support maintaining the comments but this would require a dependency change that I don't think we're ready to commit to at this point.

This PR ensures that YAML comments are shown to the user during launch when possible.

Scenarios (in all scenarios the JT has comments in extra vars):
1) JT has no survey - comments shown in extra vars prompt codemirror and Preview extra vars codemirror
2) JT has survey - comments shown in extra vars prompt codemirror but _not shown_ in Preview extra vars codemirror

This PR also impacts schedules.  When the user is _adding_ a new schedule the comments should appear in the codemirror.  _Once the schedule is saved_ the api will have stripped out all the comments and stored the extra vars as JSON so they will no longer appear in the UI.  This is expected behavior.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
The local testing that I've done has consisted of setting up all the different permutations of job template configurations and going through the launch process to ensure that a) comments are displayed when expected and b) extra vars are passed to job correctly.  

1) No default vars, no var prompting, no survey
2) No default vars, no var prompting, survey
3) No default vars, var prompting, no survey
4) No default vars, var prompting, survey
5) Default vars, no var prompting, no survey
6) Default vars, no var prompting, survey
7) Default vars, var prompting, no survey
8) Default vars, var prompting, survey

I also went over and took a look at schedules to make sure that those still behaved as expected.

Workflow node prompting is also worth looking at.  The rules that apply to jt launch should apply to workflow nodes as well.  The variables should be shown when possible and will be wiped out when a survey is present (as well as on save).
