### PR TITLE
don't write playbook stdout to sys.stdout (it's duplicated in log files)

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -86,6 +86,7 @@ class IsolatedManager(object):
                 'idle_timeout': self.idle_timeout,
                 'job_timeout': settings.AWX_ISOLATED_LAUNCH_TIMEOUT,
                 'pexpect_timeout': getattr(settings, 'PEXPECT_TIMEOUT', 5),
+                'suppress_ansible_output': True,
             },
         }
 

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1176,6 +1176,7 @@ class BaseTask(object):
                 'settings': {
                     'job_timeout': self.get_instance_timeout(self.instance),
                     'pexpect_timeout': getattr(settings, 'PEXPECT_TIMEOUT', 5),
+                    'suppress_ansible_output': True,
                     **process_isolation_params,
                 },
             }


### PR DESCRIPTION
this instructs runner to _not_ write to stdout when we invoke
runner.interface.run(); AWX consumes/ingests this strictly as events

see: https://github.com/ansible/ansible-runner/blob/2363aa4e116f0881e289cc75b865fd73ffb2bc3e/ansible_runner/utils.py#L265-L268