### PR TITLE
Don't allow Enter to proceed to next step if survey fields invalid

### DIFF
--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -229,6 +229,12 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
         };
 
         vm.keypress = (event) => {
+          if (vm.steps.survey.tab._active && !vm.readOnlyPrompts && !vm.forms.survey.$valid) {
+            return;
+          }
+          if (document.activeElement.type === 'textarea') {
+            return;
+          }
           if (event.key === 'Enter') {
             vm.next(activeTab);
           }


### PR DESCRIPTION
##### SUMMARY
Prevents `Enter` from proceeding to the next step if:
a) the user is on the Survey tab and the required fields are not filled in, or
b) the user is currently focused on a `<textarea>` (allowing the user to type a hard return instead)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

