### PR TITLE
Ensure that a root user is always present in development environment

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     container_name: tools_awx_1
     hostname: awx
+    command: /start_development.sh
     environment:
       CURRENT_UID:
       RABBITMQ_HOST: rabbitmq

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -64,12 +64,6 @@ ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
 ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 ADD tools/docker-compose/awx.egg-info /tmp/awx.egg-info
 
-RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
-RUN ln -Ffs /awx_devel/tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
-RUN ln -s /awx_devel/tools/docker-compose/start_development.sh /start_development.sh
-RUN ln -s /awx_devel/tools/docker-compose/start_tests.sh /start_tests.sh
-RUN ln -s /awx_devel/tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
-
 RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/nginx/nginx.csr -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/OU=AWX Development/CN=awx.localhost"
 RUN openssl x509 -req -days 365 -in /etc/nginx/nginx.csr -signkey /etc/nginx/nginx.key -out /etc/nginx/nginx.crt
 
@@ -118,12 +112,17 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-WORKDIR /
+ADD tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
+ADD tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
+ADD tools/docker-compose/start_development.sh /start_development.sh
+ADD tools/docker-compose/start_tests.sh /start_tests.sh
+ADD tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
 
 EXPOSE 8043 8013 8080 22
 
-ENTRYPOINT ["/tini", "--"]
-CMD /start_development.sh
+ADD tools/docker-compose/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/bash"]
 
 # Pre-create things that we need to write to
 RUN for dir in /var/lib/awx/ /var/log/tower/ /projects /.ansible /var/log/nginx /var/lib/nginx /.local; \

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -2,6 +2,7 @@
 set +x
 
 if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
+    echo "root:x:0:0:root:/root:/bin/bash" > /tmp/password
     echo "awx:x:`id -u`:`id -g`:,,,:/tmp:/bin/bash" >> /tmp/passwd
     cat /tmp/passwd > /etc/passwd
     rm /tmp/passwd

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 set +x
 
-if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
-    echo "root:x:0:0:root:/root:/bin/bash" > /tmp/password
-    echo "awx:x:`id -u`:`id -g`:,,,:/tmp:/bin/bash" >> /tmp/passwd
-    cat /tmp/passwd > /etc/passwd
-    rm /tmp/passwd
-fi
-
 # Wait for the databases to come up
 ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=postgres port=5432" all
 ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=memcached port=11211" all

--- a/tools/docker-compose/entrypoint.sh
+++ b/tools/docker-compose/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
+
+  cat << EOF > /tmp/passwd
+root:x:0:0:root:/root:/bin/bash
+awx:x:`id -u`:`id -g`:,,,:/tmp:/bin/bash
+EOF
+
+  cat /tmp/passwd > /etc/passwd
+  rm /tmp/passwd
+fi
+
+exec $@

--- a/tools/docker-compose/start_development.sh
+++ b/tools/docker-compose/start_development.sh
@@ -5,4 +5,4 @@ set +x
 
 cd /awx_devel
 # Start the services
-make supervisor
+exec /tini -- make supervisor


### PR DESCRIPTION
@AlanCoding was seeing errors in the development container when trying to run some commands as root. This fixes that.