### PR TITLE
Failing requirements update when scm_type != git

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -152,7 +152,7 @@
         args:
           chdir: "{{project_path|quote}}/roles"
         register: galaxy_result
-        when: doesRequirementsExist.stat.exists and (scm_version is undefined or (git_result is defined and git_result['before'] == git_result['after']))
+        when: doesRequirementsExist.stat.exists and (scm_version is undefined or (git_result is not skipped and git_result['before'] == git_result['after']))
         changed_when: "'was installed successfully' in galaxy_result.stdout"
 
       - name: fetch galaxy roles from requirements.yml (forced update)


### PR DESCRIPTION
##### SUMMARY
During a project update where SCM type is not `git`, and a `requirements.yml` exists within the checkout, a conditional check relating to `git` fails consistently and prevents the project update from ever completing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
```
The conditional check 'doesRequirementsExist.stat.exists and (scm_version is undefined or (git_result is defined and git_result['before'] == git_result['after']))' failed. The error was: error while evaluating conditional (doesRequirementsExist.stat.exists and (scm_version is undefined or (git_result is defined and git_result['before'] == git_result['after']))): 'dict object' has no attribute 'before'

The error appears to have been in '/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/playbooks/project_update.yml': line 142, column 9, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


      - name: fetch galaxy roles from requirements.yml
        ^ here
```
