### PR TITLE
fix analytics job counts by ordering query

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -177,9 +177,9 @@ def instance_info(since):
 def job_counts(since):
     counts = {}
     counts['total_jobs'] = models.UnifiedJob.objects.exclude(launch_type='sync').count()
-    counts['status'] = dict(models.UnifiedJob.objects.exclude(launch_type='sync').values_list('status').annotate(Count('status')))
-    counts['launch_type'] = dict(models.UnifiedJob.objects.exclude(launch_type='sync').values_list('launch_type').annotate(Count('launch_type')))
-    
+    counts['status'] = dict(models.UnifiedJob.objects.exclude(launch_type='sync').values_list('status').annotate(Count('status')).order_by())
+    counts['launch_type'] = dict(models.UnifiedJob.objects.exclude(launch_type='sync').values_list(
+        'launch_type').annotate(Count('launch_type')).order_by())
     return counts
     
     


### PR DESCRIPTION
##### SUMMARY
There is a default order_by on the UnifiedJob model that needed to be overriden when queried with an annotation for analytics collection.  

##### Before
```
In [48]: dict(UnifiedJob.objects.values_list('status').annotate(Count('status')))
Out[48]: {'failed': 1, 'successful': 1}

In [49]: UnifiedJob.objects.filter(status='successful').count()
Out[49]: 95
```


##### After

```
In [66]: UnifiedJob.objects.values('status').annotate(status_count=Count('status')).order_by()
Out[66]: <PolymorphicQuerySet [{'status': 'successful', 'status_count': 95}, {'status': 'failed', 'status_count': 10}]>
```

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

