### PR TITLE
Remove some things that are not first-order dependencies from requirements.in

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,14 +1,12 @@
 ansible-runner==1.3.4
 appdirs==1.4.2
 asgi-amqp==1.1.3
-asgiref==1.1.2
 azure-keyvault==1.1.0
 boto==2.47.0
 channels==1.1.8
 celery==4.3.0
 daphne==1.3.0   # Last before backwards-incompatible channels 2 upgrade
 twisted[tls]>=17.1   # from daphne, see https://github.com/django/daphne/pull/257
-defusedxml==0.5.0  # py36 support https://github.com/tiran/defusedxml/pull/4
 Django==1.11.20
 django-auth-ldap==1.7.0
 django-cors-headers==2.4.0
@@ -29,7 +27,6 @@ jinja2==2.10.1
 jsonschema==2.6.0
 Markdown==2.6.11    # used for formatting API help
 ordereddict==1.1
-pexpect==4.6.0
 prometheus_client==0.6.0
 psutil==5.4.3
 psycopg2==2.7.3.2   # problems with Segmentation faults / wheels on upgrade

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ ansible-runner==1.3.4
 appdirs==1.4.2
 argparse==1.4.0           # via uwsgitop
 asgi-amqp==1.1.3
-asgiref==1.1.2
+asgiref==1.1.2            # via asgi-amqp, channels, daphne
 asn1crypto==0.24.0        # via cryptography
 attrs==19.1.0             # via automat, service-identity, twisted
 autobahn==19.3.3          # via daphne
@@ -28,7 +28,7 @@ chardet==3.0.4            # via requests
 constantly==15.1.0        # via twisted
 cryptography==2.6.1       # via adal, azure-keyvault, pyopenssl, service-identity
 daphne==1.3.0
-defusedxml==0.5.0
+defusedxml==0.5.0         # via python3-openid, python3-saml, social-auth-core
 django-auth-ldap==1.7.0
 django-cors-headers==2.4.0
 django-crum==0.7.2
@@ -73,7 +73,7 @@ msrestazure==0.6.0        # via azure-keyvault
 netaddr==0.7.19           # via pyrad
 oauthlib==3.0.1           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 ordereddict==1.1
-pexpect==4.6.0
+pexpect==4.6.0            # via ansible-runner
 pkgconfig==1.5.1          # via xmlsec
 prometheus_client==0.6.0
 psutil==5.4.3


### PR DESCRIPTION
This includes a few things where the version specifiers resolve properly now without needing them in requirements.in.

