### PR TITLE
Update fields.py to convert JT Credential input into integers

### DIFF
--- a/awx/api/fields.py
+++ b/awx/api/fields.py
@@ -101,9 +101,15 @@ class DeprecatedCredentialField(serializers.IntegerField):
         super(DeprecatedCredentialField, self).__init__(**kwargs)
 
     def to_internal_value(self, pk):
+        if isinstance(pk, str):
+            self.fail('invalid')
+        try:
+            pk = int(pk)
+        except (ValueError):
+            self.fail('invalid')
         try:
             pk = int(pk)
             Credential.objects.get(pk=pk)
-        except (ObjectDoesNotExist, ValueError):
+        except (ObjectDoesNotExist):
             raise serializers.ValidationError(_('Credential {} does not exist').format(pk))
         return pk

--- a/awx/api/fields.py
+++ b/awx/api/fields.py
@@ -102,7 +102,8 @@ class DeprecatedCredentialField(serializers.IntegerField):
 
     def to_internal_value(self, pk):
         try:
+            pk = int(pk)
             Credential.objects.get(pk=pk)
-        except ObjectDoesNotExist:
+        except (ObjectDoesNotExist, ValueError):
             raise serializers.ValidationError(_('Credential {} does not exist').format(pk))
         return pk

--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -39,7 +39,6 @@ function ListJobsController (
     vm.list = { iterator, name };
     vm.job_dataset = Dataset.data;
     vm.jobs = Dataset.data.results;
-    vm.querySet = $state.params.job_search;
 
     $scope.$watch('vm.job_dataset.count', () => {
         $scope.$emit('updateCount', vm.job_dataset.count, 'jobs');
@@ -237,6 +236,8 @@ function ListJobsController (
     };
 
     function refreshJobs () {
+        console.log(SearchBasePath, $state.params.job_search);
+        console.log(vm.querySet);
         qs.search(SearchBasePath, $state.params.job_search, { 'X-WS-Session-Quiet': true })
             .then(({ data }) => {
                 vm.jobs = data.results;

--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -236,8 +236,6 @@ function ListJobsController (
     };
 
     function refreshJobs () {
-        console.log(SearchBasePath, $state.params.job_search);
-        console.log(vm.querySet);
         qs.search(SearchBasePath, $state.params.job_search, { 'X-WS-Session-Quiet': true })
             .then(({ data }) => {
                 vm.jobs = data.results;

--- a/awx/ui/client/features/jobs/jobsList.view.html
+++ b/awx/ui/client/features/jobs/jobsList.view.html
@@ -9,7 +9,6 @@
             dataset="vm.job_dataset"
             collection="vm.jobs"
             search-tags="searchTags"
-            query-set="vm.querySet"
             search-bar-full-width="vm.isPortalMode">
         </smart-search>
     </div>
@@ -106,7 +105,6 @@
         collection="vm.jobs"
         dataset="vm.job_dataset"
         iterator="job"
-        base-path="{{vm.searchBasePath}}"
-        query-set="vm.querySet">
+        base-path="{{vm.searchBasePath}}">
     </paginate>
 </at-panel-body>

--- a/awx/ui/client/features/projects/projects.strings.js
+++ b/awx/ui/client/features/projects/projects.strings.js
@@ -46,6 +46,11 @@ function ProjectsStrings (BaseString) {
         HEADER: this.error.HEADER,
         CALL: this.error.CALL,
     };
+
+    ns.sort = {
+        NAME_ASCENDING: t.s('Name (Ascending)'),
+        NAME_DESCENDING: t.s('Name (Descending)')
+    };
 }
 
 ProjectsStrings.$inject = ['BaseStringService'];

--- a/awx/ui/client/features/projects/projectsList.controller.js
+++ b/awx/ui/client/features/projects/projectsList.controller.js
@@ -27,7 +27,6 @@ function projectsListController (
     };
     vm.dataset = Dataset.data;
     vm.projects = Dataset.data.results;
-    vm.querySet = $state.params.project_search;
 
     $scope.$watch('vm.dataset.count', () => {
         $scope.$emit('updateCount', vm.dataset.count, 'projects');
@@ -48,7 +47,18 @@ function projectsListController (
         } else {
             vm.activeId = '';
         }
+        setToolbarSort();
     }, true);
+
+    function setToolbarSort () {
+        const orderByValue = _.get($state.params, 'project_search.order_by');
+        const sortValue = _.find(vm.toolbarSortOptions, (option) => option.value === orderByValue);
+        if (sortValue) {
+            vm.toolbarSortValue = sortValue;
+        } else {
+            vm.toolbarSortValue = toolbarSortDefault;
+        }
+    }
 
     const toolbarSortDefault = {
         label: `${strings.get('sort.NAME_ASCENDING')}`,
@@ -69,7 +79,7 @@ function projectsListController (
         vm.toolbarSortValue = sort;
 
         const queryParams = Object.assign(
-            vm.querySet,
+            $state.params.project_search,
             { order_by: sort.value }
         );
 

--- a/awx/ui/client/features/projects/projectsList.controller.js
+++ b/awx/ui/client/features/projects/projectsList.controller.js
@@ -27,6 +27,8 @@ function projectsListController (
     };
     vm.dataset = Dataset.data;
     vm.projects = Dataset.data.results;
+    vm.querySet = $state.params.project_search;
+
     $scope.$watch('vm.dataset.count', () => {
         $scope.$emit('updateCount', vm.dataset.count, 'projects');
     });
@@ -47,6 +49,36 @@ function projectsListController (
             vm.activeId = '';
         }
     }, true);
+
+    const toolbarSortDefault = {
+        label: `${strings.get('sort.NAME_ASCENDING')}`,
+        value: 'name'
+    };
+
+    vm.toolbarSortOptions = [
+        toolbarSortDefault,
+        {
+            label: `${strings.get('sort.NAME_DESCENDING')}`,
+            value: '-name'
+        }
+    ];
+
+    vm.toolbarSortValue = toolbarSortDefault;
+
+    vm.onToolbarSort = (sort) => {
+        vm.toolbarSortValue = sort;
+
+        const queryParams = Object.assign(
+            vm.querySet,
+            { order_by: sort.value }
+        );
+
+        qs.search(GetBasePath(vm.list.basePath), queryParams)
+            .then(({ data }) => {
+                vm.dataset = data;
+                vm.projects = vm.dataset.results;
+            });
+    };
 
     $scope.$on('ws-jobs', (e, data) => {
         $log.debug(data);

--- a/awx/ui/client/features/projects/projectsList.view.html
+++ b/awx/ui/client/features/projects/projectsList.view.html
@@ -21,10 +21,13 @@
     </div>
     <at-list-toolbar
         ng-if="vm.projects.length > 0"
-        sort-only="false"
-        on-collapse="vm.onCollapse"
         on-expand="vm.onExpand"
-        is-collapsed="vm.isCollapsed">
+        on-collapse="vm.onCollapse"
+        is-collapsed="vm.isCollapsed"
+        sort-only="false"
+        sort-value="vm.toolbarSortValue"
+        sort-options="vm.toolbarSortOptions"
+        on-sort="vm.onToolbarSort">
     </at-list-toolbar>
     <at-list results="vm.projects">
         <at-row ng-repeat="project in vm.projects"
@@ -44,7 +47,7 @@
                         <div aw-tool-tip="{{ project.scm_update_tooltip }}"
                         data-tip-watch="project.scm_update_tooltip"
                         data-placement="top">
-                            <div class="at-RowAction" 
+                            <div class="at-RowAction"
                                 ng-class="{'at-RowAction--disabled': project.scm_update_disabled }"
                                 ng-click="vm.SCMUpdate(project.id, $event)"
                                 ng-show="project.summary_fields.user_capabilities.start">
@@ -56,16 +59,16 @@
                         </at-row-action>
                         <at-row-action icon="fa-trash" ng-click="vm.deleteProject(project.id, project.name)"
                             ng-show="(project.status !== 'updating'
-                            && project.status !== 'running' 
-                            && project.status !== 'pending' 
-                            && project.status !== 'waiting')  
+                            && project.status !== 'running'
+                            && project.status !== 'pending'
+                            && project.status !== 'waiting')
                             && project.summary_fields.user_capabilities.delete">
                         </at-row-action>
                         <at-row-action icon="fa-minus-circle" ng-click="vm.cancelUpdate(project)"
-                            ng-show="(project.status == 'updating' 
-                            || project.status == 'running' 
-                            || project.status == 'pending' 
-                            || project.status == 'waiting') 
+                            ng-show="(project.status == 'updating'
+                            || project.status == 'running'
+                            || project.status == 'pending'
+                            || project.status == 'waiting')
                             && project.summary_fields.user_capabilities.start">
                         </at-row-action>
                     </div>
@@ -77,7 +80,7 @@
                         </div>
                         <at-truncate string="{{ project.scm_revision }}" maxLength="7"></at-truncate>
                     </div>
-                    <at-row-item 
+                    <at-row-item
                         label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_ORGANIZATION')}}"
                         value="{{ project.summary_fields.organization.name }}"
                         value-link="/#/organizations/{{ project.organization }}">
@@ -98,6 +101,7 @@
         collection="vm.projects"
         dataset="vm.dataset"
         iterator="project"
-        base-path="projects">
+        base-path="projects"
+        query-set="vm.querySet">
     </paginate>
 </at-panel-body>

--- a/awx/ui/client/features/projects/projectsList.view.html
+++ b/awx/ui/client/features/projects/projectsList.view.html
@@ -101,7 +101,6 @@
         collection="vm.projects"
         dataset="vm.dataset"
         iterator="project"
-        base-path="projects"
-        query-set="vm.querySet">
+        base-path="projects">
     </paginate>
 </at-panel-body>

--- a/awx/ui/client/lib/components/components.strings.js
+++ b/awx/ui/client/lib/components/components.strings.js
@@ -113,6 +113,12 @@ function ComponentsStrings (BaseString) {
     ns.list = {
         DEFAULT_EMPTY_LIST: t.s('Please add items to this list.')
     };
+
+    ns.toolbar = {
+        COMPACT: t.s('Compact'),
+        EXPANDED: t.s('Expanded'),
+        SORT_BY: t.s('SORT BY')
+    };
 }
 
 ComponentsStrings.$inject = ['BaseStringService'];

--- a/awx/ui/client/lib/components/list/_index.less
+++ b/awx/ui/client/lib/components/list/_index.less
@@ -96,6 +96,43 @@
     }
 }
 
+.at-List-toolbarDropdown {
+    border-top-right-radius: @at-border-radius;
+    padding: 2px 10px;
+
+    &:hover {
+        cursor: pointer;
+        background: @at-gray-f2;
+    }
+
+    &-toggle {
+        background: none;
+        border: none;
+        padding: 0;
+    }
+
+    &-toggleText {
+        margin-right: 10px;
+    }
+
+    &-menu {
+        border-bottom-left-radius: @at-border-radius;
+        border-bottom-right-radius: @at-border-radius;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        left: auto;
+        margin: 0;
+        right: 0;
+        width: 100%;
+    }
+
+    &-menuHeader {
+        color: @at-gray-646972;
+        font-weight: bold;
+        pointer-events: none;
+    }
+}
+
 .at-List-container {
     border: @at-border-default-width solid @at-color-list-border;
     border-radius: @at-border-radius;

--- a/awx/ui/client/lib/components/list/list-toolbar.directive.js
+++ b/awx/ui/client/lib/components/list/list-toolbar.directive.js
@@ -1,5 +1,12 @@
 const templateUrl = require('~components/list/list-toolbar.partial.html');
 
+function AtListToolbar (strings) {
+    const vm = this || {};
+    vm.strings = strings;
+}
+
+AtListToolbar.$inject = ['ComponentsStrings'];
+
 function atListToolbar () {
     return {
         restrict: 'E',
@@ -9,9 +16,14 @@ function atListToolbar () {
         scope: {
             onExpand: '=',
             onCollapse: '=',
-            sortOnly: '=',
             isCollapsed: '=',
-        }
+            onSort: '<',
+            sortOnly: '=',
+            sortOptions: '<',
+            sortValue: '<'
+        },
+        controller: AtListToolbar,
+        controllerAs: 'vm'
     };
 }
 

--- a/awx/ui/client/lib/components/list/list-toolbar.partial.html
+++ b/awx/ui/client/lib/components/list/list-toolbar.partial.html
@@ -1,5 +1,24 @@
 <div class="at-List-toolbar--attached">
-  <div ng-class="isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onCollapse()">Compact</div>
-  <div ng-class="!isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onExpand()">Expanded</div>
-  <div class="at-List-toolbar-item">Sort</div>
+    <div ng-class="isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onCollapse()">{{ vm.strings.get('toolbar.COMPACT') }}</div>
+    <div ng-class="!isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onExpand()">{{ vm.strings.get('toolbar.EXPANDED') }}</div>
+    <div class="at-List-toolbarDropdown dropdown">
+        <button
+            class="at-List-toolbarDropdown-toggle dropdown-toggle"
+            data-display="static"
+            data-toggle="dropdown">
+            <span class="at-List-toolbarDropdown-toggleText">{{ sortValue.label }}</span>
+            <i class="fa fa-angle-down" aria-hidden="true"></i>
+        </button>
+        <ul class="at-List-toolbarDropdown-menu dropdown-menu">
+            <li class="at-List-toolbarDropdown-menuHeader dropdown-item">
+                {{ vm.strings.get('toolbar.SORT_BY') }}
+            </li>
+            <li
+                class="dropdown-item"
+                ng-repeat="option in sortOptions"
+                ng-click="onSort(option)">
+                {{ option.label }}
+            </li>
+        </ul>
+    </div>
 </div>

--- a/awx/ui/client/lib/components/list/list-toolbar.partial.html
+++ b/awx/ui/client/lib/components/list/list-toolbar.partial.html
@@ -1,7 +1,7 @@
 <div class="at-List-toolbar--attached">
     <div ng-class="isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onCollapse()">{{ vm.strings.get('toolbar.COMPACT') }}</div>
     <div ng-class="!isCollapsed ? 'active' : ''" ng-if="!sortOnly" class="at-List-toolbar-item" ng-click="onExpand()">{{ vm.strings.get('toolbar.EXPANDED') }}</div>
-    <div class="at-List-toolbarDropdown dropdown">
+    <div ng-if="sortOptions" class="at-List-toolbarDropdown dropdown">
         <button
             class="at-List-toolbarDropdown-toggle dropdown-toggle"
             data-display="static"

--- a/awx/ui/test/e2e/tests/test-404-behavior.js
+++ b/awx/ui/test/e2e/tests/test-404-behavior.js
@@ -1,0 +1,22 @@
+import {
+    AWX_E2E_URL
+} from '../settings';
+
+module.exports = {
+    before: (client) => {
+
+        client
+            .login()
+            .waitForAngular()
+            .resizeWindow(1200, 1000);
+    },
+    'Verify 404 page behavior': client => {
+        client.navigateTo(AWX_E2E_URL + '#/brokenurl', false);
+        client.useXpath().waitForElementVisible('//job-status-graph');
+        client.assert.urlContains('#/home');
+    },
+
+    after: client => {
+        client.end();
+    }
+};

--- a/awx/ui/test/e2e/tests/test-404-behavior.js
+++ b/awx/ui/test/e2e/tests/test-404-behavior.js
@@ -1,5 +1,6 @@
 import {
-    AWX_E2E_URL
+    AWX_E2E_URL,
+    AWX_E2E_TIMEOUT_MEDIUM
 } from '../settings';
 
 module.exports = {
@@ -9,12 +10,35 @@ module.exports = {
             .waitForAngular()
             .resizeWindow(1200, 1000);
     },
-    'Verify 404 page behavior': client => {
+    'Test that default the 404 behavior redirects to the dashboard': client => {
         client.navigateTo(`${AWX_E2E_URL}#/brokenurl`, false);
         client.useXpath().waitForElementVisible('//job-status-graph');
         client.assert.urlContains('#/home');
     },
-
+    'Test 404 modal for job templates': client => {
+        client.navigateTo(`${AWX_E2E_URL}#/templates/job_template/99999`, false);
+        client.expect.element('//*[@id="alert-modal"]')
+            .to.be.visible.after(AWX_E2E_TIMEOUT_MEDIUM);
+        client.findThenClick('//*[@id="alert_ok_btn"]');
+    },
+    'Test 404 modal for workflow job templates': client => {
+        client.navigateTo(`${AWX_E2E_URL}#/templates/workflow_job_template/99999`, false);
+        client.expect.element('//*[@id="alert-modal"]')
+            .to.be.visible.after(AWX_E2E_TIMEOUT_MEDIUM);
+        client.findThenClick('//*[@id="alert_ok_btn"]');
+    },
+    'Test 404 modal for credentials': client => {
+        client.navigateTo(`${AWX_E2E_URL}#/credentials/99999`, false);
+        client.expect.element('//*[@id="alert-modal"]')
+            .to.be.visible.after(AWX_E2E_TIMEOUT_MEDIUM);
+        client.findThenClick('//*[@id="alert_ok_btn"]');
+    },
+    'Test 404 modal for projects': client => {
+        client.navigateTo(`${AWX_E2E_URL}#/projects/99999`, false);
+        client.expect.element('//*[@id="alert-modal"]')
+            .to.be.visible.after(AWX_E2E_TIMEOUT_MEDIUM);
+        client.findThenClick('//*[@id="alert_ok_btn"]');
+    },
     after: client => {
         client.end();
     }

--- a/awx/ui/test/e2e/tests/test-404-behavior.js
+++ b/awx/ui/test/e2e/tests/test-404-behavior.js
@@ -4,14 +4,13 @@ import {
 
 module.exports = {
     before: (client) => {
-
         client
             .login()
             .waitForAngular()
             .resizeWindow(1200, 1000);
     },
     'Verify 404 page behavior': client => {
-        client.navigateTo(AWX_E2E_URL + '#/brokenurl', false);
+        client.navigateTo(`${AWX_E2E_URL}'#/brokenurl`, false);
         client.useXpath().waitForElementVisible('//job-status-graph');
         client.assert.urlContains('#/home');
     },

--- a/awx/ui/test/e2e/tests/test-404-behavior.js
+++ b/awx/ui/test/e2e/tests/test-404-behavior.js
@@ -10,7 +10,7 @@ module.exports = {
             .resizeWindow(1200, 1000);
     },
     'Verify 404 page behavior': client => {
-        client.navigateTo(`${AWX_E2E_URL}'#/brokenurl`, false);
+        client.navigateTo(`${AWX_E2E_URL}#/brokenurl`, false);
         client.useXpath().waitForElementVisible('//job-status-graph');
         client.assert.urlContains('#/home');
     },


### PR DESCRIPTION
##### SUMMARY
Addressing Issue https://github.com/ansible/awx/issues/3346

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```


##### ADDITIONAL INFORMATION
When using the API, a TypeError was thrown if a string (rather than an integer) was provided for the `credential` parameter:

![error](https://user-images.githubusercontent.com/28930622/53835865-768cf080-3f5c-11e9-9c9c-54c449bd31b9.png)

With this change in `fields.py`, the user can POST a request with a body containing integers wrapped in quotes, like this (exactly what I used to recreate the error above): 
```
{
  "credential": "1", 
  "inventory": "1", 
  "job_type": "run", 
  "name": "test", 
  "playbook": "hello_world.yml", 
  "project": "4"
}
```

...except now the string containing a number is converted into an integer, and the job template gets created successfully, with all of the appropriate fields populated:

![yay](https://user-images.githubusercontent.com/28930622/53836321-b6a0a300-3f5d-11e9-9f02-1ffec152e4fa.png)

![fieldspopulated](https://user-images.githubusercontent.com/28930622/53836875-16e41480-3f5f-11e9-9cbc-b88b0a35ad3a.png)


When the POST body contains an actual alphanumerical string which cannot be converted into integers, the error shows up like the below (vs the TypeError):

![bettererror](https://user-images.githubusercontent.com/28930622/53836521-3595db80-3f5e-11e9-8d7c-be4208295ace.png)
