### PR TITLE
Removes Add Organization Admin Button

### DIFF
--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-admins.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-admins.controller.js
@@ -8,7 +8,7 @@ export default ['$stateParams', '$scope', 'Rest', '$state',
     '$compile', 'Wait', 'OrgAdminList', 'OrgAdminsDataset', 'i18n',
     'Prompt', 'ProcessErrors', 'GetBasePath', '$filter',
     function($stateParams, $scope, Rest, $state,
-        $compile, Wait, OrgAdminList, OrgAdminsDataset, i18n, 
+        $compile, Wait, OrgAdminList, OrgAdminsDataset, i18n,
         Prompt, ProcessErrors, GetBasePath, $filter) {
 
         var orgBase = GetBasePath('organizations');
@@ -27,6 +27,7 @@ export default ['$stateParams', '$scope', 'Rest', '$state',
                     $scope.organization_name = data.name;
                     $scope.name = data.name;
                     $scope.org_id = data.id;
+                    $scope.canAddAdmins = data.summary_fields.user_capabilities.edit;
 
                     $scope.orgRelatedUrls = data.related;
 

--- a/awx/ui/client/src/organizations/linkout/organizations-linkout.route.js
+++ b/awx/ui/client/src/organizations/linkout/organizations-linkout.route.js
@@ -275,7 +275,8 @@ let lists = [{
                 add: {
                     awToolTip: i18n._('Add existing user to organization as administrator'),
                     actionClass: 'at-Button--add',
-                    ngClick: 'addUsers()'
+                    ngClick: 'addUsers()',
+                    ngShow:'canAddAdmins'
                 }
             };
             list.listTitle = i18n._('Admins') + ` | {{ name }}`;


### PR DESCRIPTION
##### SUMMARY
This addresses issue https://github.com/ansible/tower/issues/2220

##### ISSUE TYPE
-UI Enhancement

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
3.0.1
```


##### ADDITIONAL INFORMATION
To test:

1) Create super user account.  Click on Organizations ==> in Org Card click on Admins ==> check to see if ➕ button is available.  
2) Create normal user account.  Follow same steps as above.  ➕ button should not be available.

<img width="1431" alt="Screen Shot 2019-04-04 at 8 10 05 AM" src="https://user-images.githubusercontent.com/39280967/55555349-143a2380-56b3-11e9-83ba-b6a79e364766.png">
<img width="1429" alt="Screen Shot 2019-04-04 at 8 11 00 AM" src="https://user-images.githubusercontent.com/39280967/55555358-17351400-56b3-11e9-9ce6-156e256dcb01.png">

