### PR TITLE
fix tag word wrapping for firefox

### DIFF
--- a/awx/ui/client/lib/components/tag/_index.less
+++ b/awx/ui/client/lib/components/tag/_index.less
@@ -21,6 +21,8 @@
     color: @at-white;
     margin: 2px @at-space-2x;
     align-self: center;
+    /* fallback for FF < 68 which doesn't support `break-word` */
+    word-break: break-all;
     word-break: break-word;
 
     &:hover,


### PR DESCRIPTION
##### SUMMARY
Addresses #3606 

The current stable version of firefox doesn't yet support `word-break: break-word` (though FF Nightly does). Added a fallback to the CSS. Note this can cause words to be split in the middle, but this quirk isn't present in most other browsers and will go away in higher versions of Firefox (v68+).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
