### PR TITLE
[blocked] Upgrade urllib3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -112,7 +112,7 @@ twilio==6.10.4
 twisted==18.9.0           # via daphne
 txaio==18.8.1             # via autobahn
 typing==3.6.6             # via django-extensions
-urllib3==1.24.1           # via requests
+urllib3==1.25             # via requests
 uwsgi==2.0.17
 uwsgitop==0.10.0
 vine==1.2.0               # via amqp

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -112,7 +112,7 @@ selectors2==2.0.1         # via ncclient
 six==1.11.0               # via azure-cli-core, bcrypt, cryptography, google-auth, isodate, keystoneauth1, knack, munch, ncclient, ntlm-auth, openstacksdk, ovirt-engine-sdk-python, packaging, pynacl, pyopenssl, python-dateutil, pyvmomi, pywinrm, stevedore
 stevedore==1.28.0         # via keystoneauth1
 tabulate==0.7.7           # via azure-cli-core, knack
-urllib3==1.24             # via requests
+urllib3==1.25             # via requests
 wheel==0.30.0             # via azure-cli-core
 xmltodict==0.11.0         # via pywinrm
 


### PR DESCRIPTION
##### SUMMARY
This has a CVE related to cert verification

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Some tools give the advice:

> Upgrade urllib3 to version 1.24.2 or later

This appears to be incorrect, the actual issue is at https://github.com/urllib3/urllib3/issues/1553, and that discussion seems to indicate that it is not fixed until 1.25. The [release notes](https://github.com/urllib3/urllib3/blob/c3157af5e3b272d3fbffef23ee6215a229f8c61f/CHANGES.rst) have a concerningly broad feature set for this release, so this probably needs some verification work.
