### PR TITLE
make deprecation warnings at /api/ much more obvious

### DIFF
--- a/awx/templates/rest_framework/base.html
+++ b/awx/templates/rest_framework/base.html
@@ -73,6 +73,11 @@
 
         <!-- Content -->
         <div id="content" role="main" aria-label="{% trans "content" %}">
+          {% if deprecated %}
+            <div class="breadcrumb" style="background: #FCC;">
+                <b>This resource has been deprecated and will be removed in a future release.</b>
+            </div>
+          {% endif %}
           {% block content %}
 
           <div class="region"  aria-label="{% trans "request form" %}">

--- a/awx/ui/context_processors.py
+++ b/awx/ui/context_processors.py
@@ -13,8 +13,14 @@ def settings(request):
     }
 
 def version(request):
+    context = getattr(request, 'parser_context', {})
     return {
         'version': get_awx_version(),
         'tower_version': get_awx_version(),
         'short_tower_version': get_awx_version().split('-')[0],
+        'deprecated': getattr(
+            context.get('view'),
+            'deprecated',
+            False
+        ) or request.path.startswith('/api/v1/')
     }


### PR DESCRIPTION
<img width="679" alt="image" src="https://user-images.githubusercontent.com/214912/56375287-1a5ff200-61d3-11e9-8752-7d1fcea62cdc.png">
