### PR TITLE
Removes failing symlink to /usr/bin/python3 during the image build

### DIFF
--- a/installer/roles/image_build/files/Dockerfile.sdist
+++ b/installer/roles/image_build/files/Dockerfile.sdist
@@ -13,6 +13,8 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
 RUN yum install -y nodejs
 RUN npm set progress=false
 
+RUN ln -s /usr/bin/python36 /usr/bin/python3
+
 WORKDIR "/awx"
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/installer/roles/image_build/files/Dockerfile.sdist
+++ b/installer/roles/image_build/files/Dockerfile.sdist
@@ -13,8 +13,6 @@ RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
 RUN yum install -y nodejs
 RUN npm set progress=false
 
-RUN ln -s /usr/bin/python36 /usr/bin/python3
-
 WORKDIR "/awx"
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -32,7 +32,6 @@ RUN yum -y install epel-release && \
     yum -y localinstall https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
     yum -y update && \
     yum -y install ansible git mercurial subversion curl python-psycopg2 python-pip python-setuptools libselinux-python setools-libs yum-utils sudo acl make postgresql-devel nginx python-psutil libxml2-devel libxslt-devel libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel python-pip xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 xmlsec1-openssl-devel libtool-ltdl-devel bubblewrap gcc-c++ python-devel python36-setuptools python36-devel krb5-workstation krb5-libs libcurl-devel rsync unzip && \
-    ln -s /usr/bin/python36 /usr/bin/python3 && \
     python36 -m ensurepip && \
     pip3 install virtualenv && \
     pip install virtualenv supervisor && \

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -32,6 +32,7 @@ RUN yum -y install epel-release && \
     yum -y localinstall https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
     yum -y update && \
     yum -y install ansible git mercurial subversion curl python-psycopg2 python-pip python-setuptools libselinux-python setools-libs yum-utils sudo acl make postgresql-devel nginx python-psutil libxml2-devel libxslt-devel libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel python-pip xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 xmlsec1-openssl-devel libtool-ltdl-devel bubblewrap gcc-c++ python-devel python36-setuptools python36-devel krb5-workstation krb5-libs libcurl-devel rsync unzip && \
+    ln -s /usr/bin/python36 /usr/bin/python3 && \
     python36 -m ensurepip && \
     pip3 install virtualenv && \
     pip install virtualenv supervisor && \


### PR DESCRIPTION
##### SUMMARY
Installing the latest python36-setuptools automatically creates the symlink from python3 -> python3.6 and from python36 -> /usr/bin/python3.6. Building the images fails when the symlink is created explicitly in the AWX installer.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 4.0.0
```

##### ADDITIONAL INFORMATION
Installing python36-setuptools installs python36 as a dependency.  It seems like the python36 installer  handles creating the appropriate symlinks, probably due to a change in the python36 package on 2019-03-29 08:52 

Source: [https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/p/](https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/p/)