### PR TITLE
Avoid unnecessary user get expiring session memberships

### DIFF
--- a/awx/main/models/organization.py
+++ b/awx/main/models/organization.py
@@ -161,8 +161,8 @@ class Profile(CreatedModifiedModel):
 class UserSessionMembership(BaseModel):
     '''
     A lookup table for API session membership given user. Note, there is a
-    different session created by channels for websockets using the same 
-    underlying model.  
+    different session created by channels for websockets using the same
+    underlying model.
     '''
 
     class Meta:
@@ -177,14 +177,14 @@ class UserSessionMembership(BaseModel):
     created = models.DateTimeField(default=None, editable=False)
 
     @staticmethod
-    def get_memberships_over_limit(user, now=None):
+    def get_memberships_over_limit(user_id, now=None):
         if settings.SESSIONS_PER_USER == -1:
             return []
         if now is None:
             now = tz_now()
         query_set = UserSessionMembership.objects\
             .select_related('session')\
-            .filter(user=user)\
+            .filter(user_id=user_id)\
             .order_by('-created')
         non_expire_memberships = [x for x in query_set if x.session.expire_date > now]
         return non_expire_memberships[settings.SESSIONS_PER_USER:]


### PR DESCRIPTION
##### SUMMARY
This is something to speed up our middleware by 1 database query for every request.

##### ISSUE TYPE
 - Performance

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
there seems to be no need to obtain the object at all, so we can just not do it. I tested the filter and create commands via the shell manually, and I know we have at least 1 functional unit test that covers this code path.