### PR TITLE
[WIP] Reduce time to start running jobs via task logic

### DIFF
--- a/awx/main/models/base.py
+++ b/awx/main/models/base.py
@@ -189,6 +189,8 @@ class PasswordFieldsModel(BaseModel):
         for field in self.PASSWORD_FIELDS:
             if new_instance:
                 value = getattr(self, field, '')
+                if not value:
+                    continue
                 setattr(self, '_saved_%s' % field, value)
                 setattr(self, field, '')
             else:
@@ -202,6 +204,8 @@ class PasswordFieldsModel(BaseModel):
             update_fields = []
             for field in self.PASSWORD_FIELDS:
                 saved_value = getattr(self, '_saved_%s' % field, '')
+                if not saved_value:
+                    continue
                 setattr(self, field, saved_value)
                 self.mark_field_for_save(update_fields, field)
 

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -170,15 +170,15 @@ class JobOptions(BaseModel):
 
     @property
     def network_credentials(self):
-        return list(self.credentials.filter(credential_type__kind='net'))
+        return [cred for cred in self.credentials.all() if cred.credential_type.kind == 'net']
 
     @property
     def cloud_credentials(self):
-        return list(self.credentials.filter(credential_type__kind='cloud'))
+        return [cred for cred in self.credentials.all() if cred.credential_type.kind == 'cloud']
 
     @property
     def vault_credentials(self):
-        return list(self.credentials.filter(credential_type__kind='vault'))
+        return [cred for cred in self.credentials.all() if cred.credential_type.kind == 'vault']
 
     @property
     def credential(self):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -792,9 +792,12 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
         # If this job already exists in the database, retrieve a copy of
         # the job in its prior state.
         if self.pk:
-            self_before = self.__class__.objects.get(pk=self.pk)
-            if self_before.status != self.status:
-                status_before = self_before.status
+            if 'update_fields' in kwargs and 'status' not in kwargs['update_fields']:
+                status_before = None  # status not being updated, information not needed
+            else:
+                self_before = self.__class__.objects.get(pk=self.pk)
+                if self_before.status != self.status:
+                    status_before = self_before.status
 
         # Sanity check: Is this a failure? Ensure that the failure value
         # matches the status.
@@ -841,7 +844,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
         result = super(UnifiedJob, self).save(*args, **kwargs)
 
         # If status changed, update the parent instance.
-        if self.status != status_before:
+        if status_before is not None and self.status != status_before:
             self._update_parent_instance()
 
         # Done.


### PR DESCRIPTION
##### SUMMARY
These are optimizations obtained by running the task logic through some profiling stuff. It is mostly concerned with tracking no-op conditions, but it also makes a major change to the task logic in that keeps a persistent object for the job.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Tested with the Django debug toolbar by doing this:

