### PR TITLE
Add sort toolbar to template lists

### DIFF
--- a/awx/ui/client/features/templates/routes/organizationsTemplatesList.route.js
+++ b/awx/ui/client/features/templates/routes/organizationsTemplatesList.route.js
@@ -21,7 +21,11 @@ export default {
         template_search: {
             dynamic: true,
             value: {
-                type: 'workflow_job_template,job_template',
+                type: 'job_template',
+                order_by: 'name',
+                page_size: '20',
+                or__jobtemplate__project__organization: null,
+                or__jobtemplate__inventory__organization: null
             },
         }
     },
@@ -60,11 +64,11 @@ export default {
             ($stateParams, Wait, GetBasePath, qs) => {
                 const searchPath = GetBasePath('unified_job_templates');
 
-                const searchParam = _.assign($stateParams.template_search, {
-                    or__project__organization: $stateParams.organization_id,
-                    or__jobtemplate__inventory__organization: $stateParams.organization_id,
-                });
-
+                const searchParam = Object.assign(
+                    $stateParams.template_search, {
+                    or__jobtemplate__project__organization: $stateParams.organization_id,
+                    or__jobtemplate__inventory__organization: $stateParams.organization_id}
+                );
                 Wait('start');
                 return qs.search(searchPath, searchParam)
                     .finally(() => Wait('stop'));

--- a/awx/ui/client/features/templates/routes/projectsTemplatesList.route.js
+++ b/awx/ui/client/features/templates/routes/projectsTemplatesList.route.js
@@ -6,11 +6,15 @@ const templatesListTemplate = require('~features/templates/templatesList.view.ht
 export default {
     url: "/templates",
     name: 'projects.edit.templates',
+    searchPrefix: 'template',
     params: {
         template_search: {
             dynamic: true,
             value: {
-                type: 'workflow_job_template,job_template',
+                type: 'job_template',
+                order_by: 'name',
+                page_size: '20',
+                jobtemplate__project: null
             },
         }
     },

--- a/awx/ui/client/features/templates/routes/templatesList.route.js
+++ b/awx/ui/client/features/templates/routes/templatesList.route.js
@@ -25,6 +25,8 @@ export default {
             dynamic: true,
             value: {
                 type: 'workflow_job_template,job_template',
+                order_by: 'name',
+                page_size: '20'
             },
         }
     },

--- a/awx/ui/client/features/templates/templates.strings.js
+++ b/awx/ui/client/features/templates/templates.strings.js
@@ -143,6 +143,11 @@ function TemplatesStrings (BaseString) {
         CANCEL: t.s('CANCEL'),
         SAVE_AND_EXIT: t.s('SAVE & EXIT')
     };
+
+    ns.sort = {
+        NAME_ASCENDING: t.s('Name (Ascending)'),
+        NAME_DESCENDING: t.s('Name (Descending)')
+    };
 }
 
 TemplatesStrings.$inject = ['BaseStringService'];

--- a/awx/ui/client/features/templates/templatesList.view.html
+++ b/awx/ui/client/features/templates/templatesList.view.html
@@ -8,6 +8,7 @@
             list="vm.list"
             collection="vm.templates"
             dataset="vm.dataset"
+            default-params="vm.defaultParams"
             search-tags="vm.searchTags"
             search-bar-full-width="vm.isPortalMode">
         </smart-search>
@@ -33,10 +34,13 @@
     </div>
     <at-list-toolbar
         ng-if="vm.templates.length > 0"
-        sort-only="false"
-        on-collapse="vm.onCollapse"
         on-expand="vm.onExpand"
-        is-collapsed="vm.isCollapsed">
+        on-collapse="vm.onCollapse"
+        is-collapsed="vm.isCollapsed"
+        sort-only="false"
+        sort-value="vm.toolbarSortValue"
+        sort-options="vm.toolbarSortOptions"
+        on-sort="vm.onToolbarSort">
     </at-list-toolbar>
     <at-list results="vm.templates" id="templates_list">
         <at-row ng-repeat="template in vm.templates"

--- a/awx/ui/client/src/organizations/list/organizations-list.controller.js
+++ b/awx/ui/client/src/organizations/list/organizations-list.controller.js
@@ -43,45 +43,50 @@ export default ['$stateParams', '$scope', '$rootScope',
 
         function parseCardData(cards) {
             return cards.map(function(card) {
-                var val = {},
-                    url = '/#/organizations/' + card.id + '/';
+                var val = {};
                 val.user_capabilities = card.summary_fields.user_capabilities;
                 val.name = card.name;
                 val.id = card.id;
                 val.description = card.description || undefined;
                 val.links = [];
                 val.links.push({
-                    href: url + 'users',
+                    sref: `organizations.users({organization_id: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("USERS"),
                     count: card.summary_fields.related_field_counts.users,
                     activeMode: 'users'
                 });
                 val.links.push({
-                    href: url + 'teams',
+                    sref: `organizations.teams({organization_id: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("TEAMS"),
                     count: card.summary_fields.related_field_counts.teams,
                     activeMode: 'teams'
                 });
                 val.links.push({
-                    href: url + 'inventories',
+                    sref: `organizations.inventories({organization_id: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("INVENTORIES"),
                     count: card.summary_fields.related_field_counts.inventories,
                     activeMode: 'inventories'
                 });
                 val.links.push({
-                    href: url + 'projects',
+                    sref: `organizations.projects({organization_id: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("PROJECTS"),
                     count: card.summary_fields.related_field_counts.projects,
                     activeMode: 'projects'
                 });
                 val.links.push({
-                    href: url + 'job_templates',
+                    sref: `organizations.job_templates({organization_id: ${card.id}, or__jobtemplate__project__organization: ${card.id}, or__jobtemplate__inventory__organization: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("JOB TEMPLATES"),
                     count: card.summary_fields.related_field_counts.job_templates,
                     activeMode: 'job_templates'
                 });
                 val.links.push({
-                    href: url + 'admins',
+                    sref: `organizations.admins({organization_id: ${card.id}})`,
+                    srefOpts: { inherit: false },
                     name: i18n._("ADMINS"),
                     count: card.summary_fields.related_field_counts.admins,
                     activeMode: 'admins'

--- a/awx/ui/client/src/organizations/list/organizations-list.partial.html
+++ b/awx/ui/client/src/organizations/list/organizations-list.partial.html
@@ -83,7 +83,8 @@
                                 {{ link.count }}
                             </span>
                             <a class="OrgCards-linkName"
-                                ng-href="{{ link.href }}">
+                                ui-sref="{{ link.sref }}"
+                                ui-sref-opts="{{ link.srefOpts }}">
                                 {{ link.name }}
                             </a>
                         </div>


### PR DESCRIPTION
##### SUMMARY
Tracking Issue: https://github.com/ansible/awx/issues/3355

* Add sort to:
    -  My View / Templates
    - Organization / Templates
    - Project / Templates

![templates sort](https://user-images.githubusercontent.com/15881645/55355268-ceecda80-5495-11e9-8835-c6941640c6f8.gif)

##### ISSUE TYPE
 - Enhancement Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 3.0.1
```

##### ADDITIONAL INFORMATION
Found and fixed a few bugs in the Organization Template related list. 
- In the organization card view, the job template badge count didn't match the job template list returned from our api request. To fix this, I had to modify the query string from `or__project__organization` to `or__jobtemplate__project__organization`
- Added default param values to prevent smart search from creating search tags
- Updated the organization card links to use ui-sref instead of href to disable parameter inheritance.

_Bugs fixed in this PR_
![templates bug](https://user-images.githubusercontent.com/15881645/55354526-fe024c80-5493-11e9-8c86-f159aade13e4.gif)

