### PR TITLE
Include playbook as a default search field

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -223,7 +223,7 @@ class FieldLookupBackend(BaseFilterBackend):
                 raise ValueError('%s is not searchable' % new_lookup[:-8])
             new_lookups = []
             for rm_field in related_model._meta.fields:
-                if rm_field.name in ('username', 'first_name', 'last_name', 'email', 'name', 'description'):
+                if rm_field.name in ('username', 'first_name', 'last_name', 'email', 'name', 'description', 'playbook'):
                     new_lookups.append('{}__{}__icontains'.format(new_lookup[:-8], rm_field.name))
             return value, new_lookups
         else:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4170,12 +4170,14 @@ class UnifiedJobTemplateList(ListAPIView):
 
     model = models.UnifiedJobTemplate
     serializer_class = serializers.UnifiedJobTemplateSerializer
+    search_fields = ('description', 'name', 'jobtemplate__playbook',)
 
 
 class UnifiedJobList(ListAPIView):
 
     model = models.UnifiedJob
     serializer_class = serializers.UnifiedJobListSerializer
+    search_fields = ('description', 'name', 'job__playbook',)
 
 
 def redact_ansi(line):


### PR DESCRIPTION
##### SUMMARY
If I'm a user and I type the name of my playbook into the search bar, I would like jobs & job templates that match the playbook to be returned.

This makes it so they are returned via the default search and related search, which is the first thing users get by banging on the keyboard.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
before

![Screen Shot 2019-05-01 at 3 38 45 PM](https://user-images.githubusercontent.com/1385596/57040161-9a9f4200-6c2c-11e9-940f-ce929ea7339b.png)


after

![Screen Shot 2019-05-01 at 3 39 17 PM](https://user-images.githubusercontent.com/1385596/57040178-a1c65000-6c2c-11e9-86f1-ef9ac255c3b3.png)

users might put the name of their playbook in the name of their job templates, but they also might not.

Ping @trahman73 
