### PR TITLE
subscribe to updates for scm revision and and instance group for job …

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -841,6 +841,8 @@ function JobDetailsController (
             finished,
             scm,
             inventoryScm,
+            scmRevision,
+            instanceGroup,
             environment,
             artifacts,
             executionNode
@@ -853,6 +855,8 @@ function JobDetailsController (
             vm.artifacts = getArtifactsDetails(artifacts);
             vm.executionNode = getExecutionNodeDetails(executionNode);
             vm.inventoryScm = getInventoryScmDetails(inventoryScm.id, inventoryScm.status);
+            vm.scmRevision = getSCMRevisionDetails(scmRevision);
+            vm.instanceGroup = getInstanceGroupDetails(instanceGroup);
             vm.status = getStatusDetails(status);
             vm.job.status = status;
         });


### PR DESCRIPTION
This makes it so that jobs which complete (while running) show the scm revision and instance group fields the same as if you enter the job results page for a completed job.