### PR TITLE
Fix RBAC bugs with notification attachment

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
@@ -17,9 +17,14 @@ export default ['$state', '$scope', 'ParseVariableString', 'ParseTypeChange',
 
         const inventorySourceData = inventorySource.get();
 
+        // To toggle notifications a user needs to have a read role on the inventory
+        // _and_ have at least a notification template admin role on an org.
+        // If the user has gotten this far it's safe to say they have
+        // at least read access to the inventory
+        $scope.sufficientRoleForNotifToggle = isNotificationAdmin;
+        $scope.sufficientRoleForNotif =  isNotificationAdmin || $scope.user_is_system_auditor;
         $scope.projectBasePath = GetBasePath('projects') + '?not__status=never updated';
         $scope.canAdd = inventorySourcesOptions.actions.POST;
-        $scope.isNotificationAdmin = isNotificationAdmin || false;
         const virtualEnvs = ConfigData.custom_virtualenvs || [];
         $scope.custom_virtualenvs_options = virtualEnvs;
         // instantiate expected $scope values from inventorySourceData

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
@@ -9,7 +9,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n){
     var notifications_object = {
         generateList: true,
         include: "NotificationsList",
-        ngIf: "(current_user.is_superuser || isOrgAdmin || isNotificationAdmin) && !(inventory_source_obj.source === undefined || inventory_source_obj.source === '')",
+        ngIf: "(sufficientRoleForNotif) && !(inventory_source_obj.source === undefined || inventory_source_obj.source === '')",
         ngClick: "$state.go('inventories.edit.inventory_sources.edit.notifications')"
     };
     let clone = _.clone(NotificationsList);

--- a/awx/ui/client/src/notifications/notifications.list.js
+++ b/awx/ui/client/src/notifications/notifications.list.js
@@ -20,7 +20,7 @@ export default ['i18n', 'templateUrl', function(i18n, templateUrl){
         hover: false,
         emptyListText: i18n.sprintf(i18n._("This list is populated by notification templates added from the %sNotifications%s section"), "&nbsp;<a ui-sref='notifications.add'>", "</a>&nbsp;"),
         basePath: 'notification_templates',
-        ngIf: 'current_user.is_superuser || isOrgAdmin || isNotificationAdmin',
+        ngIf: 'sufficientRoleForNotif',
         fields: {
             name: {
                 key: true,
@@ -40,7 +40,7 @@ export default ['i18n', 'templateUrl', function(i18n, templateUrl){
                 flag: 'notification_templates_success',
                 type: "toggle",
                 ngClick: "toggleNotification($event, notification.id, \"notification_templates_success\")",
-                ngDisabled: "!(current_user.is_superuser || isOrgAdmin)",
+                ngDisabled: "!sufficientRoleForNotifToggle",
                 awToolTip: "{{ schedule.play_tip }}",
                 dataTipWatch: "schedule.play_tip",
                 dataPlacement: "right",
@@ -53,7 +53,7 @@ export default ['i18n', 'templateUrl', function(i18n, templateUrl){
                 flag: 'notification_templates_error',
                 type: "toggle",
                 ngClick: "toggleNotification($event, notification.id, \"notification_templates_error\")",
-                ngDisabled: "!(current_user.is_superuser || isOrgAdmin)",
+                ngDisabled: "!sufficientRoleForNotifToggle",
                 awToolTip: "{{ schedule.play_tip }}",
                 dataTipWatch: "schedule.play_tip",
                 dataPlacement: "right",
@@ -64,7 +64,7 @@ export default ['i18n', 'templateUrl', function(i18n, templateUrl){
             add: {
                 type: 'template',
                 template: templateUrl('notifications/notification-templates-list/add-notifications-action'),
-                ngShow: 'current_user.is_superuser || (current_user_admin_orgs && current_user_admin_orgs.length > 0)'
+                ngShow: 'isNotificationAdmin'
             }
         }
 

--- a/awx/ui/client/src/notifications/shared/notification-list-init.factory.js
+++ b/awx/ui/client/src/notifications/shared/notification-list-init.factory.js
@@ -22,14 +22,6 @@ export default ['Wait', 'GetBasePath', 'ProcessErrors', 'Rest', 'GetChoices',
             url = params.url,
             id = params.id;
 
-        scope.current_user_admin_orgs = [];
-
-        Rest.setUrl($rootScope.current_user.related.admin_of_organizations);
-        Rest.get()
-            .then(({data}) => {
-                scope.current_user_admin_orgs = data.results.map(i => i.name);
-            });
-
         scope.addNotificationTemplate = function() {
             var org_id;
             if($stateParams.hasOwnProperty('project_id')){

--- a/awx/ui/client/src/organizations/main.js
+++ b/awx/ui/client/src/organizations/main.js
@@ -98,7 +98,49 @@ angular.module('Organizations', [
                                                     'status: ' + status
                                             });
                                     });
-                                }]
+                            }],
+                            isOrgAuditor: ['Rest', 'ProcessErrors', 'GetBasePath', 'i18n', '$stateParams',
+                                function(Rest, ProcessErrors, GetBasePath, i18n, $stateParams) {
+                                    Rest.setUrl(`${GetBasePath('organizations')}?role_level=auditor_role&id=${$stateParams.organization_id}`);
+                                    return Rest.get()
+                                        .then(({data}) => {
+                                            return data.count > 0;
+                                        })
+                                        .catch(({data, status}) => {
+                                            ProcessErrors(null, data, status, null, {
+                                                hdr: i18n._('Error!'),
+                                                msg: i18n._('Failed while checking to see if user is a notification administrator of this organization. GET returned ') + status
+                                            });
+                                    });
+                            }],
+                            isOrgAdmin: ['ProcessErrors', 'i18n', '$stateParams', 'OrgAdminLookup',
+                                function(ProcessErrors, i18n, $stateParams, OrgAdminLookup) {
+                                    return OrgAdminLookup.checkForAdminAccess({organization: $stateParams.organization_id})
+                                    .then(function(isOrgAdmin){
+                                        return isOrgAdmin;
+                                    })
+                                    .catch(({data, status}) => {
+                                        ProcessErrors(null, data, status, null, {
+                                            hdr: i18n._('Error!'),
+                                            msg: i18n._('Failed while checking to see if user is an administrator of this organization. GET returned ') + status
+                                        });
+                                    });
+                                    
+                            }],
+                            isNotificationAdmin: ['Rest', 'ProcessErrors', 'GetBasePath', 'i18n',
+                                function(Rest, ProcessErrors, GetBasePath, i18n) {
+                                    Rest.setUrl(`${GetBasePath('organizations')}?role_level=notification_admin_role&page_size=1`);
+                                    return Rest.get()
+                                        .then(({data}) => {
+                                            return data.count > 0;
+                                        })
+                                        .catch(({data, status}) => {
+                                            ProcessErrors(null, data, status, null, {
+                                                hdr: i18n._('Error!'),
+                                                msg: i18n._('Failed to get organizations for which this user is a notification admin. GET returned ') + status
+                                            });
+                                    });
+                            }],
                         }
                     }
                     // concat manually-defined state definitions with generated defintions

--- a/awx/ui/client/src/projects/edit/projects-edit.controller.js
+++ b/awx/ui/client/src/projects/edit/projects-edit.controller.js
@@ -20,15 +20,10 @@ export default ['$scope', '$rootScope', '$stateParams', 'ProjectsForm', 'Rest',
             master = {},
             id = $stateParams.project_id;
 
-        init();
-
-        function init() {
-            $scope.project_local_paths = [];
-            $scope.base_dir = '';
-            const virtualEnvs = ConfigData.custom_virtualenvs || [];
-            $scope.custom_virtualenvs_options = virtualEnvs;
-            $scope.isNotificationAdmin = isNotificationAdmin || false;
-        }
+        $scope.project_local_paths = [];
+        $scope.base_dir = '';
+        const virtualEnvs = ConfigData.custom_virtualenvs || [];
+        $scope.custom_virtualenvs_options = virtualEnvs;
 
         $scope.$watch('project_obj.summary_fields.user_capabilities.edit', function(val) {
             if (val === false) {
@@ -157,6 +152,12 @@ export default ['$scope', '$rootScope', '$stateParams', 'ProjectsForm', 'Rest',
                     });
 
                     $scope.project_obj = data;
+                    // To toggle notifications a user needs to have an admin role on the project
+                    // _and_ have at least a notification template admin role on an org.
+                    // Only users with admin role on the project can edit it which is why we
+                    // look at that user_capability
+                    $scope.sufficientRoleForNotifToggle = isNotificationAdmin && data.summary_fields.user_capabilities.edit;
+                    $scope.sufficientRoleForNotif =  isNotificationAdmin || $scope.user_is_system_auditor;
                     $scope.name = data.name;
                     $scope.breadcrumb.project_name = data.name;
                     $scope.$emit('projectLoaded');

--- a/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
+++ b/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
@@ -54,6 +54,12 @@ export default
 
                 CallbackHelpInit({ scope: $scope });
 
+                // To toggle notifications a user needs to have a read role on the JT
+                // _and_ have at least a notification template admin role on an org.
+                // If the user has gotten this far it's safe to say they have
+                // at least read access to the JT
+                $scope.sufficientRoleForNotifToggle = isNotificationAdmin;
+                $scope.sufficientRoleForNotif =  isNotificationAdmin || $scope.user_is_system_auditor;
                 $scope.playbook_options = null;
                 $scope.playbook = null;
                 $scope.mode = 'edit';
@@ -66,7 +72,6 @@ export default
                 $scope.skip_tag_options = [];
                 const virtualEnvs = ConfigData.custom_virtualenvs || [];
                 $scope.custom_virtualenvs_options = virtualEnvs;
-                $scope.isNotificationAdmin = isNotificationAdmin || false;
 
                 SurveyControllerInit({
                     scope: $scope,

--- a/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
+++ b/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
@@ -18,6 +18,12 @@ export default [
         workflowLaunch, $transitions, WorkflowJobTemplate, Inventory, isNotificationAdmin
     ) {
 
+        // To toggle notifications a user needs to have a read role on the WFJT
+        // _and_ have at least a notification template admin role on an org.
+        // If the user has gotten this far it's safe to say they have
+        // at least read access to the WFJT
+        $scope.sufficientRoleForNotifToggle = isNotificationAdmin;
+        $scope.sufficientRoleForNotif =  isNotificationAdmin || $scope.user_is_system_auditor;
         $scope.missingTemplates = _.has(workflowLaunch, 'node_templates_missing') && workflowLaunch.node_templates_missing.length > 0 ? true : false;
 
         $scope.$watch('workflow_job_template_obj.summary_fields.user_capabilities.edit', function(val) {
@@ -25,8 +31,6 @@ export default [
                 $scope.canAddWorkflowJobTemplate = false;
             }
         });
-
-        $scope.isNotificationAdmin = isNotificationAdmin || false;
 
         const criteriaObj = {
             from: (state) => state.name === 'templates.editWorkflowJobTemplate.workflowMaker',


### PR DESCRIPTION
##### SUMMARY
This does almost the same thing as option2, but adds exceptions for the case of organizations and projects.

In the case of organizations and projects, the ability to read these resources does not imply permission to read JTs that were launched using them. Thus, a higher, auditor-like permission is required to apply notification templates to these things.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION


prior PRs:
 - https://github.com/ansible/awx/pull/3602
 - https://github.com/ansible/awx/pull/3593
