### PR TITLE
Make root/all groups action bar a bit more responsive

### DIFF
--- a/awx/ui/client/legacy/styles/lists.less
+++ b/awx/ui/client/legacy/styles/lists.less
@@ -218,6 +218,13 @@ table, tbody {
     // float: right;
 }
 
+@media screen and (max-width: 1200px) {
+    .List-actionHolder--rootGroups {
+        justify-content: flex-start;
+        margin-bottom: 55px;
+    }
+}
+
 .List-actionHolder--leftAlign {
     margin-left: 50%;
     justify-content: flex-start;

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
@@ -17,6 +17,7 @@
         trackBy: 'group.id',
         basePath:  'api/v2/inventories/{{$stateParams.inventory_id}}/groups/',
         layoutClass: 'List-staticColumnLayout--groups',
+        actionHolderClass: 'List-actionHolder List-actionHolder--rootGroups',
         staticColumns: [
             {
                 field: 'failed_hosts',


### PR DESCRIPTION
##### SUMMARY
Wide screen:
<img width="1519" alt="Screen Shot 2019-04-10 at 12 08 19 PM" src="https://user-images.githubusercontent.com/9889020/55895121-85814700-5b89-11e9-8f6c-85f161823322.png">

Narrow screen:
<img width="1046" alt="Screen Shot 2019-04-10 at 12 08 51 PM" src="https://user-images.githubusercontent.com/9889020/55895133-887c3780-5b89-11e9-8abf-46ef4c4644d9.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI