### PR TITLE
Ensure inventory_obj is on scope before checking it

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/edit/smart-inventory-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/edit/smart-inventory-edit.controller.js
@@ -37,6 +37,8 @@ function SmartInventoryEdit($scope, $location,
 
         $scope.parseType = 'yaml';
 
+        $scope.inventory_obj = inventoryData;
+        $rootScope.breadcrumb.inventory_name = inventoryData.name;
 
         ParseTypeChange({
             scope: $scope,
@@ -50,9 +52,6 @@ function SmartInventoryEdit($scope, $location,
         .then(function(canEditOrg){
             $scope.canEditOrg = canEditOrg;
         });
-
-        $scope.inventory_obj = inventoryData;
-        $rootScope.breadcrumb.inventory_name = inventoryData.name;
 
         $scope.smart_hosts = {
             host_filter: encodeURIComponent($scope.host_filter)


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/4082

`ParseTypeChange` in this file was recently modified to take into account when the extra vars should be read-only.  The variable it uses to check this was not set yet.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
