### PR TITLE
Populate event children list via parent_uuid

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4124,8 +4124,7 @@ class JobEventSerializer(BaseSerializer):
         ))
         if obj.parent_id:
             res['parent'] = self.reverse('api:job_event_detail', kwargs={'pk': obj.parent_id})
-        if obj.children.exists():
-            res['children'] = self.reverse('api:job_event_children_list', kwargs={'pk': obj.pk})
+        res['children'] = self.reverse('api:job_event_children_list', kwargs={'pk': obj.pk})
         if obj.host_id:
             res['host'] = self.reverse('api:host_detail', kwargs={'pk': obj.host_id})
         if obj.hosts.exists():

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3864,6 +3864,12 @@ class JobEventChildrenList(SubListAPIView):
     view_name = _('Job Event Children List')
     search_fields = ('stdout',)
 
+    def get_queryset(self):
+        parent_event = self.get_parent_object()
+        self.check_parent_access(parent_event)
+        qs = self.request.user.get_queryset(self.model).filter(parent_uuid=parent_event.uuid)
+        return qs
+
 
 class JobEventHostsList(HostRelatedSearchMixin, SubListAPIView):
 

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2264,7 +2264,7 @@ class JobEventAccess(BaseAccess):
     '''
 
     model = JobEvent
-    prefetch_related = ('hosts', 'children', 'job__job_template', 'host',)
+    prefetch_related = ('hosts', 'job__job_template', 'host',)
 
     def filtered_queryset(self):
         return self.model.objects.filter(


### PR DESCRIPTION
##### SUMMARY
This makes the job event children endpoint work.

Connect https://github.com/ansible/awx/issues/3798

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Uses the method in the issue

I would like to delete the job event children relationship, but do that separately from this. This PR is to restore functionality to this endpoint.
