### PR TITLE
[WIP] Use LOG_AGGREGATOR_LEVEL to set global log levels

### DIFF
--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -17,7 +17,7 @@ from django.conf import settings
 
 from awx.main.utils.common import get_search_fields
 
-__all__ = ['SmartFilter', 'ExternalLoggerEnabled']
+__all__ = ['SmartFilter', 'ExternalLoggerEnabled', 'GlobalLogLevelFilter']
 
 logger = logging.getLogger('awx.main.utils')
 
@@ -108,6 +108,17 @@ class ExternalLoggerEnabled(Filter):
             else:
                 base_name = record.name
             return bool(base_name in loggers)
+
+
+class GlobalLogLevelFilter(Filter):
+    """Configure-tower-in-tower setting LOG_AGGREGATOR_LEVEL
+    shall be used to control the log levels of all logs in the system
+    including those writing to file
+    """
+
+    def filter(self, record):
+        allowed_level = settings.LOG_AGGREGATOR_LEVEL
+        return bool(record.levelno >= _nameToLevel[allowed_level])
 
 
 def string_to_type(t):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -989,6 +989,9 @@ LOGGING = {
         'external_log_enabled': {
             '()': 'awx.main.utils.filters.ExternalLoggerEnabled'
         },
+        'global_log_level': {
+            '()': 'awx.main.utils.filters.GlobalLogLevelFilter'
+        },
     },
     'formatters': {
         'simple': {
@@ -1008,8 +1011,7 @@ LOGGING = {
     'handlers': {
         'console': {
             '()': 'logging.StreamHandler',
-            'level': 'DEBUG',
-            'filters': ['require_debug_true_or_test'],
+            'filters': ['require_debug_true_or_test', 'global_log_level'],
             'formatter': 'simple',
         },
         'null': {
@@ -1036,27 +1038,24 @@ LOGGING = {
             'class': 'django.utils.log.AdminEmailHandler',
         },
         'tower_warnings': {
-            'level': 'WARNING',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'tower.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
             'formatter':'simple',
         },
         'callback_receiver': {
-            'level': 'WARNING',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'callback_receiver.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
             'formatter':'simple',
         },
         'dispatcher': {
-            'level': 'WARNING',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'dispatcher.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
@@ -1072,27 +1071,24 @@ LOGGING = {
             'formatter': 'timed_import',
         },
         'task_system': {
-            'level': 'INFO',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'task_system.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
             'formatter':'simple',
         },
         'management_playbooks': {
-            'level': 'DEBUG',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'management_playbooks.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
             'formatter':'simple',
         },
         'fact_receiver': {
-            'level': 'WARNING',
             'class':'logging.handlers.RotatingFileHandler',
-            'filters': ['require_debug_false'],
+            'filters': ['require_debug_false', 'global_log_level'],
             'filename': os.path.join(LOG_ROOT, 'fact_receiver.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/1998

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Tested this manually, implicitly using the "console" logger.

Seems to work, I don't get logs by default, and if I turn down the level to DEBUG, they all start coming in.

Ping @wwitzel3 you think this is still okay regarding memcache performance?

Otherwise it's not rocket science, the request is pretty clear

> There is no knob that changes the default logging level used by the service itself to syslog/stdout. Ideally, LOG_AGGREGATOR_LEVEL would set both.

I'm pretty sure that applying the filter on the handler is the correct way, but I welcome challenges on this point.