### PR TITLE
Job launch keyboard navigation improvements

### DIFF
--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -219,7 +219,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                     if(vm.steps[step].tab.order === currentTab.order) {
                         vm.steps[step].tab._active = false;
                     } else if(vm.steps[step].tab.order === currentTab.order + 1) {
-                        activeTab = currentTab
+                        activeTab = currentTab;
                         vm.steps[step].tab._active = true;
                         vm.steps[step].tab._disabled = false;
                         scope.$broadcast('promptTabChange', { step });

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -216,6 +216,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                     } else if(vm.steps[step].tab.order === currentTab.order + 1) {
                         vm.steps[step].tab._active = true;
                         vm.steps[step].tab._disabled = false;
+                        scope.$broadcast('promptTabChange', { step });
                     }
                 }
             });

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -7,8 +7,9 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
 
         let scope;
         let modal;
+        let activeTab;
 
-        vm.init = (_scope_) => {
+        vm.init = (_scope_, el) => {
             scope = _scope_;
             ({ modal } = scope[scope.ns]);
 
@@ -137,6 +138,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                                 _active: true,
                                 order: order
                             };
+                            activeTab = activeTab || vm.steps.inventory.tab;
                             order++;
                         }
                         if (vm.promptDataClone.launchConf.ask_credential_on_launch ||
@@ -152,6 +154,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                                 _disabled: (order === 1 || vm.readOnlyPrompts) ? false : true,
                                 order: order
                             };
+                            activeTab = activeTab || vm.steps.credentials.tab;
                             order++;
                         }
                         if(vm.promptDataClone.launchConf.ask_verbosity_on_launch || vm.promptDataClone.launchConf.ask_job_type_on_launch || vm.promptDataClone.launchConf.ask_limit_on_launch || vm.promptDataClone.launchConf.ask_tags_on_launch || vm.promptDataClone.launchConf.ask_skip_tags_on_launch || (vm.promptDataClone.launchConf.ask_variables_on_launch && !vm.promptDataClone.launchConf.ignore_ask_variables) || vm.promptDataClone.launchConf.ask_diff_mode_on_launch) {
@@ -161,6 +164,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                                 _disabled: (order === 1 || vm.readOnlyPrompts) ? false : true,
                                 order: order
                             };
+                            activeTab = activeTab || vm.steps.other_prompts.tab;
                             order++;
 
                             let codemirror = () =>  {
@@ -177,6 +181,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                                 _disabled: (order === 1 || vm.readOnlyPrompts) ? false : true,
                                 order: order
                             };
+                            activeTab = activeTab || vm.steps.survey.tab;
                             order++;
                         }
                         vm.steps.preview.tab.order = order;
@@ -214,12 +219,19 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
                     if(vm.steps[step].tab.order === currentTab.order) {
                         vm.steps[step].tab._active = false;
                     } else if(vm.steps[step].tab.order === currentTab.order + 1) {
+                        activeTab = currentTab
                         vm.steps[step].tab._active = true;
                         vm.steps[step].tab._disabled = false;
                         scope.$broadcast('promptTabChange', { step });
                     }
                 }
             });
+        };
+
+        vm.keypress = (event) => {
+          if (event.key === 'Enter') {
+            vm.next(activeTab);
+          }
         };
 
         vm.finish = () => {

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -9,7 +9,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
         let modal;
         let activeTab;
 
-        vm.init = (_scope_, el) => {
+        vm.init = (_scope_) => {
             scope = _scope_;
             ({ modal } = scope[scope.ns]);
 

--- a/awx/ui/client/src/templates/prompt/prompt.directive.js
+++ b/awx/ui/client/src/templates/prompt/prompt.directive.js
@@ -20,7 +20,7 @@ export default [ 'templateUrl',
             scope.ns = 'launch';
             scope[scope.ns] = { modal: {} };
 
-            promptController.init(scope);
+            promptController.init(scope, el);
         }
     };
 }];

--- a/awx/ui/client/src/templates/prompt/prompt.directive.js
+++ b/awx/ui/client/src/templates/prompt/prompt.directive.js
@@ -20,7 +20,7 @@ export default [ 'templateUrl',
             scope.ns = 'launch';
             scope[scope.ns] = { modal: {} };
 
-            promptController.init(scope, el);
+            promptController.init(scope);
         }
     };
 }];

