### PR TITLE
Expose the content type associated with roles for ActivityStream objects in the API

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4956,9 +4956,9 @@ class ActivityStreamSerializer(BaseSerializer):
 
     changes = serializers.SerializerMethodField()
     object_association = serializers.SerializerMethodField(
-        help_text="When present, shows the field name of the role or relationship that changed.")
+        help_text=_("When present, shows the field name of the role or relationship that changed."))
     object_type = serializers.SerializerMethodField(
-        help_text="When present, shows the model on which the role or relationship was defined.")
+        help_text=_("When present, shows the model on which the role or relationship was defined."))
 
     @cached_property
     def _local_summarizable_fk_fields(self):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4955,8 +4955,10 @@ class InstanceGroupSerializer(BaseSerializer):
 class ActivityStreamSerializer(BaseSerializer):
 
     changes = serializers.SerializerMethodField()
-    object_association = serializers.SerializerMethodField()
-    object_type = serializers.SerializerMethodField()
+    object_association = serializers.SerializerMethodField(
+        help_text="When present, shows the field name of the role or relationship that changed.")
+    object_type = serializers.SerializerMethodField(
+        help_text="When present, shows the model on which the role or relationship was defined.")
 
     @cached_property
     def _local_summarizable_fk_fields(self):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -128,7 +128,7 @@ SUMMARIZABLE_FK_FIELDS = {
     'inventory_source': ('source', 'last_updated', 'status'),
     'custom_inventory_script': DEFAULT_SUMMARY_FIELDS,
     'source_script': ('name', 'description'),
-    'role': ('id', 'role_field'),
+    'role': ('id', 'role_field', 'content_type'),
     'notification_template': DEFAULT_SUMMARY_FIELDS,
     'instance_group': {'id', 'name', 'controller_id'},
     'insights_credential': DEFAULT_SUMMARY_FIELDS,
@@ -5106,6 +5106,8 @@ class ActivityStreamSerializer(BaseSerializer):
                         for field in related_fields:
                             fval = getattr(thisItem, field, None)
                             if fval is not None:
+                                if field == 'content_type':
+                                    fval = str(fval)
                                 thisItemDict[field] = fval
                         summary_fields[fk].append(thisItemDict)
             except ObjectDoesNotExist:

--- a/awx/ui/client/src/activity-stream/factories/build-description.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-description.factory.js
@@ -17,6 +17,16 @@ export default function BuildDescription(BuildAnchor, $log, i18n) {
              switch(activity.object_association){
                  // explicit role dis+associations
                  case 'role':
+                     var object1 = activity.object1;
+                     var object2 = activity.object2;
+
+                     // if object1 winds up being the role's resource, we need to swap the objects
+                     // in order to make the sentence make sense.
+                     if (activity.summary_fields.role[0].content_type === object1) {
+                         object1 = activity.object2;
+                         object2 = activity.object1;
+                     }
+
                      // object1 field is resource targeted by the dis+association
                      // object2 field is the resource the role is inherited from
                      // summary_field.role[0] contains ref info about the role
@@ -24,23 +34,23 @@ export default function BuildDescription(BuildAnchor, $log, i18n) {
                          // expected outcome: "disassociated <object2> role_name from <object1>"
                          case 'disassociate':
                              if (isGroupRelationship(activity)){
-                                 activity.description += BuildAnchor(activity.summary_fields.group[1], activity.object2, activity) + activity.summary_fields.role[0].role_field +
-                                     ' from ' + BuildAnchor(activity.summary_fields.group[0], activity.object1, activity);
+                                 activity.description += BuildAnchor(activity.summary_fields.group[1], object2, activity) + activity.summary_fields.role[0].role_field +
+                                     ' from ' + BuildAnchor(activity.summary_fields.group[0], object1, activity);
                              }
                              else{
-                                 activity.description += BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity) + activity.summary_fields.role[0].role_field +
-                                 ' from ' + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity);
+                                 activity.description += BuildAnchor(activity.summary_fields[object2][0], object2, activity) + activity.summary_fields.role[0].role_field +
+                                 ' from ' + BuildAnchor(activity.summary_fields[object1][0], object1, activity);
                              }
                              break;
                          // expected outcome: "associated <object2> role_name to <object1>"
                          case 'associate':
                              if (isGroupRelationship(activity)){
-                                 activity.description += BuildAnchor(activity.summary_fields.group[1], activity.object2, activity) + activity.summary_fields.role[0].role_field +
-                                     ' to ' + BuildAnchor(activity.summary_fields.group[0], activity.object1, activity);
+                                 activity.description += BuildAnchor(activity.summary_fields.group[1], object2, activity) + activity.summary_fields.role[0].role_field +
+                                     ' to ' + BuildAnchor(activity.summary_fields.group[0], object1, activity);
                              }
                              else{
-                                 activity.description += BuildAnchor(activity.summary_fields[activity.object2][0], activity.object2, activity) + activity.summary_fields.role[0].role_field +
-                                 ' to ' + BuildAnchor(activity.summary_fields[activity.object1][0], activity.object1, activity);
+                                 activity.description += BuildAnchor(activity.summary_fields[object2][0], object2, activity) + activity.summary_fields.role[0].role_field +
+                                 ' to ' + BuildAnchor(activity.summary_fields[object1][0], object1, activity);
                              }
                              break;
                      }

--- a/awx/ui/client/src/activity-stream/factories/build-description.factory.js
+++ b/awx/ui/client/src/activity-stream/factories/build-description.factory.js
@@ -22,7 +22,7 @@ export default function BuildDescription(BuildAnchor, $log, i18n) {
 
                      // if object1 winds up being the role's resource, we need to swap the objects
                      // in order to make the sentence make sense.
-                     if (activity.summary_fields.role[0].content_type === object1) {
+                     if (activity.object_type === object1) {
                          object1 = activity.object2;
                          object2 = activity.object1;
                      }


### PR DESCRIPTION
##### SUMMARY
Due to the way ActivityStream objects are created based on actions, an association of two objects via a role could wind up in different order, depending on the direction in which the role grant was performed.  We need an extra piece of information to determine which object is the role's parent.  This PR exposes the content type from the role by manipulating the value constructed in `ActivityStream.object_relationship_type`, which should be sufficient to determine which of the two objects owns it.  We'll need this to arrange the object order in the UI for ActivityStreams associating two objects via roles.

related #3841

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
```
awx: 4.0.0
```
