### PR TITLE
Refactor can_attach to be less error-prone

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4500,9 +4500,8 @@ class RoleTeamsList(SubListAttachDetachAPIView):
             data = dict(msg=_("You cannot grant system-level permissions to a team."))
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
-        if not request.user.can_access(self.parent_model, action, role, team,
-                                       self.relationship, request.data,
-                                       skip_sub_obj_read_check=False):
+        if not request.user.can_access(self.parent_model, action, role, team.member_role,
+                                       'parents', request.data):
             raise PermissionDenied()
         if request.data.get('disassociate', None):
             team.member_role.children.remove(role)

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4465,7 +4465,7 @@ class RoleTeamsList(SubListAttachDetachAPIView):
     model = models.Team
     serializer_class = serializers.TeamSerializer
     parent_model = models.Role
-    relationship = 'member_role.parents'
+    relationship = None  # forward relationship cannot be deterministically written
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):

--- a/awx/main/tests/functional/api/test_create_attach_views.py
+++ b/awx/main/tests/functional/api/test_create_attach_views.py
@@ -6,30 +6,33 @@ from awx.api.versioning import reverse
 @pytest.mark.django_db
 def test_user_role_view_access(rando, inventory, mocker, post):
     "Assure correct access method is called when assigning users new roles"
-    role_pk = inventory.admin_role.pk
-    data = {"id": role_pk}
-    mock_access = mocker.MagicMock(can_attach=mocker.MagicMock(return_value=False))
-    with mocker.patch('awx.main.access.RoleAccess', return_value=mock_access):
+    mock_method = mocker.MagicMock(return_value=False)
+    with mocker.patch('awx.main.access.UserRoleAttachAccess.can_add', mock_method):
         post(url=reverse('api:user_roles_list', kwargs={'pk': rando.pk}),
-             data=data, user=rando, expect=403)
-    mock_access.can_attach.assert_called_once_with(
-        inventory.admin_role, rando, 'members', data,
-        skip_sub_obj_read_check=False)
+             data={"id": inventory.admin_role.pk}, user=rando, expect=403)
+    mock_method.assert_called_once_with(obj_A=inventory.admin_role, obj_B=rando)
+
+
+@pytest.mark.django_db
+def test_role_user_view_access(rando, inventory, mocker, post):
+    "Assure same call pattern is used when using the reverse URL"
+    mock_method = mocker.MagicMock(return_value=False)
+    inventory.read_role.members.add(rando)  # so parent read access is satisfied
+    with mocker.patch('awx.main.access.UserRoleAttachAccess.can_add', mock_method):
+        post(url=reverse('api:role_users_list', kwargs={'pk': inventory.admin_role.pk}),
+             data={"id": rando.pk}, user=rando, expect=403)
+    mock_method.assert_called_once_with(obj_A=inventory.admin_role, obj_B=rando)
 
 
 @pytest.mark.django_db
 def test_team_role_view_access(rando, team, inventory, mocker, post):
     "Assure correct access method is called when assigning teams new roles"
     team.admin_role.members.add(rando)
-    role_pk = inventory.admin_role.pk
-    data = {"id": role_pk}
-    mock_access = mocker.MagicMock(can_attach=mocker.MagicMock(return_value=False))
-    with mocker.patch('awx.main.access.RoleAccess', return_value=mock_access):
+    mock_method = mocker.MagicMock(return_value=False)
+    with mocker.patch('awx.main.access.RoleRoleAttachAccess.can_add', mock_method):
         post(url=reverse('api:team_roles_list', kwargs={'pk': team.pk}),
-             data=data, user=rando, expect=403)
-    mock_access.can_attach.assert_called_once_with(
-        inventory.admin_role, team, 'member_role.parents', data,
-        skip_sub_obj_read_check=False)
+             data={"id": inventory.admin_role.pk}, user=rando, expect=403)
+    mock_method.assert_called_once_with(obj_A=team.member_role, obj_B=inventory.admin_role)
 
 
 @pytest.mark.django_db
@@ -37,14 +40,11 @@ def test_role_team_view_access(rando, team, inventory, mocker, post):
     """Assure that /role/N/teams/ enforces the same permission restrictions
     that /teams/N/roles/ does when assigning teams new roles"""
     role_pk = inventory.admin_role.pk
-    data = {"id": team.pk}
-    mock_access = mocker.MagicMock(return_value=False, __name__='mocked')
-    with mocker.patch('awx.main.access.RoleAccess.can_attach', mock_access):
+    mock_method = mocker.MagicMock(return_value=False)
+    with mocker.patch('awx.main.access.RoleRoleAttachAccess.can_add', mock_method):
         post(url=reverse('api:role_teams_list', kwargs={'pk': role_pk}),
-             data=data, user=rando, expect=403)
-    mock_access.assert_called_once_with(
-        inventory.admin_role, team, 'member_role.parents', data,
-        skip_sub_obj_read_check=False)
+             data={"id": team.pk}, user=rando, expect=403)
+    mock_method.assert_called_once_with(obj_A=team.member_role, obj_B=inventory.admin_role)
 
 
 @pytest.mark.django_db
@@ -60,3 +60,23 @@ def test_org_associate_with_junk_data(rando, admin_user, organization, post):
     assert rando in organization.member_role
     # assure that this did not also make them a system auditor
     assert not rando.is_system_auditor
