### PR TITLE
Add the ksu, machinectl, and sesu methods to the builtin list of become methods

### DIFF
--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -16,7 +16,8 @@ SCHEDULEABLE_PROVIDERS = CLOUD_PROVIDERS + ('custom', 'scm',)
 PRIVILEGE_ESCALATION_METHODS = [
     ('sudo', _('Sudo')), ('su', _('Su')), ('pbrun', _('Pbrun')), ('pfexec', _('Pfexec')),
     ('dzdo', _('DZDO')), ('pmrun', _('Pmrun')), ('runas', _('Runas')),
-    ('enable', _('Enable')), ('doas', _('Doas')),
+    ('enable', _('Enable')), ('doas', _('Doas')), ('ksu', _('Ksu')),
+    ('machinectl', _('Machinectl')), ('sesu', _('Sesu')),
 ]
 CHOICES_PRIVILEGE_ESCALATION_METHODS = [('', _('None'))] + PRIVILEGE_ESCALATION_METHODS
 ANSI_SGR_PATTERN = re.compile(r'\x1b\[[0-9;]*m')


### PR DESCRIPTION

##### SUMMARY
Adds additional become methods that are supported by the Ansible CLI to the list provided by our API.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```
