### PR TITLE
add first name and last name to the headers row of the teams users list

### DIFF
--- a/awx/ui/client/src/teams/teams.form.js
+++ b/awx/ui/client/src/teams/teams.form.js
@@ -95,13 +95,21 @@ export default ['i18n', function(i18n) {
                             key: true,
                             label: i18n._('User'),
                             linkBase: 'users',
-                            columnClass: 'col-sm-6'
+                            columnClass: 'col-sm-3'
+                        },
+                        first_name: {
+                            label: i18n._('First Name'),
+                            columnClass: 'col-sm-3'
+                        },
+                        last_name: {
+                            label: i18n._('Last Name'),
+                            columnClass: 'col-sm-3'
                         },
                         role: {
                             label: i18n._('Role'),
                             type: 'role',
                             nosort: true,
-                            columnClass: 'col-sm-6'
+                            columnClass: 'col-sm-3'
                         }
                     }
                 },


### PR DESCRIPTION
##### SUMMARY
This PR addresses issue https://github.com/ansible/awx/issues/3238 and add a column for First Name and Last Name in the Teams' User list.


##### ISSUE TYPE
-enhancement

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
<img width="1123" alt="Screen Shot 2019-03-11 at 2 26 38 PM" src="https://user-images.githubusercontent.com/39280967/54148015-cd397500-4409-11e9-8455-de6e70743448.png">
