### PR TITLE
Add isolated badge to isolated instance groups

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -527,7 +527,7 @@ function getInstanceGroupDetails () {
 
     let isolated = null;
 
-    if (instanceGroup.controller_id) {
+    if (instanceGroup.is_isolated) {
         isolated = strings.get('details.ISOLATED');
     }
 

--- a/awx/ui/client/src/instance-groups/instance-groups.strings.js
+++ b/awx/ui/client/src/instance-groups/instance-groups.strings.js
@@ -14,6 +14,7 @@ function InstanceGroupsStrings (BaseString) {
         MANUAL: t.s('MANUAL'),
         PANEL_TITLE: t.s('INSTANCE GROUPS'),
         ROW_ITEM_LABEL_INSTANCES: t.s('Instances'),
+        ROW_ITEM_LABEL_ISOLATED: t.s('ISOLATED'),
         ROW_ITEM_LABEL_RUNNING_JOBS: t.s('Running Jobs'),
         ROW_ITEM_LABEL_TOTAL_JOBS: t.s('Total Jobs'),
         ROW_ITEM_LABEL_USED_CAPACITY: t.s('Used Capacity')
@@ -58,7 +59,7 @@ function InstanceGroupsStrings (BaseString) {
         DELETE: t.s('Unable to delete instance group.'),
     };
 
-    ns.alert  = {
+    ns.alert = {
         MISSING_PARAMETER: t.s('Instance Group parameter is missing.'),
     };
 }

--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
@@ -45,7 +45,9 @@
                 <div class="at-Row-items">
                     <at-row-item
                         header-value="{{ instance_group.name }}"
-                        header-link="/#/instance_groups/{{ instance_group.id }}">
+                        header-link="/#/instance_groups/{{ instance_group.id }}"
+                        header-tag="{{ instance_group.is_isolated ? vm.strings.get('list.ROW_ITEM_LABEL_ISOLATED') : '' }}"
+                    >
                     </at-row-item>
 
                     <div class="at-Row--inline">


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The API added two new properties to the InstanceGroup model - `is_controller` and `is_isolated` in https://github.com/ansible/awx/pull/3686.  This PR updates the UI to use the new `is_isolated` field to determine whether or not to show an "Isolated" badge. 

_Details_
<img width="494" alt="Screen Shot 2019-06-03 at 1 11 22 PM" src="https://user-images.githubusercontent.com/15881645/58822637-fbdc7b80-8605-11e9-894d-29864a5c1792.png">

_Instance Group List_
<img width="521" alt="Screen Shot 2019-06-03 at 1 11 49 PM" src="https://user-images.githubusercontent.com/15881645/58822618-eebf8c80-8605-11e9-8f6a-ef8ef08b9bfd.png">




##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 4.0.0
```
