### PR TITLE
hack fix for python threading issue in logging

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -176,7 +176,7 @@ class BaseHTTPSHandler(BaseHandler):
         self.verify_cert = verify_cert
         super(BaseHTTPSHandler, self).__init__(**kwargs)
         self.session = FuturesSession(executor=VerboseThreadPoolExecutor(
-            max_workers=2  # this is the default used by requests_futures
+            max_workers=1  # changed value from the default to fix python threading bug https://bugs.python.org/issue21009
         ))
         self._add_auth_information()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There is an open bug in Python that causes deadlocking with threads. We use that threading implementation in our logging. This reduces the max works to 1 from the default of 2.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx-manage --version
3.5.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
