### PR TITLE
Code Mirror: prevent console errors when CM parses invalid syntax

### DIFF
--- a/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.directive.js
+++ b/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.directive.js
@@ -17,10 +17,12 @@ function atCodeMirrorModalController (
         } else if ($scope.disabled === 'false') {
             $scope.disabled = false;
         }
-        const editor = $(`${CodeMirrorModalID} .CodeMirror`)[0].CodeMirror;
-        const height = $(ModalHeight).height() - $(ModalHeader).height() -
-            $(ModalFooter).height() - 100;
-        editor.setSize('100%', height);
+        const editor = $(`${CodeMirrorModalID} .CodeMirror`)[0];
+        if (editor) {
+            const height = $(ModalHeight).height() - $(ModalHeader).height() -
+                $(ModalFooter).height() - 100;
+            editor.CodeMirror.setSize('100%', height);
+        }
     }
 
     function toggle () {


### PR DESCRIPTION
Removes console errors resulting from invalid YAML/JSON when toggling between the two.  The error is still displayed to the user in a modal.

related #3209