### PR TITLE
Update fields.py to Display Correct Error Message When JT Credential Is Not an Integer

### DIFF
--- a/awx/api/fields.py
+++ b/awx/api/fields.py
@@ -102,6 +102,10 @@ class DeprecatedCredentialField(serializers.IntegerField):
 
     def to_internal_value(self, pk):
         try:
+            pk = int(pk)
+        except ValueError:
+            self.fail('invalid')
+        try:
             Credential.objects.get(pk=pk)
         except ObjectDoesNotExist:
             raise serializers.ValidationError(_('Credential {} does not exist').format(pk))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New PR related to https://github.com/ansible/awx/pull/3369, addressing issue https://github.com/ansible/awx/issues/3346.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```


##### ADDITIONAL INFORMATION
When using the API, a TypeError was thrown if a string (rather than an integer) was provided for the `credential` parameter:

![error](https://user-images.githubusercontent.com/28930622/53835865-768cf080-3f5c-11e9-9c9c-54c449bd31b9.png)

With this change in `fields.py`, the user can POST a request with a body containing integers wrapped in quotes, like this (exactly what I used to recreate the error above): 
```
{
  "credential": "1", 
  "inventory": "1", 
  "job_type": "run", 
  "name": "test", 
  "playbook": "hello_world.yml", 
  "project": "4"
}
```

...except now the string containing a number is converted into an integer, and the job template gets created successfully, with all of the appropriate fields populated:

![yay](https://user-images.githubusercontent.com/28930622/53836321-b6a0a300-3f5d-11e9-9f02-1ffec152e4fa.png)

![fieldspopulated](https://user-images.githubusercontent.com/28930622/53836875-16e41480-3f5f-11e9-9cbc-b88b0a35ad3a.png)


When the POST body contains an actual alphanumerical string which cannot be converted into integers, the error shows up like the below (vs the TypeError):

![bettererror](https://user-images.githubusercontent.com/28930622/53836521-3595db80-3f5e-11e9-8d7c-be4208295ace.png)
