### PR TITLE
Leverages awPopOverWatch to generate popover dynamically on workflow node templates help

### DIFF
--- a/awx/ui/client/src/partials/job-template-details.html
+++ b/awx/ui/client/src/partials/job-template-details.html
@@ -1,4 +1,4 @@
 <div class="List-infoCell" ng-if="wf_maker_template.type === 'job_template'">
-    <span class="Key-icon Key-icon--circle Key-icon--default" aw-pop-over="<dl><dt>{{ 'INVENTORY' | translate }}</dt><dd>{{wf_maker_template.popOverDetails.inventory | sanitize}}</dd></dl><dl><dt>{{ 'PROJECT' | translate }}</dt><dd>{{wf_maker_template.popOverDetails.project | sanitize}}</dd></dl><dl><dt>{{ 'PLAYBOOK' | translate }}</dt><dd>{{wf_maker_template.popOverDetails.playbook | sanitize}}</dd></dl><dl><dt>{{ 'CREDENTIAL' | translate }}</dt> <dd>{{wf_maker_template.popOverDetails.credentials | sanitize}}</dd></dl>"
+    <span class="Key-icon Key-icon--circle Key-icon--default" aw-pop-over aw-pop-over-watch="wf_maker_template.popOver"
         data-popover-title="{{wf_maker_template.name| sanitize}}">?</span>
 </div>

--- a/awx/ui/client/src/shared/directives.js
+++ b/awx/ui/client/src/shared/directives.js
@@ -886,7 +886,7 @@ function(SettingsUtils, i18n, $rootScope) {
                 delay: 0,
                 title: title,
                 content: function() {
-                    return scope[attrs.awPopOverWatch];
+                    return _.get(scope, attrs.awPopOverWatch);
                 },
                 trigger: trigger,
                 html: true,

--- a/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
@@ -5,11 +5,11 @@
  *************************************************/
 
 export default ['$scope', 'TemplatesService', 'JobTemplateModel', 'PromptService', 'Rest', '$q',
-        'TemplatesStrings', 'CreateSelect2', 'Empty', 'generateList', 'QuerySet',
+        'TemplatesStrings', 'CreateSelect2', 'Empty', 'QuerySet', '$filter',
         'GetBasePath', 'TemplateList', 'ProjectList', 'InventorySourcesList', 'ProcessErrors',
         'i18n', 'ParseTypeChange', 'WorkflowJobTemplateModel',
     function($scope, TemplatesService, JobTemplate, PromptService, Rest, $q,
-        TemplatesStrings, CreateSelect2, Empty, generateList, qs,
+        TemplatesStrings, CreateSelect2, Empty, qs, $filter,
         GetBasePath, TemplateList, ProjectList, InventorySourcesList, ProcessErrors,
         i18n, ParseTypeChange, WorkflowJobTemplate
     ) {
@@ -657,25 +657,43 @@ export default ['$scope', 'TemplatesService', 'JobTemplateModel', 'PromptService
         };
 
         const formatPopOverDetails = (model) => {
-            model.popOverDetails = {};
-            model.popOverDetails.playbook = model.playbook || i18n._('NONE SELECTED');
+            const popOverDetails = {};
+            popOverDetails.playbook = model.playbook || i18n._('NONE SELECTED');
             Object.keys(model.summary_fields).forEach(field => {
                 if (field === 'project') {
-                    model.popOverDetails.project = model.summary_fields[field].name || i18n._('NONE SELECTED');
+                    popOverDetails.project = model.summary_fields[field].name || i18n._('NONE SELECTED');
                 }
                 if (field === 'inventory') {
-                    model.popOverDetails.inventory = model.summary_fields[field].name || i18n._('NONE SELECTED');
+                    popOverDetails.inventory = model.summary_fields[field].name || i18n._('NONE SELECTED');
                 }
                 if (field === 'credentials') {
                     if (model.summary_fields[field].length <= 0) {
-                        model.popOverDetails.credentials = i18n._('NONE SELECTED');
+                        popOverDetails.credentials = i18n._('NONE SELECTED');
                     }
                     else {
                         const credentialNames = model.summary_fields[field].map(({name}) => name);
-                        model.popOverDetails.credentials = credentialNames.join('<br />');
+                        popOverDetails.credentials = credentialNames.join('<br />');
                     }
                 }
             });
+            model.popOver = `
+                <dl>
+                    <dt>${i18n._('INVENTORY')}</dt>
+                    <dd>${$filter('sanitize')(popOverDetails.inventory)}</dd>
+                </dl>
+                <dl>
+                    <dt>${i18n._('PROJECT')}</dt>
+                    <dd>${$filter('sanitize')(popOverDetails.project)}</dd>
+                </dl>
+                <dl>
+                    <dt>${i18n._('PLAYBOOK')}</dt>
+                    <dd>${$filter('sanitize')(popOverDetails.playbook)}</dd>
+                </dl>
+                <dl>
+                    <dt>${i18n._('CREDENTIAL')}</dt>
+                    <dd>${$filter('sanitize')(popOverDetails.credentials)}</dd>
+                </dl>
+            `;
         };
 
         $scope.openPromptModal = () => {


### PR DESCRIPTION
##### SUMMARY
The existing logic was working when adding a new node but the details were missing in the popover when editing a node.  These changes should give the same experience in both places.  For those interested: the issue with editing a node was that the directive was being rendered _before_ the popover contents were being set.  Using aw-pop-over-watch means we don't have to worry about that scenario.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

![workflow_node_popover](https://user-images.githubusercontent.com/9889020/55969353-a01bf480-5c4b-11e9-9c53-5ffcf6261afc.gif)
