### PR TITLE
remove COMPONENT NAME from our issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,12 +7,6 @@ about: Create a report to help us improve
 ##### ISSUE TYPE
  - Bug Report
 
-##### COMPONENT NAME
-<!-- Pick the area of AWX for this issue, you can have multiple, delete the rest: -->
- - API
- - UI
- - Installer
-
 ##### SUMMARY
 <!-- Briefly describe the problem. -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,5 @@ about: Suggest an idea for this project
 ##### ISSUE TYPE
  - Feature Idea
 
-##### COMPONENT NAME
-<!-- Pick the area of AWX for this issue, you can have multiple, delete the rest: -->
- - API
- - UI
- - Installer
-
 ##### SUMMARY
 <!-- Briefly describe the problem or desired enhancement. -->
-
-##### ADDITIONAL INFORMATION
-
-<!-- Include any links to sosreport, database dumps, screenshots or other
-information. -->


### PR DESCRIPTION
this is a remnant from our closed sourced days; upstream bug reporters
only fill this out correctly like 50% of the time, and it's often
difficult to know without knowing how AWX actually works