+
+
+@pytest.mark.django_db
+def test_sublist_create(org_admin, organization, post):
+    post(
+        url=reverse('api:organization_teams_list', kwargs={'pk': organization.pk}),
+        data={'name': 'new team'},
+        expect=201,
+        user=org_admin
+    )
+
+
+@pytest.mark.django_db
+def test_sublist_create_permission_denied(org_auditor, organization, post):
+    post(
+        url=reverse('api:organization_teams_list', kwargs={'pk': organization.pk}),
+        data={'name': 'new team'},
+        expect=403,
+        user=org_auditor
+    )

--- a/awx/main/tests/functional/test_rbac_api.py
+++ b/awx/main/tests/functional/test_rbac_api.py
@@ -311,7 +311,12 @@ def test_org_admin_add_user_to_job_template(post, organization, check_jobtemplat
     assert org_admin in check_jobtemplate.admin_role
     assert joe not in check_jobtemplate.execute_role
 
-    post(reverse('api:role_users_list', kwargs={'pk': check_jobtemplate.execute_role.id}), {'id': joe.id}, org_admin)
+    post(
+        url=reverse('api:role_users_list', kwargs={'pk': check_jobtemplate.execute_role.id}),
+        data={'id': joe.id},
+        user=org_admin,
+        expect=204
+    )
     assert joe in check_jobtemplate.execute_role
 
 
@@ -326,7 +331,12 @@ def test_org_admin_remove_user_from_job_template(post, organization, check_jobte
     assert org_admin in check_jobtemplate.admin_role
     assert joe in check_jobtemplate.execute_role
 
-    post(reverse('api:role_users_list', kwargs={'pk': check_jobtemplate.execute_role.id}), {'disassociate': True, 'id': joe.id}, org_admin)
+    post(
+        url=reverse('api:role_users_list', kwargs={'pk': check_jobtemplate.execute_role.id}),
+        data={'disassociate': True, 'id': joe.id},
+        user=org_admin,
+        expect=204
+    )
     assert joe not in check_jobtemplate.execute_role
 
 

--- a/awx/main/tests/functional/test_rbac_job_templates.py
+++ b/awx/main/tests/functional/test_rbac_job_templates.py
@@ -220,9 +220,12 @@ def test_job_template_creator_access(project, rando, post):
 
 @pytest.mark.django_db
 def test_associate_label(label, user, job_template):
-    access = JobTemplateAccess(user('joe', False))
-    job_template.admin_role.members.add(user('joe', False))
-    label.organization.read_role.members.add(user('joe', False))
+    joe = user('joe', False)
+    access = JobTemplateAccess(joe)
+    assert not access.can_attach(job_template, label, 'labels', None)
+    job_template.admin_role.members.add(joe)
+    assert not access.can_attach(job_template, label, 'labels', None)
+    label.organization.read_role.members.add(joe)
     assert access.can_attach(job_template, label, 'labels', None)
 
 

--- a/awx/main/tests/functional/test_rbac_user.py
+++ b/awx/main/tests/functional/test_rbac_user.py
@@ -107,15 +107,15 @@ def test_team_org_resource_role(ext_auth, organization, rando, org_admin, team):
         settings_mock.MANAGE_ORGANIZATION_AUTH = ext_auth
         assert [
             # use via /api/v2/teams/N/roles/
-            TeamAccess(org_admin).can_attach(team, organization.workflow_admin_role, 'roles'),
+            TeamAccess(org_admin).can_attach(team, organization.workflow_admin_role, 'member_role.children'),
             # use via /api/v2/roles/teams/
-            RoleAccess(org_admin).can_attach(organization.workflow_admin_role, team, 'member_role.parents')
+            RoleAccess(org_admin).can_attach(organization.workflow_admin_role, team.member_role, 'parents')
         ] == [True for i in range(2)]
         assert [
             # use via /api/v2/teams/N/roles/
-            TeamAccess(org_admin).can_unattach(team, organization.workflow_admin_role, 'roles'),
+            TeamAccess(org_admin).can_unattach(team, organization.workflow_admin_role, 'member_role.children'),
             # use via /api/v2/roles/teams/
-            RoleAccess(org_admin).can_unattach(organization.workflow_admin_role, team, 'member_role.parents')
+            RoleAccess(org_admin).can_unattach(organization.workflow_admin_role, team.member_role, 'parents')
         ] == [True for i in range(2)]
 
 

--- a/awx/main/tests/functional/test_rbac_workflow.py
+++ b/awx/main/tests/functional/test_rbac_workflow.py
@@ -106,6 +106,14 @@ class TestWorkflowJobTemplateNodeAccess:
         access = WorkflowJobTemplateNodeAccess(rando)
         assert access.can_delete(wfjt_node)
 
+    def test_credential_attach_permission(self, wfjt_node, credential, rando):
+        wfjt_node.workflow_job_template.admin_role.members.add(rando)
+        wfjt_node.unified_job_template.execute_role.members.add(rando)
+        access = WorkflowJobTemplateNodeAccess(rando)
+        assert not access.can_attach(wfjt_node, credential, 'credentials', data=None)
+        credential.use_role.members.add(rando)
+        assert access.can_attach(wfjt_node, credential, 'credentials', data=None)
+
 
 @pytest.mark.django_db
 class TestWorkflowJobAccess:


### PR DESCRIPTION
##### SUMMARY
The motivation of this is to prevent errors of the type fixed in https://github.com/ansible/awx/pull/3730

It also needs mentioning that with changes such as https://github.com/ansible/awx/pull/3629 as well as the previous RBAC changes to Organization membership attachment permissions have made life extremely difficult within these parts of the code base.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
In some cases, I changed the sublist base class.

This is because the action being done fundamentally doesn't make any sense. You cannot detach a group from an inventory, so why would we have a view that allows this? When making the permissions more strict, these cases come up.
