### PR TITLE
Always show search bar in smart inventory host filter modal

### DIFF
--- a/awx/ui/client/legacy/styles/lists.less
+++ b/awx/ui/client/legacy/styles/lists.less
@@ -390,6 +390,10 @@ table, tbody {
     margin-top: 0px;
 }
 
+.modal-body > .List-emptyHostFilter {
+    margin-top: 20px;
+}
+
 .List-actionButton--selected,
 .List-editButton--selected {
     background-color: @list-actn-bg-hov !important;

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
@@ -55,8 +55,10 @@ export default ['templateUrl', function(templateUrl) {
                         delete hostList.fields.inventory.ngClick;
                         hostList.fields.inventory.columnClass = 'col-sm-6';
                         hostList.fields.inventory.ngBind = 'host.summary_fields.inventory.name';
-                        hostList.emptyListText = i18n._('You must have access to at least one host in order to create a smart inventory host filter');
+                        hostList.emptyListText = i18n._('Perform a search above to define a host filter');
                         hostList.layoutClass = 'List-defaultLayout';
+                        hostList.alwaysShowSearch = true;
+                        hostList.emptyListClass = 'List-noItems List-emptyHostFilter'
                         let html = GenerateList.build({
                             list: hostList,
                             input_type: 'host-filter-modal-body',

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
@@ -58,7 +58,7 @@ export default ['templateUrl', function(templateUrl) {
                         hostList.emptyListText = i18n._('Perform a search above to define a host filter');
                         hostList.layoutClass = 'List-defaultLayout';
                         hostList.alwaysShowSearch = true;
-                        hostList.emptyListClass = 'List-noItems List-emptyHostFilter'
+                        hostList.emptyListClass = 'List-noItems List-emptyHostFilter';
                         let html = GenerateList.build({
                             list: hostList,
                             input_type: 'host-filter-modal-body',

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -200,7 +200,7 @@ export default ['$compile', 'Attr', 'Icon',
                 if (options.showSearch === undefined || options.showSearch === true) {
                     let singleSearchParam = list.singleSearchParam && list.singleSearchParam.param ? `single-search-param="${list.singleSearchParam.param}"` : '';
                     html += `
-                    <div ng-hide="${list.name}.length === 0 && (searchTags | isEmpty)">
+                    <div ng-hide="!${list.alwaysShowSearch} && ${list.name}.length === 0 && (searchTags | isEmpty)">
                         <smart-search
                             django-model="${list.name}"
                             ${singleSearchParam}
@@ -244,7 +244,8 @@ export default ['$compile', 'Attr', 'Icon',
 
                 // Show the "no items" box when loading is done and the user isn't actively searching and there are no results
                 if (options.showEmptyPanel === undefined || options.showEmptyPanel === true){
-                    html += `<div class="List-noItems" ng-show="${list.name}.length === 0 && (searchTags | isEmpty)">`;
+                    const emptyListClass = list.emptyListClass || "List-noItems";
+                    html += `<div class="${emptyListClass}" ng-show="${list.name}.length === 0 && (searchTags | isEmpty)">`;
                     html += (list.emptyListText) ? list.emptyListText :  i18n._("PLEASE ADD ITEMS TO THIS LIST");
                     html += "</div>";
                 }

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -244,8 +244,7 @@ export default ['$compile', 'Attr', 'Icon',
 
                 // Show the "no items" box when loading is done and the user isn't actively searching and there are no results
                 if (options.showEmptyPanel === undefined || options.showEmptyPanel === true){
-                    const emptyListClass = list.emptyListClass || "List-noItems";
-                    html += `<div class="${emptyListClass}" ng-show="${list.name}.length === 0 && (searchTags | isEmpty)">`;
+                    html += `<div class="${list.emptyListClass || "List-noItems"}" ng-show="${list.name}.length === 0 && (searchTags | isEmpty)">`;
                     html += (list.emptyListText) ? list.emptyListText :  i18n._("PLEASE ADD ITEMS TO THIS LIST");
                     html += "</div>";
                 }


### PR DESCRIPTION
##### SUMMARY
link #3830 

This PR allows users to specify a smart inventory without having any visible hosts defined.

![host_filter](https://user-images.githubusercontent.com/9889020/59377526-684f2d00-8d20-11e9-92f8-18b09e85691c.gif)

<img width="770" alt="Screen Shot 2019-06-12 at 2 42 19 PM" src="https://user-images.githubusercontent.com/9889020/59377543-6e450e00-8d20-11e9-84fa-f98168b582b3.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
