### PR TITLE
Fix user token application lookup column widths

### DIFF
--- a/awx/ui/client/features/users/tokens/users-tokens-add-application.route.js
+++ b/awx/ui/client/features/users/tokens/users-tokens-add-application.route.js
@@ -41,14 +41,13 @@ export default {
                 name: {
                     key: true,
                     label: 'Name',
-                    columnClass: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
+                    columnClass: 'col-sm-6',
                     awToolTip: '{{application.description | sanitize}}',
                     dataPlacement: 'top'
                 },
                 organization: {
                     label: 'Organization',
-                    columnClass: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
-                    modalColumnClass: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
+                    columnClass: 'col-sm-6',
                     key: false,
                     ngBind: 'application.summary_fields.organization.name',
                     sourceModel: 'organization',


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3977

Split the columns 50/50.

Tested by going to the create token form and opening the Application lookup modal.  This should only impact the add token form.  The modified code is not used anywhere else.

<img width="1018" alt="Screen Shot 2019-06-11 at 9 57 04 AM" src="https://user-images.githubusercontent.com/9889020/59278461-01524b00-8c30-11e9-8fb5-ab62e58dcde7.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

