### PR TITLE
Remove duplicated type methods and old Django logic

### DIFF
--- a/awx/main/models/activity_stream.py
+++ b/awx/main/models/activity_stream.py
@@ -97,12 +97,4 @@ class ActivityStream(models.Model):
             if 'update_fields' in kwargs and 'deleted_actor' not in kwargs['update_fields']:
                 kwargs['update_fields'].append('deleted_actor')
 
-        # For compatibility with Django 1.4.x, attempt to handle any calls to
-        # save that pass update_fields.
-        try:
-            super(ActivityStream, self).save(*args, **kwargs)
-        except TypeError:
-            if 'update_fields' not in kwargs:
-                raise
-            kwargs.pop('update_fields')
-            super(ActivityStream, self).save(*args, **kwargs)
+        super(ActivityStream, self).save(*args, **kwargs)

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -20,7 +20,6 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now
 from django.utils.encoding import smart_text
-from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 
 # REST Framework
@@ -40,6 +39,7 @@ from awx.main.dispatch.control import Control as ControlDispatcher
 from awx.main.registrar import activity_stream_registrar
 from awx.main.models.mixins import ResourceMixin, TaskManagerUnifiedJobMixin
 from awx.main.utils import (
+    camelcase_to_underscore, get_model_for_type,
     encrypt_dict, decrypt_field, _inventory_updates,
     copy_model_by_class, copy_m2m_relationships,
     get_type_for_model, parse_yaml_or_json, getattr_dne
@@ -486,33 +486,14 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, Notificatio
 
 class UnifiedJobTypeStringMixin(object):
     @classmethod
-    def _underscore_to_camel(cls, word):
-        return ''.join(x.capitalize() or '_' for x in word.split('_'))
-
-    @classmethod
-    def _camel_to_underscore(cls, word):
-        return re.sub('(?!^)([A-Z]+)', r'_\1', word).lower()
-
-    @classmethod
-    def _model_type(cls, job_type):
-        # Django >= 1.9
-        #app = apps.get_app_config('main')
-        model_str = cls._underscore_to_camel(job_type)
-        try:
-            return apps.get_model('main', model_str)
-        except LookupError:
-            print("Lookup model error")
-            return None
-
-    @classmethod
     def get_instance_by_type(cls, job_type, job_id):
-        model = cls._model_type(job_type)
+        model = get_model_for_type(job_type)
         if not model:
             return None
         return model.objects.get(id=job_id)
 
     def model_to_str(self):
-        return UnifiedJobTypeStringMixin._camel_to_underscore(self.__class__.__name__)
+        return camelcase_to_underscore(self.__class__.__name__)
 
 
 class UnifiedJobDeprecatedStdout(models.Model):

--- a/awx/main/tests/functional/utils/test_common.py
+++ b/awx/main/tests/functional/utils/test_common.py
@@ -3,14 +3,10 @@ import pytest
 import copy
 import json
 
-from django.db import DatabaseError
-
 from awx.main.utils.common import (
     model_instance_diff,
-    model_to_dict,
-    get_model_for_type
+    model_to_dict
 )
-from awx.main import models
 
 
 @pytest.mark.django_db
@@ -62,20 +58,3 @@ def test_model_instance_diff(alice, bob):
     assert hasattr(alice, 'is_superuser')
     assert hasattr(bob, 'is_superuser')
     assert 'is_superuser' not in output_dict
-
-
-@pytest.mark.django_db
-def test_get_model_for_invalid_type():
-    with pytest.raises(DatabaseError) as exc:
-        get_model_for_type('foobar')
-    assert 'not a valid AWX model' in str(exc)
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize("model_type,model_class", [
-    ('inventory', models.Inventory),
-    ('job_template', models.JobTemplate),
-    ('unified_job_template', models.UnifiedJobTemplate)
-])
-def test_get_model_for_valid_type(model_type, model_class):
-    assert get_model_for_type(model_type) == model_class

--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -22,7 +22,11 @@ from awx.main.models import (
     InventoryUpdate,
     ProjectUpdate,
     SystemJob,
-    WorkflowJob
+    WorkflowJob,
+    Inventory,
+    JobTemplate,
+    UnifiedJobTemplate,
+    UnifiedJob
 )
 
 
@@ -92,17 +96,38 @@ def test_set_environ():
     assert key not in os.environ
 
 
-# Cases relied on for scheduler dependent jobs list
-@pytest.mark.parametrize('model,name', [
+TEST_MODELS = [
     (Job, 'job'),
     (AdHocCommand, 'ad_hoc_command'),
     (InventoryUpdate, 'inventory_update'),
     (ProjectUpdate, 'project_update'),
     (SystemJob, 'system_job'),
-    (WorkflowJob, 'workflow_job')
-])
+    (WorkflowJob, 'workflow_job'),
+    (UnifiedJob, 'unified_job'),
+    (Inventory, 'inventory'),
+    (JobTemplate, 'job_template'),
+    (UnifiedJobTemplate, 'unified_job_template')
+]
+
+
+# Cases relied on for scheduler dependent jobs list
+@pytest.mark.parametrize('model,name', TEST_MODELS)
 def test_get_type_for_model(model, name):
     assert common.get_type_for_model(model) == name
+
+
+@pytest.mark.django_db
+def test_get_model_for_invalid_type():
+    with pytest.raises(LookupError):
+        common.get_model_for_type('foobar')
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("model_type,model_class", [
+    (name, cls) for cls, name in TEST_MODELS
+])
+def test_get_model_for_valid_type(model_type, model_class):
+    assert common.get_model_for_type(model_type) == model_class
 
 
 @pytest.fixture

--- a/awx/main/utils/polymorphic.py
+++ b/awx/main/utils/polymorphic.py
@@ -2,6 +2,8 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
+from awx.main.utils.common import camelcase_to_underscore
+
 
 def build_polymorphic_ctypes_map(cls):
     # {'1': 'unified_job', '2': 'Job', '3': 'project_update', ...}
@@ -9,7 +11,7 @@ def build_polymorphic_ctypes_map(cls):
     for ct in ContentType.objects.filter(app_label='main'):
         ct_model_class = ct.model_class()
         if ct_model_class and issubclass(ct_model_class, cls):
-            mapping[ct.id] = ct_model_class._camel_to_underscore(ct_model_class.__name__)
+            mapping[ct.id] = camelcase_to_underscore(ct_model_class.__name__)
     return mapping
 
 


### PR DESCRIPTION
##### SUMMARY
This is a general tech debt cleanup item.

Idea of this change: to remove all code in our models that has comments with reference to some old Django version.

We don't want this around as we move to Django 2.0.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
