### PR TITLE
Restore pip and setuptools to how they were

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,5 +121,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.0.3
-setuptools==41.0.0
+pip==9.0.1
+setuptools==36.0.1


### PR DESCRIPTION
##### SUMMARY
Restore pip and setuptools to the versions before the critical dependency upgrades were applied

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
This mucked with some tooling. I'll add additional information later.
