### PR TITLE
Makes daphne websocket_timeout infinite.

### DIFF
--- a/installer/roles/image_build/files/supervisor.conf
+++ b/installer/roles/image_build/files/supervisor.conf
@@ -25,7 +25,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:daphne]
-command = /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1 -p 8051 awx.asgi:channel_layer
+command = /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
 directory = /var/lib/awx
 autostart = true
 autorestart = true


### PR DESCRIPTION
##### SUMMARY
Daphne has a default timeout of 86400 seconds, so after 1 day of starting
awx_web container, the stdout stops refreshing automatically on the web UI.
This fixes this issue by making the timeout infinite, so the connection
between nginx and daphne's websocket never gets closed.

relateds #1556, #1831

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 3.0.1
```


##### ADDITIONAL INFORMATION
[Daphne websocket default timeout](https://github.com/django/daphne/blob/9c574083ff04037cd728bfda351b5ca3327f1fff/daphne/server.py#L45)
