### PR TITLE
Resolved issue with ovirt4 dynamic inventory script.

### DIFF
--- a/awx/plugins/inventory/ovirt4.py
+++ b/awx/plugins/inventory/ovirt4.py
@@ -179,7 +179,7 @@ def get_dict_of_struct(connection, vm):
             if vm.name in [vm.name for vm in connection.follow_link(group.vms)]
         ],
         'statistics': dict(
-            (stat.name, stat.values[0].datum) for stat in stats
+            (stat.name, stat.values[0].datum) for stat in stats if len(stat.values)
         ),
         'devices': dict(
             (device.name, [ip.address for ip in device.ips]) for device in devices if device.ips


### PR DESCRIPTION


##### SUMMARY
When using RHV 4.3 as a dynamic inventory source, there was an issue 
syncing inventory when one or more VMs were powered off. The value for 
the statistic cpu.usage.history (and possibly more) are empty when the 
VM is off and the inventory script did not account for this when parsing 
the statistics.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ovirt4 dyanmic inventory

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
This issue may be new with RHV 4.3, but I do not have a RHV 4.2 environment available to test. This change will be backwards compatible.
