### PR TITLE
Refactor Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,9 @@ docker-compose-build: awx-devel-build
 
 # Base development image build
 awx-devel-build:
-	docker build -t ansible/awx_devel -f tools/docker-compose/Dockerfile .
+	# To enable the 'experimental' features in Docker:
+	# https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file
+	docker build --squash -t ansible/awx_devel -f tools/docker-compose/Dockerfile .
 	docker tag ansible/awx_devel $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
 	#docker push $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
 

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -1,16 +1,67 @@
 FROM centos:7
 
-# Do we need this?
-#RUN locale-gen en_US.UTF-8
-#ENV LANG en_US.UTF-8
-#ENV LANGUAGE en_US:en
-#ENV LC_ALL en_US.UTF-8
-
 USER root
 
-# Init System
+ADD ansible.repo /etc/yum.repos.d/ansible.repo
+ADD RPM-GPG-KEY-ansible-release /etc/pki/rpm-gpg/RPM-GPG-KEY-ansible-release
+
+RUN yum -y update && yum -y install epel-release
+
+# sync with tools/docker-compose/Dockerfile
+RUN yum -y install acl \
+  ansible \
+  bubblewrap \
+  curl \
+  cyrus-sasl \
+  cyrus-sasl-devel \
+  gcc \
+  gcc-c++ \
+  git \
+  krb5-devel \
+  krb5-libs \
+  krb5-workstation \
+  libcurl-devel \
+  libffi-devel \
+  libselinux-python \
+  libstdc++.so.6 \
+  libtool-ltdl-devel \
+  libxml2-devel \
+  libxslt-devel \
+  make \
+  mercurial \
+  mg \
+  nginx \
+  nodejs \
+  openldap-devel \
+  openssh-server \
+  postgresql-devel \
+  python-devel \
+  python-pip \
+  python-pip \
+  python-psutil \
+  python-psycopg2 \
+  python-setuptools \
+  python36-devel \
+  python36-setuptools \
+  rsync \
+  setools-libs \
+  subversion \
+  sudo \
+  swig \
+  tmux \
+  unzip \
+  vim \
+  xmlsec1 \
+  xmlsec1-devel \
+  xmlsec1-openssl \
+  xmlsec1-openssl-devel \
+  yum-utils
+
 ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
 RUN chmod +x /tini
+
+RUN python3 -m ensurepip && pip3 install virtualenv
+RUN pip install supervisor
 
 ADD Makefile /tmp/Makefile
 RUN mkdir /tmp/requirements
@@ -21,51 +72,67 @@ ADD requirements/requirements_ansible.txt \
     requirements/requirements_tower_uninstall.txt \
     requirements/requirements_git.txt \
     /tmp/requirements/
-ADD ansible.repo /etc/yum.repos.d/ansible.repo
-ADD config-watcher /usr/bin/config-watcher
-ADD RPM-GPG-KEY-ansible-release /etc/pki/rpm-gpg/RPM-GPG-KEY-ansible-release
-# OS Dependencies
-WORKDIR /tmp
-RUN mkdir -p /var/lib/awx/public/static
-RUN chgrp -Rf root /var/lib/awx && chmod -Rf g+w /var/lib/awx
-# sync with tools/docker-compose/Dockerfile
-RUN yum -y install epel-release && \
-    yum -y localinstall https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
-    yum -y update && \
-    yum -y install ansible git mercurial subversion curl python-psycopg2 python-pip python-setuptools libselinux-python setools-libs yum-utils sudo acl make postgresql-devel nginx python-psutil libxml2-devel libxslt-devel libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel python-pip xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 xmlsec1-openssl-devel libtool-ltdl-devel bubblewrap gcc-c++ python-devel python36-setuptools python36-devel krb5-workstation krb5-libs libcurl-devel rsync unzip && \
-    python36 -m ensurepip && \
-    pip3 install virtualenv && \
-    pip install virtualenv supervisor && \
-    CFLAGS="-DXMLSEC_NO_SIZE_T" \
-    VENV_BASE=/var/lib/awx/venv make requirements_ansible && \
-    VENV_BASE=/var/lib/awx/venv make requirements_awx && \
-    yum -y remove gcc postgresql-devel libxml2-devel libxslt-devel cyrus-sasl-devel openldap-devel xmlsec1-devel krb5-devel xmlsec1-openssl-devel libtool-ltdl-devel gcc-c++ python-devel python36-devel && \
-    yum -y clean all && \
-    rm -rf /root/.cache
+RUN cd /tmp && VENV_BASE="/var/lib/awx/venv" make requirements
 
