### PR TITLE
Use querset special case to let org members see teams

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1245,6 +1245,7 @@ class TeamAccess(BaseAccess):
      - I'm a superuser.
      - I'm an admin of the team
      - I'm a member of that team.
+     - I'm a member of the team's organization
     I can create/change a team when:
      - I'm a superuser.
      - I'm an admin for the team
@@ -1257,7 +1258,10 @@ class TeamAccess(BaseAccess):
         if settings.ORG_ADMINS_CAN_SEE_ALL_USERS and \
                 (self.user.admin_of_organizations.exists() or self.user.auditor_of_organizations.exists()):
             return self.model.objects.all()
-        return self.model.accessible_objects(self.user, 'read_role')
+        return self.model.objects.filter(
+            Q(organization=Organization.accessible_pk_qs(self.user, 'member_role')) |
+            Q(pk__in=self.model.accessible_pk_qs(self.user, 'read_role'))
+        )
 
     @check_superuser
     def can_add(self, data):

--- a/awx/main/tests/functional/test_projects.py
+++ b/awx/main/tests/functional/test_projects.py
@@ -175,13 +175,6 @@ def test_team_project_list(get, team_project_list):
     assert get(reverse('api:user_projects_list', kwargs={'pk':admin.pk,}), alice).data['count'] == 2
 
 
-@pytest.mark.django_db
-def test_team_project_list_fail1(get, team_project_list):
-    objects = team_project_list
-    res = get(reverse('api:team_projects_list', kwargs={'pk':objects.teams.team2.pk,}), objects.users.alice)
-    assert res.status_code == 403
-
-
 @pytest.mark.parametrize("u,expected_status_code", [
     ('rando', 403),
     ('org_member', 403),

--- a/awx/main/tests/functional/test_rbac_team.py
+++ b/awx/main/tests/functional/test_rbac_team.py
@@ -152,3 +152,18 @@ def test_org_admin_view_all_teams(org_admin, enabled):
     with mock.patch('awx.main.access.settings') as settings_mock:
         settings_mock.ORG_ADMINS_CAN_SEE_ALL_USERS = enabled
         assert access.can_read(other_team) is enabled
+
+
+@pytest.mark.django_db
+def test_team_member_read(rando, organization, team):
+    assert team.organization == organization
+    organization.member_role.members.add(rando)
+    assert TeamAccess(rando).can_read(team)
+    assert team in TeamAccess(rando).get_queryset()
+
+
+@pytest.mark.django_db
+def test_team_list_no_duplicate_entries(rando, organization, team):
+    organization.member_role.members.add(rando)
+    team.read_role.members.add(rando)
+    assert list(TeamAccess(rando).get_queryset()) == [team]


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/1087

This lets organization members see teams within their organization.

This is done via non-standard means of changing the queryset that the access list returns. These organization members will not be shown as having read access to the team, although users who have team read access via other means will be shown.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
I confirmed basic functionality through the UI.

 - created an organization with teams in it
 - create user org_member
   - make member of that organization
   - make admin of WFJT, give execute role to another
 - confirmed (via UI) that user is able to give team permissions to WFJT that user has admin role for
 - confirmed that user cannot delegate permissions to teams for the WFJT that user has execute role for
