### PR TITLE
Fixes links in various lists to maintain query params while navigating to edit form

### DIFF
--- a/awx/ui/client/features/applications/list-applications.view.html
+++ b/awx/ui/client/features/applications/list-applications.view.html
@@ -43,7 +43,7 @@
                 <div class="at-Row-items">
                     <at-row-item
                         header-value="{{ application.name }}"
-                        header-link="/#/applications/{{ application.id }}">
+                        header-state="applications.edit({application_id:{{application.id}}})">
                     </at-row-item>
                     <at-row-item
                         label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_ORGANIZATION') }}"

--- a/awx/ui/client/features/projects/projectsList.view.html
+++ b/awx/ui/client/features/projects/projectsList.view.html
@@ -40,7 +40,7 @@
                         status-tip="{{ project.statusTip }}"
                         status-click="vm.showSCMStatus(project.id)"
                         header-value="{{ project.name }}"
-                        header-link="/#/projects/{{ project.id }}"
+                        header-state="projects.edit({project_id:{{project.id}}})"
                         header-tag="{{ vm.projectTypes[project.scm_type] }}">
                     </at-row-item>
                     <div class="at-Row-actions">

--- a/awx/ui/client/features/templates/templatesList.view.html
+++ b/awx/ui/client/features/templates/templatesList.view.html
@@ -53,13 +53,13 @@
                     <div class="at-Row-container">
                         <at-row-item
                             header-value="{{ template.name }}"
-                            header-link="/#/templates/job_template/{{ template.id }}"
+                            header-state="templates.editJobTemplate({job_template_id:{{template.id}}})"
                             header-tag="{{ vm.templateTypes[template.type] }}"
                             ng-if="template.type === 'job_template'">
                         </at-row-item>
                         <at-row-item
                             header-value="{{ template.name }}"
-                            header-link="/#/templates/workflow_job_template/{{ template.id }}"
+                            header-state="templates.editWorkflowJobTemplate({workflow_job_template_id:{{template.id}}})"
                             header-tag="{{ vm.templateTypes[template.type] }}"
                             ng-if="template.type === 'workflow_job_template'">
                         </at-row-item>

--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
@@ -45,7 +45,7 @@
                 <div class="at-Row-items">
                     <at-row-item
                         header-value="{{ instance_group.name }}"
-                        header-link="/#/instance_groups/{{ instance_group.id }}"
+                        header-state="instanceGroups.edit({instance_group_id:{{instance_group.id}}})"
                         header-tag="{{ instance_group.is_isolated ? vm.strings.get('list.ROW_ITEM_LABEL_ISOLATED') : '' }}"
                     >
                     </at-row-item>


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/3829

Needed to use `ui-sref` to maintain query params when linking out to the edit form(s).  This has been updated on the following lists:

Templates
Projects
Applications
Instance Groups

Clicking on a resource from any of these lists should now maintain the query params in the url.

Tested locally by going to the lists and clicking the links and then checking to make sure query params were reflected in the url.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
