### PR TITLE
Fix field enablement on workflow form

### DIFF
--- a/awx/ui/client/src/templates/workflows.form.js
+++ b/awx/ui/client/src/templates/workflows.form.js
@@ -42,14 +42,14 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                     label: i18n._('Name'),
                     type: 'text',
                     required: true,
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)',
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)',
                     column: 1
                 },
                 description: {
                     label: i18n._('Description'),
                     type: 'text',
                     column: 1,
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                 },
                 organization: {
                     label: i18n._('Organization'),
@@ -65,8 +65,8 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                         reqExpression: '!current_user.is_superuser'
                     },
                     column: 1,
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate) || !canEditOrg',
-                    awLookupWhen: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate) && canEditOrg'
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit) || !canEditOrg',
+                    awLookupWhen: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit) && canEditOrg'
                 },
                 inventory: {
                     label: i18n._('Inventory'),
@@ -87,7 +87,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                         ngChange: 'workflow_job_template_form.inventory_name.$validate()',
                         text: i18n._('Prompt on launch')
                     },
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate) || !canEditInventory',
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit) || !canEditInventory',
                 },
                 labels: {
                     label: i18n._('Labels'),
@@ -102,7 +102,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                         ngShow: 'workflow_job_template_labels_isValid !== true',
                         text: i18n._('Max 512 characters per label.'),
                     },
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                 },
                 variables: {
                     label: i18n._('Extra Variables'),
@@ -119,7 +119,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                         variable: 'ask_variables_on_launch',
                         text: i18n._('Prompt on launch')
                     },
-                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)' // TODO: get working
+                    ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)' // TODO: get working
                 },
                 checkbox_group: {
                     label: i18n._('Options'),
@@ -133,7 +133,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                         dataPlacement: 'right',
                         dataTitle: i18n._('Enable Concurrent Jobs'),
                         dataContainer: "body",
-                        ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                        ngDisabled: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                     }]
                 }
             },
@@ -142,22 +142,22 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                 launch: {
                     component: 'at-launch-template',
                     templateObj: 'workflow_job_template_obj',
-                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.start || canAddWorkflowJobTemplate)',
+                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.start || canAddOrEdit)',
                     ngDisabled: 'disableLaunch || workflow_job_template_form.$dirty',
                     showTextButton: 'true'
                 },
                 cancel: {
                     ngClick: 'formCancel()',
-                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                 },
                 close: {
                     ngClick: 'formCancel()',
-                    ngShow: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                    ngShow: '!(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                 },
                 save: {
                     ngClick: 'formSave()',    //$scope.function to call on click, optional
                     ngDisabled: "workflow_job_template_form.$invalid || can_edit!==true", //Disable when $pristine or $invalid, optional and when can_edit = false, for permission reasons
-                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                    ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                 }
             },
 
@@ -183,7 +183,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                             awToolTip: i18n._('Add a permission'),
                             actionClass: 'at-Button--add',
                             actionId: 'button-add',
-                            ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)'
+                            ngShow: '(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)'
                         }
                     },
 
@@ -226,7 +226,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
             relatedButtons: {
                 view_survey: {
                     ngClick: 'editSurvey()',
-                    ngShow: '($state.is(\'templates.addWorkflowJobTemplate\') || $state.is(\'templates.editWorkflowJobTemplate\') || $state.is(\'templates.editWorkflowJobTemplate.workflowMaker\')) && survey_exists && !(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate)',
+                    ngShow: '($state.is(\'templates.addWorkflowJobTemplate\') || $state.is(\'templates.editWorkflowJobTemplate\') || $state.is(\'templates.editWorkflowJobTemplate.workflowMaker\')) && survey_exists && !(workflow_job_template_obj.summary_fields.user_capabilities.edit || canAddOrEdit)',
                     label: i18n._('View Survey'),
                     class: 'Form-primaryButton'
                 },

--- a/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
+++ b/awx/ui/client/src/templates/workflows/add-workflow/workflow-add.controller.js
@@ -20,7 +20,7 @@ export default [
 
          const workflowTemplate = resolvedModels[1];
 
-         $scope.canAddOrEdit = workflowTemplate.options('actions.POST');
+         $scope.canAddOrEdit = workflowTemplate.options('actions.POST') ? true : false;
 
          $scope.canEditOrg = true;
          $scope.canEditInventory = true;

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.partial.html
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.partial.html
@@ -137,6 +137,6 @@
     </div>
     <div class="WorkflowMaker-buttonHolder">
         <button type="button" class="btn btn-sm WorkflowMaker-cancelButton" ng-click="closeDialog()"> {{:: strings.get('CLOSE') }}</button>
-        <button type="button" class="btn btn-sm WorkflowMaker-saveButton" ng-click="saveWorkflowMaker()" ng-show="workflowJobTemplateObj.summary_fields.user_capabilities.edit || canAddWorkflowJobTemplate" ng-disabled="formState.showNodeForm || formState.showLinkForm"> {{:: strings.get('SAVE') }}</button>
+        <button type="button" class="btn btn-sm WorkflowMaker-saveButton" ng-click="saveWorkflowMaker()" ng-show="workflowJobTemplateObj.summary_fields.user_capabilities.edit || canAddOrEdit" ng-disabled="formState.showNodeForm || formState.showLinkForm"> {{:: strings.get('SAVE') }}</button>
     </div>
 </div>

--- a/awx/ui/client/src/workflow-results/workflow-results.partial.html
+++ b/awx/ui/client/src/workflow-results/workflow-results.partial.html
@@ -367,7 +367,6 @@
                 <workflow-chart
                     graph-state="graphState"
                     workflow-zoomed="workflowZoomed(zoom)"
-                    can-add-workflow-job-template="canAddWorkflowJobTemplate"
                     mode="details"
                     read-only="readOnly"
                     class="WorkflowMaker-chart">


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/4091

See https://github.com/ansible/awx/pull/4041 for original changes

The variable `canAddWorkflowJobTemplate` was changed to `canAddOrEdit`.  That changed needed to be reflected in the form.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
I checked that a superuser could add and edit a workflow and that a system auditor would see read only versions of the edit form and the visualizer.
