### PR TITLE
bwrap/runner: Add /etc/ssh in bind mounted folder

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -818,6 +818,7 @@ class BaseTask(object):
                 'process_isolation_hide_paths': [
                     settings.AWX_PROOT_BASE_PATH,
                     '/etc/tower',
+                    '/etc/ssh',
                     '/var/lib/awx',
                     '/var/log',
                     settings.PROJECTS_ROOT,

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -460,7 +460,7 @@ class TestGenericRun():
                   '/AWX_PROOT_HIDE_PATHS1',
                   '/AWX_PROOT_HIDE_PATHS2']:
             assert p in process_isolation_params['process_isolation_hide_paths']
-        assert 8 == len(process_isolation_params['process_isolation_hide_paths'])
+        assert 9 == len(process_isolation_params['process_isolation_hide_paths'])
         assert '/ANSIBLE_VENV_PATH' in process_isolation_params['process_isolation_ro_paths']
         assert '/AWX_VENV_PATH' in process_isolation_params['process_isolation_ro_paths']
         assert 2 == len(process_isolation_params['process_isolation_ro_paths'])

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -452,6 +452,7 @@ class TestGenericRun():
 
         for p in [settings.AWX_PROOT_BASE_PATH,
                   '/etc/tower',
+                  '/etc/ssh',
                   '/var/lib/awx',
                   '/var/log',
                   settings.PROJECTS_ROOT,


### PR DESCRIPTION
##### SUMMARY

/etc/ssh is currently not bound when run into bwrap, this leads to
error like "Bad owner or permissions on /etc/ssh/ssh_config.d/05-redhat.conf"
since it cannot access this file.

https://github.com/ansible/awx/pull/3391 was done pre runner
integration.

Fixes: https://github.com/ansible/awx/issues/3392

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - API
 
##### AWX VERSION

 - devel

##### ADDITIONAL INFORMATION

 - N/A
