### PR TITLE
Don't obscure modal buttons when code mirror modal throws error

### DIFF
--- a/awx/ui/client/lib/components/code-mirror/_index.less
+++ b/awx/ui/client/lib/components/code-mirror/_index.less
@@ -68,6 +68,10 @@
     height: 100%;
 }
 
+.CodeMirror-modal .CodeMirror {
+  max-height: calc(~"100vh - 230px");
+}
+
 .NetworkingExtraVars .CodeMirror{
 	overflow-x: hidden;
 }
@@ -81,6 +85,6 @@
 }
 
 .atCodeMirror-badge{
-    display: initial; 
+    display: initial;
     margin-right: 20px;
 }

--- a/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.partial.html
+++ b/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.partial.html
@@ -1,7 +1,7 @@
 <div id="CodeMirror-modal" class="CodeMirror-modal modal" role="dialog">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-header">
+            <div class="modal-heading">
                 <div class="atCodeMirror-label">
                     <div class="atCodeMirror-labelLeftSide">
                          <span class="atCodeMirror-labelText" ng-class="labelClass">


### PR DESCRIPTION
Addresses issue #3639 - don't obscure the modal controls if the Code Mirror modal throws an error.