### PR TITLE
Emphasize a recent version of Docker

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,7 @@ Before you can run a deployment, you'll need the following installed in your loc
 
 - [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.4+
 - [Docker](https://docs.docker.com/engine/installation/)
+    + A recent version
 - [docker](https://pypi.org/project/docker/) Python module
     + This is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
     + We use this module instead of `docker-py` because it is what the `docker-compose` Python module requires.


### PR DESCRIPTION
##### SUMMARY

I had 1.13 installed as part of Centos Extras and spent hours attempting to install AWX 4.0.0; the attempts all threw masses of permission denied errors.


<!--- Describe the change, including rationale and design decisions -->
Uninstalling that version and replacing with a current docker-ce then worked.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 4.0.0
```


