### PR TITLE
Set Ansible name transform setting for built-in sources

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1886,6 +1886,8 @@ class PluginFileInjector(object):
         else:
             injector_env = self.get_script_env(inventory_update, private_data_dir, private_data_files)
         env.update(injector_env)
+        # Preserves current behavior for Ansible change in default planned for 2.10
+        env['ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS'] = 'never'
         return env
 
     def _get_shared_env(self, inventory_update, private_data_dir, private_data_files):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1996,8 +1996,6 @@ class RunInventoryUpdate(BaseTask):
             else:
                 env['ANSIBLE_INVENTORY_ENABLED'] = 'script'
 
-        # TODO: option for Automatic transformation of group names, ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS
-
         if inventory_update.source in ['scm', 'custom']:
             for env_k in inventory_update.source_vars_dict:
                 if str(env_k) not in env and str(env_k) not in settings.INV_ENV_VARIABLE_BLACKLIST:

--- a/awx/main/tests/data/inventory/plugins/azure_rm/env.json
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/env.json
@@ -4,5 +4,6 @@
     "AZURE_TENANT": "fooo",
     "AZURE_SECRET": "fooo",
     "AZURE_CLOUD_ENVIRONMENT": "fooo",
-    "ANSIBLE_JINJA2_NATIVE": "True"
+    "ANSIBLE_JINJA2_NATIVE": "True",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/plugins/ec2/env.json
+++ b/awx/main/tests/data/inventory/plugins/ec2/env.json
@@ -2,5 +2,6 @@
     "AWS_ACCESS_KEY_ID": "fooo",
     "AWS_SECRET_ACCESS_KEY": "fooo",
     "AWS_SECURITY_TOKEN": "fooo",
-    "ANSIBLE_JINJA2_NATIVE": "True"
+    "ANSIBLE_JINJA2_NATIVE": "True",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/plugins/gce/env.json
+++ b/awx/main/tests/data/inventory/plugins/gce/env.json
@@ -1,4 +1,3 @@
 {
-    "OS_CLIENT_CONFIG_FILE": "{{ file_reference }}",
     "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/plugins/openstack/env.json
+++ b/awx/main/tests/data/inventory/plugins/openstack/env.json
@@ -1,4 +1,3 @@
 {
-    "OS_CLIENT_CONFIG_FILE": "{{ file_reference }}",
     "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/plugins/satellite6/env.json
+++ b/awx/main/tests/data/inventory/plugins/satellite6/env.json
@@ -1,5 +1,6 @@
 {
     "FOREMAN_SERVER": "https://foo.invalid",
     "FOREMAN_USER": "fooo",
-    "FOREMAN_PASSWORD": "fooo"
+    "FOREMAN_PASSWORD": "fooo",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/plugins/tower/env.json
+++ b/awx/main/tests/data/inventory/plugins/tower/env.json
@@ -2,5 +2,6 @@
     "TOWER_HOST": "https://foo.invalid",
     "TOWER_USERNAME": "fooo",
     "TOWER_PASSWORD": "fooo",
-    "TOWER_VERIFY_SSL": "False"
+    "TOWER_VERIFY_SSL": "False",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/azure_rm/env.json
+++ b/awx/main/tests/data/inventory/scripts/azure_rm/env.json
@@ -4,5 +4,6 @@
     "AZURE_TENANT": "fooo",
     "AZURE_SECRET": "fooo",
     "AZURE_CLOUD_ENVIRONMENT": "fooo",
-    "AZURE_INI_PATH": "{{ file_reference }}"
+    "AZURE_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/cloudforms/env.json
+++ b/awx/main/tests/data/inventory/scripts/cloudforms/env.json
@@ -1,3 +1,4 @@
 {
-    "CLOUDFORMS_INI_PATH": "{{ file_reference }}"
+    "CLOUDFORMS_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/ec2/env.json
+++ b/awx/main/tests/data/inventory/scripts/ec2/env.json
@@ -2,5 +2,6 @@
     "AWS_ACCESS_KEY_ID": "fooo",
     "AWS_SECRET_ACCESS_KEY": "fooo",
     "AWS_SECURITY_TOKEN": "fooo",
-    "EC2_INI_PATH": "{{ file_reference }}"
+    "EC2_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/gce/env.json
+++ b/awx/main/tests/data/inventory/scripts/gce/env.json
@@ -3,5 +3,6 @@
     "GCE_PROJECT": "fooo",
     "GCE_CREDENTIALS_FILE_PATH": "{{ file_reference }}",
     "GCE_ZONE": "us-east4-a,us-west1-b",
-    "GCE_INI_PATH": "{{ file_reference }}"
+    "GCE_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/rhv/env.json
+++ b/awx/main/tests/data/inventory/scripts/rhv/env.json
@@ -2,5 +2,6 @@
     "OVIRT_INI_PATH": "{{ file_reference }}",
     "OVIRT_URL": "https://foo.invalid",
     "OVIRT_USERNAME": "fooo",
-    "OVIRT_PASSWORD": "fooo"
+    "OVIRT_PASSWORD": "fooo",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/satellite6/env.json
+++ b/awx/main/tests/data/inventory/scripts/satellite6/env.json
@@ -1,3 +1,4 @@
 {
-    "FOREMAN_INI_PATH": "{{ file_reference }}"
+    "FOREMAN_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/tower/env.json
+++ b/awx/main/tests/data/inventory/scripts/tower/env.json
@@ -4,5 +4,6 @@
     "TOWER_PASSWORD": "fooo",
     "TOWER_VERIFY_SSL": "False",
     "TOWER_INVENTORY": "42",
-    "TOWER_LICENSE_TYPE": "open"
+    "TOWER_LICENSE_TYPE": "open",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }

--- a/awx/main/tests/data/inventory/scripts/vmware/env.json
+++ b/awx/main/tests/data/inventory/scripts/vmware/env.json
@@ -3,5 +3,6 @@
     "VMWARE_PASSWORD": "fooo",
     "VMWARE_HOST": "https://foo.invalid",
     "VMWARE_VALIDATE_CERTS": "False",
-    "VMWARE_INI_PATH": "{{ file_reference }}"
+    "VMWARE_INI_PATH": "{{ file_reference }}",
+    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never"
 }


### PR DESCRIPTION
##### SUMMARY
This is future-proofing our behavior.

This is the current default but will change in the future for these sources, we do not want behavior change.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
This would be important if you were using the current AWX version with Ansible 2.10.

That might not be highly plausible, but if we didn't do it now, we would have to do it later.

This change is not made for custom sources, see https://github.com/ansible/awx/issues/3513, because we would like to respect `ansible.cfg`, if present, in those cases. Using a custom config file is not possible for built-in sources, so this is a safe change.

Setting this was always the intention, but we flip-flopped with `compatibility_mode`. After discussing, I agree this makes more sense with the current scheme.

The reason this is duplicated in all the test data files is because it is critically important for reproducing our behavior on the CLI, this is true in _all_ cases.