### PR TITLE
Fix 'Groups' list item styling.

### DIFF
--- a/awx/ui/client/legacy/styles/lists.less
+++ b/awx/ui/client/legacy/styles/lists.less
@@ -588,12 +588,7 @@ table, tbody {
 
 .List-staticColumnLayout--groups {
     display: grid;
-    grid-template-columns: 5px 25px auto;
-}
-
-.List-staticColumnLayout--inventoryGroups {
-    display: grid;
-    grid-template-columns: 5px 25px 25px auto;
+    grid-template-columns: @at-space @at-space-5x @at-space-5x auto;
 }
 
 .List-staticColumnLayout--hosts {

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
@@ -16,7 +16,7 @@
         multiSelect: true,
         trackBy: 'group.id',
         basePath:  'api/v2/inventories/{{$stateParams.inventory_id}}/groups/',
-        layoutClass: 'List-staticColumnLayout--inventoryGroups',
+        layoutClass: 'List-staticColumnLayout--groups',
         staticColumns: [
             {
                 field: 'failed_hosts',


### PR DESCRIPTION
##### SUMMARY
RELATED #3421

Fix our groups list views from this:
![Screen Shot 2019-03-21 at 1 48 57 PM](https://user-images.githubusercontent.com/2293210/54773512-1e9eec80-4be0-11e9-854f-8b8be03e1f67.png)


To this:
![Screen Shot 2019-03-21 at 1 46 10 PM](https://user-images.githubusercontent.com/2293210/54773416-e7c8d680-4bdf-11e9-99f0-b0397b4ad9db.png)

Affects all views that show the `GROUPS` list view, e.g. Inventory and Hosts view.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.1
```
