### PR TITLE
Fixes bug where save changes modal was shown to user with execute permissions

### DIFF
--- a/awx/ui/client/src/templates/main.js
+++ b/awx/ui/client/src/templates/main.js
@@ -498,7 +498,7 @@ angular.module('templates', [surveyMaker.name, jobTemplates.name, labels.name, p
                     },
                     views: {
                         'modal': {
-                            template: `<workflow-maker ng-if="includeWorkflowMaker" workflow-job-template-obj="workflow_job_template_obj" can-add-workflow-job-template="canAddWorkflowJobTemplate"></workflow-maker>`
+                            template: `<workflow-maker ng-if="includeWorkflowMaker" workflow-job-template-obj="workflow_job_template_obj" can-add-or-edit="canAddOrEdit"></workflow-maker>`
                         },
                         'jobTemplateList@templates.editWorkflowJobTemplate.workflowMaker': {
                             templateProvider: function(WorkflowMakerJobTemplateList, generateList) {

--- a/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
+++ b/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
@@ -20,7 +20,7 @@ export default [
 
          const workflowTemplate = resolvedModels[1];
 
-         $scope.canAddWorkflowJobTemplate = workflowTemplate.options('actions.POST');
+         $scope.canAddOrEdit = workflowTemplate.options('actions.POST');
 
          $scope.canEditOrg = true;
          $scope.canEditInventory = true;

--- a/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
+++ b/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
@@ -26,12 +26,6 @@ export default [
         $scope.sufficientRoleForNotif =  isNotificationAdmin || $scope.user_is_system_auditor;
         $scope.missingTemplates = _.has(workflowLaunch, 'node_templates_missing') && workflowLaunch.node_templates_missing.length > 0 ? true : false;
 
-        $scope.$watch('workflow_job_template_obj.summary_fields.user_capabilities.edit', function(val) {
-            if (val === false) {
-                $scope.canAddWorkflowJobTemplate = false;
-            }
-        });
-
         const criteriaObj = {
             from: (state) => state.name === 'templates.editWorkflowJobTemplate.workflowMaker',
             to: (state) => state.name === 'templates.editWorkflowJobTemplate'
@@ -289,7 +283,7 @@ export default [
 
         $scope.workflow_job_template_obj = workflowJobTemplateData;
         $scope.name = workflowJobTemplateData.name;
-        $scope.can_edit = workflowJobTemplateData.summary_fields.user_capabilities.edit;
+        $scope.can_edit = $scope.canAddOrEdit = workflowJobTemplateData.summary_fields.user_capabilities.edit;
         $scope.breadcrumb.workflow_job_template_name = $scope.name;
         let fld, i;
         for (fld in form.fields) {

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.directive.js
@@ -11,7 +11,7 @@ export default ['templateUrl', 'CreateDialog', 'Wait', '$state', '$window',
         return {
             scope: {
                 workflowJobTemplateObj: '=',
-                canAddWorkflowJobTemplate: '='
+                canAddOrEdit: '='
             },
             restrict: 'E',
             templateUrl: templateUrl('templates/workflows/workflow-maker/workflow-maker'),
@@ -63,7 +63,11 @@ export default ['templateUrl', 'CreateDialog', 'Wait', '$state', '$window',
                 });
 
                 scope.closeDialog = function(exitWithUnsavedChanges) {
-                    if (exitWithUnsavedChanges || !(scope.workflowChangesUnsaved || scope.workflowChangesStarted)) {
+                    if (
+                        !scope.canAddOrEdit
+                        || exitWithUnsavedChanges
+                        || !(scope.workflowChangesUnsaved || scope.workflowChangesStarted)
+                    ) {
                         scope.unsavedChangesVisible = false;
                         $('#workflow-modal-dialog').dialog('destroy');
                         $('body').removeClass('WorkflowMaker-preventBodyScrolling');

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.directive.js
@@ -64,9 +64,9 @@ export default ['templateUrl', 'CreateDialog', 'Wait', '$state', '$window',
 
                 scope.closeDialog = function(exitWithUnsavedChanges) {
                     if (
-                        !scope.canAddOrEdit
-                        || exitWithUnsavedChanges
-                        || !(scope.workflowChangesUnsaved || scope.workflowChangesStarted)
+                        !scope.canAddOrEdit ||
+                        exitWithUnsavedChanges ||
+                        !(scope.workflowChangesUnsaved || scope.workflowChangesStarted)
                     ) {
                         scope.unsavedChangesVisible = false;
                         $('#workflow-modal-dialog').dialog('destroy');


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3378

tldr; of these changes are that we now ignore the saved changes modal if the user cannot add/edit the wfjt in question.

User with execute permissions:
![execute_user](https://user-images.githubusercontent.com/9889020/59283998-7f671f80-8c39-11e9-8e48-a2d911b79ec5.gif)

User with admin permissions:
![admin_user](https://user-images.githubusercontent.com/9889020/59283982-7a09d500-8c39-11e9-9f69-9d994ca03c27.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Locally tested the original use case listed in the bug but these changes could impact permissions around adding/editing the visualizer in general so I went ahead and tested the basic use cases (adding/editing WF graph with a superuser/user with admin permissions and viewing the WF graph with a user with the execute role).
