### PR TITLE
Fix ovirt4.py dynamic inventory for oVirt 4.3

### DIFF
--- a/awx/plugins/inventory/ovirt4.py
+++ b/awx/plugins/inventory/ovirt4.py
@@ -179,7 +179,7 @@ def get_dict_of_struct(connection, vm):
             if vm.name in [vm.name for vm in connection.follow_link(group.vms)]
         ],
         'statistics': dict(
-            (stat.name, stat.values[0].datum) for stat in stats
+            (stat.name, stat.values[0].datum) for stat in stats if stat.values
         ),
         'devices': dict(
             (device.name, [ip.address for ip in device.ips]) for device in devices if device.ips


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The ovirt4.py dynamic inventory script fails with the following error:
~~~
Traceback (most recent call last):
  File "inventory/ovirt", line 259, in <module>
    main()
  File "inventory/ovirt", line 250, in main
    vm_name=args.host,
  File "inventory/ovirt", line 209, in get_data
    vms[name] = get_dict_of_struct(connection, vm)
  File "inventory/ovirt", line 178, in get_dict_of_struct
    (stat.name, stat.values[0].datum) for stat in stats
  File "inventory/ovirt", line 178, in <genexpr>
    (stat.name, stat.values[0].datum) for stat in stats
IndexError: list index out of range
~~~
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - ovirt4.py

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.0.1
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
