### PR TITLE
Fix the middleware ordering

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1186,10 +1186,9 @@ AWX_CLEANUP_PATHS = True
 
 MIDDLEWARE = [
     'awx.main.middleware.TimingMiddleware',
-    'awx.main.middleware.SessionTimeoutMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'awx.main.middleware.MigrationRanCheckMiddleware',
     'corsheaders.middleware.CorsMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -1199,4 +1198,5 @@ MIDDLEWARE = [
     'awx.sso.middleware.SocialAuthMiddleware',
     'crum.CurrentRequestUserMiddleware',
     'awx.main.middleware.URLModificationMiddleware',
+    'awx.main.middleware.SessionTimeoutMiddleware',
 ]


### PR DESCRIPTION
##### SUMMARY
We recently attempted to reorder the middleware stack to eliminate the problems with the migrations check middleware, but got the wrong one.

related #3875 

I have now verified that this does the right thing both in the initially logged-in case and the non-logged-in case when a migration is created, and then when the migration is applied.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 4.0.0
```
