### PR TITLE
Add "Disable SSL Verification" checkbox to webhook notification

### DIFF
--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('awx.main.notifications.webhook_backend')
 class WebhookBackend(AWXBaseEmailBackend):
 
     init_parameters = {"url": {"label": "Target URL", "type": "string"},
-                       "disable_ssl_verification": {"label": "Verify SSL", "type": "bool"},
+                       "disable_ssl_verification": {"label": "Verify SSL", "type": "bool", "default": false},
                        "headers": {"label": "HTTP Headers", "type": "object"}}
     recipient_parameter = "url"
     sender_parameter = None

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('awx.main.notifications.webhook_backend')
 class WebhookBackend(AWXBaseEmailBackend):
 
     init_parameters = {"url": {"label": "Target URL", "type": "string"},
-                       "disable_ssl_verification": {"label": "Verify SSL", "type": "bool", "default": false},
+                       "disable_ssl_verification": {"label": "Verify SSL", "type": "bool", "default": False},
                        "headers": {"label": "HTTP Headers", "type": "object"}}
     recipient_parameter = "url"
     sender_parameter = None

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -15,13 +15,13 @@ logger = logging.getLogger('awx.main.notifications.webhook_backend')
 class WebhookBackend(AWXBaseEmailBackend):
 
     init_parameters = {"url": {"label": "Target URL", "type": "string"},
-                       "webhook_no_verify_ssl": {"label": "Verify SSL", "type": "bool"},
+                       "disable_ssl_verification": {"label": "Verify SSL", "type": "bool"},
                        "headers": {"label": "HTTP Headers", "type": "object"}}
     recipient_parameter = "url"
     sender_parameter = None
 
-    def __init__(self, headers, webhook_no_verify_ssl=False, fail_silently=False, **kwargs):
-        self.webhook_no_verify_ssl = webhook_no_verify_ssl
+    def __init__(self, headers, disable_ssl_verification=False, fail_silently=False, **kwargs):
+        self.disable_ssl_verification = disable_ssl_verification
         self.headers = headers
         super(WebhookBackend, self).__init__(fail_silently=fail_silently)
 
@@ -36,7 +36,7 @@ class WebhookBackend(AWXBaseEmailBackend):
             r = requests.post("{}".format(m.recipients()[0]),
                               json=m.body,
                               headers=self.headers,
-                              verify=(not self.webhook_no_verify_ssl))
+                              verify=(not self.disable_ssl_verification))
             if r.status_code >= 400:
                 logger.error(smart_text(_("Error sending notification webhook: {}").format(r.text)))
                 if not self.fail_silently:

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -15,11 +15,13 @@ logger = logging.getLogger('awx.main.notifications.webhook_backend')
 class WebhookBackend(AWXBaseEmailBackend):
 
     init_parameters = {"url": {"label": "Target URL", "type": "string"},
+                       "webhook_no_verify_ssl": {"label": "Verify SSL", "type": "bool"},
                        "headers": {"label": "HTTP Headers", "type": "object"}}
     recipient_parameter = "url"
     sender_parameter = None
 
-    def __init__(self, headers, fail_silently=False, **kwargs):
+    def __init__(self, headers, webhook_no_verify_ssl=False, fail_silently=False, **kwargs):
+        self.webhook_no_verify_ssl = webhook_no_verify_ssl
         self.headers = headers
         super(WebhookBackend, self).__init__(fail_silently=fail_silently)
 
@@ -33,7 +35,8 @@ class WebhookBackend(AWXBaseEmailBackend):
         for m in messages:
             r = requests.post("{}".format(m.recipients()[0]),
                               json=m.body,
-                              headers=self.headers)
+                              headers=self.headers,
+                              verify=(not self.webhook_no_verify_ssl))
             if r.status_code >= 400:
                 logger.error(smart_text(_("Error sending notification webhook: {}").format(r.text)))
                 if not self.fail_silently:

--- a/awx/main/tests/functional/test_notifications.py
+++ b/awx/main/tests/functional/test_notifications.py
@@ -28,7 +28,7 @@ def test_basic_parameterization(get, post, user, organization):
                          description="test webhook",
                          organization=organization.id,
                          notification_type="webhook",
-                         notification_configuration=dict(url="http://localhost",
+                         notification_configuration=dict(url="http://localhost", disable_ssl_verification=False,
                                                          headers={"Test": "Header"})),
                     u)
     assert response.status_code == 201
@@ -81,7 +81,7 @@ def test_inherited_notification_templates(get, post, user, organization, project
                              description="test webhook {}".format(nfiers),
                              organization=organization.id,
                              notification_type="webhook",
-                             notification_configuration=dict(url="http://localhost",
+                             notification_configuration=dict(url="http://localhost", disable_ssl_verification=False,
                                                              headers={"Test": "Header"})),
                         u)
         assert response.status_code == 201
@@ -143,7 +143,7 @@ def test_custom_environment_injection(post, user, organization):
                          description="test webhook",
                          organization=organization.id,
                          notification_type="webhook",
-                         notification_configuration=dict(url="https://example.org",
+                         notification_configuration=dict(url="https://example.org", disable_ssl_verification=False,
                                                          headers={"Test": "Header"})),
                     u)
     assert response.status_code == 201

--- a/awx/ui/client/src/notifications/notificationTemplates.form.js
+++ b/awx/ui/client/src/notifications/notificationTemplates.form.js
@@ -399,7 +399,7 @@ export default ['i18n', function(i18n) {
                 subForm: 'typeSubForm',
                 ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)'
             },
-            webhook_no_verify_ssl: {
+            disable_ssl_verification: {
                 label: i18n._('Disable SSL Verification'),
                 type: 'checkbox',
                 ngShow: "notification_type.value == 'webhook' ",

--- a/awx/ui/client/src/notifications/notificationTemplates.form.js
+++ b/awx/ui/client/src/notifications/notificationTemplates.form.js
@@ -399,6 +399,13 @@ export default ['i18n', function(i18n) {
                 subForm: 'typeSubForm',
                 ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)'
             },
+            webhook_no_verify_ssl: {
+                label: i18n._('Disable SSL Verification'),
+                type: 'checkbox',
+                ngShow: "notification_type.value == 'webhook' ",
+                subForm: 'typeSubForm',
+                ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)'
+            },
             headers: {
                 label: i18n._('HTTP Headers'),
                 dataTitle: i18n._('HTTP Headers'),


### PR DESCRIPTION
##### SUMMARY
This commit will add a checkbox which will disable SSL verification on
the generic webhook notification type. This is required when using
self-signed certificates.

This option is copied from already existing notification types like
* grafana
* mattermost
* rocket.chat

related #3838 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
BEFORE against self-signed https endpoints:
```
awx.main.tasks Send Notification Failed ("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)
```

AFTER
```
awx.main.dispatch publish awx.main.tasks.send_notifications(dba84e5d-aaab-468e-b726-55c813583171, queue=awx_private_queue)
awx.main.dispatch delivered dba84e5d-aaab-468e-b726-55c813583171 to worker[180] qsize 0
awx.main.dispatch task dba84e5d-aaab-468e-b726-55c813583171 starting awx.main.tasks.send_notifications(*[[34]])
awx.main.dispatch task dba84e5d-aaab-468e-b726-55c813583171 is finished
```

SCREENSHOT
![webhook_notification](https://user-images.githubusercontent.com/5683163/57234257-87231b00-7020-11e9-9f99-8cccdb80d3a1.png)