### PR TITLE
remove invalid json renderer from metrics endpoint

### DIFF
--- a/awx/api/views/metrics.py
+++ b/awx/api/views/metrics.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 
 # Django REST Framework
 from rest_framework.response import Response
-from rest_framework.renderers import JSONRenderer
 from rest_framework.exceptions import PermissionDenied
 
 
@@ -32,8 +31,7 @@ class MetricsView(APIView):
     swagger_topic = 'Metrics'
 
     renderer_classes = [renderers.PlainTextRenderer,
-                        renderers.BrowsableAPIRenderer,
-                        JSONRenderer,]
+                        renderers.BrowsableAPIRenderer,]
 
     def get(self, request, format='txt'):
         ''' Show Metrics Details '''


### PR DESCRIPTION
##### SUMMARY
@one-t noticed that Content-type json is currently not outputting json but is showing as an option in the HTTP OPTIONS.  This PR removes json as a content type for this endpoint. If there is sufficient need for json as an option, we can look into it then.  

> We should be able to call the collector functions directly for that, if that is what we want to do.  

