### PR TITLE
Fix Django debug toolbar after its upgrade

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -112,14 +112,17 @@ if 'django_jenkins' in INSTALLED_APPS:
     PEP8_RCFILE = "setup.cfg"
     PYLINT_RCFILE = ".pylintrc"
 
+
+# debug toolbar and swagger assume that requirements/requirements_dev.txt are installed
+
 INSTALLED_APPS += [   # NOQA
     'rest_framework_swagger',
     'debug_toolbar',
 ]
 
-MIDDLEWARE += [  # NOQA
+MIDDLEWARE = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
+] + MIDDLEWARE  # NOQA
 
 DEBUG_TOOLBAR_CONFIG = {
     'ENABLE_STACKTRACES' : True,

--- a/awx/settings/local_settings.py.docker_compose
+++ b/awx/settings/local_settings.py.docker_compose
@@ -21,6 +21,12 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
+# Enable the following lines and install the browser extension to use Django debug toolbar
+# if your deployment method is not VMWare of Docker-for-Mac you may
+# need a different IP address from request.META['REMOTE_ADDR']
+# INTERNAL_IPS = ('172.19.0.1', '172.18.0.1', '192.168.100.1')
+# ALLOWED_HOSTS = ['*']
+
 # Database settings to use PostgreSQL for development.
 DATABASES = {
     'default': {

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -2,6 +2,7 @@
 # All Rights Reserved.
 
 from django.conf.urls import url, include
+from django.conf import settings
 from awx.main.views import (
     handle_400,
     handle_403,
@@ -20,6 +21,19 @@ urlpatterns = [
     url(r'^(?:api/)?404.html$', handle_404),
     url(r'^(?:api/)?500.html$', handle_500),
 ]
+
+if settings.SETTINGS_MODULE == 'awx.settings.development':
+    try:
+        import debug_toolbar
+        urlpatterns += [
+            # for Django version 2.0
+            # path('__debug__/', include(debug_toolbar.urls)),
+
+            # TODO: this is the Django < 2.0 version, REMOVEME
+            url(r'^__debug__/', include(debug_toolbar.urls))
+        ]
+    except ImportError:
+        pass
 
 handler400 = 'awx.main.views.handle_400'
 handler403 = 'awx.main.views.handle_403'


### PR DESCRIPTION
##### SUMMARY
I upgraded this library and didn't realize the needed configuration steps had changed.

https://github.com/jazzband/django-debug-toolbar/blob/master/docs/changes.rst

> Support for automatic setup has been removed as it was frequently problematic. Installation now requires explicit setup.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Will delay merging until https://github.com/ansible/awx/pull/3854 lands, ping @beeankha 

