### PR TITLE
Restore old use pattern for gce_ modules, update token_uri URL

### DIFF
--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -19,18 +19,19 @@ def gce(cred, env, private_data_dir):
     project = cred.get_input('project', default='')
     username = cred.get_input('username', default='')
 
-    if 'INVENTORY_UPDATE_ID' not in env:
-        env['GCE_EMAIL'] = username
-        env['GCE_PROJECT'] = project
     json_cred = {
         'type': 'service_account',
         'private_key': cred.get_input('ssh_key_data', default=''),
         'client_email': username,
-        'project_id': project,
-        # need token uri for inventory plugins
-        # should this really be hard coded? Good question.
-        'token_uri': 'https://accounts.google.com/o/oauth2/token',
+        'project_id': project
     }
+    if 'INVENTORY_UPDATE_ID' not in env:
+        env['GCE_EMAIL'] = username
+        env['GCE_PROJECT'] = project
+    else:
+        # gcp_compute inventory plugin requires token_uri
+        # although it probably should not, since gce_modules do not
+        json_cred['token_uri'] = 'https://oauth2.googleapis.com/token'
 
     handle, path = tempfile.mkstemp(dir=private_data_dir)
     f = os.fdopen(handle, 'w')

--- a/awx/main/tests/data/inventory/plugins/gce/files/GCE_CREDENTIALS_FILE_PATH
+++ b/awx/main/tests/data/inventory/plugins/gce/files/GCE_CREDENTIALS_FILE_PATH
@@ -3,5 +3,5 @@
   "private_key": "{{private_key}}",
   "client_email": "fooo",
   "project_id": "fooo",
-  "token_uri": "https://accounts.google.com/o/oauth2/token"
+  "token_uri": "https://oauth2.googleapis.com/token"
 }

--- a/awx/main/tests/data/inventory/scripts/gce/files/GCE_CREDENTIALS_FILE_PATH
+++ b/awx/main/tests/data/inventory/scripts/gce/files/GCE_CREDENTIALS_FILE_PATH
@@ -3,5 +3,5 @@
   "private_key": "{{private_key}}",
   "client_email": "fooo",
   "project_id": "fooo",
-  "token_uri": "https://accounts.google.com/o/oauth2/token"
+  "token_uri": "https://oauth2.googleapis.com/token"
 }


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/3922

The only question this leaves open is why it was ever changed to apply `token_uri` in playbook runs? Quite simply, we prefer to make inventory & playbook use of a credential be the same. We had a test case for the module, and it worked fine with this parameter added. Given the linked issue, that probably means that we lacked something in our test case.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
Tested manually with the up-to-date inventory plugin gcp_compute, and this is working fine.
