### PR TITLE
fix a failing test in the unit-test target used to generate swagger docs

### DIFF
--- a/tools/docker-compose/unit-tests/docker-compose.yml
+++ b/tools/docker-compose/unit-tests/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     environment:
       SWIG_FEATURES: "-cpperraswarn -includeall -I/usr/include/openssl"
       TEST_DIRS: awx/main/tests/functional awx/main/tests/unit awx/conf/tests awx/sso/tests
+      RABBITMQ_HOST: rabbitmq
+      RABBITMQ_USER: guest
+      RABBITMQ_PASS: guest
+      RABBITMQ_VHOST: /
     command: ["make test_combined"]
     volumes:
       - ../../../:/awx_devel


### PR DESCRIPTION
This change is necessary for this test to pass:

https://github.com/ansible/awx/blob/devel/awx/main/tests/functional/api/test_settings.py#L390

...using e.g.,

`~ docker-compose -f tools/docker-compose/unit-tests/docker-compose.yml run --rm unit-tests 'make swagger'`