### PR TITLE
Fix offline builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,6 @@ virtualenv_ansible:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
 			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1 && \
 			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==19.1.1; \
 		fi; \
@@ -146,7 +145,8 @@ virtualenv_awx:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/awx" ]; then \
 			$(PYTHON) -m venv --system-site-packages $(VENV_BASE)/awx; \
-			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed docutils==0.14; \
+			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1; \
+			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==19.1.1; \
 		fi; \
 	fi
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ argparse==1.4.0           # via uwsgitop
 asgi-amqp==1.1.3
 asgiref==1.1.2            # via asgi-amqp, channels, daphne
 asn1crypto==0.24.0        # via cryptography
-attrs==19.1.0             # via automat, service-identity, twisted
+attrs==18.1.0             # via automat, service-identity, twisted
 autobahn==19.5.1          # via daphne
 automat==0.7.0            # via twisted
 azure-common==1.1.21      # via azure-keyvault


### PR DESCRIPTION
Our internal offline builds started failing after #4046. The solution was to use `--no-use-pep517` in our builds, but I had to make these tweaks to get that to work. I will open upstream issues after a bit more investigation work.

- Force upgrade of setuptools and pip in awx venv (to get `--no-use-pep517`)
- `attrs==19.1.0` breaks the usage of `--no-use-pep517`