### PR TITLE
fix a bug that caused parent_uuid not to be persisted

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1042,7 +1042,7 @@ class BaseTask(object):
         AWX only saves the parent_uuid if the event is for a Job.
         '''
         if event_data.get(self.event_data_key, None):
-            if event_data[self.event_data_key] != 'job_id':
+            if self.event_data_key != 'job_id':
                 event_data.pop('parent_uuid', None)
         should_write_event = False
         event_data.setdefault(self.event_data_key, self.instance.id)


### PR DESCRIPTION
Before:

```sql
awx-dev=> SELECT uuid, parent_uuid FROM main_jobevent WHERE job_id=17;
                 uuid                 | parent_uuid
--------------------------------------+-------------
 382af33d-3c2c-4d6c-b56b-ad233f2be77f |
 0242ac12-0005-e88a-dd42-000000000006 |
 0242ac12-0005-e88a-dd42-00000000000c |
 0242ac12-0005-e88a-dd42-000000000008 |
 81be285d-5d9d-4b27-bdf6-180e7d17acef |
 1aac0f4d-8a39-4f48-9c24-df875d97e1ed |
 eb163f9d-d4a7-44a5-a615-5d935f825b79 |
(7 rows)
```

After:
```sql
awx-dev=> SELECT uuid, parent_uuid FROM main_jobevent WHERE job_id=15;
                 uuid                 |             parent_uuid
--------------------------------------+--------------------------------------
 592ce07a-df3d-4b03-88ec-0dd6212c0ed0 |
 0242ac12-0005-c5ce-0c10-000000000006 | 592ce07a-df3d-4b03-88ec-0dd6212c0ed0
 0242ac12-0005-c5ce-0c10-00000000000c | 0242ac12-0005-c5ce-0c10-000000000006
 0242ac12-0005-c5ce-0c10-000000000008 | 0242ac12-0005-c5ce-0c10-000000000006
 a95278d8-9c0e-46f9-a72f-24bb250b5b28 | 592ce07a-df3d-4b03-88ec-0dd6212c0ed0
 7820d5a5-cef2-4934-99aa-e0dcb127bb82 | 0242ac12-0005-c5ce-0c10-00000000000c
 3225ceb3-95a6-417c-8d36-2e7fcd24beb2 | 0242ac12-0005-c5ce-0c10-000000000008
(7 rows)
```