### PR TITLE
Fix job output name in websocket service.

### DIFF
--- a/awx/ui/client/src/shared/socket/socket.service.js
+++ b/awx/ui/client/src/shared/socket/socket.service.js
@@ -96,8 +96,7 @@ export default
                 $log.debug('Received From Server: ' + e.data);
 
                 var data = JSON.parse(e.data), str = "";
-
-                if(!window.liveUpdates && data.group_name !== "control" && $state.current.name !== "jobResult"){
+                if(!window.liveUpdates && data.group_name !== "control" && $state.current.name !== "output"){
                     $log.debug('Message from server dropped: ' + e.data);
                     needsRefreshAfterBlur = true;
                     return;


### PR DESCRIPTION
##### SUMMARY
Related ansible/tower#3414

The block of code that allows us to process web socket messages for job details views is now corrected.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```
