### PR TITLE
Allow managing instances via API token

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -489,7 +489,7 @@ class InstanceAccess(BaseAccess):
         return False
 
     def can_change(self, obj, data):
-        return False
+        return self.user.is_superuser
 
     def can_delete(self, obj):
         return False


### PR DESCRIPTION
##### SUMMARY
There was a bug where users were not able to modify instances using API token based authentication

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Everything done as superuser.

Before:

```
$ tower-cli instance modify 5 --enabled=false -v
*** DETAILS: Getting existing record. *****************************************
*** DETAILS: Getting the record. **********************************************
GET https://localhost:8043/api/v2/instances/5/
Params: []

*** DETAILS: Writing the record. **********************************************
PATCH https://localhost:8043/api/v2/instances/5/
Data: {'enabled': False}

Error: You don't have permission to do that (HTTP 403).
```

After

```
$ tower-cli instance modify 5 --enabled=true -v
*** DETAILS: Getting existing record. *****************************************
*** DETAILS: Getting the record. **********************************************
GET https://localhost:8043/api/v2/instances/5/
Params: []

*** DETAILS: Writing the record. **********************************************
PATCH https://localhost:8043/api/v2/instances/5/
Data: {'enabled': True}

Resource changed.
== ======== ======== ================= =================== ======= ================= 
id hostname capacity consumed_capacity capacity_adjustment enabled managed_by_policy 
== ======== ======== ================= =================== ======= ================= 
 5 awx_3          39                 0 1.00                   true              true
== ======== ======== ================= =================== ======= ================= 
```

This uses tokens because login was done via `tower-cli login` command

requires https://github.com/ansible/tower-cli/pull/692