### PR TITLE
Update Custom Middleware to New Style

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -75,7 +75,7 @@ class TimingMiddleware(threading.local):
 
 class ActivityStreamMiddleware(threading.local):
 
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         self.disp_uid = None
         self.instance_ids = []
         self.get_response = get_response
@@ -177,7 +177,7 @@ def _customize_graph():
 
 class URLModificationMiddleware(object):
 
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         self.get_response = get_response
         models = [m for m in apps.get_app_config('main').get_models() if hasattr(m, 'get_absolute_url')]
         generate_graph(models)

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -79,7 +79,7 @@ class ActivityStreamMiddleware(MiddlewareMixin, threading.local):
     def __init__(self, get_response=None):
         self.disp_uid = None
         self.instance_ids = []
-        self.get_response = get_response
+        super().__init__(get_response)
 
     def process_request(self, request):
         if hasattr(request, 'user') and hasattr(request.user, 'is_authenticated') and request.user.is_authenticated():

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -216,7 +216,7 @@ class URLModificationMiddleware(object):
         return '/'.join(url_units)
 
     def __call__(self, request):
-        response = self.process_request(request)
+        response = self.get_response(request)
         return response
 
     def process_request(self, request):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -251,7 +251,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (  # NOQA
+MIDDLEWARE = (  # NOQA
     'awx.main.middleware.TimingMiddleware',
     'awx.main.middleware.MigrationRanCheckMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -628,7 +628,7 @@ AWX_REBUILD_SMART_MEMBERSHIP = False
 ALLOW_JINJA_IN_EXTRA_VARS = 'template'
 
 # Enable dynamically pulling roles from a requirement.yml file
-# when updating SCM projects 
+# when updating SCM projects
 # Note: This setting may be overridden by database settings.
 AWX_ROLES_ENABLED = True
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -251,29 +251,11 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE = (  # NOQA
-    'awx.main.middleware.TimingMiddleware',
-    'awx.main.middleware.MigrationRanCheckMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'awx.main.middleware.ActivityStreamMiddleware',
-    'awx.sso.middleware.SocialAuthMiddleware',
-    'crum.CurrentRequestUserMiddleware',
-    'awx.main.middleware.URLModificationMiddleware',
-    'awx.main.middleware.SessionTimeoutMiddleware',
-)
-
-
 ROOT_URLCONF = 'awx.urls'
 
 WSGI_APPLICATION = 'awx.wsgi.application'
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.messages',
@@ -294,7 +276,7 @@ INSTALLED_APPS = (
     'awx.ui',
     'awx.sso',
     'solo'
-)
+]
 
 INTERNAL_IPS = ('127.0.0.1',)
 
@@ -447,16 +429,6 @@ AWX_ISOLATED_VERBOSITY = 0
 #     }
 # }
 
-# Use Django-Debug-Toolbar if installed.
-try:
-    import debug_toolbar
-    INSTALLED_APPS += (debug_toolbar.__name__,)
-except ImportError:
-    pass
-
-DEBUG_TOOLBAR_CONFIG = {
-    'ENABLE_STACKTRACES' : True,
-}
 
 DEVSERVER_DEFAULT_ADDR = '0.0.0.0'
 DEVSERVER_DEFAULT_PORT = '8013'
@@ -1211,3 +1183,21 @@ AWX_REQUEST_PROFILE = False
 
 # Delete temporary directories created to store playbook run-time
 AWX_CLEANUP_PATHS = True
+
+MIDDLEWARE = [  # NOQA
+    'awx.main.middleware.TimingMiddleware',
+    'awx.main.middleware.MigrationRanCheckMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'awx.main.middleware.ActivityStreamMiddleware',
+    'awx.sso.middleware.SocialAuthMiddleware',
+    'crum.CurrentRequestUserMiddleware',
+    'awx.main.middleware.URLModificationMiddleware',
+    'awx.main.middleware.SessionTimeoutMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1199,5 +1199,4 @@ MIDDLEWARE = [
     'crum.CurrentRequestUserMiddleware',
     'awx.main.middleware.URLModificationMiddleware',
     'awx.main.middleware.SessionTimeoutMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1184,7 +1184,7 @@ AWX_REQUEST_PROFILE = False
 # Delete temporary directories created to store playbook run-time
 AWX_CLEANUP_PATHS = True
 
-MIDDLEWARE = [  # NOQA
+MIDDLEWARE = [
     'awx.main.middleware.TimingMiddleware',
     'awx.main.middleware.MigrationRanCheckMiddleware',
     'corsheaders.middleware.CorsMiddleware',

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -93,7 +93,7 @@ INSIGHTS_TRACKING_STATE = False
 # Use Django-Jenkins if installed. Only run tests for awx.main app.
 try:
     import django_jenkins
-    INSTALLED_APPS += (django_jenkins.__name__,)  # noqa
+    INSTALLED_APPS += [django_jenkins.__name__,] # noqa
     PROJECT_APPS = ('awx.main.tests', 'awx.api.tests',)
 except ImportError:
     pass
@@ -112,7 +112,18 @@ if 'django_jenkins' in INSTALLED_APPS:
     PEP8_RCFILE = "setup.cfg"
     PYLINT_RCFILE = ".pylintrc"
 
-INSTALLED_APPS += ('rest_framework_swagger',)
+INSTALLED_APPS += [   # NOQA
+    'rest_framework_swagger',
+    'debug_toolbar',
+]
+
+MIDDLEWARE += [  # NOQA
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]
+
+DEBUG_TOOLBAR_CONFIG = {
+    'ENABLE_STACKTRACES' : True,
+}
 
 # Configure a default UUID for development only.
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
@@ -162,9 +173,3 @@ except Exception:
     os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
 
 WEBSOCKET_ORIGIN_WHITELIST = ['https://localhost:8043', 'https://localhost:3000']
-
-MIDDLEWARE = [
-    # ...
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-    # ...
-]

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -162,3 +162,9 @@ except Exception:
     os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
 
 WEBSOCKET_ORIGIN_WHITELIST = ['https://localhost:8043', 'https://localhost:3000']
+
+MIDDLEWARE = [
+    # ...
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+    # ...
+]

--- a/awx/sso/middleware.py
+++ b/awx/sso/middleware.py
@@ -4,8 +4,6 @@
 # Python
 import urllib.parse
 
-# Six
-
 # Django
 from django.conf import settings
 from django.utils.functional import LazyObject
@@ -20,9 +18,12 @@ from social_django.middleware import SocialAuthExceptionMiddleware
 
 class SocialAuthMiddleware(SocialAuthExceptionMiddleware):
 
-    def process_view(self, request, callback, callback_args, callback_kwargs):
-        if request.path.startswith('/sso/login/'):
-            request.session['social_auth_last_backend'] = callback_kwargs['backend']
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.process_request(request)
+        return response
 
     def process_request(self, request):
         if request.path.startswith('/sso'):
@@ -53,6 +54,11 @@ class SocialAuthMiddleware(SocialAuthExceptionMiddleware):
                     request.user = request.user._wrapped
                 request.session.pop('social_auth_error', None)
                 request.session.pop('social_auth_last_backend', None)
+        return self.get_response(request)
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        if request.path.startswith('/sso/login/'):
+            request.session['social_auth_last_backend'] = callback_kwargs['backend']
 
     def process_exception(self, request, exception):
         strategy = getattr(request, 'social_strategy', None)

--- a/awx/sso/middleware.py
+++ b/awx/sso/middleware.py
@@ -18,13 +18,6 @@ from social_django.middleware import SocialAuthExceptionMiddleware
 
 class SocialAuthMiddleware(SocialAuthExceptionMiddleware):
 
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.process_request(request)
-        return response
-
     def process_request(self, request):
         if request.path.startswith('/sso'):
             # django-social keeps a list of backends in memory that it gathers

--- a/awx/wsgi.py
+++ b/awx/wsgi.py
@@ -41,20 +41,11 @@ if social_django.__version__ != '2.1.0':
             still works".format(social_django.__version__))
 
 
-if django.__version__ != '1.11.20':
-    raise RuntimeError("Django version other than 1.11.20 detected {}. \
+if not django.__version__.startswith('1.'):
+    raise RuntimeError("Django version other than 1.XX detected {}. \
             Inherit from WSGIHandler to support short-circuit Django Middleware. \
-            This is known to work for Django 1.11.20 and may not work with other, \
+            This is known to work for Django 1.XX and may not work with other, \
             even minor, versions.".format(django.__version__))
-
-
-if settings.MIDDLEWARE:
-    raise RuntimeError("MIDDLEWARE setting detected. \
-            The 'migration in progress' view feature short-circuits OLD Django \
-            MIDDLEWARE_CLASSES behavior. With the new Django MIDDLEWARE beahvior \
-            it's possible to short-ciruit the middleware onion through supported \
-            middleware mechanisms. Further, from django.core.wsgi.get_wsgi_application() \
-            should be called to get an instance of WSGIHandler().")
 
 
 class AWXWSGIHandler(WSGIHandler):

--- a/awx/wsgi.py
+++ b/awx/wsgi.py
@@ -8,11 +8,10 @@ from awx import __version__ as tower_version
 from awx import prepare_env, MODE
 prepare_env()
 
-
-from django.core.wsgi import WSGIHandler  # NOQA
 import django  # NOQA
 from django.conf import settings  # NOQA
 from django.urls import resolve  # NOQA
+from django.core.wsgi import get_wsgi_application # NOQA
 import social_django  # NOQA
 
 
@@ -48,25 +47,5 @@ if not django.__version__.startswith('1.'):
             even minor, versions.".format(django.__version__))
 
 
-class AWXWSGIHandler(WSGIHandler):
-    def _legacy_get_response(self, request):
-        try:
-            # resolve can raise a 404, in that case, pass through to the
-            # "normal" middleware
-            if getattr(resolve(request.path), 'url_name', '') == 'migrations_notran':
-                # short-circuit middleware
-                request._cors_enabled = False
-                return self._get_response(request)
-        except django.urls.Resolver404:
-            pass
-        # fall through to middle-ware
-        return super(AWXWSGIHandler, self)._legacy_get_response(request)
-
-
 # Return the default Django WSGI application.
-def get_wsgi_application():
-    django.setup(set_prefix=False)
-    return AWXWSGIHandler()
-
-
 application = get_wsgi_application()


### PR DESCRIPTION
##### SUMMARY

When running any `awx-manage` commands in the AWX shell in `devel`, this warning would pop up:

```
System check identified some issues:

WARNINGS:
?: (debug_toolbar.W001) debug_toolbar.middleware.DebugToolbarMiddleware is missing from MIDDLEWARE_CLASSES.
    HINT: Add debug_toolbar.middleware.DebugToolbarMiddleware to MIDDLEWARE_CLASSES.
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
When I added the debug toolbar to `MIDDLEWARE` in `development.py`, the following warning came up:
```
System check identified some issues:

WARNINGS:
?: (1_10.W001) The MIDDLEWARE_CLASSES setting is deprecated in Django 1.10 and the MIDDLEWARE setting takes precedence. Since you've set MIDDLEWARE, the value of MIDDLEWARE_CLASSES is ignored.
```

Thus the additional change from `MIDDLEWARE_CLASSES` ---> `MIDDLEWARE` in `defaults.py`.