-RUN mkdir -p /var/log/tower
-RUN chmod -R g+w /var/log/tower
-RUN mkdir -p /etc/tower
-COPY {{ awx_sdist_file }} /tmp/{{ awx_sdist_file }}
-RUN OFFICIAL=yes /var/lib/awx/venv/awx/bin/pip install /tmp/{{ awx_sdist_file }}
+RUN yum -y remove cyrus-sasl-devel \
+  gcc \
+  gcc-c++ \
+  krb5-devel \
+  libtool-ltdl-devel \
+  libxml2-devel \
+  libxslt-devel \
+  openldap-devel \
+  postgresql-devel \
+  python-devel \
+  python36-devel \
+  nodejs \
+  xmlsec1-devel \
+  xmlsec1-openssl-devel
+
+RUN yum -y clean all
+RUN rm -rf /root/.cache
+
+RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN ln -s /var/lib/awx/venv/awx/bin/awx-manage /usr/bin/awx-manage
 RUN rm -rf /tmp/*
 
 RUN echo "{{ awx_version }}" > /var/lib/awx/.tower_version
+COPY {{ awx_sdist_file }} /tmp/{{ awx_sdist_file }}
+RUN OFFICIAL=yes /var/lib/awx/venv/awx/bin/pip install /tmp/{{ awx_sdist_file }}
+
+ADD settings.py /etc/tower/settings.py
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD supervisor.conf /supervisor.conf
 ADD supervisor_task.conf /supervisor_task.conf
 ADD launch_awx.sh /usr/bin/launch_awx.sh
 ADD launch_awx_task.sh /usr/bin/launch_awx_task.sh
-RUN chmod +rx /usr/bin/launch_awx.sh && chmod +rx /usr/bin/launch_awx_task.sh && chmod +rx /usr/bin/config-watcher
-ADD settings.py /etc/tower/settings.py
-RUN chmod g+w /etc/passwd
-RUN chmod -R 777 /var/log/nginx && chmod -R 777 /var/lib/nginx
+ADD config-watcher /usr/bin/config-watcher
+RUN chmod +rx /usr/bin/launch_awx.sh && \
+    chmod +rx /usr/bin/launch_awx_task.sh && \
+    chmod +rx /usr/bin/config-watcher
+
+RUN find /var/lib/awx -not -path '/var/lib/awx/venv*' | xargs chgrp root
+RUN find /var/lib/awx -not -path '/var/lib/awx/venv*' | xargs chmod g+w
+
+# Pre-create things that we need to write to
+RUN for dir in /home/awx /var/log/tower /var/log/nginx /var/lib/nginx; \
+  do mkdir -p $dir; chmod -R g+rwx $dir; chgrp -R root $dir; done
+
+RUN for file in /etc/passwd /var/run/nginx.pid; \
+  do touch $file; chmod -R g+rwx $file; chgrp -R root $file; done
+
 VOLUME /var/lib/nginx
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
+
+ENV HOME=/home/awx
+WORKDIR ${HOME}
 USER 1000
 EXPOSE 8052
-WORKDIR /var/lib/awx
+
 ENTRYPOINT ["/tini", "--"]
 CMD /usr/bin/launch_awx.sh

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -2,25 +2,82 @@ FROM centos:7
 
 ARG UID=0
 
-ADD Makefile /tmp/Makefile
-
-RUN mkdir /tmp/requirements
-
 RUN yum -y update && yum -y install epel-release
-RUN yum -y localinstall https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm
 
 # sync with installer/roles/image_build/templates/Dockerfile.j2
-RUN yum -y install ansible git mercurial subversion curl python-psycopg2 python-pip python-setuptools libselinux-python setools-libs yum-utils sudo acl make postgresql-devel nginx python-psutil libxml2-devel libxslt-devel libstdc++.so.6 gcc cyrus-sasl-devel cyrus-sasl openldap-devel libffi-devel python-pip xmlsec1-devel swig krb5-devel xmlsec1-openssl xmlsec1 xmlsec1-openssl-devel libtool-ltdl-devel bubblewrap gcc-c++ python-devel python36-setuptools python36-devel krb5-workstation krb5-libs libcurl-devel rsync unzip
+RUN yum -y install acl \
+  ansible \
+  bubblewrap \
+  curl \
+  cyrus-sasl \
+  cyrus-sasl-devel \
+  gcc \
+  gcc-c++ \
+  git \
+  krb5-devel \
+  krb5-libs \
+  krb5-workstation \
+  libcurl-devel \
+  libffi-devel \
+  libselinux-python \
+  libstdc++.so.6 \
+  libtool-ltdl-devel \
+  libxml2-devel \
+  libxslt-devel \
+  make \
+  mercurial \
+  mg \
+  nginx \
+  nodejs \
+  openldap-devel \
+  openssh-server \
+  postgresql-devel \
+  python-devel \
+  python-pip \
+  python-pip \
+  python-psutil \
+  python-psycopg2 \
+  python-setuptools \
+  python36-devel \
+  python36-setuptools \
+  rsync \
+  setools-libs \
+  subversion \
+  sudo \
+  swig \
+  tmux \
+  unzip \
+  vim \
+  xmlsec1 \
+  xmlsec1-devel \
+  xmlsec1-openssl \
+  xmlsec1-openssl-devel \
+  yum-utils
 
-RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
-RUN yum -y install nodejs openssh-server tmux vim mg
+ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
+RUN chmod +x /tini
 
-RUN python3 -m ensurepip
-RUN pip3 install virtualenv
 RUN /usr/bin/ssh-keygen -q -t rsa -N "" -f /root/.ssh/id_rsa
 RUN mkdir -p /data/db
+
+ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
+ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
+ADD tools/docker-compose/awx.egg-info /tmp/awx.egg-info
+
+RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
+RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
+RUN ln -s /awx_devel/tools/docker-compose/start_development.sh /start_development.sh
+RUN ln -s /awx_devel/tools/docker-compose/start_tests.sh /start_tests.sh
+RUN ln -s /awx_devel/tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
+
+RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/nginx/nginx.csr -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/OU=AWX Development/CN=awx.localhost"
+RUN openssl x509 -req -days 365 -in /etc/nginx/nginx.csr -signkey /etc/nginx/nginx.key -out /etc/nginx/nginx.crt
+
+RUN python3 -m ensurepip && pip3 install virtualenv
 RUN pip install supervisor
 
+ADD Makefile /tmp/Makefile
+RUN mkdir /tmp/requirements
 ADD requirements/requirements.txt \
   requirements/requirements_git.txt \
   requirements/requirements_ansible.txt \
@@ -29,32 +86,42 @@ ADD requirements/requirements.txt \
   requirements/requirements_ansible_uninstall.txt \
   requirements/requirements_tower_uninstall.txt \
   /tmp/requirements/
-
-ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
-ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
-ADD tools/docker-compose/awx.egg-info /tmp/awx.egg-info
-RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
-RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
-RUN ln -s /awx_devel/tools/docker-compose/start_development.sh /start_development.sh
-RUN ln -s /awx_devel/tools/docker-compose/start_tests.sh /start_tests.sh
-RUN ln -s /awx_devel/tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
-RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/nginx/nginx.csr -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/OU=AWX Development/CN=awx.localhost"
-RUN openssl x509 -req -days 365 -in /etc/nginx/nginx.csr -signkey /etc/nginx/nginx.key -out /etc/nginx/nginx.crt
-WORKDIR /tmp
-
 RUN mkdir -p /venv && chmod g+w /venv
-RUN CFLAGS="-DXMLSEC_NO_SIZE_T" VENV_BASE="/venv" make requirements_dev
-RUN yum -y remove gcc postgresql-devel libxml2-devel libxslt-devel cyrus-sasl-devel openldap-devel xmlsec1-devel krb5-devel xmlsec1-openssl-devel libtool-ltdl-devel gcc-c++ python-devel python36-devel
+RUN cd /tmp && VENV_BASE="/venv" make requirements_dev
+
+# Use the distro provided npm to bootstrap our required version of node
+RUN npm install -g n
+RUN n 8.15.0
+ENV PATH /usr/bin:/usr/local/n/versions/node/8.15.0/bin:$PATH
+
+RUN yum -y remove cyrus-sasl-devel \
+  gcc \
+  gcc-c++ \
+  krb5-devel \
+  libtool-ltdl-devel \
+  libxml2-devel \
+  libxslt-devel \
+  openldap-devel \
+  postgresql-devel \
+  python-devel \
+  python36-devel \
+  nodejs \
+  xmlsec1-devel \
+  xmlsec1-openssl-devel
+
 RUN yum -y clean all
+
 RUN rm -rf /root/.cache
+
 RUN localedef -c -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
-RUN chmod +x /tini
+
 WORKDIR /
+
 EXPOSE 8043 8013 8080 22
+
 ENTRYPOINT ["/tini", "--"]
 CMD /start_development.sh
 


### PR DESCRIPTION
This commit does a few things:

- Add the `--squash` option to the `awx-devel-build` make target. This reduces the resulting image size from 2.12 GB to 1.37 GB. I think we can get this down even more by inspecting the image contents.
- Reorganize commands so that the cache expires less often. Before this commit, any changes to the Makefile would essentially cause the entire image to rebuild.
- Break yum dependencies up into multiple lines. This makes it easier to see what changes in a diff.
- Use `n` to install our required version of node (rather `curl node | bash`). I’ve found this to be easier to maintain / more portable when working with other Dockerfiles.
- General organizational changes to make things easier to parse visually.