### PR TITLE
Fixes issue with inventory group names that are extremely long.

### DIFF
--- a/awx/ui/client/legacy/styles/lists.less
+++ b/awx/ui/client/legacy/styles/lists.less
@@ -109,7 +109,7 @@ table, tbody {
 .List-tableCell {
     padding: 7px 15px;
     border-top:0px!important;
-    word-wrap: break-word;
+    word-break: break-word;
     display: flex;
     align-items: center;
     height: 100%;

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
@@ -38,7 +38,7 @@
                 label: i18n._('Groups'),
                 key: true,
                 uiSref: "inventories.edit.groups.edit({group_id:group.id})",
-                columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
+                columnClass: 'col-lg-10 col-md-10 col-sm-10 col-xs-10',
                 class: 'InventoryManage-breakWord',
             }
         },
@@ -98,7 +98,7 @@
 
         fieldActions: {
 
-            columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6 text-right',
+            columnClass: 'col-lg-2 col-md-2 col-sm-2 col-xs-2 text-right',
 
             edit: {
                 //label: 'Edit',

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -64,7 +64,7 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Hosts'),
                 uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
                 ngClass: "{ 'host-disabled-label': !host.enabled }",
-                columnClass: 'col-lg-3 col-md-4 col-sm-8 col-xs-7',
+                columnClass: 'col-lg-5 col-md-4 col-sm-8 col-xs-7',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
                 class: 'InventoryManage-breakWord'
@@ -80,7 +80,7 @@ export default ['i18n', function(i18n) {
 
         fieldActions: {
 
-            columnClass: 'col-sm-4 col-xs-5 text-right',
+            columnClass: 'col-lg-2 col-sm-4 col-xs-5 text-right',
             edit: {
                 ngClick: "editHost(host)",
                 icon: 'icon-edit',


### PR DESCRIPTION
##### SUMMARY
This PR addresses issue https://github.com/ansible/awx/issues/3395 and https://github.com/ansible/awx/issues/3361 where a group with a really long name could not be deleted.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
<img width="1440" alt="Screen Shot 2019-03-14 at 7 40 10 AM" src="https://user-images.githubusercontent.com/39280967/54354339-bc1c7e00-462c-11e9-9690-fd9a139f4e4d.png">

