### PR TITLE
Fix workflow results layout when extra vars has long line

### DIFF
--- a/awx/ui/client/src/workflow-results/workflow-results.block.less
+++ b/awx/ui/client/src/workflow-results/workflow-results.block.less
@@ -17,6 +17,8 @@
 }
 
 .WorkflowResults-leftSide {
+    max-width: 33%;
+
     .OnePlusTwo-left--panel(100%, @breakpoint-md);
     height: ~"calc(100vh - 120px)";
     min-height: 350px;


### PR DESCRIPTION
Addresses issue #2526 

Details column of the workflow results page is now capped at 33% width:

![Screen Shot 2019-04-09 at 1 47 29 PM](https://user-images.githubusercontent.com/410794/55822790-5ce84700-5ace-11e9-9ad7-d77f7e53aaf5.png)
