### PR TITLE
openshift: Ensure char in password are not interpreted

### DIFF
--- a/installer/roles/kubernetes/tasks/openshift_auth.yml
+++ b/installer/roles/kubernetes/tasks/openshift_auth.yml
@@ -17,7 +17,7 @@
   shell: |
     {{ openshift_oc_bin }} login {{ openshift_host }} \
       -u {{ openshift_user }} \
-      -p {{ openshift_password }} \
+      -p {{ openshift_password | quote }} \
       --insecure-skip-tls-verify={{ openshift_skip_tls_verify | default(false) | bool }}
   when:
     - openshift_user is defined


### PR DESCRIPTION
##### SUMMARY

If password contains ';' (and potentially any shell interpretable chars)
it won't be interpreted properly as the openshift password.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

 - devel

##### ADDITIONAL INFORMATION

 - N/A
