### PR TITLE
include tower header to insights on plan fetch

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -64,13 +64,15 @@ from awx.main.dispatch import get_local_queuename, reaper
 from awx.main.utils import (get_ssh_version, update_scm_url,
                             get_licenser,
                             ignore_inventory_computed_fields,
-                            ignore_inventory_group_removal, extract_ansible_vars, schedule_task_manager)
+                            ignore_inventory_group_removal, extract_ansible_vars, schedule_task_manager,
+                            get_awx_version)
 from awx.main.utils.common import _get_ansible_version
 from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
 from awx.main.utils.reload import stop_local_services
 from awx.main.utils.pglock import advisory_lock
 from awx.main.consumers import emit_channel_notification
 from awx.conf import settings_registry
+from awx.conf.license import get_license
 
 from rest_framework.exceptions import PermissionDenied
 
@@ -1718,6 +1720,8 @@ class RunProjectUpdate(BaseTask):
         extra_vars.update({
             'project_path': project_update.get_project_path(check_if_exists=False),
             'insights_url': settings.INSIGHTS_URL_BASE,
+            'awx_license_type': get_license(show_key=False).get('license_type', 'UNLICENSED'),
+            'awx_version': get_awx_version(),
             'scm_type': project_update.scm_type,
             'scm_url': scm_url,
             'scm_branch': scm_branch,

--- a/awx/playbooks/action_plugins/insights.py
+++ b/awx/playbooks/action_plugins/insights.py
@@ -40,10 +40,20 @@ class ActionModule(ActionBase):
         username = self._task.args.get('username', None)
         password = self._task.args.get('password', None)
         proj_path = self._task.args.get('project_path', None)
+        license = self._task.args.get('awx_license_type', None)
+        awx_version = self._task.args.get('awx_version', None)
 
         session = requests.Session()
         session.auth = requests.auth.HTTPBasicAuth(username, password)
-        headers = {'Content-Type': 'application/json'}
+        headers = {
+            'Content-Type': 'application/json',
+            'User-Agent': '{} {} ({})'.format(
+                'AWX' if license == 'open' else 'Red Hat Ansible Tower',
+                awx_version,
+                license
+            )
+        }
+
         
         url = '{}/r/insights/v3/maintenance?ansible=true'.format(insights_url)
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -14,6 +14,8 @@
 # scm_revision: current revision in tower
 # scm_revision_output: where to store gathered revision (temporary file)
 # roles_enabled: Allow us to pull roles from a requirements.yml file
+# awx_version: Current running version of the awx or tower as a string
+# awx_license_type: "open" for AWX; else presume Tower
 
 - hosts: all
   connection: local
@@ -110,6 +112,8 @@
           username: "{{scm_username}}"
           password: "{{scm_password}}"
           project_path: "{{project_path}}"
+          awx_license_type: "{{awx_license_type}}"
+          awx_version: "{{awx_version}}"
         register: results
 
       - name: Save Insights Version


### PR DESCRIPTION
related to https://github.com/ansible/awx/issues/3590

* We include a special header value in the user agent when tower proxies
requests to get per-host rules.
* This extends that header logic to when we fetch plans (playbooks)
