### PR TITLE
Include defined fields from all parent classes of a HybridDictField

### DIFF
--- a/awx/conf/tests/functional/test_api.py
+++ b/awx/conf/tests/functional/test_api.py
@@ -8,6 +8,7 @@ from awx.main.utils.encryption import decrypt_field
 from awx.conf import fields
 from awx.conf.registry import settings_registry
 from awx.conf.models import Setting
+from awx.sso import fields as sso_fields
 
 
 @pytest.fixture
@@ -137,7 +138,7 @@ def test_setting_signleton_retrieve_hierachy(api_request, dummy_setting):
 
 
 @pytest.mark.django_db
-def test_setting_signleton_retrieve_readonly(api_request, dummy_setting):
+def test_setting_singleton_retrieve_readonly(api_request, dummy_setting):
     with dummy_setting(
         'FOO_BAR',
         field_class=fields.IntegerField,
@@ -184,6 +185,30 @@ def test_setting_singleton_update(api_request, dummy_setting):
 
 
 @pytest.mark.django_db
+def test_setting_singleton_update_hybriddictfield_with_forbidden(api_request, dummy_setting):
+    # Some HybridDictField subclasses have a child of _Forbidden,
+    # indicating that only the defined fields can be filled in.  Make
+    # sure that the _Forbidden validator doesn't get used for the
+    # fields.  See also https://github.com/ansible/awx/issues/4099.
+    with dummy_setting(
+        'FOO_BAR',
+        field_class=sso_fields.SAMLOrgAttrField,
+        category='FooBar',
+        category_slug='foobar',
+    ), mock.patch('awx.conf.views.handle_setting_changes'):
+        api_request(
+            'patch',
+            reverse('api:setting_singleton_detail', kwargs={'category_slug': 'foobar'}),
+            data={'FOO_BAR': {'saml_admin_attr': 'Admins', 'saml_attr': 'Orgs'}}
+        )
+        response = api_request(
+            'get',
+            reverse('api:setting_singleton_detail', kwargs={'category_slug': 'foobar'})
+        )
+        assert response.data['FOO_BAR'] == {'saml_admin_attr': 'Admins', 'saml_attr': 'Orgs'}
+
+
+@pytest.mark.django_db
 def test_setting_singleton_update_dont_change_readonly_fields(api_request, dummy_setting):
     with dummy_setting(
         'FOO_BAR',
@@ -206,7 +231,7 @@ def test_setting_singleton_update_dont_change_readonly_fields(api_request, dummy
 
 
 @pytest.mark.django_db
-def test_setting_singleton_update_dont_change_encripted_mark(api_request, dummy_setting):
+def test_setting_singleton_update_dont_change_encrypted_mark(api_request, dummy_setting):
     with dummy_setting(
         'FOO_BAR',
         field_class=fields.CharField,

--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -93,12 +93,14 @@ class HybridDictField(fields.DictField):
         self.allow_blank = kwargs.pop('allow_blank', False)
 
         fields = [
-            (field_name, obj)
-            for field_name, obj in self.__class__.__dict__.items()
-            if isinstance(obj, Field) and field_name != 'child'
+            sorted(
+                ((field_name, obj) for field_name, obj in cls.__dict__.items()
+                 if isinstance(obj, Field) and field_name != 'child'),
+                key=lambda x: x[1]._creation_counter
+            )
+            for cls in reversed(self.__class__.__mro__)
         ]
-        fields.sort(key=lambda x: x[1]._creation_counter)
-        self._declared_fields = collections.OrderedDict(fields)
+        self._declared_fields = collections.OrderedDict(f for group in fields for f in group)
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
##### SUMMARY
Include defined fields from all parent classes of a HybridDictField

since our settings registry adds a mixin class when doing validation on these.

see: #4099

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 5.0.0
```