### PR TITLE
Dynamically show instance group name in breadcrumb

### DIFF
--- a/awx/ui/client/src/instance-groups/instance-groups.strings.js
+++ b/awx/ui/client/src/instance-groups/instance-groups.strings.js
@@ -7,8 +7,7 @@ function InstanceGroupsStrings (BaseString) {
     ns.state = {
         INSTANCE_GROUPS_BREADCRUMB_LABEL: t.s('INSTANCE GROUPS'),
         INSTANCES_BREADCRUMB_LABEL: t.s('INSTANCES'),
-        ADD_BREADCRUMB_LABEL: t.s('CREATE INSTANCE GROUP'),
-        EDIT_BREADCRUMB_LABEL: t.s('EDIT INSTANCE GROUP')
+        ADD_BREADCRUMB_LABEL: t.s('CREATE INSTANCE GROUP')
     };
 
     ns.list = {

--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.controller.js
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.controller.js
@@ -1,5 +1,28 @@
-export default ['$scope', '$filter', '$state', 'Alert', 'resolvedModels', 'Dataset', 'InstanceGroupsStrings','ProcessErrors', 'Prompt', 'Wait',
-    function($scope, $filter, $state, Alert, resolvedModels, Dataset, strings, ProcessErrors, Prompt, Wait) {
+export default [
+    '$rootScope',
+    '$scope',
+    '$filter',
+    '$state',
+    'Alert',
+    'resolvedModels',
+    'Dataset',
+    'InstanceGroupsStrings',
+    'ProcessErrors',
+    'Prompt',
+    'Wait',
+    function(
+        $rootScope,
+        $scope,
+        $filter,
+        $state,
+        Alert,
+        resolvedModels,
+        Dataset,
+        strings,
+        ProcessErrors,
+        Prompt,
+        Wait
+    ) {
         const vm = this;
         const { instanceGroup } = resolvedModels;
         let paginateQuerySet = {};
@@ -10,6 +33,7 @@ export default ['$scope', '$filter', '$state', 'Alert', 'resolvedModels', 'Datas
         init();
 
         function init(){
+            $rootScope.breadcrumb.instance_group_name = instanceGroup.get('name');
             $scope.list = {
                 iterator: 'instance_group',
                 name: 'instance_groups'

--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.controller.js
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.controller.js
@@ -33,7 +33,7 @@ export default [
         init();
 
         function init(){
-            $rootScope.breadcrumb.instance_group_name = instanceGroup.get('name');
+            $rootScope.breadcrumb.instance_group_name = $filter('sanitize')(instanceGroup.get('name'));
             $scope.list = {
                 iterator: 'instance_group',
                 name: 'instance_groups'

--- a/awx/ui/client/src/instance-groups/main.js
+++ b/awx/ui/client/src/instance-groups/main.js
@@ -148,7 +148,7 @@ function InstanceGroupsRun ($stateExtender, strings) {
         name: 'instanceGroups.edit',
         route: '/:instance_group_id',
         ncyBreadcrumb: {
-            label: strings.get('state.EDIT_BREADCRUMB_LABEL')
+            label: '{{breadcrumb.instance_group_name}}'
         },
         params: {
             instance_search: {


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/3886

* Dynamically update instance group breadcrumb

<img width="1171" alt="Screen Shot 2019-05-16 at 4 54 31 PM" src="https://user-images.githubusercontent.com/15881645/57887555-b8100680-77fd-11e9-85dc-c94a5efd02a1.png">

![bc](https://user-images.githubusercontent.com/15881645/57886150-92353280-77fa-11e9-85b0-c1c24596fd04.gif)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
