### PR TITLE
don't show implicit update jobs in dashboard

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -277,7 +277,7 @@ class DashboardJobsGraphView(APIView):
         period = request.query_params.get('period', 'month')
         job_type = request.query_params.get('job_type', 'all')
 
-        user_unified_jobs = get_user_queryset(request.user, models.UnifiedJob)
+        user_unified_jobs = get_user_queryset(request.user, models.UnifiedJob).exclude(launch_type='sync')
 
         success_query = user_unified_jobs.filter(status='successful')
         failed_query = user_unified_jobs.filter(status='failed')


### PR DESCRIPTION
##### SUMMARY

The dashboard included implicit project updates in the jobs count (and success & failure counts).  This removes `launch_type='sync'` jobs.  

This job graph is called by the UI here: https://github.com/ansible/awx/blob/devel/awx/ui/client/src/home/dashboard/graphs/job-status/job-status-graph.service.js#L30


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