```diff
diff --git a/awx/api/views/__init__.py b/awx/api/views/__init__.py
index eb02aec10f..8feec16413 100644
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3543,6 +3543,26 @@ class JobDetail(UnifiedJobDeletionMixin, RetrieveUpdateDestroyAPIView):
             methods.remove('PATCH')
         return methods
 
+    def get(self, request, *args, **kwargs):
+        obj = self.get_object()
+        from awx.main.tasks import RunJob
+        from unittest import mock
+        from collections import namedtuple
+
+        def substitute_run(**_kw):
+            Res = namedtuple('Result', ['status', 'rc'])
+            return Res('successful', 0)
+
+        # Mock this so that it will not send events to the callback receiver
+        # because doing so in pytest land creates large explosions
+        with mock.patch('awx.main.queue.CallbackQueueDispatcher.dispatch', lambda self, obj: None):
+            # The point of this test is that we replace run with assertions
+            with mock.patch('awx.main.tasks.ansible_runner.interface.run', substitute_run):
+                # so this sets up everything for a run and then yields control over to substitute_run
+                task = RunJob()
+                task.run(obj.pk)
+        return Response({})
+
     def put(self, request, *args, **kwargs):
         if get_request_version(self.request) > 1:
             return Response({"error": _("PUT not allowed for Job Details in version 2 of the API")},
diff --git a/awx/main/tasks.py b/awx/main/tasks.py
index 4d791a2e40..c3652e7a79 100644
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1110,6 +1110,7 @@ class BaseTask(object):
         '''
         Run the job/task and capture its output.
         '''
+        start_outer = time.time()
         # self.instance because of the update_model pattern and when it's used in callback handlers
         self.instance = self.update_model(pk, status='running',
                                           start_args='')  # blank field to remove encrypted passwords
@@ -1250,7 +1251,9 @@ class BaseTask(object):
                 self.event_ct = len(isolated_manager_instance.handled_events)
             else:
                 self.dispatcher = CallbackQueueDispatcher()
+                start_inner = time.time()
                 res = ansible_runner.interface.run(**params)
+                finish_inner = time.time()
                 status = res.status
                 rc = res.rc
 
@@ -1284,6 +1287,10 @@ class BaseTask(object):
             logger.exception('{} Final run hook errored.'.format(self.instance.log_format))
 
         self.instance.websocket_emit_status(status)
+        finish_outer = time.time()
+        logger.info('Time for running job, prep: {}, run: {}, finish: {}'.format(
+            start_inner - start_outer, finish_inner - start_inner, finish_outer -finish_inner
+        ))
         if status != 'successful':
             if status == 'canceled':
                 raise AwxTaskError.TaskCancel(self.instance, rc)
diff --git a/awx/settings/defaults.py b/awx/settings/defaults.py
index 85d56728a3..526cb841da 100644
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -628,7 +628,7 @@ AWX_REBUILD_SMART_MEMBERSHIP = False
 ALLOW_JINJA_IN_EXTRA_VARS = 'template'
 
 # Enable dynamically pulling roles from a requirement.yml file
-# when updating SCM projects 
+# when updating SCM projects
 # Note: This setting may be overridden by database settings.
 AWX_ROLES_ENABLED = True
 
@@ -1014,7 +1014,7 @@ LOGGING = {
         'console': {
             '()': 'logging.StreamHandler',
             'level': 'DEBUG',
-            'filters': ['require_debug_true_or_test'],
+            # 'filters': ['require_debug_true_or_test'],
             'formatter': 'simple',
         },
         'null': {
```

Some results:

```
in optimization branch:
awx_1        | 2019-05-13 15:42:04,610 INFO     awx.main.tasks Time for running job, prep: 0.692488431930542, run: 0.00033164024353027344, finish: 0.06170034408569336
awx_1        | 2019-05-13 16:07:28,119 INFO     awx.main.tasks Time for running job, prep: 0.3466510772705078, run: 0.0003898143768310547, finish: 0.062465667724609375
awx_1        | 2019-05-13 16:07:34,206 INFO     awx.main.tasks Time for running job, prep: 0.3850884437561035, run: 0.0004067420959472656, finish: 0.06271839141845703
awx_1        | 2019-05-13 16:07:37,967 INFO     awx.main.tasks Time for running job, prep: 0.6079730987548828, run: 0.0003314018249511719, finish: 0.06001162528991699

in devel:
awx_1        | 2019-05-13 15:47:54,156 INFO     awx.main.tasks Time for running job, prep: 0.9255514144897461, run: 0.0005123615264892578, finish: 0.10568857192993164
awx_1        | 2019-05-13 15:48:51,790 INFO     awx.main.tasks Time for running job, prep: 0.5584995746612549, run: 0.0004189014434814453, finish: 0.10896682739257812
awx_1        | 2019-05-13 15:48:59,743 INFO     awx.main.tasks Time for running job, prep: 0.9592108726501465, run: 0.0005075931549072266, finish: 0.1099698543548584
awx_1        | 2019-05-13 15:49:04,851 INFO     awx.main.tasks Time for running job, prep: 0.8540959358215332, run: 0.0006184577941894531, finish: 0.1058661937713623
```

I got these numbers by turning off `DEBUG`


I still want to run cProfile stuff.