### PR TITLE
sosreport plugin improvements

### DIFF
--- a/tools/sosreport/tower.py
+++ b/tools/sosreport/tower.py
@@ -5,7 +5,6 @@ import sos
 from distutils.version import LooseVersion
 
 SOSREPORT_TOWER_COMMANDS = [
-    "ansible --version",      # ansible core version
     "awx-manage --version", # tower version
     "awx-manage list_instances", # tower cluster configuration
     "awx-manage run_dispatcher --status", # tower dispatch worker status
@@ -23,15 +22,11 @@ SOSREPORT_TOWER_COMMANDS = [
 
 SOSREPORT_TOWER_DIRS = [
     "/etc/tower/",
-    "/etc/ansible/",
     "/etc/supervisord.d/",
     "/etc/nginx/",
     "/var/log/tower",
     "/var/log/nginx",
     "/var/log/supervisor",
-    "/var/log/syslog",
-    "/var/log/udev",
-    "/var/log/kern*",
     "/var/log/dist-upgrade",
     "/var/log/installer",
     "/var/log/unattended-upgrades",
@@ -50,7 +45,7 @@ SOSREPORT_FORBIDDEN_PATHS = [
 if LooseVersion(sos.__version__) >= LooseVersion('3.0'):
     from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
-    class tower(Plugin, RedHatPlugin, UbuntuPlugin):
+    class Tower(Plugin, RedHatPlugin, UbuntuPlugin):
         '''Collect Ansible Tower related information'''
         plugin_name = "tower"
 
@@ -59,16 +54,14 @@ if LooseVersion(sos.__version__) >= LooseVersion('3.0'):
             for path in SOSREPORT_TOWER_DIRS:
                 self.add_copy_spec(path)
 
-            for path in SOSREPORT_FORBIDDEN_PATHS:
-                self.add_forbidden_path(path)
+            self.add_forbidden_path(SOSREPORT_FORBIDDEN_PATHS)
 
-            for command in SOSREPORT_TOWER_COMMANDS:
-                self.add_cmd_output(command)
+            self.add_cmd_output(SOSREPORT_TOWER_COMMANDS)
 
 else:
     import sos.plugintools
 
-    class tower(sos.plugintools.PluginBase):
+    class Tower(sos.plugintools.PluginBase):
         '''Collect Ansible Tower related information'''
 
         def setup(self):

--- a/tools/sosreport/tower.py
+++ b/tools/sosreport/tower.py
@@ -1,8 +1,7 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-import sos
-from distutils.version import LooseVersion
+from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
 SOSREPORT_TOWER_COMMANDS = [
     "awx-manage --version", # tower version
@@ -42,36 +41,17 @@ SOSREPORT_FORBIDDEN_PATHS = [
     "/var/log/tower/profile"
 ]
 
-if LooseVersion(sos.__version__) >= LooseVersion('3.0'):
-    from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
 
-    class Tower(Plugin, RedHatPlugin, UbuntuPlugin):
-        '''Collect Ansible Tower related information'''
-        plugin_name = "tower"
+class Tower(Plugin, RedHatPlugin, UbuntuPlugin):
+    '''Collect Ansible Tower related information'''
+    plugin_name = "tower"
 
-        def setup(self):
+    def setup(self):
 
-            for path in SOSREPORT_TOWER_DIRS:
-                self.add_copy_spec(path)
+        for path in SOSREPORT_TOWER_DIRS:
+            self.add_copy_spec(path)
 
-            self.add_forbidden_path(SOSREPORT_FORBIDDEN_PATHS)
+        self.add_forbidden_path(SOSREPORT_FORBIDDEN_PATHS)
 
-            self.add_cmd_output(SOSREPORT_TOWER_COMMANDS)
-
-else:
-    import sos.plugintools
-
-    class Tower(sos.plugintools.PluginBase):
-        '''Collect Ansible Tower related information'''
-
-        def setup(self):
-
-            for path in SOSREPORT_TOWER_DIRS:
-                self.addCopySpec(path)
-
-            for path in SOSREPORT_FORBIDDEN_PATHS:
-                self.addForbiddenPath(path)
-
-            for command in SOSREPORT_TOWER_COMMANDS:
-                self.collectExtOutput(command)
+        self.add_cmd_output(SOSREPORT_TOWER_COMMANDS)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug Report

##### SUMMARY
Few improvements of https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py from a contributor of `sosreport` tool.

##### ENVIRONMENT
upstream code review

##### STEPS TO REPRODUCE
n.a., not much wrong in particular, rather code improvements suggestions.

##### EXPECTED RESULTS
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L8:
   - `ansible --version` is already collected by `ansible` plugin (https://github.com/sosreport/sos/blob/master/sos/plugins/ansible.py#L29) - this call is redundant (until you call `sosreport -o tower` or `sosreport -n ansible`)
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L26:
   - `/etc/ansible` is already collected by `ansible` plugin (https://github.com/sosreport/sos/blob/master/sos/plugins/ansible.py#L25) - this collection is redundant and in very rare cases, it can be dangerous (see https://github.com/sosreport/sos/issues/1596)
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L32-L34:
  - these three log patterns are already collected by `logs` plugin - again, redundant and potentially dangerous duplicate collection
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L50:
  - is this still applicable? Are there systems with sosreport version *older* than 3.0 (that was released 5years ago)?
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L53 and https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L71 : 
  - we stick to name plugins starting with capital letter ;-)
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L59-L60:
  - this can be shortened to `self.add_copy_spec(SOSREPORT_TOWER_DIRS)` as the method supports also lists as its argument. But you might want to stick on the current code in case more than 25MB data are expected to be collected altogether; *one* call of `add_copy_spec` collects files from newest to oldest and stops collecting after reaching 25MB limit (by default; it is configurable via `--log-size=..` or `--all-logs` options). So if e.g. each of three logdirs would have 10MB, one copyspec would skip some oldest file(s), while copyspec called for each logdir individually will collect everything.
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L62-L63:
  - like above, worth calling single `self.add_forbidden_path(SOSREPORT_FORBIDDEN_PATHS)` ; no catches here
- https://github.com/ansible/awx/blob/devel/tools/sosreport/tower.py#L65-L66:
  - like above, worth calling single `self.add_cmd_output(SOSREPORT_TOWER_COMMANDS)` ; no catches here

##### ACTUAL RESULTS

<!-- What actually happened? -->

##### ADDITIONAL INFORMATION
PR for #3775 .