### PR TITLE
makes the card for the workflow display taller

### DIFF
--- a/awx/ui/client/src/workflow-results/workflow-results.block.less
+++ b/awx/ui/client/src/workflow-results/workflow-results.block.less
@@ -18,19 +18,27 @@
 
 .WorkflowResults-leftSide {
     .OnePlusTwo-left--panel(100%, @breakpoint-md);
-    height: ~"calc(100vh - 177px)";
+    height: ~"calc(100vh - 120px)";
     min-height: 350px;
-
+    display:flex;
     .card {
+        width: 100%;
         overflow: scroll;
+    }
+    @media screen and (width: @breakpoint-md - 1px){
+        width: 100%;
     }
 }
 
 .WorkflowResults-rightSide {
     .OnePlusTwo-right--panel(100%, @breakpoint-md);
-    height: ~"calc(100vh - 177px)";
+    height: ~"calc(100vh - 120px)";
     min-height: 350px;
     min-width: 0;
+    display:flex;
+    .card {
+        width:100%
+    }
 
     @media (max-width: @breakpoint-md - 1px) {
         padding-right: 15px;


### PR DESCRIPTION
##### SUMMARY
The workflow display visualizer was not using the whole height of the screen.  This PR uses the whole height of the screen.  It addresses issue https://github.com/ansible/awx/issues/3258

##### ISSUE TYPE
 - UX Enhancement

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
<img width="1668" alt="Screen Shot 2019-03-18 at 2 43 02 PM" src="https://user-images.githubusercontent.com/39280967/54555145-83620900-498c-11e9-8d2c-5f27d6b86c8b.png">

