### PR TITLE
Avoid slicing if the inventory only has 1 host

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -256,7 +256,7 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
         if towervars:
             fetch_fields.append('enabled')
         hosts = self.hosts.filter(**hosts_kw).order_by('name').only(*fetch_fields)
-        if slice_count > 1:
+        if slice_count > 1 and slice_number > 0:
             offset = slice_number - 1
             hosts = hosts[offset::slice_count]
 

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -352,6 +352,10 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
             kwargs['_parent_field_name'] = "job_template"
             kwargs.setdefault('_eager_fields', {})
             kwargs['_eager_fields']['is_sliced_job'] = True
+        elif self.job_slice_count > 1 and (not prevent_slicing):
+            # Unique case where JT was set to slice but hosts not available
+            kwargs.setdefault('_eager_fields', {})
+            kwargs['_eager_fields']['job_slice_count'] = 1
         elif prevent_slicing:
             kwargs.setdefault('_eager_fields', {})
             kwargs['_eager_fields'].setdefault('job_slice_count', 1)

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -332,9 +332,19 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
         '''
         return self.create_unified_job(**kwargs)
 
+    def get_effective_slice_ct(self, kwargs):
+        actual_inventory = self.inventory
+        if self.ask_inventory_on_launch and 'inventory' in kwargs:
+            actual_inventory = kwargs['inventory']
+        if actual_inventory:
+            return min(self.job_slice_count, actual_inventory.hosts.count())
+        else:
+            return self.job_slice_count
+
     def create_unified_job(self, **kwargs):
         prevent_slicing = kwargs.pop('_prevent_slicing', False)
-        slice_event = bool(self.job_slice_count > 1 and (not prevent_slicing))
+        slice_ct = self.get_effective_slice_ct(kwargs)
+        slice_event = bool(slice_ct > 1 and (not prevent_slicing))
         if slice_event:
             # A Slice Job Template will generate a WorkflowJob rather than a Job
             from awx.main.models.workflow import WorkflowJobTemplate, WorkflowJobNode
@@ -347,13 +357,7 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
             kwargs['_eager_fields'].setdefault('job_slice_count', 1)
         job = super(JobTemplate, self).create_unified_job(**kwargs)
         if slice_event:
-            try:
-                wj_config = job.launch_config
-            except JobLaunchConfig.DoesNotExist:
-                wj_config = JobLaunchConfig()
-            actual_inventory = wj_config.inventory if wj_config.inventory else self.inventory
-            for idx in range(min(self.job_slice_count,
-                                 actual_inventory.hosts.count())):
+            for idx in range(slice_ct):
                 create_kwargs = dict(workflow_job=job,
                                      unified_job_template=self,
                                      ancestor_artifacts=dict(job_slice=idx + 1))


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/3492

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Avoids creating a sliced workflow job if the inventory of the JT only has 1 host.

Why: the recent_jobs sparkline list https://github.com/ansible/awx/pull/2873 just can't cope with the case of 1 job in a workflow job. I don't want to change the data model, so this seems like the most sensible thing to do.