### PR TITLE
Revert xlib deps

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -16,10 +16,8 @@ RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
   libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel \
   xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 \
   xmlsec1-openssl-devel libtool-ltdl-devel rabbitmq-server bubblewrap \
-  zanata-python-client gettext gcc-c++ libcurl-devel bzip2 rsync \
-  libXcomposite libXcursor libXdamage libXext libXfixes libXi libXrender \
-  libXtst cups-libs libXScrnSaver libXrandr alsa-lib pango cairo \
-  atk at-spi2-atk gtk3 gdk-pixbuf2
+  zanata-python-client gettext gcc-c++ libcurl-devel bzip2 \
+  rsync
 
 RUN ln -s /usr/bin/python36 /usr/bin/python3
 

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -17,11 +17,9 @@ RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
   xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 \
   xmlsec1-openssl-devel libtool-ltdl-devel rabbitmq-server bubblewrap \
   zanata-python-client gettext gcc-c++ libcurl-devel bzip2 rsync \
-  pango libXcomposite libXcursor libXdamage \
-  libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 alsa-lib atk \
-  gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi \
-  xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 \
-  xorg-x11-fonts-misc
+  libXcomposite libXcursor libXdamage libXext libXfixes libXi libXrender \
+  libXtst cups-libs libXScrnSaver libXrandr alsa-lib pango cairo \
+  atk at-spi2-atk gtk3 gdk-pixbuf2
 
 RUN ln -s /usr/bin/python36 /usr/bin/python3
 


### PR DESCRIPTION
Sorry @saito-hideki I need to revert this. These dependencies are crazy and not ultimately used by the UI team when running tests.

I perform all UI tasks outside of the dev container, if our docs aren't clear there then we need to fix those up.