### PR TITLE
move wf and jt form launch buttons to the left instead of the right

### DIFF
--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -393,6 +393,13 @@ function(NotificationsList, i18n) {
             },
 
             buttons: { //for now always generates <button> tags
+                launch: {
+                    component: 'at-launch-template',
+                    templateObj: 'job_template_obj',
+                    ngShow: '(job_template_obj.summary_fields.user_capabilities.start || canAddJobTemplate)',
+                    ngDisabled: 'disableLaunch || job_template_form.$dirty',
+                    showTextButton: 'true'
+                },
                 cancel: {
                     ngClick: 'formCancel()',
                     ngShow: '(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
@@ -405,13 +412,6 @@ function(NotificationsList, i18n) {
                     ngClick: 'formSave()',    //$scope.function to call on click, optional
                     ngDisabled: "job_template_form.$invalid",//true          //Disable when $pristine or $invalid, optional and when can_edit = false, for permission reasons
                     ngShow: '(job_template_obj.summary_fields.user_capabilities.edit || canAddJobTemplate)'
-                },
-                launch: {
-                    component: 'at-launch-template',
-                    templateObj: 'job_template_obj',
-                    ngShow: '(job_template_obj.summary_fields.user_capabilities.start || canAddJobTemplate)',
-                    ngDisabled: 'disableLaunch || job_template_form.$dirty',
-                    showTextButton: 'true'
                 }
             },
 

--- a/awx/ui/client/src/templates/workflows.form.js
+++ b/awx/ui/client/src/templates/workflows.form.js
@@ -139,6 +139,13 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
             },
 
             buttons: { //for now always generates <button> tags
+                launch: {
+                    component: 'at-launch-template',
+                    templateObj: 'workflow_job_template_obj',
+                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.start || canAddWorkflowJobTemplate)',
+                    ngDisabled: 'disableLaunch || workflow_job_template_form.$dirty',
+                    showTextButton: 'true'
+                },
                 cancel: {
                     ngClick: 'formCancel()',
                     ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
@@ -151,13 +158,6 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                     ngClick: 'formSave()',    //$scope.function to call on click, optional
                     ngDisabled: "workflow_job_template_form.$invalid || can_edit!==true", //Disable when $pristine or $invalid, optional and when can_edit = false, for permission reasons
                     ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
-                },
-                launch: {
-                    component: 'at-launch-template',
-                    templateObj: 'workflow_job_template_obj',
-                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.start || canAddWorkflowJobTemplate)',
-                    ngDisabled: 'disableLaunch || workflow_job_template_form.$dirty',
-                    showTextButton: 'true'
                 }
             },
 


### PR DESCRIPTION
link #3349 

Just moves the launch button on these two forms to be on the left instead of the right.