### PR TITLE
Update SSL support for docker-compose install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -443,6 +443,10 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 > Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. Defaults to *80*.
 
+*host_port_ssl*
+
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container for SSL support. Defaults to *443*, only works if you also set `ssl_certificate` (see below).
+
 *ssl_certificate*
 
 > Optionally, provide the path to a file that contains a certificate and its private key.

--- a/installer/inventory
+++ b/installer/inventory
@@ -53,6 +53,7 @@ awx_task_hostname=awx
 awx_web_hostname=awxweb
 postgres_data_dir=/tmp/pgdocker
 host_port=80
+host_port_ssl=443
 #ssl_certificate=
 docker_compose_dir=/tmp/awxcompose
 

--- a/installer/roles/image_build/templates/nginx.conf.j2
+++ b/installer/roles/image_build/templates/nginx.conf.j2
@@ -35,9 +35,19 @@ http {
         server 127.0.0.1:8051;
     }
 
+    {% if ssl_certificate is defined %}
+    server {
+        listen 8052 default_server;
+        server_name _;
+
+        # Redirect all HTTP links to the matching HTTPS page
+        return 301 https://$host$request_uri;
+    }
+    {%endif %}
+
     server {
         {% if ssl_certificate is defined %}
-        listen 8052 ssl default_server;
+        listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;
         ssl_certificate_key /etc/nginx/awxweb.pem;
@@ -54,14 +64,14 @@ http {
 
         # Protect against click-jacking https://www.owasp.org/index.php/Testing_for_Clickjacking_(OTG-CLIENT-009)
         add_header X-Frame-Options "DENY";
-        
+
         location /nginx_status {
           stub_status on;
           access_log off;
           allow 127.0.0.1;
           deny all;
         }
-        
+
         location /static/ {
             alias /var/lib/awx/public/static/;
         }

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -26,6 +26,9 @@ services:
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
     {% endif %}
+    {% if ssl_certificate is defined %}
+      - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:
@@ -71,6 +74,9 @@ services:
     {% endif %}
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
+    {% endif %}
+    {% if ssl_certificate is defined %}
+      - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
     {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -12,6 +12,9 @@ services:
       - postgres
       {% endif %}
     ports:
+      {% if ssl_certificate is defined %}
+      - "{{ host_port_ssl }}:8053"
+      {% endif %}
       - "{{ host_port }}:8052"
     hostname: {{ awx_web_hostname }}
     user: root


### PR DESCRIPTION
##### SUMMARY

As part of #3322, this functionality was added, which is great! However, it only added the functionality to standalone Docker, so when that was removed in 07e5a00f14b2e3472ad0657f5cbc74299b768b0f, it meant that this functionality broke entirely.

Additionally, this was set up in #3322 such that it superseded HTTP, but ran on port 80, which is not what most (all?) browsers expect for HTTPS traffic. To better facilitate not only that, but also HSTS support (which has been present for some time), a redirect for HTTP → HTTPS is added here.

Relates to:

* #3322 
* #1549 
* 07e5a00f14b2e3472ad0657f5cbc74299b768b0f

##### ISSUE TYPE

- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME

- Installer

##### AWX VERSION

```
awx: 4.0.0
```

##### ADDITIONAL INFORMATION

n/a