### PR TITLE
Remove unused output_replacements logic

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1180,8 +1180,6 @@ class BaseTask(object):
             password_prompts = self.get_password_prompts(passwords)
             expect_passwords = self.create_expect_passwords_data_struct(password_prompts, passwords)
 
-            self.instance = self.update_model(self.instance.pk)
-
             params = {
                 'ident': self.instance.id,
                 'private_data_dir': private_data_dir,


### PR DESCRIPTION
##### SUMMARY
Since the ansible-runner integration, this logic is no longer being used, so we no longer need to keep it around.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION

