### PR TITLE
Allow relaunching other user jobs with public vars

### DIFF
--- a/awx/main/tests/functional/test_rbac_job.py
+++ b/awx/main/tests/functional/test_rbac_job.py
@@ -248,7 +248,7 @@ class TestJobRelaunchAccess:
         jt.execute_role.members.add(alice, bob)
 
         with impersonate(bob):
-            job = jt.create_unified_job(extra_vars={'job_var': 'foo2'})
+            job = jt.create_unified_job(extra_vars={'job_var': 'foo2', 'my_secret': '$encrypted$foo'})
 
         assert 'job_var' in job.launch_config.extra_data
         assert bob.can_access(Job, 'start', job, validate_license=False)

--- a/awx/main/tests/unit/test_access.py
+++ b/awx/main/tests/unit/test_access.py
@@ -11,6 +11,7 @@ from awx.main.access import (
     JobTemplateAccess,
     WorkflowJobTemplateAccess,
     SystemJobTemplateAccess,
+    vars_are_encrypted
 )
 
 from awx.main.models import (
@@ -112,6 +113,20 @@ class TestRelatedFieldAccess:
         # important for PUT requests
         assert access.check_related(
             'related', mocker.MagicMock, data, obj=resource, mandatory=True)
+
+
+def test_encrypted_vars_detection():
+    assert vars_are_encrypted({
+        'aaa': {'b': 'c'},
+        'alist': [],
+        'test_var_eight': '$encrypted$UTF8$AESCBC$Z0FBQUF...==',
+        'test_var_five': 'four',
+    })
+    assert not vars_are_encrypted({
+        'aaa': {'b': 'c'},
+        'alist': [],
+        'test_var_five': 'four',
+    })
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
The previous check here was too restrictive.

If you can _read_ the job then you can see the variables that the other user provided, except for encrypted variables. Thus, there is no security difference between before vs. after this change.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION

