### PR TITLE
Bumps jquery from 3.3.x to 3.4.x

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -7910,9 +7910,9 @@
       "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jquery-mousewheel": {
       "version": "3.1.13",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -123,7 +123,7 @@
     "html-entities": "^1.2.1",
     "inherits": "^1.0.2",
     "javascript-detect-element-resize": "^0.5.3",
-    "jquery": "~3.3.1",
+    "jquery": "~3.4.1",
     "jquery-ui": "^1.12.1",
     "js-yaml": "^3.2.7",
     "legacy-loader": "0.0.2",


### PR DESCRIPTION
##### SUMMARY
According to the 3.4.0 release announcement: `There should be no compatibility issues if upgrading from jQuery 3.0+` (we're going from 3.3.x to 3.4.x)

I've gone through basic creation of a JT and all related resources without an issue.

##### ISSUE TYPE
 - Task

##### COMPONENT NAME
 - UI
