### PR TITLE
Fixed to send message by correct username to destination slack channels

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -45,12 +45,13 @@ class SlackBackend(AWXBaseEmailBackend):
                     else:
                         ret = connection.api_call("chat.postMessage",
                                                   channel=r,
+                                                  as_user=True,
                                                   text=m.subject)
                     logger.debug(ret)
                     if ret['ok']:
                         sent_messages += 1
                     else:
-                        raise RuntimeError("Slack Notification unable to send {}: {}".format(r, m.subject))
+                        raise RuntimeError("Slack Notification unable to send {}: {} (Error: {})".format(r, m.subject, ret['error']))
             except Exception as e:
                 logger.error(smart_text(_("Exception sending messages: {}").format(e)))
                 if not self.fail_silently:

--- a/awx/ui/client/src/notifications/notificationTemplates.form.js
+++ b/awx/ui/client/src/notifications/notificationTemplates.form.js
@@ -156,7 +156,7 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Destination Channels'),
                 type: 'textarea',
                 rows: 3,
-                awPopOver: i18n._('Enter one Slack channel per line. The pound symbol (#) is required for channels.'),
+                awPopOver: i18n._('Enter one Slack channel per line. The pound symbol (#) is required for channels. The user who owns the token must be joined all destination channels.'),
                 dataTitle: i18n._('Destination Channels'),
                 dataPlacement: 'right',
                 dataContainer: "body",


### PR DESCRIPTION
##### SUMMARY
This PR fixes the slack backend to send a message with the username who owns the token,
 even if the user does not specify the color option(ansible/tower#3294).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
- AWX 3.0.1
- Ansible Tower 3.4

##### ADDITIONAL INFORMATION
None