### PR TITLE
plugins/tower.py: Use urllib.parse rather than urlparse

### DIFF
--- a/awx/plugins/inventory/tower.py
+++ b/awx/plugins/inventory/tower.py
@@ -34,7 +34,11 @@ import sys
 import json
 import requests
 from requests.auth import HTTPBasicAuth
-from urlparse import urljoin
+
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 
 def parse_configuration():


### PR DESCRIPTION
##### SUMMARY

`urlparse` does not exist in python3, it has been replaced by `urllib.parse`

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - API

##### AWX VERSION

  - devel

##### ADDITIONAL INFORMATION

  - N/A
