### PR TITLE
Increasing requests-credssp ver to 1.0.2

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -57,6 +57,6 @@ pyvmomi==6.5
 backports.ssl-match-hostname==3.5.0.1
 pywinrm[kerberos]==0.3.0
 requests
-requests-credssp==0.1.0   # For windows authentication awx/issues/1144
+requests-credssp==1.0.2   # For windows authentication awx/issues/1144
 # OpenStack
 openstacksdk==0.23.0

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -103,7 +103,7 @@ python-dateutil==2.6.1    # via adal, azure-storage, botocore
 pyvmomi==6.5
 pywinrm[kerberos]==0.3.0
 pyyaml==5.1               # via azure-cli-core, knack, openstacksdk, os-client-config
-requests-credssp==0.1.0
+requests-credssp==1.0.2
 requests-kerberos==0.12.0  # via pywinrm
 requests-ntlm==1.1.0      # via pywinrm
 requests-oauthlib==0.8.0  # via msrest


### PR DESCRIPTION
Current requests-credssp version (0.1.0) causes an issue when using CredSSP as Auth protocol on Windows hosts. The job finishes with the following error:

File \"/var/lib/awx/venv/ansible/lib/python2.7/site-packages/requests_credssp/credssp.py\", line 451, in _get_rsa_public_key
    length = openssl_lib.i2d_RSAPublicKey(rsa, buf)[0m
AttributeError: 'module' object has no attribute 'i2d_RSAPublicKey'

By increasing the requests-credssp module to version 1.0.2 fixes the issue and the job finishes successfully.

Signed-off-by: Adam Nagy <anagy@netsuite.com>
