### PR TITLE
Chrome75 workaround for e2e tests

### DIFF
--- a/awx/ui/test/e2e/nightwatch.conf.js
+++ b/awx/ui/test/e2e/nightwatch.conf.js
@@ -30,6 +30,7 @@ module.exports = {
             desiredCapabilities: {
                 browserName: 'chrome',
                 chromeOptions: {
+                    w3c: false,
                     args: [
                         'window-size=1024,768'
                     ]
@@ -61,6 +62,7 @@ module.exports = {
             desiredCapabilities: {
                 browserName: 'chrome',
                 chromeOptions: {
+                    w3c: false,
                     args: [
                         'headless',
                         'disable-web-security',


### PR DESCRIPTION
##### SUMMARY
Chrome75 made w3c the default protocol for the chrome webdriver instead of the jsonWire protocol. This is currently incompatible with nightwatch 0.9.X as nightwatch depends on the missing APIs. Setting w3c to `false` will return selenium communication to the jsonWire protocol.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI