### PR TITLE
WFJT Node Activity Stream Bug Fix

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4021,7 +4021,7 @@ class WorkflowJobTemplateNodeDetailSerializer(WorkflowJobTemplateNodeSerializer)
     Influence the api browser sample data to not include workflow_job_template
     when editing a WorkflowNode.
 
-    Note: I was not able to accomplish this trough the use of extra_kwargs.
+    Note: I was not able to accomplish this through the use of extra_kwargs.
     Maybe something to do with workflow_job_template being a relational field?
     '''
     def build_relational_field(self, field_name, relation_info):
@@ -5070,6 +5070,18 @@ class ActivityStreamSerializer(BaseSerializer):
                                     if fval is not None:
                                         job_template_item[field] = fval
                                 summary_fields['job_template'].append(job_template_item)
+                        if fk == 'workflow_job_template_node':
+                            summary_fields['workflow_job_template'] = []
+                            workflow_job_template_item = {}
+                            workflow_job_template_fields = SUMMARIZABLE_FK_FIELDS['workflow_job_template']
+                            workflow_job_template = getattr(thisItem, 'workflow_job_template', None)
+                            if workflow_job_template is not None:
+                                for field in workflow_job_template_fields:
+                                    fval = getattr(workflow_job_template, field, None)
+                                    if fval is not None:
+                                        workflow_job_template_item[field] = fval
+                                summary_fields['workflow_job_template'].append(workflow_job_template_item)
+# to adhere to DRY principles, the above can eventually be combined into a helper method
                         if fk == 'schedule':
                             unified_job_template = getattr(thisItem, 'unified_job_template', None)
                             if unified_job_template is not None:

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5081,7 +5081,6 @@ class ActivityStreamSerializer(BaseSerializer):
                                     if fval is not None:
                                         workflow_job_template_item[field] = fval
                                 summary_fields['workflow_job_template'].append(workflow_job_template_item)
-# to adhere to DRY principles, the above can eventually be combined into a helper method
                         if fk == 'schedule':
                             unified_job_template = getattr(thisItem, 'unified_job_template', None)
                             if unified_job_template is not None:

--- a/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
@@ -10,6 +10,7 @@ export default function BuildAnchor($log, $filter) {
              // catch-all case to avoid generating urls if a resource has been deleted
              // if a resource still exists, it'll be serialized in the activity's summary_fields
              if (!activity.summary_fields[resource]){
+                  console.log(activity);
                  throw {name : 'ResourceDeleted', message: 'The referenced resource no longer exists'};
              }
              let name;

--- a/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
@@ -12,6 +12,7 @@ export default function BuildAnchor($log, $filter) {
              if (!activity.summary_fields[resource]){
                  throw {name : 'ResourceDeleted', message: 'The referenced resource no longer exists'};
              }
+             let name;
              switch (resource) {
                  case 'custom_inventory_script':
                      url += 'inventory_scripts/' + obj.id + '/';
@@ -76,7 +77,8 @@ export default function BuildAnchor($log, $filter) {
                      url += `templates/workflow_job_template/${obj.id}`;
                      break;
                  case 'workflow_job_template_node':
-                     url += `templates/workflow_job_template/${obj.summary_fields.workflow_job_template.id}`;
+                     url += `templates/workflow_job_template/${activity.summary_fields.workflow_job_template[0].id}`;
+                     name = activity.summary_fields.workflow_job_template[0].name;
                      break;
                  case 'workflow_job':
                      url += `workflows/${obj.id}`;
@@ -95,7 +97,7 @@ export default function BuildAnchor($log, $filter) {
                      url += resource + 's/' + obj.id + '/';
              }
 
-             const name = $filter('sanitize')(obj.name || obj.username);
+             name = $filter('sanitize')(name || obj.name || obj.username);
 
              if (url) {
                 return ` <a href=\"${url}\">&nbsp;${name}&nbsp;</a> `;

--- a/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-anchor.factory.js
@@ -75,6 +75,9 @@ export default function BuildAnchor($log, $filter) {
                  case 'workflow_job_template':
                      url += `templates/workflow_job_template/${obj.id}`;
                      break;
+                 case 'workflow_job_template_node':
+                     url += `templates/workflow_job_template/${obj.summary_fields.workflow_job_template.id}`;
+                     break;
                  case 'workflow_job':
                      url += `workflows/${obj.id}`;
                      break;

--- a/awx/ui/client/src/activity-stream/factories/build-description.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-description.factory.js
@@ -85,8 +85,12 @@ export default function BuildDescription(BuildAnchor, $log, i18n) {
                                      'from ' + activity.object1 + BuildAnchor(activity.summary_fields.group[0], activity.object1, activity);
                              }
                              else {
-                                 activity.description += activity.object2 + BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity) +
-                                     'from ' + activity.object1 + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity);
+                               if (activity.object1 === 'workflow_job_template_node' && activity.object2 === 'workflow_job_template_node') {
+                                  activity.description += 'two nodes on workflow' + BuildAnchor(activity.summary_fields[activity.object1[0]], activity.object1, activity);
+                                } else {
+                                  activity.description += activity.object2 + BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity) +
+                                       'from ' + activity.object1 + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity);
+                                }
                              }
                              break;
                          // expected outcome "associated <object2> to <object1>"
@@ -97,8 +101,12 @@ export default function BuildDescription(BuildAnchor, $log, i18n) {
                                      'to ' + activity.object2 + BuildAnchor(activity.summary_fields.group[1], activity.object2, activity);
                              }
                              else {
-                                 activity.description += activity.object1 + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity) +
-                                     'to ' + activity.object2 + BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity);
+                                 if (activity.object1 === 'workflow_job_template_node' && activity.object2 === 'workflow_job_template_node') {
+                                   activity.description += 'two nodes on workflow' + BuildAnchor(activity.summary_fields[activity.object1[0]], activity.object1, activity);
+                                 } else {
+                                   activity.description += activity.object1 + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity) +
+                                       'to ' + activity.object2 + BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity);
+                                 }
                              }
                              break;
                          case 'delete':


### PR DESCRIPTION
##### SUMMARY

Trying to make a link to the appropriate WFJT appear in the activity stream entries that involve WFJT nodes getting created, associated with each other, etc.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```

##### ADDITIONAL INFORMATION

In the Activity Stream page, a link to the WFJT would be ideal for any node-related activities (see screenshot below for an example of links to a WFJT):

![WFJTActivityStream](https://user-images.githubusercontent.com/28930622/54619297-c2e72e80-4a3a-11e9-8eee-109db11c6bad.png)


Below is an example of what node creation detail looks like currently:

![NodeCreation36](https://user-images.githubusercontent.com/28930622/54619429-f4f89080-4a3a-11e9-85d6-2b33a416217f.png)

...and node association:

![NodeAssociation42](https://user-images.githubusercontent.com/28930622/54619439-f88c1780-4a3a-11e9-8032-ca9a36a11c4b.png)


Ideally, the above would contain links to the WFJT.  
