### PR TITLE
Check to make sure the activity stream button should be shown after refresh

### DIFF
--- a/awx/ui/client/src/bread-crumb/bread-crumb.directive.js
+++ b/awx/ui/client/src/bread-crumb/bread-crumb.directive.js
@@ -59,7 +59,7 @@ export default
                             scope.loadingLicense = false;
                             scope.activityStreamActive = ($state.current.name === 'activityStream') ? true : false;
                             scope.activityStreamTooltip = ($state.current.name === 'activityStream') ? 'Hide Activity Stream' : 'View Activity Stream';
-                            scope.showActivityStreamButton = (FeaturesService.featureEnabled('activity_streams') || $state.current.name ==='activityStream') ? true : false;
+                            scope.showActivityStreamButton = ((FeaturesService.featureEnabled('activity_streams') && streamConfig && streamConfig.activityStream) || $state.current.name ==='activityStream') ? true : false;
                         }
                     });
 


### PR DESCRIPTION
##### SUMMARY
We recently hid the activity stream on the management jobs view but refreshing that page would still show the activity stream button.  This change ensures that we check the stream config when determining whether or not to show button.  This bug was specific to refreshing the page.  Normal navigation was working as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
