### PR TITLE
properly set ansible_python_interpreter for local task execution

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                                              created_by=superuser)
                 Host.objects.create(name='localhost',
                                     inventory=i,
-                                    variables="ansible_connection: local",
+                                    variables="ansible_connection: local\nansible_python_interpreter: '{{ ansible_playbook_python }}'",
                                     created_by=superuser)
                 jt = JobTemplate.objects.create(name='Demo Job Template',
                                                 playbook='hello_world.yml',

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -18,7 +18,6 @@
 # awx_license_type: "open" for AWX; else presume Tower
 
 - hosts: all
-  connection: local
   gather_facts: false
   tasks:
 
@@ -27,6 +26,7 @@
         path: "{{project_path|quote}}"
         state: absent
       when: scm_delete_on_update|default('')
+      delegate_to: localhost
 
     - block:
       - name: check repo using git
@@ -59,6 +59,7 @@
           scm_version: "{{ git_result['after'] }}"
         when: "'after' in git_result"
       when: scm_type == 'git'
+      delegate_to: localhost
 
     - block:
       - name: update project using hg
@@ -78,6 +79,7 @@
         set_fact:
           scm_version: "{{scm_version|regex_replace('^([A-Za-z0-9]+).*$', '\\1')}}"
       when: scm_type == 'hg'
+      delegate_to: localhost
 
     - block:
       - name: update project using svn
@@ -99,6 +101,7 @@
         set_fact:
           scm_version: "{{scm_version|regex_replace('^.*Revision: ([0-9]+).*$', '\\1')}}"
       when: scm_type == 'svn'
+      delegate_to: localhost
 
     - block:
       - name: Ensure the project directory is present
@@ -121,6 +124,7 @@
           scm_version: "{{results.version}}"
         when: results is defined
       when: scm_type == 'insights'
+      delegate_to: localhost
 
 
     - name: Repository Version
@@ -132,9 +136,9 @@
         dest: "{{ scm_revision_output }}"
         content: "{{ scm_version }}"
       when: scm_version is defined and scm_revision_output is defined
+      delegate_to: localhost
 
 - hosts: all
-  connection: local
   gather_facts: false
   tasks:
 
@@ -158,3 +162,4 @@
         when: doesRequirementsExist.stat.exists and galaxy_result is skipped
 
       when: roles_enabled|bool
+      delegate_to: localhost


### PR DESCRIPTION
this works around a limitation in ansible for `connection: local` and makes it so
that you can run connection: local playbooks with a `/usr/bin/python` that
is Python3 and an Ansible virtualenv that is Python2

see: https://github.com/ansible/awx/issues/3267