### PR TITLE
Add sort and pagination to instances list

### DIFF
--- a/awx/ui/client/src/instance-groups/instances/instances-list.partial.html
+++ b/awx/ui/client/src/instance-groups/instances/instances-list.partial.html
@@ -16,7 +16,7 @@
                 iterator="instance"
                 list="vm.list"
                 collection="vm.instances"
-                dataset="vm.dataset"
+                dataset="vm.instance_dataset"
                 search-tags="vm.searchTags">
             </smart-search>
 
@@ -34,6 +34,13 @@
                 <div ui-view="modal"></div>
             </div>
         </div>
+        <at-list-toolbar
+            ng-if="vm.instances.length > 0"
+            sort-only="true"
+            sort-value="vm.toolbarSortValue"
+            sort-options="vm.toolbarSortOptions"
+            on-sort="vm.onToolbarSort">
+        </at-list-toolbar>
         <at-list results='vm.instances'>
             <at-row ng-repeat="instance in vm.instances"
                 ng-class="{'at-Row--active': (instance.id === vm.activeId)}">
@@ -84,4 +91,10 @@
             </at-row>
         </at-list>
     </at-panel-body>
+    <paginate
+        collection="vm.instances"
+        dataset="vm.instance_dataset"
+        iterator="instance"
+        base-path="{{vm.list.basePath}}">
+    </paginate>
 </at-panel>

--- a/awx/ui/client/src/instance-groups/main.js
+++ b/awx/ui/client/src/instance-groups/main.js
@@ -190,7 +190,8 @@ function InstanceGroupsRun ($stateExtender, strings) {
         params: {
             instance_search: {
                 value: {
-                    order_by: 'hostname'
+                    order_by: 'hostname',
+                    page_size: '10'
                 },
                 dynamic: true
             }


### PR DESCRIPTION
##### SUMMARY
Tracking Issue: https://github.com/ansible/awx/issues/3355
*Add sort dropdown and pagination to Instances list
*Sort by `hostname`

![Screen Shot 2019-03-18 at 1 51 55 PM](https://user-images.githubusercontent.com/15881645/54551729-04b59d80-4985-11e9-85cf-9966b805caaf.png)

##### ISSUE TYPE
 - Enhancement Pull Request

##### COMPONENT NAME
 - UI
