### PR TITLE
ui: added resize option for .CodeMirror class

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -2202,9 +2202,6 @@ input[disabled].ui-spinner-input {
 }
 
 .CodeMirror-scroll {
-    margin-bottom: 0;
-    padding-bottom: 0;
-    margin-right: 0;
     overflow: auto !important;
     overflow-y: auto !important;
     border-radius: 5px;

--- a/awx/ui/client/legacy/styles/codemirror.less
+++ b/awx/ui/client/legacy/styles/codemirror.less
@@ -6,6 +6,7 @@
  */
 
 .CodeMirror {
+    resize: auto;
     height: auto;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added ``resize: both;`` option in ``.CodeMirror`` class. This PR addresses issue #3436. If I'm missing anything or there's an error somewhere, please let me know :)
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
