### PR TITLE
Fixes ca_trust_dir and project_data_dir for Kubernetes

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -133,7 +133,6 @@ secret_key=awxsecret
 # CA Trust directory. If you need to provide custom CA certificates, supplying
 # this variable causes this directory on the host to be bind mounted over
 # /etc/pki/ca-trust in the awx_task and awx_web containers.
-# NOTE: only obeyed in local_docker install
 #ca_trust_dir=/etc/pki/ca-trust/source/anchors
 
 # Include /etc/nginx/awx_extra.conf

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -141,6 +141,16 @@ spec:
           ports:
             - containerPort: 8052
           volumeMounts:
+{% if ca_trust_dir is defined %}
+            - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              readOnly: true
+{% endif %}
+{% if project_data_dir is defined %}
+            - name: {{ kubernetes_deployment_name }}-project-data-dir
+              mountPath: "/var/lib/awx/projects"
+              readOnly: false
+{% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
@@ -176,6 +186,16 @@ spec:
             - /usr/bin/launch_awx_task.sh
           imagePullPolicy: Always
           volumeMounts:
+{% if ca_trust_dir is defined %}
+            - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              readOnly: true
+{% endif %}
+{% if project_data_dir is defined %}
+            - name: {{ kubernetes_deployment_name }}-project-data-dir
+              mountPath: "/var/lib/awx/projects"
+              readOnly: false
+{% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py
@@ -274,6 +294,18 @@ spec:
               cpu: "{{ memcached_cpu_limit }}m"
 {% endif %}
       volumes:
+{% if ca_trust_dir is defined %}
+        - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+          hostPath:
+            path: "{{ ca_trust_dir }}"
+            type: Directory
+{% endif %}
+{% if project_data_dir is defined %}
+        - name: {{ kubernetes_deployment_name }}-project-data-dir
+          hostPath:
+            path: "{{ project_data_dir }}"
+            type: Directory
+{% endif %}
         - name: {{ kubernetes_deployment_name }}-application-config
           configMap:
             name: {{ kubernetes_deployment_name }}-config

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -191,11 +191,6 @@ spec:
               mountPath: "/etc/pki/ca-trust/source/anchors/"
               readOnly: true
 {% endif %}
-{% if project_data_dir is defined %}
-            - name: {{ kubernetes_deployment_name }}-project-data-dir
-              mountPath: "/var/lib/awx/projects"
-              readOnly: false
-{% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config
               mountPath: "/etc/tower/settings.py"
               subPath: settings.py


### PR DESCRIPTION
##### SUMMARY
Ensure the `ca_trust_dir` and `project_data_dir` variables set in the `inventory` are applied into the Kubernetes.

Fixes: #3134 

Prior to this patch, whenever the `ca_trust_dir` or the  `project_data_dir` variables were set in the `inventory`, the host directory was not being presented to the `awx-0` pod.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 5.0.0.0
```


##### ADDITIONAL INFORMATION
With this patch, now the `awx-task` and the `awx-web`  maps the expected directories from the host nodes to the pods.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 kubectl describe pod awx-0
[...]
  awx-web:
    Container ID:   containerd://8cbeae68c97ef288d6a18b8ded0a7a89397f8067a13a39d337d2f1a05fbb7c40
    Image:          ansible/awx_web:5.0.0
    Image ID:       docker.io/ansible/awx_web@sha256:a21ace2c47c0e2b68615572adfd136eea9f78b948df7e02e74c83c016e900cd1
    Port:           8052/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Wed, 19 Jun 2019 21:25:02 -0400
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:        150m
      memory:     1Gi
    Environment:  <none>
    Mounts:
      /etc/pki/ca-trust/source/anchors/ from awx-ca-trust-dir (ro)
      /etc/tower/SECRET_KEY from awx-secret-key (ro,path="SECRET_KEY")
      /etc/tower/conf.d/ from awx-application-credentials (ro)
      /etc/tower/settings.py from awx-application-config (ro,path="settings.py")
      /var/lib/awx/projects from awx-project-data-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from awx-token-fspm9 (ro)

[...]
  awx-celery:
    Container ID:  containerd://0b328a1eec6fa20acb611b4f60703f4609eb98a29bdd0b66644403b21d814be8
    Image:         ansible/awx_task:5.0.0
    Image ID:      docker.io/ansible/awx_task@sha256:d1d57712ee696f10a1f8d77f8f0d24933eb95c6730a5b87940c60680cb6ad39b
    Port:          <none>
    Host Port:     <none>
    Command:
      /usr/bin/launch_awx_task.sh
    State:          Running
      Started:      Wed, 19 Jun 2019 21:25:03 -0400
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:     150m
      memory:  2Gi
    Environment:
      AWX_SKIP_MIGRATIONS:  1
    Mounts:
      /etc/pki/ca-trust/source/anchors/ from awx-ca-trust-dir (ro)
      /etc/tower/SECRET_KEY from awx-secret-key (ro,path="SECRET_KEY")
      /etc/tower/conf.d/ from awx-application-credentials (ro)
      /etc/tower/settings.py from awx-application-config (ro,path="settings.py")
      /var/run/secrets/kubernetes.io/serviceaccount from awx-token-fspm9 (ro)
[...]
Volumes:
  awx-ca-trust-dir:
    Type:          HostPath (bare host directory volume)
    Path:          /etc/pki/ca-trust/source/anchors
    HostPathType:  Directory
  awx-project-data-dir:
    Type:          HostPath (bare host directory volume)
    Path:          /var/lib/awx/projects
    HostPathType:  Directory
```
