### PR TITLE
Fix some docker standalone bits

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -446,7 +446,7 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 *docker_compose_dir*
 
-When using docker-compose, the `docker-compose.yml` file will be created there (default `/tmp/awxcompose`).
+> When using docker-compose, the `docker-compose.yml` file will be created there (default `/tmp/awxcompose`).
 
 *ca_trust_dir*
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,9 @@ Before you can run a deployment, you'll need the following installed in your loc
 
 - [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.4+
 - [Docker](https://docs.docker.com/engine/installation/)
-- [docker-py](https://github.com/docker/docker-py) Python module
+- [docker](https://pypi.org/project/docker/) Python module
+    + This is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
+    + We use this module instead of `docker-py` because it is what the `docker-compose` Python module requires.
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Git](https://git-scm.com/) Requires Version 1.8.4+
 - [Node 8.x LTS version](https://nodejs.org/en/download/)
@@ -396,7 +398,8 @@ Unlike Openshift's `Route` the Kubernetes `Ingress` doesn't yet handle SSL termi
 ### Prerequisites
 
 - [Docker](https://docs.docker.com/engine/installation/) on the host where AWX will be deployed. After installing Docker, the Docker service must be started (depending on your OS, you may have to add the local user that uses Docker to the ``docker`` group, refer to the documentation for details)
-- [docker-py](https://github.com/docker/docker-py) Python module.
+- [docker-compose](https://pypi.org/project/docker-compose/) Python module.
+    + This also installs the `docker` Python module, which is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
 - [Docker Compose](https://docs.docker.com/compose/install/).
 
 ### Pre-build steps

--- a/installer/inventory
+++ b/installer/inventory
@@ -54,11 +54,10 @@ awx_web_hostname=awxweb
 postgres_data_dir=/tmp/pgdocker
 host_port=80
 #ssl_certificate=
+docker_compose_dir=/tmp/awxcompose
 
 # Required for Openshift when building the image on your own
 # Optional for Openshift if using Dockerhub or another prebuilt registry
-# Required for Standalone Docker Install if building the image on your own
-# Optional for Standalone Docker Install if using Dockerhub or another prebuilt registry
 # Required for Docker Compose Install if building the image on your own
 # Optional for Docker Compose Install if using Dockerhub or another prebuilt registry
 # Define if you want the image pushed to a registry. The container definition will also use these images

--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -11,5 +11,3 @@ rabbitmq_password: "guest"
 
 postgresql_version: "9.6"
 postgresql_image: "postgres:{{postgresql_version}}"
-
-docker_compose_dir: "/tmp/awxcompose"


### PR DESCRIPTION
##### SUMMARY

This PR has these effects:

- Ensure that folks do not install `docker-py`, since the `docker-compose` Python module requires the `docker` Python module, and `docker-py` and `docker` are incompatible
- Avoid having the `docker_compose_dir` inventory variable handled & set in a way inconsistent with other inventory variables
- Clean up some install docs

Relates to #3505 & 07e5a00f14b2e3472ad0657f5cbc74299b768b0f

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

- Installer

##### AWX VERSION

```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION

While working on updating our setup to use the newly shipped SSL support, I came across these things. The `docker` vs. `docker-py` Python module issue could really trip someone up who hadn’t already dealt with that, and the inconsistent `docker_compose_dir` variable might confuse someone unfamiliar with Ansible (I only knew I could set it because that variable used to be in inventory).