### PR TITLE
Downgrade pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,8 @@ virtualenv_ansible:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
 			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1 && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==19.1.1; \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
 		fi; \
 	fi
 
@@ -146,7 +145,8 @@ virtualenv_awx:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/awx" ]; then \
 			$(PYTHON) -m venv --system-site-packages $(VENV_BASE)/awx; \
-			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed docutils==0.14; \
+			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1; \
+			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
 		fi; \
 	fi
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -74,7 +74,7 @@ netaddr==0.7.19           # via pyrad
 oauthlib==3.0.1           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 ordereddict==1.1
 pexpect==4.6.0            # via ansible-runner
-pkgconfig==1.5.1          # via xmlsec
+pkgconfig==1.4.0          # via xmlsec
 prometheus_client==0.6.0
 psutil==5.4.3
 psycopg2==2.7.3.2
@@ -122,5 +122,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.1.1
+pip==18.1
 setuptools==41.0.1

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -122,5 +122,5 @@ wheel==0.30.0             # via azure-cli-core
 xmltodict==0.12.0         # via pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.1.1
+pip==18.1
 setuptools==41.0.1

--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -5,3 +5,5 @@ pytest-runner
 isort
 virtualenv
 m2r
+flit
+intreehooks


### PR DESCRIPTION
pip 19 added support for something called `pyproject.toml`. Several packages have been setting the option `build-backend = "setuptools.build_meta”` (bcrypt, attrs, jaraco) which seems to be the root of the problem when building from source. Until the community sorts this out I’m inclined to avoid pip 19.