### PR TITLE
fix a bug in isolated OpenSSH key syncing

### DIFF
--- a/awx/plugins/isolated/mkfifo.py
+++ b/awx/plugins/isolated/mkfifo.py
@@ -4,6 +4,12 @@ import stat
 from ansible.module_utils.basic import AnsibleModule
 
 
+#
+# the purpose of this plugin is to call mkfifo and
+# write raw SSH key data into the fifo created on the remote isolated host
+#
+
+
 def main():
     module = AnsibleModule(
         argument_spec={
@@ -16,7 +22,14 @@ def main():
     path = module.params['path']
     os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
     with open(path, 'w') as fifo:
-        fifo.write(module.params['content'])
+        data = module.params['content']
+        if 'OPENSSH PRIVATE KEY' in data and not data.endswith('\n'):
+            # we use ansible's lookup() to read this file from the disk,
+            # but ansible's lookup() *strips* newlines
+            # OpenSSH wants certain private keys to end with a newline (or it
+            # won't accept them)
+            data += '\n'
+        fifo.write(data)
     module.exit_json(dest=path, changed=True)
 
 


### PR DESCRIPTION
OpenSSH keys _must_ end with a `\n` to be accepted by ssh-add; enforce
a newline if there isn't one

Ansible's `lookup()` strips the newline here (from OpenSSH key files):
https://github.com/ansible/awx/blob/8f089c02a5131653ae6f564aac882dcc5f35603f/awx/playbooks/run_isolated.yml#L11