### PR TITLE
fixed row item labels to view horizontally instead of vertically

### DIFF
--- a/awx/ui/client/lib/components/list/_index.less
+++ b/awx/ui/client/lib/components/list/_index.less
@@ -260,7 +260,7 @@
 
 .at-RowItem--labels {
     line-height: @at-line-height-list-row-item-labels;
-    display: inline-block;
+    display: inline-flex;
 
     * {
         font-size: 10px;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
As seen in issue #4076, the Item Labels on Templates and other elements overflow vertically, which when a lot of labels are in use, can overflow the screen making the expanded view a little less user friendly. The change required occurs on the following css element

.at-RowItem--labels

such that the display field must be changed from inline-block to inline-flex.

The design consideration improves usability as well as screen real-estate as observed in the images provided in the issue.

Only the changes in lines 262-265 are required (actually just the single line)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
3.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
