### PR TITLE
disabled instance does not mean offline instance

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -339,10 +339,7 @@ class InstanceDetail(RetrieveUpdateAPIView):
         r = super(InstanceDetail, self).update(request, *args, **kwargs)
         if status.is_success(r.status_code):
             obj = self.get_object()
-            if obj.enabled:
-                obj.refresh_capacity()
-            else:
-                obj.capacity = 0
+            obj.refresh_capacity()
             obj.save()
             r.data = serializers.InstanceSerializer(obj, context=self.get_serializer_context()).to_representation(obj)
         return r

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -396,14 +396,9 @@ def cluster_node_heartbeat():
             instance_list.remove(inst)
     if this_inst:
         startup_event = this_inst.is_lost(ref_time=nowtime)
-        if this_inst.capacity == 0 and this_inst.enabled:
-            logger.warning('Rejoining the cluster as instance {}.'.format(this_inst.hostname))
-        if this_inst.enabled:
-            this_inst.refresh_capacity()
-        elif this_inst.capacity != 0 and not this_inst.enabled:
-            this_inst.capacity = 0
-            this_inst.save(update_fields=['capacity'])
+        this_inst.refresh_capacity()
         if startup_event:
+            logger.warning('Rejoining the cluster as instance {}.'.format(this_inst.hostname))
             return
     else:
         raise RuntimeError("Cluster Host Not Found: {}".format(settings.CLUSTER_HOST_ID))


### PR DESCRIPTION
* Disabling an instance is used to stop and instance from being the
target of new jobs to run.
* The instance should still perform it's heartbeat so that it isn't
considered offline.
* If the instance was allowed to go offline on an openshift cluster it
would be deleted from the database.


I _do_ like the idea of the capacity being set to 0. But I do _not_ like that capacity 0 also means that he instance is offline.