--- a/awx/ui/client/src/templates/prompt/prompt.partial.html
+++ b/awx/ui/client/src/templates/prompt/prompt.partial.html
@@ -7,7 +7,7 @@
             <at-tab id="prompt_survey_tab" ng-if="vm.steps.survey.tab" state="vm.steps.survey.tab">{{:: vm.strings.get('prompt.SURVEY') }}</at-tab>
             <at-tab id="prompt_preview_tab" state="vm.steps.preview.tab">{{:: vm.strings.get('prompt.PREVIEW') }}</at-tab>
         </at-tab-group>
-        <div class="Prompt-step">
+        <div class="Prompt-step" ng-keypress="vm.keypress($event)">
             <div ng-if="vm.steps.inventory.includeStep" ng-show="vm.steps.inventory.tab._active" id="prompt_inventory_step">
                 <prompt-inventory
                     prompt-data="vm.promptDataClone"

--- a/awx/ui/client/src/templates/prompt/prompt.partial.html
+++ b/awx/ui/client/src/templates/prompt/prompt.partial.html
@@ -10,9 +10,9 @@
         <div class="Prompt-step">
             <div ng-if="vm.steps.inventory.includeStep" ng-show="vm.steps.inventory.tab._active" id="prompt_inventory_step">
                 <prompt-inventory
-                prompt-data="vm.promptDataClone"
-                read-only-prompts="vm.readOnlyPrompts">
-            </prompt-inventory>
+                    prompt-data="vm.promptDataClone"
+                    read-only-prompts="vm.readOnlyPrompts">
+                </prompt-inventory>
             </div>
             <div ng-if="vm.steps.credential.includeStep" ng-show="vm.steps.credential.tab._active" id="prompt_credential_step">
                 <prompt-credential

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
@@ -12,7 +12,7 @@ export default
 
             let scope;
 
-            vm.init = (_scope_) => {
+            vm.init = (_scope_, controller, el) => {
                 scope = _scope_;
 
                 scope.parseType = 'yaml';
@@ -102,6 +102,13 @@ export default
                     return ToJSON(scope.parseType, scope.extraVariables, true);
                 }
                 scope.validate = validate;
+
+                angular.element(el).ready(() => {
+                  const inputs = el.find('input, select');
+                  if (inputs.length) {
+                    inputs.get(0).focus();
+                  }
+                });
             };
 
 

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.controller.js
@@ -103,15 +103,25 @@ export default
                 }
                 scope.validate = validate;
 
-                angular.element(el).ready(() => {
-                  const inputs = el.find('input, select');
+                function focusFirstInput () {
+                  const inputs = el.find('input[type=text], select, textarea:visible, .CodeMirror textarea');
                   if (inputs.length) {
                     inputs.get(0).focus();
                   }
+                }
+
+                angular.element(el).ready(() => {
+                    focusFirstInput();
+                });
+
+                scope.$on('promptTabChange', (event, args) => {
+                    if (args.step === 'other_prompts') {
+                        angular.element(el).ready(() => {
+                          focusFirstInput();
+                        });
+                    }
                 });
             };
-
-
 
             vm.toggleDiff = () => {
                 scope.promptData.prompts.diffMode.value = !scope.promptData.prompts.diffMode.value;

--- a/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.directive.js
+++ b/awx/ui/client/src/templates/prompt/steps/other-prompts/prompt-other-prompts.directive.js
@@ -28,7 +28,7 @@ export default [ 'templateUrl',
             const launchController = controllers[0];
             const promptOtherPromptsController = controllers[1];
 
-            promptOtherPromptsController.init(scope, launchController);
+            promptOtherPromptsController.init(scope, launchController, el);
         }
     };
 }];


### PR DESCRIPTION
##### SUMMARY

Improves keyboard navigation in the Launch JT dialog:

* When the dialog opens to the "other prompts" tab, the first input is given focus so the user can begin typing
* Pressing enter will proceed to the next tab in the dialog (unless focus is in a codemirror textarea, so hard returns can still be typed)

related #407

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
