### PR TITLE
update credential deletion prompt queries

### DIFF
--- a/awx/ui/client/lib/models/Credential.js
+++ b/awx/ui/client/lib/models/Credential.js
@@ -107,7 +107,7 @@ function setDependentResources (id) {
         {
             model: new JobTemplate(),
             params: {
-                credential: id,
+                credentials__id: id,
                 ask_credential_on_launch: false
             }
         },
@@ -120,7 +120,7 @@ function setDependentResources (id) {
         {
             model: new InventorySource(),
             params: {
-                credential: id
+                credentials__id: id
             }
         }
     ];


### PR DESCRIPTION
##### SUMMARY
resolves https://github.com/ansible/awx/issues/4037

When we show deletion warnings that say things like “Are you sure you want to delete this credential, several of these other things might break as a result” we use queries that look like this:

```
/job_templates/?credential=40
/inventory_sources/?credential=40
/projects/?credential=40
```

“Give me all job templates, inventory sources, and projects that are related to credential 40"

This updates the job templates and inventory_source queries to use `credentials__id=id` so they no longer filter on the `credential` field.


