### PR TITLE
rename analytics setting

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -78,7 +78,7 @@ def gather(dest=None, module=None):
         logger.exception("Invalid License provided, or No License Provided")
         return "Error: Invalid License provided, or No License Provided"
     
-    if not settings.INSIGHTS_DATA_ENABLED:
+    if not settings.INSIGHTS_TRACKING_STATE:
         logger.error("Insights analytics not enabled")
         return "Error: Insights analytics not enabled"
 

--- a/awx/main/analytics/metrics.py
+++ b/awx/main/analytics/metrics.py
@@ -49,7 +49,7 @@ def metrics():
     license_info = get_license(show_key=False)
     SYSTEM_INFO.info({
         'install_uuid': settings.INSTALL_UUID,
-        'insights_analytics': str(settings.INSIGHTS_DATA_ENABLED),
+        'insights_analytics': str(settings.INSIGHTS_TRACKING_STATE),
         'tower_url_base': settings.TOWER_URL_BASE,
         'tower_version': get_awx_version(),
         'ansible_version': get_ansible_version(),

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -309,7 +309,7 @@ register(
 )
 
 register(
-    'INSIGHTS_DATA_ENABLED',
+    'INSIGHTS_TRACKING_STATE',
     field_class=fields.BooleanField,
     default=False,
     label=_('Gather data for Automation Insights'),

--- a/awx/main/tests/functional/analytics/test_core.py
+++ b/awx/main/tests/functional/analytics/test_core.py
@@ -37,7 +37,7 @@ def mock_valid_license():
 
 @pytest.mark.django_db
 def test_gather(mock_valid_license):
-    settings.INSIGHTS_DATA_ENABLED = True
+    settings.INSIGHTS_TRACKING_STATE = True
     
     tgz = gather(module=importlib.import_module(__name__))
     files = {}

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -670,7 +670,7 @@ PENDO_TRACKING_STATE = "off"
 
 # Enables Insights data collection for Ansible Tower.
 # Note: This setting may be overridden by database settings.
-INSIGHTS_DATA_ENABLED = False
+INSIGHTS_TRACKING_STATE = False
 
 
 # Default list of modules allowed for ad hoc commands.

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -88,7 +88,7 @@ AWX_ISOLATED_LAUNCH_TIMEOUT = 30
 # Disable Pendo on the UI for development/test.
 # Note: This setting may be overridden by database settings.
 PENDO_TRACKING_STATE = "off"
-INSIGHTS_DATA_ENABLED = False
+INSIGHTS_TRACKING_STATE = False
 
 # Use Django-Jenkins if installed. Only run tests for awx.main app.
 try:

--- a/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
+++ b/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
@@ -59,7 +59,7 @@ export default ['i18n', function(i18n) {
                 type: 'textarea',
                 reset: 'CUSTOM_VENV_PATHS'
             },
-            INSIGHTS_DATA_ENABLED: {
+            INSIGHTS_TRACKING_STATE: {
                 type: 'toggleSwitch'
             }
         },

--- a/awx/ui/client/src/login/authenticationServices/insightsEnablement.service.js
+++ b/awx/ui/client/src/login/authenticationServices/insightsEnablement.service.js
@@ -11,11 +11,11 @@ export default ['$rootScope', 'Rest', 'GetBasePath', 'ProcessErrors',
             updateInsightsTrackingState: function(tracking_type) {
                 if (tracking_type === true || tracking_type === false) {
                         Rest.setUrl(`${GetBasePath('settings')}system`);
-                        Rest.patch({ INSIGHTS_DATA_ENABLED: tracking_type })
+                        Rest.patch({ INSIGHTS_TRACKING_STATE: tracking_type })
                             .catch(function ({data, status}) {
                                 ProcessErrors($rootScope, data, status, null, {
                                     hdr: 'Error!',
-                                    msg: 'Failed to patch INSIGHTS_DATA_ENABLED in settings: ' +
+                                    msg: 'Failed to patch INSIGHTS_TRACKING_STATE in settings: ' +
                                         status });
                             });
                 } else {


### PR DESCRIPTION
##### SUMMARY
We've decided that `INSIGHTS_TRACKING_STATE` is more consistent with the Pendo setting name than `INSIGHTS_DATA_ENABLED`.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

