### PR TITLE
fix save success modal when adding new application

### DIFF
--- a/awx/ui/client/src/shared/Utilities.js
+++ b/awx/ui/client/src/shared/Utilities.js
@@ -78,7 +78,7 @@ angular.module('Utilities', ['RestServices', 'Utilities'])
             $('#alert2-modal-msg').html(msg);
 
             alertClass = (cls) ? cls : 'alert-danger'; //default alert class is alert-danger
-            local_backdrop = (backdrop === undefined) ? "static" : backdrop;
+            local_backdrop = (backdrop === undefined || backdrop === null) ? "static" : backdrop;
 
             $('#alert2-modal-msg').attr({ "class": "alert " + alertClass });
             $('#alert-modal2').modal({
@@ -107,7 +107,7 @@ angular.module('Utilities', ['RestServices', 'Utilities'])
             $('#alertHeader').html(hdr);
             $('#alert-modal-msg').html(msg);
             alertClass = (cls) ? cls : 'alert-danger'; //default alert class is alert-danger
-            local_backdrop = (backdrop === undefined) ? "static" : backdrop;
+            local_backdrop = (backdrop === undefined || backdrop === null) ? "static" : backdrop;
 
             $('#alert-modal-msg').attr({ "class": "alert " + alertClass });
             $('#alert-modal').modal({


### PR DESCRIPTION
Prevent `null` being passed to Bootstrap modal as the `backdrop` option. This was throwing an error that prevented the confirmation modal opening after the user saves a new application.

related #3374 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - UI