### PR TITLE
Fix dashboard dropdowns after bootstrap upgrade

### DIFF
--- a/awx/ui/client/src/home/dashboard/graphs/dashboard-graphs.block.less
+++ b/awx/ui/client/src/home/dashboard/graphs/dashboard-graphs.block.less
@@ -99,6 +99,10 @@
     text-transform: uppercase;
     transition: background-color 0.2s;
     width: 100%;
+
+    > span {
+        width: 100%;
+    }
 }
 
 .DashboardGraphs-filterDropdownText:hover {
@@ -110,6 +114,8 @@
     font-size: 12px;
     width: 20px;
     padding: 0 10px;
+    float: right;
+    margin-top: 1px;
 }
 
 .DashboardGraphs-filterDropdownItems {

--- a/awx/ui/client/src/home/dashboard/graphs/dashboard-graphs.partial.html
+++ b/awx/ui/client/src/home/dashboard/graphs/dashboard-graphs.partial.html
@@ -12,7 +12,10 @@
                     data-target="#"
                     href="/page.html"
                     class="DashboardGraphs-filterDropdownText">
-                        <translate>Past Month</translate> <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                        <span id="period-dropdown-display">
+                            <span translate>Past Month</span>
+                            <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                        </span>
                     </a>
                     <ul class="dropdown-menu DashboardGraphs-filterDropdownItems
                         DashboardGraphs-filterDropdownItems--period" role="menu" aria-labelledby="period-dropdown">
@@ -34,7 +37,10 @@
 
                         <a id="type-dropdown" role="button" data-toggle="dropdown" data-target="#" class="DashboardGraphs-filterDropdownText"
                         href="/page.html">
-                            <translate>All</translate> <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                            <span id="type-dropdown-display">
+                                <span translate>All</span>
+                                <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                            </span>
                         </a>
 
                     <ul class="dropdown-menu DashboardGraphs-filterDropdownItems
@@ -62,10 +68,10 @@
                     data-target="#"
                     href="/page.html"
                     class="DashboardGraphs-filterDropdownText">
-                        <translate>All</translate>
-                        <i class="fa fa-angle-down
-                            DashboardGraphs-filterIcon">
-                        </i>
+                        <span id="status-dropdown-display">
+                            <span translate>All</span>
+                            <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                        </span>
                     </a>
 
                     <ul class="dropdown-menu DashboardGraphs-filterDropdownItems

--- a/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
+++ b/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
@@ -126,13 +126,11 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
                     $('.n').off('click').on("click", function(){
                         period = this.getAttribute("id");
 
-                        $('#period-dropdown')
-                            .replaceWith(`
-                                <a id="period-dropdown" class="DashboardGraphs-filterDropdownText DashboardGraphs-filterDropdownItems--period" role="button"
-                                   data-toggle="dropdown" data-target="#" href="/page.html">
-                                    <span>${this.text}</span>
-                                    <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
-                                </a>`);
+                        $('#period-dropdown-display')
+                            .html(`
+                                <span>${this.text}</span>
+                                <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                            `);
 
                         scope.$parent.isFailed = true;
                         scope.$parent.isSuccessful = true;
@@ -141,15 +139,14 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
 
                     //On click, update with new data
                     $('.m').off('click').on("click", function(){
+                        console.log('click');
                         job_type = this.getAttribute("id");
 
-                        $('#type-dropdown')
-                            .replaceWith(`
-                                <a id="type-dropdown" class="DashboardGraphs-filterDropdownText DashboardGraphs-filterDropdownItems--jobType" role="button"
-                                   data-toggle="dropdown" data-target="#" href="/page.html">
-                                    <span>${this.text}</span>
-                                    <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
-                                </a>`);
+                        $('#type-dropdown-display')
+                            .html(`
+                                <span>${this.text}</span>
+                                <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                            `);
 
                         scope.$parent.isFailed = true;
                         scope.$parent.isSuccessful = true;
@@ -159,13 +156,11 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
                     $('.o').off('click').on('click', function() {
                         var job_status = this.getAttribute('id');
 
-                        $('#status-dropdown')
-                            .replaceWith(`
-                                <a id="status-dropdown" class="DashboardGraphs-filterDropdownText DashboardGraphs-filterDropdownItems--status" role="button"
-                                   data-toggle="dropdown" data-target="#" href="/page.html">
-                                    <span>${this.text}</span>
-                                    <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
-                                </a>`);
+                        $('#status-dropdown-display')
+                            .html(`
+                                <span>${this.text}</span>
+                                <i class="fa fa-angle-down DashboardGraphs-filterIcon"></i>
+                            `);
 
                         recreateGraph(scope.period, scope.jobType, job_status);
                     });

--- a/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
+++ b/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.directive.js
@@ -139,7 +139,6 @@ function JobStatusGraph($window, adjustGraphSize, templateUrl, i18n, moment, gra
 
                     //On click, update with new data
                     $('.m').off('click').on("click", function(){
-                        console.log('click');
                         job_type = this.getAttribute("id");
 
                         $('#type-dropdown-display')


### PR DESCRIPTION
##### SUMMARY
The dashboard dropdowns would not be hidden after a selection was made.  This bug was due to the jquery/bootstrap upgrade that occurred some weeks ago.  This solution should restore the dashboard to it's previous state of functionality.  There was also a bug where the dropdown (if open while resizing) would be repositioned to the top right corner of the screen.  I'm no longer able to reproduce that issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Tested dropdowns in both Chrome and Firefox to ensure that the dropdown portion is hidden after selection and that the display text is updated appropriately.  Also checked to make sure the graph itself was still updating appropriately.  Tested resizing the screen while one of the dropdowns was open.

![dashboard_graph_dropdowns](https://user-images.githubusercontent.com/9889020/53820553-fd7ca180-3f39-11e9-8f87-6f9e08151da0.gif)