### PR TITLE
Fixes analytics & metrics instance specific job counts

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -156,7 +156,7 @@ def projects_by_scm_type(since):
 @register('instance_info')
 def instance_info(since):
     info = {}
-    instances = models.Instance.objects.values_list('hostname').annotate().values(
+    instances = models.Instance.objects.values_list('hostname').values(
         'uuid', 'version', 'capacity', 'cpu', 'memory', 'managed_by_policy', 'hostname', 'last_isolated_check', 'enabled')
     for instance in instances:
         instance_info = {
@@ -187,12 +187,12 @@ def job_counts(since):
 def job_instance_counts(since):
     counts = {}
     job_types = models.UnifiedJob.objects.exclude(launch_type='sync').values_list(
-        'execution_node', 'launch_type').annotate(job_launch_type=Count('launch_type'))
+        'execution_node', 'launch_type').annotate(job_launch_type=Count('launch_type')).order_by()
     for job in job_types:
         counts.setdefault(job[0], {}).setdefault('launch_type', {})[job[1]] = job[2]
         
     job_statuses = models.UnifiedJob.objects.exclude(launch_type='sync').values_list(
-        'execution_node', 'status').annotate(job_status=Count('status'))
+        'execution_node', 'status').annotate(job_status=Count('status')).order_by()
     for job in job_statuses:
         counts.setdefault(job[0], {}).setdefault('status', {})[job[1]] = job[2]
     return counts


### PR DESCRIPTION
##### SUMMARY
Follow-up from issue: https://github.com/ansible/awx/pull/4000/

This same `.order_by()` issue was present in another collectors.py function for instance specific job metrics.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


