### PR TITLE
Adding an option to run all the tests without a retry statement

### DIFF
--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -25,6 +25,7 @@
     "jshint": "grunt jshint:source --no-color",
     "test:ci": "npm run test -- --single-run --reporter junit,dots --browsers=chromeHeadless",
     "e2e": "./test/e2e/runner.js --config ./test/e2e/nightwatch.conf.js --suiteRetries=2",
+    "e2e-no-retry": "./test/e2e/runner.js --config ./test/e2e/nightwatch.conf.js",
     "headless-e2e": "./test/e2e/runner.js --config ./test/e2e/nightwatch.conf.js --env headless --suiteRetries=2",
     "unit": "karma start test/unit/karma.unit.js",
     "lint": "eslint .",


### PR DESCRIPTION
##### SUMMARY
As a means to reduce the flakiness of the results, we've historically had a retry on failure command on all e2e test results. This has led to some headaches while debugging and also masked some general flakiness in all test results. This new script should allow us to isolate flaky tests.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI