### PR TITLE
Correctly manage current apps for the action_node addition

### DIFF
--- a/awx/main/migrations/0061_v350_track_native_credentialtype_source.py
+++ b/awx/main/migrations/0061_v350_track_native_credentialtype_source.py
@@ -5,9 +5,11 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 from awx.main.models import CredentialType
+from awx.main.utils.common import set_current_apps
 
 
 def migrate_to_static_inputs(apps, schema_editor):
+    set_current_apps(apps)
     CredentialType.setup_tower_managed_defaults()
 
 

--- a/awx/main/migrations/0067_v350_credential_plugins.py
+++ b/awx/main/migrations/0067_v350_credential_plugins.py
@@ -9,9 +9,11 @@ import taggit.managers
 # AWX
 import awx.main.fields
 from awx.main.models import CredentialType
+from awx.main.utils.common import set_current_apps
 
 
 def setup_tower_managed_defaults(apps, schema_editor):
+    set_current_apps(apps)
     CredentialType.setup_tower_managed_defaults()
 
 

--- a/awx/main/migrations/0080_v360_replace_job_origin.py
+++ b/awx/main/migrations/0080_v360_replace_job_origin.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+from awx.main.utils.common import set_current_apps
+
 
 class Migration(migrations.Migration):
 
@@ -12,6 +14,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(migrations.RunPython.noop, lambda apps, schema_editor: set_current_apps(apps)),
         migrations.RemoveField(
             model_name='joborigin',
             name='instance',
@@ -28,4 +31,5 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='JobOrigin',
         ),
+        migrations.RunPython(lambda apps, schema_editor: set_current_apps(apps), migrations.RunPython.noop)
     ]


### PR DESCRIPTION
##### SUMMARY
What happened?

In some scenarios, users could hit an error migrating through the 0061 migration number.

Why?

Because the default state of the global variable in utils, `current_apps` is effectively apps at HEAD - the current code state. Since current apps were never set, this the default was used. Activity stream at HEAD has a new field - `action_node`. Since the database pre-0061 did not have this column, it would error.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
More cases of this are still possible, but if we can address them with this same pattern, they should be fairly clean and easy to fix.
