### PR TITLE
deprecate /api/v2/dashboard in favor of /api/v2/metrics

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -168,6 +168,8 @@ def api_exception_handler(exc, context):
 
 class DashboardView(APIView):
 
+    deprecated = True
+
     view_name = _("Dashboard")
     swagger_topic = 'Dashboard'
 


### PR DESCRIPTION
<img width="805" alt="image" src="https://user-images.githubusercontent.com/214912/56373793-bee03500-61cf-11e9-8cd8-45bd432efc9e.png">
