### PR TITLE
more verbose list_instance messaging

### DIFF
--- a/awx/main/management/commands/list_instances.py
+++ b/awx/main/management/commands/list_instances.py
@@ -44,8 +44,10 @@ class Command(BaseCommand):
             print((fmt + ']').format(instance_group))
             for x in instance_group.instances.all():
                 color = '\033[92m'
-                if x.capacity == 0 or x.enabled is False:
+                if x.capacity == 0:
                     color = '\033[91m'
+                if x.enabled is False:
+                    color = '\033[90m[DISABLED] '
                 fmt = '\t' + color + '{0.hostname} capacity={0.capacity} version={1}'
                 if x.last_isolated_check:
                     fmt += ' last_isolated_check="{0.last_isolated_check:%Y-%m-%d %H:%M:%S}"'


### PR DESCRIPTION
##### SUMMARY
Adds the value of enabled to the `list_instance` manage command output for easier debugging.  



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION

```
bash-4.2$ awx-manage list_instances
[tower capacity=294 policy=100%]
	awx capacity=294 version=4.0.0-512-g6feb58f enabled=True  heartbeat="2019-05-09 17:44:19"

```
