### PR TITLE
Fix Organization User badge linkout

### DIFF
--- a/awx/ui/client/src/organizations/list/organizations-list.controller.js
+++ b/awx/ui/client/src/organizations/list/organizations-list.controller.js
@@ -50,7 +50,7 @@ export default ['$stateParams', '$scope', '$rootScope',
                 val.description = card.description || undefined;
                 val.links = [];
                 val.links.push({
-                    sref: `organizations.users({organization_id: ${card.id}})`,
+                    sref: `organizations.edit.users({organization_id: ${card.id}})`,
                     srefOpts: { inherit: false },
                     name: i18n._("USERS"),
                     count: card.summary_fields.related_field_counts.users,


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where the Organization Users tab and Users badge linked to different states. This bug was introduced when I changed the Org card links from href to sref here: https://github.com/ansible/awx/pull/3576

##### BUG
Users Tab linked to:
- State: `organizations.edit.users`
- API request: `/api/v2/organizations/:id/access_list/`

Users Badge linked to:
- State: `organizations.users`
- API request: `/api/v2/organizations/:id/users/`

![org users](https://user-images.githubusercontent.com/15881645/55628957-0e5e4400-5780-11e9-8f91-a6c86b64f63e.gif)

##### FIX
Both link to `organizations.edit.users` state
![org users fixed](https://user-images.githubusercontent.com/15881645/55629027-32ba2080-5780-11e9-885e-7b9e802e56af.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```

