### PR TITLE
Ensures extra vars are converted to yaml before being passed along to prompt steps

### DIFF
--- a/awx/ui/client/src/templates/prompt/prompt.service.js
+++ b/awx/ui/client/src/templates/prompt/prompt.service.js
@@ -27,7 +27,7 @@ function PromptService (Empty, $filter)  {
         if(hasCurrentExtraVars && hasDefaultExtraVars) {
             extraVars = jsyaml.safeDump(_.merge(jsyaml.safeLoad(params.launchConf.defaults.extra_vars), params.currentValues.extra_data));
         } else if(hasCurrentExtraVars) {
-            extraVars = params.currentValues.extra_data;
+            extraVars = jsyaml.safeDump(params.currentValues.extra_data);
         } else if(hasDefaultExtraVars) {
             extraVars = params.launchConf.defaults.extra_vars;
         }


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3567

Regression introduced by https://github.com/ansible/awx/pull/3359

Tested the scenario outlined in 3567 as well as the yaml comment scenario fixed by 3359.  These changes should satisfy both cases.  Note that `params.launchConf.defaults.extra_vars` is already in yaml form so we don't need to worry about dumping that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
