### PR TITLE
The python 3.6 package seems to already make this symlink

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -19,9 +19,7 @@ RUN yum -y update && yum -y install openssh-server ansible mg vim tmux \
   zanata-python-client gettext gcc-c++ libcurl-devel bzip2 \
   rsync
 
-RUN ln -s /usr/bin/python36 /usr/bin/python3
-
-RUN python36 -m ensurepip
+RUN python3 -m ensurepip
 RUN pip3 install virtualenv
 RUN /usr/bin/ssh-keygen -q -t rsa -N "" -f /root/.ssh/id_rsa
 RUN mkdir -p /data/db


### PR DESCRIPTION
```
[root@045499f99bbf /]# yum whatprovides /usr/bin/python3                                                                                                                                 
python34u-3.4.8-1.ius.centos7.x86_64 : Version 3 of the Python programming language aka Python 3000                                                                                      
Repo        : ius                                                                                                                                                                        
python36-3.6.6-5.el7.x86_64 : Interpreter of the Python programming language                                                                                                             
Repo        : epel                                                                                                                                                                       
python36-3.6.6-5.el7.x86_64 : Interpreter of the Python programming language                                                                                                             
Repo        : epel
```                                                                                                                                                                                                   