### PR TITLE
Prevents replacing encoded quotes while searching against host filter

### DIFF
--- a/awx/ui/client/src/shared/smart-search/smart-search.controller.js
+++ b/awx/ui/client/src/shared/smart-search/smart-search.controller.js
@@ -202,7 +202,7 @@ function SmartSearchController (
                     });
             }
 
-            qs.search(path, queryset)
+            qs.search(path, queryset, singleSearchParam)
                 .then(({ data }) => {
                     if ($scope.querySet) {
                         $scope.querySet = queryset;

--- a/awx/ui/client/src/shared/smart-search/smart-search.service.js
+++ b/awx/ui/client/src/shared/smart-search/smart-search.service.js
@@ -14,6 +14,10 @@ export default [function() {
             let groups = [];
             let quoted;
 
+            // This split _may_ split search terms down the middle
+            // ex) searchString=ansible_facts.some_other_thing:"foo foobar" ansible_facts.some_thing:"foobar"
+            // would result in 3 different substring's but only two search terms
+            // This logic handles that scenario with the `quoted` variable
             searchString.split(' ').forEach(substring => {
                 if (/:"/g.test(substring)) {
                     if (/"$/.test(substring)) {


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3160

Though I'm not crazy about passing this flag around to a bunch of different functions this felt like the most direct solution to the problem.  For regular searches, we do want to strip out the encoded quotes that come after the `:`.  When searching using the host_filter param those quotes are actually important and should be maintained in the request.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
