### PR TITLE
#3004 Adding proxy support to memcached, postgresql and rabbitmq

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -104,11 +104,18 @@ services:
       RABBITMQ_DEFAULT_USER: "{{ rabbitmq_user }}"
       RABBITMQ_DEFAULT_PASS: "{{ rabbitmq_password }}"
       RABBITMQ_ERLANG_COOKIE: {{ rabbitmq_erlang_cookie }}
+      http_proxy: {{ http_proxy | default('') }}
+      https_proxy: {{ https_proxy | default('') }}
+      no_proxy: {{ no_proxy | default('') }}
 
   memcached:
     image: memcached:alpine
     container_name: awx_memcached
     restart: unless-stopped
+    environment:
+      http_proxy: {{ http_proxy | default('') }}
+      https_proxy: {{ https_proxy | default('') }}
+      no_proxy: {{ no_proxy | default('') }}
 
   {% if pg_hostname is not defined %}
   postgres:
@@ -122,4 +129,7 @@ services:
       POSTGRES_PASSWORD: {{ pg_password }}
       POSTGRES_DB: {{ pg_database }}
       PGDATA: /var/lib/postgresql/data/pgdata
+      http_proxy: {{ http_proxy | default('') }}
+      https_proxy: {{ https_proxy | default('') }}
+      no_proxy: {{ no_proxy | default('') }}
   {% endif %}


### PR DESCRIPTION
##### SUMMARY
Adding proxy support to memcached, postgresql and rabbitmq 

Related #3004 Adding proxy support to memcached, postgresql and rabbitmq

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
 - Installer

##### AWX VERSION
'awx: 4.0.0'

