### PR TITLE
Read-only codemirror cleanup

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/edit/groups-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/edit/groups-edit.controller.js
@@ -35,6 +35,7 @@ export default ['$state', '$stateParams', '$scope', 'ParseVariableString', 'rbac
                 scope: $scope,
                 field_id: 'group_group_variables',
                 variable: 'group_variables',
+                readOnly: !$scope.summary_fields.user_capabilities.edit
             });
         }
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/edit/sources-edit.controller.js
@@ -89,6 +89,7 @@ export default ['$state', '$scope', 'ParseVariableString', 'ParseTypeChange',
                     field_id: varName,
                     variable: varName,
                     parse_variable: 'envParseType',
+                    readOnly: !$scope.summary_fields.user_capabilities.edit
                 });
             }
         });

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/edit/smart-inventory-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/edit/smart-inventory-edit.controller.js
@@ -42,7 +42,8 @@ function SmartInventoryEdit($scope, $location,
             scope: $scope,
             variable: 'smartinventory_variables',
             parse_variable: 'parseType',
-            field_id: 'smartinventory_smartinventory_variables'
+            field_id: 'smartinventory_smartinventory_variables',
+            readOnly: !$scope.inventory_obj.summary_fields.user_capabilities.edit
         });
 
         OrgAdminLookup.checkForAdminAccess({organization: inventoryData.organization})

--- a/awx/ui/client/src/notifications/edit/edit.controller.js
+++ b/awx/ui/client/src/notifications/edit/edit.controller.js
@@ -147,11 +147,13 @@ export default ['Rest', 'Wait',
                     if (!$scope.headers) {
                         $scope.headers = "{\n}";
                     }
+
                     ParseTypeChange({
                         scope: $scope,
                         parse_variable: 'parse_type',
                         variable: 'headers',
                         field_id: 'notification_template_headers',
+                        readOnly: !$scope.notification_template.summary_fields.user_capabilities.edit
                     });
                     Wait('stop');
                 })
@@ -221,6 +223,7 @@ export default ['Rest', 'Wait',
                 parse_variable: 'parse_type',
                 variable: 'headers',
                 field_id: 'notification_template_headers',
+                readOnly: !$scope.notification_template.summary_fields.user_capabilities.edit
             });
         };
 

--- a/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
+++ b/awx/ui/client/src/templates/job_templates/edit-job-template/job-template-edit.controller.js
@@ -291,7 +291,8 @@ export default
                     scope: $scope,
                     field_id: 'extra_vars',
                     variable: 'extra_vars',
-                    onChange: callback
+                    onChange: callback,
+                    readOnly: !$scope.job_template_obj.summary_fields.user_capabilities.edit
                 });
                 jobTemplateLoadFinished();
                 launchHasBeenEnabled = true;

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -229,7 +229,7 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
         };
 
         vm.keypress = (event) => {
-          if (vm.steps.survey.tab._active && !vm.readOnlyPrompts && !vm.forms.survey.$valid) {
+          if (vm.steps.survey.tab && vm.steps.survey.tab._active && !vm.readOnlyPrompts && !vm.forms.survey.$valid) {
             return;
           }
           if (document.activeElement.type === 'textarea') {

--- a/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
+++ b/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
@@ -315,7 +315,11 @@ export default [
                 // Parse extra_vars, converting to YAML.
                 $scope.variables = ParseVariableString(workflowJobTemplateData.extra_vars);
 
-                ParseTypeChange({ scope: $scope, field_id: 'workflow_job_template_variables' });
+                ParseTypeChange({
+                    scope: $scope,
+                    field_id: 'workflow_job_template_variables',
+                    readOnly: !workflowJobTemplateData.summary_fields.user_capabilities.edit
+                });
             }
             if (form.fields[fld].type === 'lookup' && workflowJobTemplateData.summary_fields[form.fields[fld].sourceModel]) {
                 $scope[form.fields[fld].sourceModel + '_' + form.fields[fld].sourceField] =


### PR DESCRIPTION
##### SUMMARY
This work came out of investigating https://github.com/ansible/awx/issues/3298

Makes the codemirror's in the following places read-only when the user doesn't have the ability to edit:

1) Groups edit
2) Sources edit
3) Smart Inventory edit
4) Notifications edit
5) Workflow JT edit

This PR also fixes a small bug that got introduced by https://github.com/ansible/awx/pull/4003.  If the JT prompts for extra vars but no survey tab exists then an error is thrown.  We just need to double check to make sure that tab is there before checking to see if it's active.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
