### PR TITLE
ensure "create_preload_data" is honored in docker-compose deployments

### DIFF
--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -124,8 +124,8 @@
   delegate_to: localhost
 
 - name: Stage launch_awx_task
-  copy:
-    src: launch_awx_task.sh
+  template:
+    src: launch_awx_task.sh.j2
     dest: "{{ docker_base_path }}/launch_awx_task.sh"
     mode: '0700'
   delegate_to: localhost

--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -18,7 +18,9 @@ fi
 
 if [ ! -z "$AWX_ADMIN_USER" ]&&[ ! -z "$AWX_ADMIN_PASSWORD" ]; then
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('$AWX_ADMIN_USER', 'root@localhost', '$AWX_ADMIN_PASSWORD')" | awx-manage shell
+    {% if create_preload_data %}
     awx-manage create_preload_data
+    {% endif %}
 fi
 echo 'from django.conf import settings; x = settings.AWX_TASK_ENV; x["HOME"] = "/var/lib/awx"; settings.AWX_TASK_ENV = x' | awx-manage shell
 awx-manage provision_instance --hostname=$(hostname)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Use a templated version of launch_awx_task.sh which conditionally preloads
sample data according to create_preload_data value.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
"awx: 5.0.0"
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Without this patch, docker-compose deployments end up having preloaded data into the DB, regardless of `create_preload_data`value.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
