### PR TITLE
Apply optimizations via standard methods

### DIFF
--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -115,12 +115,6 @@ class InventoryList(ListCreateAPIView):
     model = Inventory
     serializer_class = InventorySerializer
 
-    def get_queryset(self):
-        qs = Inventory.accessible_objects(self.request.user, 'read_role')
-        qs = qs.select_related('admin_role', 'read_role', 'update_role', 'use_role', 'adhoc_role')
-        qs = qs.prefetch_related('created_by', 'modified_by', 'organization')
-        return qs
-
 
 class InventoryDetail(RelatedJobsPreventDeleteMixin, ControlledByScmMixin, RetrieveUpdateDestroyAPIView):
 

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -167,7 +167,7 @@ class ApiV1PingView(APIView):
                                               capacity=instance.capacity, version=instance.version))
             sorted(response['instances'], key=operator.itemgetter('node'))
         response['instance_groups'] = []
-        for instance_group in InstanceGroup.objects.all():
+        for instance_group in InstanceGroup.objects.prefetch_related('instances'):
             response['instance_groups'].append(dict(name=instance_group.name,
                                                     capacity=instance_group.capacity,
                                                     instances=[x.hostname for x in instance_group.instances.all()]))


### PR DESCRIPTION
##### SUMMARY
This is fairly routine work which is intended to be done periodically.

The most non-routine part about this is migrating the `get_queryset` logic from the view to the method in access.py.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Some more details on just one of these at: https://github.com/ansible/awx/pull/3797

If anyone is interested in formally documenting this process, I would be all ears. The basic idea is that we get >25 entries for a single type, say Notification Templates, for example. Then the obvious metric is the query count. Typically we will see some N x 25, where N is the number of related things the serializer is looking for, plus around 7-ish base queries, depending on the thing. All of the `O(N)` factories can be eliminated, unless we do something un-optimizable, like use the django-polymorphic library.

There are a ton of weird gotchas. Like, for instance, if you `select_related` a polymorphic item, then if that item is used, the "real" item may be fetched which will undermine the `select_related` optimization.
