### PR TITLE
[WIP] Force swagger activity stream host to be constant

### DIFF
--- a/awx/main/tests/docs/test_swagger_generation.py
+++ b/awx/main/tests/docs/test_swagger_generation.py
@@ -163,6 +163,8 @@ class TestSwaggerGeneration():
     @classmethod
     def teardown_class(cls):
         with open('swagger.json', 'w') as f:
+            if 'action_node' in cls.JSON:
+                cls.JSON['action_node'] = 'foo.host.invalid'
             data = json.dumps(cls.JSON, cls=i18nEncoder, indent=2, sort_keys=True)
             # replace ISO dates w/ the same value so we don't generate
             # needless diffs

--- a/awx/main/tests/docs/test_swagger_generation.py
+++ b/awx/main/tests/docs/test_swagger_generation.py
@@ -66,6 +66,8 @@ class TestSwaggerGeneration():
                 for method in node:
                     if path in deprecated_paths:
                         node[method]['deprecated'] = True
+                    if 'action_node' in node:
+                        node['action_node'] = 'foo.host.invalid'
                     if 'description' in node[method]:
                         # Pop off the first line and use that as the summary
                         lines = node[method]['description'].splitlines()

--- a/awx/main/tests/docs/test_swagger_generation.py
+++ b/awx/main/tests/docs/test_swagger_generation.py
@@ -68,6 +68,10 @@ class TestSwaggerGeneration():
                         node[method]['deprecated'] = True
                     if 'action_node' in node:
                         node['action_node'] = 'foo.host.invalid'
+                    if 'results' in node:
+                        for entry in node['results']:
+                            if 'action_node' in entry:
+                                entry['action_node'] = 'foo.host.invalid'
                     if 'description' in node[method]:
                         # Pop off the first line and use that as the summary
                         lines = node[method]['description'].splitlines()


### PR DESCRIPTION
##### SUMMARY
This is to make the swagger schema generation static again

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
