### PR TITLE
hide rows from lists where adding would be redundant

### DIFF
--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
@@ -119,11 +119,16 @@ export default ['$rootScope', '$scope', 'GetBasePath', 'Rest', '$q', 'Wait', 'Pr
                 var url = GetBasePath(selectedValue.type + "s") + selectedValue.id +
                     "/roles/";
 
-                 (selectedValue.roles || [])
-                    .map(function(role) {
-                        Rest.setUrl(url);
-                        requests.push(Rest.post({ "id": role.value || role.id }));
-                    });
+                if (scope.onlyMemberRole === 'true') {
+                    Rest.setUrl(url);
+                    requests.push(Rest.post({ "id": scope.roles.member_role.id }));
+                } else {
+                    (selectedValue.roles || [])
+                        .map(function(role) {
+                            Rest.setUrl(url);
+                            requests.push(Rest.post({ "id": role.value || role.id }));
+                        });
+                }
             });
         });
 

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
@@ -12,6 +12,7 @@ export default ['templateUrl', '$state',
         return {
             restrict: 'E',
             scope: {
+                defaultParams: '=?',
                 usersDataset: '=',
                 teamsDataset: '=',
                 resourceData: '=',

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
@@ -17,6 +17,7 @@ export default ['templateUrl', '$state',
                 teamsDataset: '=',
                 resourceData: '=',
                 withoutTeamPermissions: '@',
+                onlyMemberRole: '@',
                 title: '@'
             },
             controller: controller,

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.directive.js
@@ -18,6 +18,7 @@ export default ['templateUrl', '$state',
                 resourceData: '=',
                 withoutTeamPermissions: '@',
                 onlyMemberRole: '@',
+                queryPrefix: '@',
                 title: '@'
             },
             controller: controller,

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
@@ -20,7 +20,7 @@
             </div>
             <div class="AddPermissions-body">
                 <div class="AddPermissions-directions">
-                    <span class="AddPermissions-directionNumber">
+                    <span class="AddPermissions-directionNumber" ng-hide='onlyMemberRole === "true"'>
                         1
                     </span>
                     <div ng-hide='withoutTeamPermissions' translate>
@@ -51,7 +51,7 @@
                     <rbac-multiselect-list view="Teams" all-selected="allSelected" dataset="teamsDataset" object-type="object.type"></rbac-multiselect-list>
                 </div>
 
-                <span ng-show="hasSelectedRows()">
+                <span ng-show="hasSelectedRows() && !onlyMemberRole">
                     <div class="AddPermissions-separator"></div>
                     <div class="AddPermissions-directions">
                         <span class="AddPermissions-directionNumber">
@@ -110,7 +110,7 @@
                     <button type="button"
                         class="btn btn-sm Form-saveButton"
                         ng-click="updatePermissions()"
-                        ng-disabled="userRoleForm.$invalid || !allSelected || !hasSelectedRows()" translate>
+                        ng-disabled="(onlyMemberRole === 'true' && !hasSelectedRows()) && (userRoleForm.$invalid || !allSelected || !hasSelectedRows())" translate>
                         Save
                     </button>
                 </div>

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
@@ -45,7 +45,7 @@
                 </div>
 
                 <div id="AddPermissions-users" class="AddPermissions-list" ng-show="tab.users">
-                    <rbac-multiselect-list view="Users" all-selected="allSelected" default-params="defaultParams" dataset="usersDataset" object-type="object.type"></rbac-multiselect-list>
+                    <rbac-multiselect-list view="Users" all-selected="allSelected" default-params="defaultParams" dataset="usersDataset" object-type="object.type" query-prefix="{{ queryPrefix }}"></rbac-multiselect-list>
                 </div>
                 <div id="AddPermissions-teams" class="AddPermissions-list" ng-if="tab.teams">
                     <rbac-multiselect-list view="Teams" all-selected="allSelected" dataset="teamsDataset" object-type="object.type"></rbac-multiselect-list>

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
@@ -45,7 +45,7 @@
                 </div>
 
                 <div id="AddPermissions-users" class="AddPermissions-list" ng-show="tab.users">
-                    <rbac-multiselect-list view="Users" all-selected="allSelected" dataset="usersDataset" object-type="object.type"></rbac-multiselect-list>
+                    <rbac-multiselect-list view="Users" all-selected="allSelected" default-params="defaultParams" dataset="usersDataset" object-type="object.type"></rbac-multiselect-list>
                 </div>
                 <div id="AddPermissions-teams" class="AddPermissions-list" ng-if="tab.teams">
                     <rbac-multiselect-list view="Teams" all-selected="allSelected" dataset="teamsDataset" object-type="object.type"></rbac-multiselect-list>

--- a/awx/ui/client/src/access/rbac-multiselect/permissionsUsers.list.js
+++ b/awx/ui/client/src/access/rbac-multiselect/permissionsUsers.list.js
@@ -15,7 +15,7 @@
         multiSelectExtended: true,
         index: false,
         hover: true,
-        emptyListText : i18n._('No Users exist'),
+        emptyListText: i18n._('No Users to add'),
         disableRow: "{{ objectType === 'organization' && user.summary_fields.user_capabilities.edit === false }}",
         disableRowValue: "objectType === 'organization' && user.summary_fields.user_capabilities.edit === false",
         disableTooltip: {

--- a/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
+++ b/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
@@ -17,6 +17,7 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
             allSelected: '=',
             view: '@',
             dataset: '=',
+            defaultParams: '=?',
             objectType: '='
         },
         template: "<div class='addPermissionsList-inner'></div>",
@@ -149,6 +150,11 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
 
             scope.list = list;
             scope[`${list.iterator}_dataset`] = scope.dataset.data;
+
+            if (scope.defaultParams) {
+                scope[`${list.iterator}_default_params`] = scope.defaultParams;
+            }
+
             scope[`${list.name}`] = scope[`${list.iterator}_dataset`].results;
 
             scope.$watch(list.name, function(){

--- a/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
+++ b/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
@@ -18,7 +18,8 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
             view: '@',
             dataset: '=',
             defaultParams: '=?',
-            objectType: '='
+            objectType: '=',
+            queryPrefix: '@'
         },
         template: "<div class='addPermissionsList-inner'></div>",
         link: function(scope, element, attrs, ctrl) {
@@ -35,6 +36,9 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                 Organizations: OrganizationList
             };
             list = _.cloneDeep(listMap[scope.view]);
+            if (scope.queryPrefix) {
+                list.iterator = scope.queryPrefix;
+            }
             list.multiSelect = true;
             list.multiSelectExtended = true;
             list.listTitleBadge = false;
@@ -93,7 +97,9 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                     list.fields.name.columnClass = 'col-sm-12';
                     break;
                 case 'Users':
-                    list.querySet = { order_by: 'username', page_size: '5' };
+                    if (!scope.queryPrefix) {
+                        list.querySet = { order_by: 'username', page_size: '5' };
+                    }
                     list.fields = {
                         username: list.fields.username,
                         first_name: list.fields.first_name,

--- a/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
@@ -5,9 +5,9 @@
  *************************************************/
 
  export default ['$scope', '$rootScope', 'ProcessErrors', 'GetBasePath', 'generateList',
- '$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'GroupList',
+ '$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'GroupList', 'i18n',
  function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
-     $state, Rest, $q, Wait, $window, qs, GroupList) {
+     $state, Rest, $q, Wait, $window, qs, GroupList, i18n) {
      $scope.$on("linkLists", function() {
 
          init();
@@ -26,6 +26,8 @@
              if($state.params.group_id) {
                  $scope.associate_group_default_params.not__id = $state.params.group_id;
                  $scope.associate_group_queryset.not__id = $state.params.group_id;
+                 $scope.associate_group_default_params.not__parents = $state.params.group_id;
+                 $scope.associate_group_queryset.not__parents = $state.params.group_id;
              }
 
              let list = _.cloneDeep(GroupList);
@@ -39,6 +41,7 @@
                  selectedRows: 'selectedItems',
                  availableRows: 'associate_groups'
              };
+             list.emptyListText = i18n._('No groups to add');
              delete list.actions;
              delete list.fieldActions;
              delete list.fields.failed_hosts;

--- a/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
@@ -23,11 +23,14 @@
                  page_size: 5
              };
 
-             if($state.params.group_id) {
+             if ($state.params.group_id) {
                  $scope.associate_group_default_params.not__id = $state.params.group_id;
                  $scope.associate_group_queryset.not__id = $state.params.group_id;
                  $scope.associate_group_default_params.not__parents = $state.params.group_id;
                  $scope.associate_group_queryset.not__parents = $state.params.group_id;
+             } else if ($state.params.host_id) {
+                 $scope.associate_group_default_params.not__hosts = $state.params.host_id;
+                 $scope.associate_group_queryset.not__hosts = $state.params.host_id;
              }
 
              let list = _.cloneDeep(GroupList);

--- a/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.controller.js
@@ -5,9 +5,9 @@
  *************************************************/
 
  export default ['$scope', '$rootScope', 'ProcessErrors', 'GetBasePath', 'generateList',
- '$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'RelatedHostsListDefinition',
+ '$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'RelatedHostsListDefinition', 'i18n',
  function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
-     $state, Rest, $q, Wait, $window, qs, RelatedHostsListDefinition) {
+     $state, Rest, $q, Wait, $window, qs, RelatedHostsListDefinition, i18n) {
      $scope.$on("linkLists", function() {
 
          init();
@@ -23,6 +23,11 @@
                  page_size: 5
              };
 
+             if ($state.params.group_id) {
+                 $scope.associate_host_default_params.not__groups = $state.params.group_id;
+                 $scope.associate_host_queryset.not__groups = $state.params.group_id;
+             }
+
              let list = _.cloneDeep(RelatedHostsListDefinition);
              list.basePath = GetBasePath('inventory') + $state.params.inventory_id + '/hosts';
              list.iterator = 'associate_host';
@@ -36,6 +41,7 @@
                  selectedRows: 'selectedItems',
                  availableRows: 'associate_hosts'
              };
+             list.emptyListText = i18n._('No hosts to add');
              delete list.fields.toggleHost;
              delete list.fields.active_failures;
              delete list.fields.groups;

--- a/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
+++ b/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
@@ -28,11 +28,9 @@ function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
         if ($scope.addType === 'Administrators') {
             Rest.setUrl(GetBasePath('organizations') + `${$state.params.organization_id}/object_roles`);
             Rest.get().then(({data}) => {
-                notAdminAlreadyParams.not__roles__in = data.results
+                notAdminAlreadyParams.not__roles = data.results
                     .filter(({name}) => name === i18n._('Admin'))
-                    .map(({id}) => id)
-                    .join(',');
-                notAdminAlreadyParams.is_superuser = 'false';              
+                    .map(({id}) => id)[0];            
                 init();
             });
         } else {

--- a/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
+++ b/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
@@ -12,9 +12,9 @@
  */
 
 export default ['$scope', '$rootScope', 'ProcessErrors', 'GetBasePath', 'generateList',
-'$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'UserList',
+'$state', 'Rest', '$q', 'Wait', '$window', 'QuerySet', 'UserList', 'i18n',
 function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
-    $state, Rest, $q, Wait, $window, qs, UserList) {
+    $state, Rest, $q, Wait, $window, qs, UserList, i18n) {
     $scope.$on("linkLists", function() {
 
         if ($state.current.name.split(".")[1] === "users") {
@@ -23,18 +23,32 @@ function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
             $scope.addType = "Administrators";
         }
 
-        init();
+        let notAdminAlreadyParams = {};
+
+        if ($scope.addType === 'Administrators') {
+            Rest.setUrl(GetBasePath('organizations') + `${$state.params.organization_id}/object_roles`);
+            Rest.get().then(({data}) => {
+                notAdminAlreadyParams.not__roles__in = data.results
+                    .filter(({name}) => name === i18n._('Admin'))
+                    .map(({id}) => id)
+                    .join(',');
+                notAdminAlreadyParams.is_superuser = 'false';              
+                init();
+            });
+        } else {
+            init();
+        }
 
         function init(){
-            $scope.add_user_default_params = {
+            $scope.add_user_default_params = Object.assign({
                 order_by: 'username',
                 page_size: 5
-            };
+            }, notAdminAlreadyParams);
 
-            $scope.add_user_queryset = {
+            $scope.add_user_queryset = Object.assign({
                 order_by: 'username',
                 page_size: 5
-            };
+            }, notAdminAlreadyParams);
 
             let list = _.cloneDeep(UserList);
             list.basePath = 'users';
@@ -46,6 +60,9 @@ function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
             list.fields.first_name.columnClass = 'col-sm-4';
             list.fields.last_name.columnClass = 'col-sm-4';
             list.layoutClass = 'List-staticColumnLayout--statusOrCheckbox';
+            if ($scope.addType === 'Administrators') {
+                list.emptyListText = i18n._('No users available to add as adminstrators');
+            }
             delete list.actions;
             delete list.fieldActions;
 

--- a/awx/ui/client/src/organizations/linkout/organizations-linkout.route.js
+++ b/awx/ui/client/src/organizations/linkout/organizations-linkout.route.js
@@ -54,7 +54,7 @@ let lists = [{
         OrgUsersDataset: ['OrgUserList', 'QuerySet', '$stateParams', 'GetBasePath',
             function(list, qs, $stateParams, GetBasePath) {
                 let path = GetBasePath(list.basePath) || list.basePath;
-                return qs.search(path, $stateParams.user_search);
+                return qs.search(path, $stateParams.org_user_search);
             }
         ],
         OrgUserList: ['UserList', 'GetBasePath', '$stateParams', 'i18n', function(UserList, GetBasePath, $stateParams, i18n) {

--- a/awx/ui/client/src/shared/stateDefinitions.factory.js
+++ b/awx/ui/client/src/shared/stateDefinitions.factory.js
@@ -581,8 +581,8 @@ function($injector, $stateExtender, $log, i18n) {
 
                 states.push($stateExtender.buildDefinition({
                     name: `${formStateDefinition.name}.users.add`,
-                    squashSearchUrl: true,
                     url: '/add-user',
+                    searchPrefix: 'add_user',
                     params: {
                         add_user_search: {
                             value: { order_by: 'username', page_size: '5' },
@@ -591,7 +591,7 @@ function($injector, $stateExtender, $log, i18n) {
                     },
                     views: {
                         [`modal@${formStateDefinition.name}`]: {
-                            template: `<add-rbac-resource default-params="$resolve.defaultParams" users-dataset="$resolve.usersDataset" selected="allSelected" resource-data="$resolve.resourceData" without-team-permissions="true" title="` + i18n._('Add Users') + `" only-member-role="true"></add-rbac-resource>`
+                            template: `<add-rbac-resource default-params="$resolve.defaultParams" users-dataset="$resolve.usersDataset" selected="allSelected" resource-data="$resolve.resourceData" without-team-permissions="true" title="` + i18n._('Add Users') + `" only-member-role="true" query-prefix="add_user"></add-rbac-resource>`
                         }
                     },
                     ncyBreadcrumb:{

--- a/awx/ui/client/src/shared/stateDefinitions.factory.js
+++ b/awx/ui/client/src/shared/stateDefinitions.factory.js
@@ -591,83 +591,28 @@ function($injector, $stateExtender, $log, i18n) {
                     },
                     views: {
                         [`modal@${formStateDefinition.name}`]: {
-                            template: `<add-rbac-resource default-params="$resolve.defaultParams" users-dataset="$resolve.usersDataset" selected="allSelected" resource-data="$resolve.resourceData" without-team-permissions="true" title="` + i18n._('Add Users') + `"></add-rbac-resource>`
+                            template: `<add-rbac-resource default-params="$resolve.defaultParams" users-dataset="$resolve.usersDataset" selected="allSelected" resource-data="$resolve.resourceData" without-team-permissions="true" title="` + i18n._('Add Users') + `" only-member-role="true"></add-rbac-resource>`
                         }
                     },
                     ncyBreadcrumb:{
                         skip:true
                     },
                     resolve: {
-                        orgId:  ['$stateParams', 'Rest', 'GetBasePath', function($stateParams, Rest, GetBasePath) {
-                            let id;
-                            if ($stateParams.team_id) {
-                                Rest.setUrl(GetBasePath('teams') + `${$stateParams.team_id}`);
-                                id = Rest.get().then(({data}) => {
-                                    return data.summary_fields.organization.id;
-                                });
-                            } else {
-                                id = null;
-                            }
-                            return id;
-                        }],
-                        teamRoles:  ['$stateParams', 'Rest', 'GetBasePath', 'i18n', function($stateParams, Rest, GetBasePath, i18n) {
-                            let roles = null;
-                            if ($stateParams.team_id) {
-                                const basePath = GetBasePath('teams') + `${$stateParams.team_id}/object_roles`;
+                        roleToExclude: ['$stateParams', 'Rest', 'GetBasePath', 'i18n', function($stateParams, Rest, GetBasePath, i18n) {
+                                const basePath = ($stateParams.team_id) ? GetBasePath('teams') + `${$stateParams.team_id}/object_roles` :
+                                    GetBasePath('organizations') + `${$stateParams.organization_id}/object_roles`;
                                 Rest.setUrl(basePath);
-                                roles = Rest.get().then(({data}) => {
-                                    return data.results
-                                        .filter(({name}) => name === i18n._('Member') || name === i18n._('Admin'))
-                                        .map(({id}) => id)
-                                        .join(',');
-                                });
-                            }
-                            return roles;
-                        }],
-                        orgAdminRole:  ['$stateParams', 'orgId', 'Rest', 'GetBasePath', 'i18n',
-                            function($stateParams, orgId, Rest, GetBasePath, i18n) {
-                                let orgIdToCheck = $stateParams.organization_id || orgId;
-                                let role = null;
-                                if (orgIdToCheck) {
-                                    const basePath = GetBasePath('organizations') + `${orgIdToCheck}/object_roles`;
-                                    Rest.setUrl(basePath);
-                                    role = Rest.get().then(({data}) => {
-                                        return data.results
-                                            .filter(({name}) => name === i18n._('Admin'))
-                                            .map(({id}) => id)[0];
-                                    });
-                                }
-                                return role;
-                        }],
-                        orgMemberRole:  ['$stateParams', 'Rest', 'GetBasePath', 'i18n', function($stateParams, Rest, GetBasePath, i18n) {
-                            let role = null;
-                            if ($stateParams.organization_id) {
-                                const basePath = GetBasePath('organizations') + `${$stateParams.organization_id}/object_roles`;
-                                Rest.setUrl(basePath);
-                                role = Rest.get().then(({data}) => {
+                                return Rest.get().then(({data}) => {
                                     return data.results
                                         .filter(({name}) => name === i18n._('Member'))
                                         .map(({id}) => id)[0];
                                 });
-                            }
-                            return role;
                         }],
-                        rolesToExclude: ['teamRoles', 'orgAdminRole', 'orgMemberRole', '$stateParams',
-                            function(teamRoles, orgAdminRole, orgMemberRole, $stateParams) {
-                                let roles = null;
-                                if ($stateParams.team_id) {
-                                    roles = `${teamRoles},${orgAdminRole}`;
-                                } else if ($stateParams.organization_id) {
-                                    roles = `${orgAdminRole},${orgMemberRole}`;
-                                }
-                                return roles;
-                        }],
-                        usersDataset: ['addPermissionsUsersList', 'QuerySet', '$stateParams', 'GetBasePath', 'rolesToExclude',
-                            function(list, qs, $stateParams, GetBasePath, rolesToExclude) {
+                        usersDataset: ['addPermissionsUsersList', 'QuerySet', '$stateParams', 'GetBasePath', 'roleToExclude',
+                            function(list, qs, $stateParams, GetBasePath, roleToExclude) {
                                 let path = GetBasePath(list.basePath) || GetBasePath(list.name);
-                                if (rolesToExclude) {
-                                    $stateParams.add_user_search.not__roles__in = rolesToExclude;
-                                    $stateParams.add_user_search.is_superuser = 'false';
+                                if (roleToExclude) {
+                                    $stateParams.add_user_search.not__roles = roleToExclude;
                                 }
                                 return qs.search(path, $stateParams.add_user_search);
                             }


### PR DESCRIPTION
link #345 

This PR takes care of removing all redundant rows from add flows.  By redundant, I mean that they are already part of the collection, so showing them as an option to add is just noise to the user.  In addition, all of these views have been updated from the default empty list message ("please add items to this list"), to ("no [resource] to add"), as this is a more semantically correct indication to the user as to _why_ there would be no items showing up in the list.

This also updates the add users to org and team modals to only being a user select list (and not allowing role addition other than the member role).  For adding additional roles, the permissions tab can be used.

Here are the following flows that have been updated:

ORGANIZATIONS:
ADD USERS: Adding a user to an org list should not include users already in the org with member role.

![Screen Shot 2019-03-15 at 12 42 38 PM](https://user-images.githubusercontent.com/1342624/54447812-bacc7d80-4720-11e9-940a-283404386ec4.png)
![Screen Shot 2019-03-15 at 12 42 46 PM](https://user-images.githubusercontent.com/1342624/54447813-bb651400-4720-11e9-9967-9bf78a281c77.png)

ADD ADMINS: Adding an admin to an org list should not include admins already in the org with admin role.

![Screen Shot 2019-03-15 at 12 43 11 PM](https://user-images.githubusercontent.com/1342624/54447845-c7e96c80-4720-11e9-99d4-4e3caf9ce770.png)
![Screen Shot 2019-03-15 at 12 43 20 PM](https://user-images.githubusercontent.com/1342624/54447846-c7e96c80-4720-11e9-82fe-a04d30724657.png)

TEAMS:
ADD USERS: Adding a user to a team list should not include users already in the team with member role.

![Screen Shot 2019-03-15 at 12 43 39 PM](https://user-images.githubusercontent.com/1342624/54447855-cc158a00-4720-11e9-99ca-2d4f4d70d8c2.png)
![Screen Shot 2019-03-15 at 12 43 47 PM](https://user-images.githubusercontent.com/1342624/54447856-ccae2080-4720-11e9-85d9-785c2700deaf.png)

INVENTORIES: 
Adding existing hosts to group should not include hosts that are already in that group

![Screen Shot 2019-03-15 at 12 45 31 PM](https://user-images.githubusercontent.com/1342624/54447877-d46dc500-4720-11e9-8052-322cfd9cb66b.png)
![Screen Shot 2019-03-15 at 12 45 39 PM](https://user-images.githubusercontent.com/1342624/54447878-d46dc500-4720-11e9-8a84-2e3750d29be5.png)

Adding existing groups to group should not include that group (which was already done) or already exist in it

![Screen Shot 2019-03-15 at 12 44 32 PM](https://user-images.githubusercontent.com/1342624/54447889-dc2d6980-4720-11e9-91a1-ece5d3566b47.png)
![Screen Shot 2019-03-15 at 12 44 40 PM](https://user-images.githubusercontent.com/1342624/54447890-dc2d6980-4720-11e9-8eea-2c8782fd4c2f.png)

---

Note that if you read comments on #345, I (incorrectly) mentioned our lookups on forms to also be part of this work.  What I didn't realize was that our lookups (and multi-select) actually maintain the state of what is selected when they are opened.  If we were to not show the items that are currently selected, we would actually diminish the UX, as if they are shown "they can be reselected (in the case of single selection), or deselected (in the case of multi selection) without having to jump back and forth between the selection flow and the root list flow).  I confirmed this with @trahman73.