### PR TITLE
Reload uwsgi workers after hitting 600MB virtual memory usage

### DIFF
--- a/installer/roles/image_build/files/supervisor.conf
+++ b/installer/roles/image_build/files/supervisor.conf
@@ -13,7 +13,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:uwsgi]
-command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --reload-on-as=600 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
 directory = /var/lib/awx
 autostart = true
 autorestart = true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related #3578 

This changes causes the uwsgi works to restart after 600MB of virtual memory allocation. There is already a parameter to restart them after 1000 requests but where you have environments such as K8s and are resource limiting the containers you are most likely to hit the memory limit before the request limit. Rather than just chucking more memory at the container this will restart the uwsgi workers so memory can be freed up and reused. In my tests this means you can set a resource limit of 2GB to the web container without having the container go OOM and the memory manger ungracefully kill the uwsgi workers.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make 4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before: 
command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768

After:

command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --reload-on-as=600 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768

```
