### PR TITLE
Adjust the access logic for settings.MANAGE_ORGANIZATION_AUTH = False

### DIFF
--- a/awx/main/tests/functional/test_rbac_organization.py
+++ b/awx/main/tests/functional/test_rbac_organization.py
@@ -36,3 +36,15 @@ def test_organization_access_user(cl, organization, user):
     org = access.get_queryset()[0]
     assert len(org.admin_role.members.all()) == 0
     assert len(org.member_role.members.all()) == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ext_auth', [True, False])
+def test_org_resource_role(ext_auth, organization, rando, org_admin):
+    with mock.patch('awx.main.access.settings') as settings_mock:
+        settings_mock.MANAGE_ORGANIZATION_AUTH = ext_auth
+        access = OrganizationAccess(org_admin)
+
+        assert access.can_attach(organization, rando, 'member_role.members') == ext_auth
+        organization.member_role.members.add(rando)
+        assert access.can_unattach(organization, rando, 'member_role.members') == ext_auth

--- a/awx/main/tests/functional/test_rbac_role.py
+++ b/awx/main/tests/functional/test_rbac_role.py
@@ -3,7 +3,9 @@ import pytest
 from awx.main.access import (
     RoleAccess,
     UserAccess,
-    TeamAccess)
+    OrganizationAccess,
+    TeamAccess,
+)
 from awx.main.models import Role, Organization
 
 
@@ -160,12 +162,17 @@ def test_need_all_orgs_to_admin_user(user):
     assert not user_access.can_change(org12_member, {'last_name': 'Witzel'})
 
     role_access = RoleAccess(org1_admin)
+    org_access = OrganizationAccess(org1_admin)
     assert not role_access.can_attach(org1.admin_role, org12_member, 'members', None)
     assert not role_access.can_attach(org1.member_role, org12_member, 'members', None)
+    assert not org_access.can_attach(org1, org12_member, 'admin_role.members')
+    assert not org_access.can_attach(org1, org12_member, 'member_role.members')
 
     org2.admin_role.members.add(org1_admin)
     assert role_access.can_attach(org1.admin_role, org12_member, 'members', None)
     assert role_access.can_attach(org1.member_role, org12_member, 'members', None)
+    assert org_access.can_attach(org1, org12_member, 'admin_role.members')
+    assert org_access.can_attach(org1, org12_member, 'member_role.members')
 
 
 # Orphaned user can be added to member role, only in special cases

--- a/awx/main/tests/functional/test_rbac_role.py
+++ b/awx/main/tests/functional/test_rbac_role.py
@@ -17,24 +17,21 @@ def test_team_access_attach(rando, team, inventory):
     # team has read_role for the inventory
     team.member_role.children.add(inventory.read_role)
 
-    access = TeamAccess(rando)
+    team_access = TeamAccess(rando)
+    role_access = RoleAccess(rando)
     data = {'id': inventory.admin_role.pk}
-    assert not access.can_attach(team, inventory.admin_role, 'member_role.children', data, False)
+    assert not team_access.can_attach(team, inventory.admin_role, 'member_role.children', data, False)
+    assert not role_access.can_attach(inventory.admin_role, team, 'member_role.parents', data, False)
 
 
 @pytest.mark.django_db
 def test_user_access_attach(rando, inventory):
     inventory.read_role.members.add(rando)
-    access = UserAccess(rando)
+    user_access = UserAccess(rando)
+    role_access = RoleAccess(rando)
     data = {'id': inventory.admin_role.pk}
-    assert not access.can_attach(rando, inventory.admin_role, 'roles', data, False)
-
-
-@pytest.mark.django_db
-def test_role_access_attach(rando, inventory):
-    inventory.read_role.members.add(rando)
-    access = RoleAccess(rando)
-    assert not access.can_attach(inventory.admin_role, rando, 'members', None)
+    assert not user_access.can_attach(rando, inventory.admin_role, 'roles', data, False)
+    assert not role_access.can_attach(inventory.admin_role, rando, 'members', data, False)
 
 
 @pytest.mark.django_db
@@ -68,8 +65,11 @@ def test_org_user_role_attach(user, organization, inventory):
     organization.admin_role.members.add(admin)
 
     role_access = RoleAccess(admin)
+    org_access = OrganizationAccess(admin)
     assert not role_access.can_attach(organization.member_role, nonmember, 'members', None)
     assert not role_access.can_attach(organization.admin_role, nonmember, 'members', None)
+    assert not org_access.can_attach(organization, nonmember, 'member_role.members', None)
+    assert not org_access.can_attach(organization, nonmember, 'admin_role.members', None)
 
 
 # Permissions when adding users/teams to org special-purpose roles
@@ -83,8 +83,14 @@ def test_user_org_object_roles(organization, org_admin, org_member):
     assert RoleAccess(org_admin).can_attach(
         organization.notification_admin_role, org_member, 'members', None
     )
