### PR TITLE
Allow multiple custom credentials with inventory source

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2194,6 +2194,7 @@ class InventorySourceCredentialsList(SubListAttachDetachAPIView):
             return {'msg': error}
         return None
 
+
 class InventorySourceUpdateView(RetrieveAPIView):
 
     model = models.InventorySource

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -528,8 +528,11 @@ class TestInventorySourceCredential:
             user=admin_user, expect=200
         )
         assert r.data['count'] == 2
+        r = get(url=inv_src.get_absolute_url(), user=admin_user, expect=200)
+        # the credential field could be either of the credentials
+        assert r.data['credential'] in [gce_cred.pk, aws_cred.pk]
 
-    def test_associate_multiple_credentials(self, project, inventory, post, admin_user):
+    def test_associate_multiple_credentials(self, project, inventory, post, patch, admin_user):
         inv_src = InventorySource.objects.create(
             inventory=inventory, name='foobar', source='scm',
             source_project=project, source_path=''
@@ -548,6 +551,8 @@ class TestInventorySourceCredential:
                 expect=204
             )
         assert set(inv_src.credentials.all()) == set([aws_cred, gce_cred])
+        patch(url=inv_src.get_absolute_url(), data={'credential': gce_cred.pk}, user=admin_user, expect=200)
+        assert set(inv_src.credentials.all()) == set([gce_cred])
 
     def test_credentials_relationship_mapping(self, project, inventory, organization, admin_user, post, patch):
         """The credentials relationship is used to manage the cloud credential


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/277

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
The task logic for this was already in place (with inventory plugins, at least), this is just opening up the endpoint to allow using it. Tested and works.
