### PR TITLE
selinux permissive for docker-compose, related #3642

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -401,6 +401,7 @@ Unlike Openshift's `Route` the Kubernetes `Ingress` doesn't yet handle SSL termi
 - [docker-compose](https://pypi.org/project/docker-compose/) Python module.
     + This also installs the `docker` Python module, which is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
 - [Docker Compose](https://docs.docker.com/compose/install/).
+- selinux must be in permissive mode on the target system
 
 ### Pre-build steps
 


### PR DESCRIPTION
selinux must be in permissive mode as described in ansible/awx#3642

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I had trouble deploying following the instructions and created an issue. It was shared that selinux needed to be in permissive mode for the installation to work, but this was not included in the install guide. This pull request aims to change that.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related #3642, adds a line stating that a prerequisite to the docker-compose install is selinux in permissive mode
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Refer to the linked issue for verbose error information.
<!--- Paste verbatim command output below, e.g. before and after your change -->

This is only my second time proposing changes to the documentation, and I apologize if I missed something (go easy on me, I'm just trying to make this better!).