### PR TITLE
More precise handling of schedule computed fields no-ops

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -227,15 +227,23 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         job_kwargs['_eager_fields'] = {'launch_type': 'scheduled', 'schedule': self}
         return job_kwargs
 
-    def update_computed_fields(self):
-        future_rs = Schedule.rrulestr(self.rrule)
-        next_run_actual = future_rs.after(now())
+    def update_computed_fields_no_save(self):
+        affects_fields = ['next_run', 'dtstart', 'dtend']
+        starting_values = {}
+        for field_name in affects_fields:
+            starting_values[field_name] = getattr(self, field_name)
 
-        if next_run_actual is not None:
-            if not datetime_exists(next_run_actual):
-                # skip imaginary dates, like 2:30 on DST boundaries
-                next_run_actual = future_rs.after(next_run_actual)
-            next_run_actual = next_run_actual.astimezone(pytz.utc)
+        future_rs = Schedule.rrulestr(self.rrule)
+
+        if self.enabled:
+            next_run_actual = future_rs.after(now())
+            if next_run_actual is not None:
+                if not datetime_exists(next_run_actual):
+                    # skip imaginary dates, like 2:30 on DST boundaries
+                    next_run_actual = future_rs.after(next_run_actual)
+                next_run_actual = next_run_actual.astimezone(pytz.utc)
+        else:
+            next_run_actual = None
 
         self.next_run = next_run_actual
         try:
@@ -248,11 +256,38 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 self.dtend = future_rs[-1].astimezone(pytz.utc)
             except IndexError:
                 self.dtend = None
+
+        changed = any(getattr(self, field_name) != starting_values[field_name] for field_name in affects_fields)
+        return changed
+
+    def update_computed_fields(self):
+        changed = self.update_computed_fields_no_save()
+        if not changed:
+            return
         emit_channel_notification('schedules-changed', dict(id=self.id, group_name='schedules'))
+        # Must save self here before calling unified_job_template computed fields
+        # in order for that method to be correct
+        # by adding modified to update fields, we avoid updating modified time
+        super(Schedule, self).save(update_fields=['next_run', 'dtstart', 'dtend', 'modified'])
         with ignore_inventory_computed_fields():
             self.unified_job_template.update_computed_fields()
 
     def save(self, *args, **kwargs):
-        self.update_computed_fields()
         self.rrule = Schedule.coerce_naive_until(self.rrule)
+        changed = self.update_computed_fields_no_save()
+        if changed and 'update_fields' in kwargs:
+            for field_name in ['next_run', 'dtstart', 'dtend']:
+                if field_name not in kwargs['update_fields']:
+                    kwargs['update_fields'].append(field_name)
         super(Schedule, self).save(*args, **kwargs)
+        if changed:
+            with ignore_inventory_computed_fields():
+                self.unified_job_template.update_computed_fields()
+
+    def delete(self, *args, **kwargs):
+        ujt = self.unified_job_template
+        r = super(Schedule, self).delete(*args, **kwargs)
+        if ujt:
+            with ignore_inventory_computed_fields():
+                ujt.update_computed_fields()
+        return r

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -107,9 +107,6 @@ def dispatch_startup():
     for sch in Schedule.objects.all():
         try:
             sch.update_computed_fields()
-            from awx.main.signals import disable_activity_stream
-            with disable_activity_stream():
-                sch.save()
         except Exception:
             logger.exception("Failed to rebuild schedule {}.".format(sch))
 
@@ -496,7 +493,7 @@ def awx_periodic_scheduler():
 
         old_schedules = Schedule.objects.enabled().before(last_run)
         for schedule in old_schedules:
-            schedule.save()
+            schedule.update_computed_fields()
         schedules = Schedule.objects.enabled().between(last_run, run_now)
 
         invalid_license = False
@@ -507,7 +504,7 @@ def awx_periodic_scheduler():
 
         for schedule in schedules:
             template = schedule.unified_job_template
-            schedule.save() # To update next_run timestamp.
+            schedule.update_computed_fields() # To update next_run timestamp.
             if template.cache_timeout_blocked:
                 logger.warn("Cache timeout is in the future, bypassing schedule for template %s" % str(template.id))
                 continue


### PR DESCRIPTION
Do not set a next_run value for disabled schedules
Bail if no fields are changed
Do not update related template if its fields did not change

Change call pattern to schedule.update_computed_fields()
in doing so, fix bug where template does not pick up schedule
  due to schedules next_run not being saved

Handle the case (also a bug) where template was not updated
  when schedule was deleted

##### SUMMARY
Replaces https://github.com/ansible/awx/pull/3917

Connect https://github.com/ansible/awx/issues/3912

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
A reasonable ask here might be for performance comparison before / after this. But that's honestly really hard to do. I have 5 schedules, and before it took like 50 queries, and with this it takes 1. It grabs the schedule list, and none of them truly update the next run, so no updates are done.

The main way this is achievable is by:

> Do not set a next_run value for disabled schedules

If we go with this, then I'd say this is deserving of a release note. At first, I thought that nulling out the next_run for disabled schedules was obvious, but now I see it might not be so obvious.

If that isn't changed, I suspect that we can still get more than sufficient performance improvement by keeping just the handling of the no-op cases.