### PR TITLE
[performance] fix slow query with inventory list

### DIFF
--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -115,12 +115,6 @@ class InventoryList(ListCreateAPIView):
     model = Inventory
     serializer_class = InventorySerializer
 
-    def get_queryset(self):
-        qs = Inventory.accessible_objects(self.request.user, 'read_role')
-        qs = qs.select_related('admin_role', 'read_role', 'update_role', 'use_role', 'adhoc_role')
-        qs = qs.prefetch_related('created_by', 'modified_by', 'organization')
-        return qs
-
 
 class InventoryDetail(RelatedJobsPreventDeleteMixin, ControlledByScmMixin, RetrieveUpdateDestroyAPIView):
 

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -815,7 +815,7 @@ class InventoryAccess(BaseAccess):
     '''
 
     model = Inventory
-    select_related = ('created_by', 'modified_by', 'organization',)
+    prefetch_related = ('created_by', 'modified_by', 'organization',)
 
     def filtered_queryset(self, allowed=None, ad_hoc=None):
         return self.model.accessible_objects(self.user, 'read_role')


### PR DESCRIPTION
##### SUMMARY
This addresses on particular slow query in the /api/v2/inventories/ list

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
We were prefetching the roles for an inventory. We have optimizations defined in `access.py`, but these were being abandoned by the view itself because of overriding `get_queryset`.

Prefetching or doing a select_related of the roles is entirely not necessary. All the summary information about the roles is available in the field itself, and this optimization was implemented system wide long ago.

Performance of this query before change:

```sql
SELECT
   "main_inventory"."id",
   "main_inventory"."created",
   "main_inventory"."modified",
   "main_inventory"."description",
   "main_inventory"."created_by_id",
   "main_inventory"."modified_by_id",
   "main_inventory"."name",
   "main_inventory"."organization_id",
   "main_inventory"."variables",
   "main_inventory"."has_active_failures",
   "main_inventory"."total_hosts",
   "main_inventory"."hosts_with_active_failures",
   "main_inventory"."total_groups",
   "main_inventory"."groups_with_active_failures",
   "main_inventory"."has_inventory_sources",
   "main_inventory"."total_inventory_sources",
   "main_inventory"."inventory_sources_with_failures",
   "main_inventory"."kind",
   "main_inventory"."host_filter",
   "main_inventory"."admin_role_id",
   "main_inventory"."update_role_id",
   "main_inventory"."adhoc_role_id",
   "main_inventory"."use_role_id",
   "main_inventory"."read_role_id",
   "main_inventory"."insights_credential_id",
   "main_inventory"."pending_deletion",
   "main_rbac_roles"."id",
   "main_rbac_roles"."role_field",
   "main_rbac_roles"."singleton_name",
   "main_rbac_roles"."implicit_parents",
   "main_rbac_roles"."content_type_id",
   "main_rbac_roles"."object_id",
   T3."id",
   T3."role_field",
   T3."singleton_name",
   T3."implicit_parents",
   T3."content_type_id",
   T3."object_id",
   T4."id",
   T4."role_field",
   T4."singleton_name",
   T4."implicit_parents",
   T4."content_type_id",
   T4."object_id",
   T5."id",
   T5."role_field",
   T5."singleton_name",
   T5."implicit_parents",
   T5."content_type_id",
   T5."object_id",
   T6."id",
   T6."role_field",
   T6."singleton_name",
   T6."implicit_parents",
   T6."content_type_id",
   T6."object_id" 
FROM
   "main_inventory" 
   LEFT OUTER JOIN
      "main_rbac_roles" 
      ON ("main_inventory"."admin_role_id" = "main_rbac_roles"."id") 
   LEFT OUTER JOIN
      "main_rbac_roles" T3 
      ON ("main_inventory"."update_role_id" = T3."id") 
   LEFT OUTER JOIN
      "main_rbac_roles" T4 
      ON ("main_inventory"."adhoc_role_id" = T4."id") 
   LEFT OUTER JOIN
      "main_rbac_roles" T5 
      ON ("main_inventory"."use_role_id" = T5."id") 
   LEFT OUTER JOIN
      "main_rbac_roles" T6 
      ON ("main_inventory"."read_role_id" = T6."id") 
WHERE
   "main_inventory"."id" IN 
   (
      SELECT DISTINCT
         V0."object_id" AS Col1 
      FROM
         "main_rbac_role_ancestors" V0 
      WHERE
         (
            V0."ancestor_id" IN 
            (
               SELECT
                  U0."id" AS Col1 
               FROM
                  "main_rbac_roles" U0 
                  INNER JOIN
                     "main_rbac_roles_members" U1 
                     ON (U0."id" = U1."role_id") 
               WHERE
                  U1."user_id" = 1
            )
            AND V0."role_field" = 'read_role' 
            AND V0."content_type_id" = 43
         )
   )
ORDER BY
   "main_inventory"."total_hosts" DESC LIMIT 25
```

https://explain.depesz.com/s/2Mdp

That was as admin user. I observed times of 50ms-200ms, which is kind of a red flag. I have 2000+ inventories that I'm testing with.

After change, as an org admin:

https://explain.depesz.com/s/LaCb

```sql
SELECT
   "main_inventory"."id",
   "main_inventory"."created",
   "main_inventory"."modified",
   "main_inventory"."description",
   "main_inventory"."created_by_id",
   "main_inventory"."modified_by_id",
   "main_inventory"."name",
   "main_inventory"."organization_id",
   "main_inventory"."variables",
   "main_inventory"."has_active_failures",
   "main_inventory"."total_hosts",
   "main_inventory"."hosts_with_active_failures",
   "main_inventory"."total_groups",
   "main_inventory"."groups_with_active_failures",
   "main_inventory"."has_inventory_sources",
   "main_inventory"."total_inventory_sources",
   "main_inventory"."inventory_sources_with_failures",
   "main_inventory"."kind",
   "main_inventory"."host_filter",
   "main_inventory"."admin_role_id",
   "main_inventory"."update_role_id",
   "main_inventory"."adhoc_role_id",
   "main_inventory"."use_role_id",
   "main_inventory"."read_role_id",
   "main_inventory"."insights_credential_id",
   "main_inventory"."pending_deletion" 
FROM
   "main_inventory" 
WHERE
   "main_inventory"."id" IN 
   (
      SELECT DISTINCT
         V0."object_id" AS Col1 
      FROM
         "main_rbac_role_ancestors" V0 
      WHERE
         (
            V0."ancestor_id" IN 
            (
               SELECT
                  U0."id" AS Col1 
               FROM
                  "main_rbac_roles" U0 
                  INNER JOIN
                     "main_rbac_roles_members" U1 
                     ON (U0."id" = U1."role_id") 
               WHERE
                  U1."user_id" = 34
            )
            AND V0."role_field" = 'read_role' 
            AND V0."content_type_id" = 43
         )
   )
ORDER BY
   "main_inventory"."total_hosts" DESC LIMIT 25
```

This completes in 3.2ms. The prefetch_related items still bog down the page somewhat, obviously, but those all have specific summary_fields tied to them.
