### PR TITLE
Make use of user-defined settings for defining the isolated nodes heartbeat

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -491,11 +491,7 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(seconds=20),
         'options': {'expires': 20}
     },
-    'isolated_heartbeat': {
-        'task': 'awx.main.tasks.awx_isolated_heartbeat',
-        'schedule': timedelta(seconds=AWX_ISOLATED_PERIODIC_CHECK),
-        'options': {'expires': AWX_ISOLATED_PERIODIC_CHECK * 2},
-    }
+    # 'isolated_heartbeat': set up at the end of production.py and development.py
 }
 AWX_INCONSISTENT_TASK_INTERVAL = 60 * 3
 

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -142,6 +142,15 @@ except ImportError:
     traceback.print_exc()
     sys.exit(1)
 
+
+CELERYBEAT_SCHEDULE.update({  # noqa
+    'isolated_heartbeat': {
+        'task': 'awx.main.tasks.awx_isolated_heartbeat',
+        'schedule': timedelta(seconds=AWX_ISOLATED_PERIODIC_CHECK),  # noqa
+        'options': {'expires': AWX_ISOLATED_PERIODIC_CHECK * 2},  # noqa
+    }
+})
+
 CLUSTER_HOST_ID = socket.gethostname()
 
 try:

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -107,3 +107,12 @@ except IOError:
             raise ImproperlyConfigured(msg)
     else:
         raise
+
+
+CELERYBEAT_SCHEDULE.update({  # noqa
+    'isolated_heartbeat': {
+        'task': 'awx.main.tasks.awx_isolated_heartbeat',
+        'schedule': timedelta(seconds=AWX_ISOLATED_PERIODIC_CHECK),  # noqa
+        'options': {'expires': AWX_ISOLATED_PERIODIC_CHECK * 2},  # noqa
+    }
+})


### PR DESCRIPTION
##### SUMMARY
Just in case the user has created custom settings files which set
AWX_ISOLATED_PERIODIC_CHECK.

So, we now push off the definition of the `'isolated_heartbeat'` task until near the end of the settings files.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 3.0.1
```