+    assert OrganizationAccess(org_admin).can_attach(
+        organization, org_member, 'notification_admin_role.members', None
+    )
     assert not RoleAccess(org_member).can_attach(
         organization.notification_admin_role, org_member, 'members', None
+    )
+    assert not OrganizationAccess(org_member).can_attach(
+        organization, org_member, 'notification_admin_role.members', None
     )
 
 
@@ -120,8 +126,11 @@ def test_org_superuser_role_attach(admin_user, org_admin, organization):
     organization.member_role.members.add(admin_user)
 
     role_access = RoleAccess(org_admin)
+    org_access = OrganizationAccess(org_admin)
     assert not role_access.can_attach(organization.member_role, admin_user, 'members', None)
     assert not role_access.can_attach(organization.admin_role, admin_user, 'members', None)
+    assert not org_access.can_attach(organization, admin_user, 'member_role.members', None)
+    assert not org_access.can_attach(organization, admin_user, 'admin_role.members', None)
     user_access = UserAccess(org_admin)
     assert not user_access.can_change(admin_user, {'last_name': 'Witzel'})
 
@@ -185,7 +194,9 @@ def test_orphaned_user_allowed(org_admin, rando, organization):
     *orphaned means user is not a member of any organization
     '''
     role_access = RoleAccess(org_admin)
+    org_access = OrganizationAccess(org_admin)
     assert role_access.can_attach(organization.member_role, rando, 'members', None)
+    assert org_access.can_attach(organization, rando, 'member_role.members', None)
     # Cannot edit the user directly without adding to org first
     user_access = UserAccess(org_admin)
     assert not user_access.can_change(rando, {'last_name': 'Witzel'})

--- a/awx/main/tests/functional/test_rbac_team.py
+++ b/awx/main/tests/functional/test_rbac_team.py
@@ -21,7 +21,21 @@ def test_team_attach_unattach(team, user):
     u2 = user('non-member', False)
     access = TeamAccess(u2)
     assert not access.can_attach(team, team.member_role, 'member_role.children', None)
-    assert not access.can_unattach(team, team.member_role, 'member_role.chidlren')
+    assert not access.can_unattach(team, team.member_role, 'member_role.children')
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ext_auth', [True, False])
+def test_team_org_resource_role(ext_auth, team, user, rando):
+    with mock.patch('awx.main.access.settings') as settings_mock:
+        settings_mock.MANAGE_ORGANIZATION_AUTH = ext_auth
+        u = user('member', False)
+        team.organization.admin_role.members.add(u)
+        access = TeamAccess(u)
+
+        assert access.can_attach(team, rando, 'member_role.members') == ext_auth
+        team.member_role.members.add(rando)
+        assert access.can_unattach(team, rando, 'member_role.members') == ext_auth
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_rbac_user.py
+++ b/awx/main/tests/functional/test_rbac_user.py
@@ -77,19 +77,27 @@ def test_manage_org_auth_setting(ext_auth, superuser, expect, organization, rand
         assert [
             # use via /api/v2/users/N/roles/
             UserAccess(u).can_attach(rando, organization.admin_role, 'roles'),
+            UserAccess(u).can_attach(rando, organization.member_role, 'roles'),
             UserAccess(u).can_attach(rando, team.admin_role, 'roles'),
+            UserAccess(u).can_attach(rando, team.member_role, 'roles'),
             # use via /api/v2/roles/N/users/
             RoleAccess(u).can_attach(organization.admin_role, rando, 'members'),
-            RoleAccess(u).can_attach(team.admin_role, rando, 'members')
-        ] == [expect for i in range(4)]
+            RoleAccess(u).can_attach(organization.member_role, rando, 'members'),
+            RoleAccess(u).can_attach(team.admin_role, rando, 'members'),
+            RoleAccess(u).can_attach(team.member_role, rando, 'members'),
+        ] == [expect for i in range(8)]
         assert [
             # use via /api/v2/users/N/roles/
             UserAccess(u).can_unattach(rando, organization.admin_role, 'roles'),
+            UserAccess(u).can_unattach(rando, organization.member_role, 'roles'),
             UserAccess(u).can_unattach(rando, team.admin_role, 'roles'),
+            UserAccess(u).can_unattach(rando, team.member_role, 'roles'),
             # use via /api/v2/roles/N/users/
             RoleAccess(u).can_unattach(organization.admin_role, rando, 'members'),
-            RoleAccess(u).can_unattach(team.admin_role, rando, 'members')
-        ] == [expect for i in range(4)]
+            RoleAccess(u).can_unattach(organization.member_role, rando, 'members'),
+            RoleAccess(u).can_unattach(team.admin_role, rando, 'members'),
+            RoleAccess(u).can_unattach(team.member_role, rando, 'members'),
+        ] == [expect for i in range(8)]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
This setting is intended to prevent changes to membership under situations where that is being externally managed, such as via an LDAP service.  Previously, the access logic was bailing out quickly whenever this setting was false and the user wasn't a superuser, even if attempting to grant access to a resource, rather than changing organization or team membership.  This PR limits the restrictions to just membership and admin status.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 4.0.0
```
