### PR TITLE
properly record Instance.cpu and Instance.memory for isolated nodes

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -299,12 +299,14 @@ class IsolatedManager(object):
 
         if instance.capacity == 0 and task_result['capacity_cpu']:
             logger.warning('Isolated instance {} has re-joined.'.format(instance.hostname))
+        instance.cpu = int(task_result['cpu'])
+        instance.memory = int(task_result['mem'])
         instance.cpu_capacity = int(task_result['capacity_cpu'])
         instance.mem_capacity = int(task_result['capacity_mem'])
         instance.capacity = get_system_task_capacity(scale=instance.capacity_adjustment,
                                                      cpu_capacity=int(task_result['capacity_cpu']),
                                                      mem_capacity=int(task_result['capacity_mem']))
-        instance.save(update_fields=['cpu_capacity', 'mem_capacity', 'capacity', 'version', 'modified'])
+        instance.save(update_fields=['cpu', 'memory', 'cpu_capacity', 'mem_capacity', 'capacity', 'version', 'modified'])
 
     def health_check(self, instance_qs):
         '''
@@ -343,6 +345,8 @@ class IsolatedManager(object):
                         logger.exception('Failed to read status from isolated instances')
                     if 'awx_capacity_cpu' in task_result and 'awx_capacity_mem' in task_result:
                         task_result = {
+                            'cpu': task_result['awx_cpu'],
+                            'mem': task_result['awx_mem'],
                             'capacity_cpu': task_result['awx_capacity_cpu'],
                             'capacity_mem': task_result['awx_capacity_mem'],
                             'version': task_result['awx_capacity_version']

--- a/awx/plugins/isolated/awx_capacity.py
+++ b/awx/plugins/isolated/awx_capacity.py
@@ -57,13 +57,15 @@ def main():
         module.fail_json(msg=str(e))
         return
     # NOTE: Duplicated with awx.main.utils.common capacity utilities
-    _, capacity_cpu = get_cpu_capacity()
-    _, capacity_mem = get_mem_capacity()
+    cpu, capacity_cpu = get_cpu_capacity()
+    mem, capacity_mem = get_mem_capacity()
 
     # Module never results in a change
     module.exit_json(changed=False, capacity_cpu=capacity_cpu,
                      capacity_mem=capacity_mem, version=version,
                      ansible_facts=dict(
+                         awx_cpu=cpu,
+                         awx_mem=mem,
                          awx_capacity_cpu=capacity_cpu,
                          awx_capacity_mem=capacity_mem,
                          awx_capacity_version=version


### PR DESCRIPTION
Before:

```
curl -ks "https://ryan:ryan@awx:8043/api/v2/instances/isolated/" | python -m json.tool | egrep "mem|cpu"
    "cpu": 0,
    "cpu_capacity": 16,
    "mem_capacity": 99,
    "memory": 0,
```

After:

```
curl -ks "https://ryan:ryan@awx:8043/api/v2/instances/isolated/" | python -m json.tool | egrep "mem|cpu"
    "cpu": 4,
    "cpu_capacity": 16,
    "mem_capacity": 99,
    "memory": 12580229120,
```