### PR TITLE
reorder migrations to avoid session error

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1186,6 +1186,7 @@ AWX_CLEANUP_PATHS = True
 
 MIDDLEWARE = [
     'awx.main.middleware.TimingMiddleware',
+    'awx.main.middleware.SessionTimeoutMiddleware',
     'awx.main.middleware.MigrationRanCheckMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -1198,5 +1199,4 @@ MIDDLEWARE = [
     'awx.sso.middleware.SocialAuthMiddleware',
     'crum.CurrentRequestUserMiddleware',
     'awx.main.middleware.URLModificationMiddleware',
-    'awx.main.middleware.SessionTimeoutMiddleware',
 ]


### PR DESCRIPTION
##### SUMMARY

@jbradberry figured out the cause of the SuspiciousOperation Error we have all become familiar.  

> the check migrations middleware is higher up on the list, but short-circuits the request/response cycle in the case where there are migrations to be run, therefore bypassing the session middleware and breaking the contract

So when have migrations _and_ your session has expired, you get this nasty 500.  The solution is to reorder the migrations so that the SessiontimeoutMiddleware checks the session expiry _before_ the Migration check middleware.  

This appears to fix it more me locally.  

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

