### PR TITLE
Apply same pip and setuptools to AWX and Ansible venv

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,5 +121,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools
+pip==9.0.1
+setuptools==36.0.1


### PR DESCRIPTION
##### SUMMARY
These are out of date, but if we don't include them, they use the most recent packages, and this causes problems. See:

4742cede0ddd240b9577a2e82d69f5387ceca2f4

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
This was attempted in a prior PR, and that went wrong because the version numbers were not in sync with what was used elsewhere. Exactly reasons are still unclear to me, but this is what the Ansible venv uses.
