### PR TITLE
Add support for kubernetes nodeSelector, tolerations and affinity

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -90,7 +90,7 @@
         helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
         echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="5.3.9" \
+          --version="6.2.1" \
           --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
           --values - \
           stable/postgresql

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -90,7 +90,7 @@
         helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
         echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="5.3.13" \
+          --version="6.2.1" \
           --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
           --values - \
           stable/postgresql
@@ -103,7 +103,7 @@
 
 - name: Set postgresql hostname to helm package service (Kubernetes)
   set_fact:
-    pg_hostname: "{{ postgresql_service_name }}-postgresql"
+    pg_hostname: "{{ postgresql_service_name }}"
   when:
     - pg_hostname is not defined or pg_hostname == ''
     - kubernetes_context is defined

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -90,7 +90,7 @@
         helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
         echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="6.2.1" \
+          --version="5.3.13" \
           --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
           --values - \
           stable/postgresql

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -78,27 +78,28 @@
     - postgres_svc_details is defined and postgres_svc_details.rc != 0
     - openshift_host is defined
 
-- name: Deploy and Activate Postgres (Kubernetes)
-  shell: |
-    helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
-    helm upgrade {{ postgresql_service_name }} --install \
-      --namespace {{ kubernetes_namespace }} \
-      --set postgresqlUsername={{ pg_username }} \
-      --set postgresqlPassword={{ pg_password | quote }} \
-      --set postgresqlDatabase={{ pg_database }} \
-      --set persistence.size={{ pg_volume_capacity|default('5')}}Gi \
-      --version="2.0.0" \
-      --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
-      {{ '--set persistence.storageClass='+pg_persistence_storageClass if pg_persistence_storageClass is defined else ' ' }} \
-      {{ '--set resources.limits.cpu='+(pg_cpu_limit | string)+'m' if pg_cpu_limit is defined else ' ' }} \
-      {{ '--set resources.limits.memory='+(pg_mem_limit | string)+'Gi' if pg_mem_limit is defined else ' ' }} \
-      stable/postgresql
+- name: Deploy PostgreSQL (Kubernetes)
+  block:
+    - name: Template PostgreSQL Deployment (Kubernetes)
+      set_fact:
+        pg_values: "{{ lookup('template', 'postgresql-values.yml.j2') }}"
+      no_log: yes
+
+    - name: Deploy and Activate Postgres (Kubernetes)
+      shell: |
+        helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
+        echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
+          --namespace {{ kubernetes_namespace }} \
+          --version="5.3.9" \
+          --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
+          --values - \
+          stable/postgresql
+      register: kubernetes_pg_activate
+      no_log: yes
   when:
     - pg_hostname is not defined or pg_hostname == ''
     - postgres_svc_details is defined and postgres_svc_details.rc != 0
     - kubernetes_context is defined
-  register: kubernetes_pg_activate
-  no_log: yes
 
 - name: Set postgresql hostname to helm package service (Kubernetes)
   set_fact:

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -325,6 +325,18 @@ spec:
 {% if memcached_cpu_limit is defined %}
               cpu: "{{ memcached_cpu_limit }}m"
 {% endif %}
+{% if tolerations is defined %}
+      tolerations:
+{{ tolerations | to_nice_yaml(indent=2) | indent(width=8, indentfirst=True) }}
+{% endif %}
+{% if node_selector is defined %}
+      nodeSelector:
+{{ node_selector | to_nice_yaml(indent=2) | indent(width=8, indentfirst=True) }}
+{% endif %}
+{% if affinity is defined %}
+      affinity:
+{{ affinity | to_nice_yaml(indent=2) | indent(width=8, indentfirst=True) }}
+{% endif %}
       volumes:
 {% if ca_trust_dir is defined %}
         - name: {{ kubernetes_deployment_name }}-ca-trust-dir

--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -33,6 +33,18 @@ spec:
 {% if management_cpu_limit is defined %}
           cpu: "{{ management_cpu_limit }}m"
 {% endif %}
+{% if tolerations is defined %}
+  tolerations:
+{{ tolerations | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
+{% if node_selector is defined %}
+  nodeSelector:
+{{ node_selector | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
+{% if affinity is defined %}
+  affinity:
+{{ affinity | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
   volumes:
     - name: {{ kubernetes_deployment_name }}-application-config
       configMap:

--- a/installer/roles/kubernetes/templates/postgresql-values.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-values.yml.j2
@@ -1,0 +1,33 @@
+postgresqlUsername: {{ pg_username }}
+postgresqlPassword: {{ pg_password }}
+postgresqlDatabase: {{ pg_database }}
+persistence:
+  size: {{ pg_volume_capacity|default('5') }}Gi
+{% if pg_persistence_storageClass is defined %}
+  storageClass: {{ pg_persistence_storageClass }}
+{% endif %}
+{% if pg_cpu_limit is defined or pg_mem_limit is defined %}
+resources:
+  limits:
+{% if pg_cpu_limit is defined %}
+    cpu: {{ pg_cpu_limit | string }}m
+{% endif %}
+{% if pg_mem_limit is defined %}
+    memory: {{ pg_mem_limit | string }}Gi
+{% endif %}
+{% endif %}
+{% if tolerations is defined or node_selector is defined or affinity is defined %}
+master:
+{% if tolerations is defined %}
+  tolerations:
+{{ tolerations | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
+{% if node_selector is defined %}
+  nodeSelector:
+{{ node_selector | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
+{% if affinity is defined %}
+  affinity:
+{{ affinity | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
Add support for kubernetes nodeSelector, tolerations and affinity to installer.
I've also bumped the version of the installed postgresql helm chart from 2.0.0 to 3.18.3.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
Nodes in a kubernetes cluster may be assigned "taints", to ensure only pods with matching "tolerations" may be scheduled to run on them. This is useful in shared kubernetes clusters, where different teams or applications may have a separate, dedicated pools of nodes.

See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

Additionally, pods may also have nodeSelectors that cause them to attract to nodes with matching labels.

See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

Affinity is the successor to nodeSelector, and will eventually replace it.

See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

I've moved the templating of values for the postgresql helm chart to an external template, so an arbitrary number of nodeSelector, tolerations and affinity entries may be added via jinja2 for loops. Unfortunately, defining multiple nodeSelector/tolerations/affinity entries via the inventory file is ugly. Feel free to suggest ways to make this more elegant:
```
node_selector={'organization':'foo', 'team':'bar'}
tolerations=[{'key':'organization', 'value':'foo', 'effect':'NoSchedule'}, {'key':'team', 'value':'bar', 'effect':'NoSchedule'}]
```
Alternatively, the tolerations & nodeSelector could be defined in a separate JSON or YAML file:
```
tolerations:
- key: "organization"
  value: "foo"
  effect: "NoSchedule"
- key: "team"
  value: "bar"
  effect: "NoSchedule"
nodeSelector:
  organization: foo
  team: bar
```

...and included with something like `--extra-vars '@tolerations.yml'`.