### PR TITLE
Add the ability of installing roles by reading several requirements.yml files placed on subdirectories inside of roles/

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -144,22 +144,28 @@
 
     - block:
       - name: detect requirements.yml
-        stat: path={{project_path|quote}}/roles/requirements.yml
+        find:
+          path: "{{project_path|quote}}/roles/"
+          file_type: file
+          patterns: 'requirements.yml'
+          recurse: true
         register: doesRequirementsExist
 
       - name: fetch galaxy roles from requirements.yml
-        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/
-        args:
-          chdir: "{{project_path|quote}}/roles"
+        command: "ansible-galaxy install -r {{item.path}} -p {{item.path|dirname}}"
         register: galaxy_result
-        when: doesRequirementsExist.stat.exists and (scm_version is undefined or (git_result is defined and git_result['before'] == git_result['after']))
+        loop: "{{doesRequirementsExist.files}}"
+        loop_control:
+          label: "{{item.path}}"
+        when: item.path is defined and (scm_version is undefined or (git_result is defined and git_result['before'] == git_result['after']))
         changed_when: "'was installed successfully' in galaxy_result.stdout"
 
       - name: fetch galaxy roles from requirements.yml (forced update)
-        command: ansible-galaxy install -r requirements.yml -p {{project_path|quote}}/roles/ --force
-        args:
-          chdir: "{{project_path|quote}}/roles"
-        when: doesRequirementsExist.stat.exists and galaxy_result is skipped
+        command: "ansible-galaxy install -r {{item.path}} -p {{item.path|dirname}} --force"
+        loop: "{{doesRequirementsExist.files}}"
+        loop_control:
+          label: "{{item.path}}"
+        when: item.path is defined and galaxy_result is skipped
 
       when: roles_enabled|bool
       delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
At the moment AWX only supports installing roles if those are placed in a requirements.yml inside of roles/ (roles/requirements.yml). This change gives the flexibility to detect and read one or several requirements.yml files that can be placed in any subdirectory under the parent directory "roles/"

This can be useful when you want to split the roles, for example, by origin in different requirements.yml files in your Ansible repo. Personally I find this way much cleaner that mixing everything in just one roles/requirements.yml.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 4.0.0

##### ADDITIONAL INFORMATION
This is compatible with the expected functionality this process has right now, however, it allows you to have a configuration on your repo like for example:
```
roles/
 |_company/requirements.yml
 |_galaxy/requirements.yml
 |_whatever/requirements.yml
```
Or just:
```
roles/requirements.yml
```
Or even:
```
roles/
 |_directory1
    |_subdirectory1/requirements.yml
```
Or all the previous combined.

When updating your project from the web interface as usual, all the roles will be pulled by "ansible-galaxy install" on their respective directory where the requirement file is.