### PR TITLE
[option2] Fix RBAC bugs with notification attachment

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -466,18 +466,15 @@ class NotificationAttachMixin(BaseAccess):
     def can_attach(self, obj, sub_obj, relationship, data, skip_sub_obj_read_check=False):
         if isinstance(sub_obj, NotificationTemplate):
             # reverse obj and sub_obj
-            return NotificationTemplateAccess(self.user).can_attach(
-                sub_obj, obj, relationship, data
-            )
+            return NotificationTemplateAccess(self.user).can_attach(sub_obj, obj, relationship, data)
         return super(NotificationAttachMixin, self).can_attach(
             obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
 
     @check_superuser
     def can_unattach(self, obj, sub_obj, relationship, data=None):
         if isinstance(sub_obj, NotificationTemplate):
-            # due to this special case, we must whitelist case symmetrical with attach permission
-            if NotificationTemplateAccess(self.user).can_attach(sub_obj, obj, relationship, data):
-                return True
+            # due to this special case, we use symmetrical logic with attach permission
+            return NotificationTemplateAccess(self.user).can_attach(sub_obj, obj, relationship, data)
         return super(NotificationAttachMixin, self).can_unattach(
             obj, sub_obj, relationship, relationship, data=data
         )

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -465,12 +465,23 @@ class NotificationAttachMixin(BaseAccess):
     @check_superuser
     def can_attach(self, obj, sub_obj, relationship, data, skip_sub_obj_read_check=False):
         if isinstance(sub_obj, NotificationTemplate):
-            if not self.check_related(
-                    'organization', Organization, {}, obj=sub_obj,
-                    role_field='notification_admin_role', mandatory=True):
-                return False
+            # reverse obj and sub_obj
+            return NotificationTemplateAccess(self.user).can_attach(
+                sub_obj, obj, relationship, data
+            )
         return super(NotificationAttachMixin, self).can_attach(
             obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
+
+    @check_superuser
+    def can_unattach(self, obj, sub_obj, relationship, data=None):
+        if isinstance(sub_obj, NotificationTemplate):
+            # due to this special case, needs to be symmetrical with attach permission
+            return NotificationTemplateAccess(self.user).can_attach(
+                sub_obj, obj, relationship, data
+            )
+        return super(NotificationAttachMixin, self).can_unattach(
+            obj, sub_obj, relationship, relationship, data=data
+        )
 
 
 class InstanceAccess(BaseAccess):

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -475,10 +475,9 @@ class NotificationAttachMixin(BaseAccess):
     @check_superuser
     def can_unattach(self, obj, sub_obj, relationship, data=None):
         if isinstance(sub_obj, NotificationTemplate):
-            # due to this special case, needs to be symmetrical with attach permission
-            return NotificationTemplateAccess(self.user).can_attach(
-                sub_obj, obj, relationship, data
-            )
+            # due to this special case, we must whitelist case symmetrical with attach permission
+            if NotificationTemplateAccess(self.user).can_attach(sub_obj, obj, relationship, data):
+                return True
         return super(NotificationAttachMixin, self).can_unattach(
             obj, sub_obj, relationship, relationship, data=data
         )

--- a/awx/main/tests/functional/test_rbac_notifications.py
+++ b/awx/main/tests/functional/test_rbac_notifications.py
@@ -176,10 +176,10 @@ def test_org_role_JT_attach(rando, job_template, project, workflow_job_template,
 @pytest.mark.django_db
 @pytest.mark.parametrize("res_role,expect", [
     ('admin_role', True),
-    ('execute_role', False),
-    ('use_role', False),
-    ('update_role', False),
-    ('read_role', False),
+    ('execute_role', True),
+    ('use_role', True),
+    ('update_role', True),
+    ('read_role', True),
     (None, False)
 ])
 def test_object_role_JT_attach(rando, job_template, project, workflow_job_template, inventory_source,

--- a/awx/main/tests/functional/test_rbac_notifications.py
+++ b/awx/main/tests/functional/test_rbac_notifications.py
@@ -4,11 +4,7 @@ from awx.main.models import Organization
 from awx.main.access import (
     NotificationTemplateAccess,
     NotificationAccess,
-    JobTemplateAccess,
-    ProjectAccess,
-    WorkflowJobTemplateAccess,
-    OrganizationAccess,
-    InventorySourceAccess
+    JobTemplateAccess
 )
 
 
@@ -152,24 +148,72 @@ def test_system_auditor_JT_attach(system_auditor, job_template, notification_tem
 ])
 def test_org_role_JT_attach(rando, job_template, project, workflow_job_template, inventory_source,
                             notification_template, org_role, expect):
+    ref_organization = Organization.objects.create(name='organization just for the notification template')
+    notification_template.organization = ref_organization
+    notification_template.save()
     getattr(notification_template.organization, org_role).members.add(rando)
     kwargs = dict(
         sub_obj=notification_template,
         relationship='notification_templates_success',
         data={'id': notification_template.id}
     )
-    job_template.admin_role.members.add(rando)
-    assert JobTemplateAccess(rando).can_attach(job_template, **kwargs) is expect
-    project.admin_role.members.add(rando)
-    assert ProjectAccess(rando).can_attach(project, **kwargs) is expect
-    workflow_job_template.admin_role.members.add(rando)
-    assert workflow_job_template.organization == notification_template.organization
-    assert WorkflowJobTemplateAccess(rando).can_attach(workflow_job_template, **kwargs) is expect
-    second_organization = Organization.objects.create(name='fooooorg')
-    second_organization.admin_role.members.add(rando)
-    assert OrganizationAccess(rando).can_attach(second_organization, **kwargs) is expect
-    inventory_source.inventory.admin_role.members.add(rando)
-    assert InventorySourceAccess(rando).can_attach(inventory_source, **kwargs) is expect
+    permissions = {}
+    expected_permissions = {}
+    organization = Organization.objects.create(name='objective organization')
+
+    for resource in (organization, job_template, project, workflow_job_template, inventory_source):
+        permission_resource = resource
+        if resource == inventory_source:
+            permission_resource = inventory_source.inventory
+        getattr(permission_resource, 'admin_role').members.add(rando)
+        model_name = resource.__class__.__name__
+        permissions[model_name] = rando.can_access(resource.__class__, 'attach', resource, **kwargs)
+        expected_permissions[model_name] = expect
+
+    assert permissions == expected_permissions
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("res_role,expect", [
+    ('admin_role', True),
+    ('execute_role', False),
+    ('use_role', False),
+    ('update_role', False),
+    ('read_role', False),
+    (None, False)
+])
+def test_object_role_JT_attach(rando, job_template, project, workflow_job_template, inventory_source,
+                               notification_template, res_role, expect):
+    ref_organization = Organization.objects.create(name='organization just for the notification template')
+    getattr(ref_organization, 'admin_role').members.add(rando)
+    notification_template.organization = ref_organization
+    notification_template.save()
+    kwargs = dict(
+        sub_obj=notification_template,
+        relationship='notification_templates_success',
+        data={'id': notification_template.id}
+    )
+    permissions = {}
+    expected_permissions = {}
+    organization = Organization.objects.create(name='objective organization')
+
+    for resource in (organization, job_template, project, workflow_job_template, inventory_source):
+        permission_resource = resource
+        if resource == inventory_source:
+            permission_resource = inventory_source.inventory
+        model_name = resource.__class__.__name__
+        if res_role is None or hasattr(permission_resource, res_role):
+            if res_role is not None:
+                getattr(permission_resource, res_role).members.add(rando)
+            permissions[model_name] = rando.can_access(
+                resource.__class__, 'attach', resource, **kwargs
+            )
+            expected_permissions[model_name] = expect
+        else:
+            permissions[model_name] = None
+            expected_permissions[model_name] = None
+
+    assert permissions == expected_permissions
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
Does something similar to https://github.com/ansible/awx/pull/3593, but with a different paradigm of attachment rules.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
This reverses attachment permission, `A->B` vs `B->A`, as opposed to the other PR, the other PR conservatively requires "admin" to both A and B
