### PR TITLE
Revert pip and setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,9 @@ virtualenv_ansible:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
 			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1 && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==19.1.1; \
 		fi; \
 	fi
 
@@ -145,8 +146,7 @@ virtualenv_awx:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/awx" ]; then \
 			$(PYTHON) -m venv --system-site-packages $(VENV_BASE)/awx; \
-			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==41.0.1; \
-			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
+			$(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --ignore-installed docutils==0.14; \
 		fi; \
 	fi
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,8 +1,6 @@
 The requirements.txt and requirements_ansible.txt files are generated from requirements.in and requirements_ansible.in, respectively, using `pip-tools` `pip-compile`. The following commands should do this if ran inside the tools_awx container.
 
 Run these commands from the root of the awx repo. This will produce python 3 requirements files.
-If you do not wish to upgrade dependencies generally (such as adding a specific dependency
-needed for a feature) then do not use the `-U` flag.
 
 ```
 python3 -m venv /buildit

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -45,5 +45,5 @@ tacacs_plus==1.0
 twilio==6.10.4
 uWSGI==2.0.17
 uwsgitop==0.10.0
-pip==19.1.1
-setuptools==41.0.1
+pip==9.0.1
+setuptools==36.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -122,5 +122,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.1.1
-setuptools==41.0.1
+pip==9.0.1
+setuptools==36.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -74,7 +74,7 @@ netaddr==0.7.19           # via pyrad
 oauthlib==3.0.1           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 ordereddict==1.1
 pexpect==4.6.0            # via ansible-runner
-pkgconfig==1.4.0          # via xmlsec
+pkgconfig==1.5.1          # via xmlsec
 prometheus_client==0.6.0
 psutil==5.4.3
 psycopg2==2.7.3.2
@@ -122,5 +122,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==18.1
+pip==19.1.1
 setuptools==41.0.1

--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -53,8 +53,8 @@ pycurl==7.43.0.1    # higher versions will not install without SSL backend speci
 pexpect==4.6.0    # same as AWX requirement
 psutil==5.4.3    # same as AWX requirement
 ptyprocess==0.5.2 # via pexpect, but needs to be pinned. Read the blame.
-pip==19.1.1
-setuptools==41.0.1
+setuptools==36.0.1
+pip==9.0.1
 # VMware
 pyvmomi==6.5
 # WinRM

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -122,5 +122,5 @@ wheel==0.30.0             # via azure-cli-core
 xmltodict==0.12.0         # via pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==19.1.1
-setuptools==41.0.1
+pip==9.0.1
+setuptools==36.0.1

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -122,5 +122,5 @@ wheel==0.30.0             # via azure-cli-core
 xmltodict==0.12.0         # via pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==18.1
+pip==19.1.1
 setuptools==41.0.1

--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -5,5 +5,3 @@ pytest-runner
 isort
 virtualenv
 m2r
-flit
-intreehooks


### PR DESCRIPTION
This further reverts things from #4106 and #4046 after a surprising amount of fallout we are experiencing in our downstream regression pipelines. We need to figure this out *before* merging stuff like this.