### PR TITLE
bwrap: Add /etc/ssh in bind mounted folder

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -831,7 +831,7 @@ def wrap_args_with_proot(args, cwd, **kwargs):
     new_args = [getattr(settings, 'AWX_PROOT_CMD', 'bwrap'), '--unshare-pid', '--dev-bind', '/', '/', '--proc', '/proc']
     hide_paths = [settings.AWX_PROOT_BASE_PATH]
     if not kwargs.get('isolated'):
-        hide_paths.extend(['/etc/tower', '/var/lib/awx', '/var/log',
+        hide_paths.extend(['/etc/tower', '/var/lib/awx', '/var/log', '/etc/ssh',
                            settings.PROJECTS_ROOT, settings.JOBOUTPUT_ROOT])
     hide_paths.extend(getattr(settings, 'AWX_PROOT_HIDE_PATHS', None) or [])
     for path in sorted(set(hide_paths)):


### PR DESCRIPTION
##### SUMMARY

/etc/ssh is currently not bound when run into bwrap, this leads to error
like `Bad owner or permissions on /etc/ssh/ssh_config.d/05-redhat.conf`
since it cannot access this file.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - UI

##### AWX VERSION

  - devel

##### ADDITIONAL INFORMATION

 This is what happened when running a project sync with private keys:

```
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/git clone --origin origin '' /var/lib/awx/projects/_279__test", "msg": "Cloning into '/var/lib/awx/projects/_279__test'...\nBad owner or permissions on /etc/ssh/ssh_config.d/05-redhat.conf\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.", "rc": 128, "stderr": "Cloning into '/var/lib/awx/projects/_279__test'...\nBad owner or permissions on /etc/ssh/ssh_config.d/05-redhat.conf\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n", "stderr_lines": ["Cloning into '/var/lib/awx/projects/_279__test'...", "Bad owner or permissions on /etc/ssh/ssh_config.d/05-redhat.conf", "fatal: Could not read from remote repository.", "", "Please make sure you have the correct access rights", "and the repository exists."], "stdout": "", "stdout_lines": []}
```