### PR TITLE
Updated IsolatedManager to take a callback that captures the remote command

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -188,16 +188,17 @@ class IsolatedManager(object):
                                                       self.private_data_dir,
                                                       extravars=extravars)
             status, rc = runner_obj.status, runner_obj.rc
-            if self.check_callback is not None:
-                config_path = self.path_to('artifacts', self.ident, 'config')
-                # If the configuration artifact has been synced back, update the model
-                if os.path.exists(config_path):
-                    with open(config_path, 'r') as f:
-                        data = json.load(f)
-                    self.check_callback(data)
             self.consume_events(dispatcher)
 
             last_check = time.time()
+
+        if self.check_callback is not None:
+            config_path = self.path_to('artifacts', self.ident, 'config')
+            # If the configuration artifact has been synced back, update the model
+            if os.path.exists(config_path):
+                with open(config_path, 'r') as f:
+                    data = json.load(f)
+                self.check_callback(data)
 
         if status == 'successful':
             status_path = self.path_to('artifacts', self.ident, 'status')

--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -189,12 +189,12 @@ class IsolatedManager(object):
                                                       extravars=extravars)
             status, rc = runner_obj.status, runner_obj.rc
             if self.check_callback is not None:
-                command_path = self.path_to('artifacts', self.ident, 'command')
-                # If the command artifact has been synced back, update the model
-                if os.path.exists(command_path):
-                    with open(command_path, 'r') as f:
+                config_path = self.path_to('artifacts', self.ident, 'config')
+                # If the configuration artifact has been synced back, update the model
+                if os.path.exists(config_path):
+                    with open(config_path, 'r') as f:
                         data = json.load(f)
-                    self.check_callback(data['command'], data['cwd'], self.runner_params['envvars'].copy())
+                    self.check_callback(data)
             self.consume_events(dispatcher)
 
             last_check = time.time()

--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -39,7 +39,7 @@ class IsolatedManager(object):
         self.check_callback = check_callback
         self.idle_timeout = max(60, 2 * settings.AWX_ISOLATED_CONNECTION_TIMEOUT)
         self.started_at = None
-        self.captured_config_artifact = False
+        self.captured_command_artifact = False
 
     def build_runner_params(self, hosts, verbosity=1):
         env = dict(os.environ.items())
@@ -190,15 +190,15 @@ class IsolatedManager(object):
                                                       extravars=extravars)
             status, rc = runner_obj.status, runner_obj.rc
 
-            if self.check_callback is not None and not self.captured_config_artifact:
-                config_path = self.path_to('artifacts', self.ident, 'config')
+            if self.check_callback is not None and not self.captured_command_artifact:
+                command_path = self.path_to('artifacts', self.ident, 'command')
                 # If the configuration artifact has been synced back, update the model
-                if os.path.exists(config_path):
+                if os.path.exists(command_path):
                     try:
-                        with open(config_path, 'r') as f:
+                        with open(command_path, 'r') as f:
                             data = json.load(f)
                         self.check_callback(data)
-                        self.captured_config_artifact = True
+                        self.captured_command_artifact = True
                     except json.decoder.JSONDecodeError:  # Just in case it's not fully here yet.
                         pass
 

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1222,7 +1222,7 @@ class BaseTask(object):
                 ansible_runner.utils.dump_artifacts(params)
                 isolated_manager_instance = isolated_manager.IsolatedManager(
                     cancelled_callback=lambda: self.update_model(self.instance.pk).cancel_flag,
-                    check_callback=self.check_callback,
+                    check_callback=self.check_handler,
                 )
                 status, rc = isolated_manager_instance.run(self.instance,
                                                            private_data_dir,

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1084,7 +1084,7 @@ class BaseTask(object):
         self.instance = self.update_model(self.instance.pk,
                                           job_args=json.dumps(config['command']),
                                           job_cwd=config['cwd'],
-                                          job_env=config['env'])
+                                          job_env=build_safe_env(config['env']))
 
 
     @with_path_cleanup

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1077,14 +1077,14 @@ class BaseTask(object):
             self.instance = self.update_model(self.instance.pk, job_args=json.dumps(runner_config.command),
                                               job_cwd=runner_config.cwd, job_env=job_env)
 
-    def check_handler(self, command, cwd, env):
+    def check_handler(self, config):
         '''
         IsolatedManager callback triggered by the repeated checks of the isolated node
         '''
         self.instance = self.update_model(self.instance.pk,
-                                          job_args=command,
-                                          job_cwd=cwd,
-                                          job_env=build_safe_env(env))
+                                          job_args=json.dumps(config['command']),
+                                          job_cwd=config['cwd'],
+                                          job_env=config['env'])
 
 
     @with_path_cleanup


### PR DESCRIPTION
##### SUMMARY
It was discovered that running tasks against isolated nodes was failing to capture and store the command, working directory, and environment of the remote command being run by ansible-runner.  This PR and the associated ansible-runner one fixes this issue by creating a new artifact file with the missing information, and then when it gets synced back up to the controlling instance, write the values back into the relevant model.

ref: ansible/ansible-runner#244


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 4.0.0
```