### PR TITLE
Move dynamic log level logic to filter

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -19,12 +19,11 @@ from django.conf import settings
 from requests_futures.sessions import FuturesSession
 
 # AWX
-from awx.main.constants import LOGGER_BLACKLIST
 from awx.main.utils.formatters import LogstashFormatter
 
 
 __all__ = ['BaseHTTPSHandler', 'TCPHandler', 'UDPHandler',
-           'AWXProxyHandler', 'RotatingProductionLogHandler']
+           'AWXProxyHandler']
 
 
 logger = logging.getLogger('awx.main.utils.handlers')
@@ -90,28 +89,6 @@ class SocketResult:
 
     def result(self):
         return self
-
-
-class DynamicLevelMixin(object):
-
-    @property
-    def level(self):
-        from django.conf import settings
-        for logger_name in LOGGER_BLACKLIST:
-            if self.name.startswith(logger_name):
-                return 30  # WARNING
-        try:
-            return logging._nameToLevel[settings.LOG_AGGREGATOR_LEVEL]
-        except Exception:
-            return 30  # WARNING
-
-    @level.setter
-    def level(self, level):
-        pass  # no-op, this value comes from the database
-
-
-class RotatingProductionLogHandler(logging.handlers.RotatingFileHandler, DynamicLevelMixin):
-    pass
 
 
 class BaseHandler(logging.Handler):
@@ -295,7 +272,7 @@ HANDLER_MAPPING = {
 }
 
 
-class AWXProxyHandler(logging.Handler, DynamicLevelMixin):
+class AWXProxyHandler(logging.Handler):
     '''
     Handler specific to the AWX external logging feature
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -966,6 +966,9 @@ LOGGING = {
         'external_log_enabled': {
             '()': 'awx.main.utils.filters.ExternalLoggerEnabled'
         },
+        'dynamic_level_filter': {
+            '()': 'awx.main.utils.filters.DynamicLevelFilter'
+        }
     },
     'formatters': {
         'simple': {
@@ -1005,7 +1008,7 @@ LOGGING = {
         'external_logger': {
             'class': 'awx.main.utils.handlers.AWXProxyHandler',
             'formatter': 'json',
-            'filters': ['external_log_enabled'],
+            'filters': ['external_log_enabled', 'dynamic_level_filter'],
         },
         'mail_admins': {
             'level': 'ERROR',
@@ -1014,8 +1017,8 @@ LOGGING = {
         },
         'tower_warnings': {
             # don't define a level here, it's set by settings.LOG_AGGREGATOR_LEVEL
-            'class':'awx.main.utils.handlers.RotatingProductionLogHandler',
-            'filters': ['require_debug_false'],
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filters': ['require_debug_false', 'dynamic_level_filter'],
             'filename': os.path.join(LOG_ROOT, 'tower.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
@@ -1023,8 +1026,8 @@ LOGGING = {
         },
         'callback_receiver': {
             # don't define a level here, it's set by settings.LOG_AGGREGATOR_LEVEL
-            'class':'awx.main.utils.handlers.RotatingProductionLogHandler',
-            'filters': ['require_debug_false'],
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filters': ['require_debug_false', 'dynamic_level_filter'],
             'filename': os.path.join(LOG_ROOT, 'callback_receiver.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
@@ -1032,8 +1035,8 @@ LOGGING = {
         },
         'dispatcher': {
             # don't define a level here, it's set by settings.LOG_AGGREGATOR_LEVEL
-            'class':'awx.main.utils.handlers.RotatingProductionLogHandler',
-            'filters': ['require_debug_false'],
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filters': ['require_debug_false', 'dynamic_level_filter'],
             'filename': os.path.join(LOG_ROOT, 'dispatcher.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,
@@ -1050,8 +1053,8 @@ LOGGING = {
         },
         'task_system': {
             # don't define a level here, it's set by settings.LOG_AGGREGATOR_LEVEL
-            'class':'awx.main.utils.handlers.RotatingProductionLogHandler',
-            'filters': ['require_debug_false'],
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filters': ['require_debug_false', 'dynamic_level_filter'],
             'filename': os.path.join(LOG_ROOT, 'task_system.log'),
             'maxBytes': 1024 * 1024 * 5, # 5 MB
             'backupCount': 5,


### PR DESCRIPTION
##### SUMMARY
This is to fix Zuul tests, as well as get the blacklist to work in general.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
The root of the problem is here:

https://github.com/ansible/awx/blob/d9965cfe7e0f7a82fea04acb3b6b49852874f655/awx/main/utils/handlers.py#L101

Here, `self` is the instance of the handler, not the log record, so this is using the blacklist incorrectly, it will always be the name of the handler, which is "dispatcher" or "task_system", whereas the blacklist is logger names like "awx.main.utils" or "awx.conf".

The reason this diff is so large is because the log record is generally not available in this context where the handler property method is written. Simplest solution - change it to a filter, which does have access to the log record.
