### PR TITLE
Whitelist table elements for use in bootstrap popovers

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -430,6 +430,10 @@ textarea.allowresize {
       p:last-child {
           margin-bottom: 0;
       }
+
+      table {
+        color: @default-bg; //white
+      }
   }
   .popover.right>.arrow:after  {
       border-right-color: @default-interface-txt;

--- a/awx/ui/client/src/vendor.js
+++ b/awx/ui/client/src/vendor.js
@@ -31,6 +31,13 @@ require('bootstrap-datepicker');
 const btn = $.fn.button.noConflict();
 $.fn.btn = btn;
 
+// Whitelist table elements so they can be used in popovers
+$.fn.popover.Constructor.Default.whiteList.table = [];
+$.fn.popover.Constructor.Default.whiteList.tr = [];
+$.fn.popover.Constructor.Default.whiteList.td = [];
+$.fn.popover.Constructor.Default.whiteList.tbody = [];
+$.fn.popover.Constructor.Default.whiteList.thead = [];
+
 require('select2');
 
 // Standalone libs


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3811

See ^^ the issue for more details but the gist is that in order to use table elements in the Bootstrap popover we need to whitelist the elements.  This PR does that and also overrides the Bootstrap table `color` style to ensure that the text is white:

<img width="396" alt="Screen Shot 2019-06-10 at 4 10 39 PM" src="https://user-images.githubusercontent.com/9889020/59223740-b803ec00-8b9a-11e9-9c6d-726460c07c7a.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
