### PR TITLE
Fix permissions of sensitive files in docker-compose installation

### DIFF
--- a/installer/install.yml
+++ b/installer/install.yml
@@ -1,7 +1,6 @@
 ---
 - name: Build and deploy AWX
   hosts: all
-  gather_facts: false
   roles:
     - { role: check_vars }
     - { role: image_build, when: "dockerhub_base is not defined" }

--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -12,4 +12,3 @@ rabbitmq_default_password: "guest"
 postgresql_version: "9.6"
 postgresql_image: "postgres:{{postgresql_version}}"
 
-docker_compose_dir: "/var/lib/awx"

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -8,22 +8,26 @@
   template:
     src: docker-compose.yml.j2
     dest: "{{ docker_compose_dir }}/docker-compose.yml"
+    mode: 0600
   register: awx_compose_config
 
 - name: Render secrets file
   template:
     src: environment.sh.j2
     dest: "{{ docker_compose_dir }}/environment.sh"
+    mode: 0600
 
 - name: Render application credentials
   template:
     src: credentials.py.j2
     dest: "{{ docker_compose_dir }}/credentials.py"
+    mode: 0600
 
 - name: Render SECRET_KEY file
   copy:
     content: "{{ secret_key }}"
     dest: "{{ docker_compose_dir }}/SECRET_KEY"
+    mode: 0600
 
 - name: Start the containers
   docker_service:

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -1,4 +1,13 @@
 ---
+- include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'     # CentOS-7
+        - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml'        # RedHat-7
+        - '{{ ansible_distribution }}.yml'                                              # CentOS
+        - '{{ ansible_os_family }}.yml'                                                 # RedHat
+        - 'default.yml'
+
 - name: Create {{ docker_compose_dir }} directory
   file:
     path: "{{ docker_compose_dir }}"
@@ -33,7 +42,7 @@
   docker_service:
     project_src: "{{ docker_compose_dir }}"
   register: awx_compose_start
-    
+
 - name: Update CA trust in awx_web container
   command: docker exec awx_web_1 '/usr/bin/update-ca-trust'
   when: awx_compose_config.changed or awx_compose_start.changed

--- a/installer/roles/local_docker/vars/Darwin.yml
+++ b/installer/roles/local_docker/vars/Darwin.yml
@@ -1,0 +1,1 @@
+docker_compose_dir: "/usr/local/var/lib/awx"

--- a/installer/roles/local_docker/vars/default.yml
+++ b/installer/roles/local_docker/vars/default.yml
@@ -1,0 +1,1 @@
+docker_compose_dir: "/var/lib/awx"


### PR DESCRIPTION
Also allow for platform specific variables in docker-compose install. This changes the default `docker_compose_dir` on macOS to a writeable location.