### PR TITLE
Refactored the ca_trust_dir and added the options git_ssl_no_verify and ca_trust_anchors_dir.

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -149,7 +149,7 @@ secret_key=awxsecret
 # whenever syncing a Git SCM project. If the CA is not trusted, you might face the
 # 'Peer's Certificate issuer is not recognized' error.
 # Besides being not recommended, you can enable this option to allow AWX to sync Git SCM projects
-# with verifying its Certificate Authority.
+# without verifying its Certificate Authority.
 #git_ssl_no_verify=true
 
 # Include /etc/nginx/awx_extra.conf

--- a/installer/inventory
+++ b/installer/inventory
@@ -134,7 +134,7 @@ secret_key=awxsecret
 # this variable causes the CA Anchors directory on the host to be bind mounted over
 # /etc/pki/ca-trust/source/anchors in the awx_task and awx_web containers.
 # NOTE: This option is only obeyed in the local_docker install as the container image
-# must to be customized with the `update-ca-trust` command.
+# must be customized with the `update-ca-trust` command.
 #ca_trust_anchors_dir=/etc/pki/ca-trust/source/anchors
 
 # To provide custom CA certificates in deployments with the official AWX images, it is

--- a/installer/inventory
+++ b/installer/inventory
@@ -131,9 +131,26 @@ secret_key=awxsecret
 #project_data_dir=/var/lib/awx/projects
 
 # CA Trust directory. If you need to provide custom CA certificates, supplying
-# this variable causes this directory on the host to be bind mounted over
-# /etc/pki/ca-trust in the awx_task and awx_web containers.
-#ca_trust_dir=/etc/pki/ca-trust/source/anchors
+# this variable causes the CA Anchors directory on the host to be bind mounted over
+# /etc/pki/ca-trust/source/anchors in the awx_task and awx_web containers.
+# NOTE: This option is only obeyed in the local_docker install as the container image
+# must to be customized with the `update-ca-trust` command.
+#ca_trust_anchors_dir=/etc/pki/ca-trust/source/anchors
+
+# To provide custom CA certificates in deployments with the official AWX images, it is
+# preferrabled to export the whole /etc/pki/ca-trust directory from the host node to be
+# mounted over the /etc/pki/ca-trust directory in the awx_task and awx_web containers.
+# NOTE: This option will be obeyed in local_docker or kubernetes install and does not require
+# the `update-ca-trust` command.
+#ca_trust_dir=/etc/pki/ca-trust
+
+# Git SCM SSL Verify
+# By default, AWX must trust in the Certificate Authority used to sign an SSL certificate
+# whenever syncing a Git SCM project. If the CA is not trusted, you might face the
+# 'Peer's Certificate issuer is not recognized' error.
+# Besides being not recommended, you can enable this option to allow AWX to sync Git SCM projects
+# with verifying its Certificate Authority.
+#git_ssl_no_verify=true
 
 # Include /etc/nginx/awx_extra.conf
 # Note the use of glob pattern for nginx

--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -150,7 +150,7 @@
 
 - name: Stage settings.py
   copy:
-    src: settings.py
+    src: settings.py.j2
     dest: "{{ docker_base_path }}/settings.py"
   delegate_to: localhost
 

--- a/installer/roles/image_build/templates/settings.py.j2
+++ b/installer/roles/image_build/templates/settings.py.j2
@@ -25,6 +25,10 @@ INTERNAL_API_URL = 'http://awxweb:8052'
 # Container environments don't like chroots
 AWX_PROOT_ENABLED = False
 
+{% if git_ssl_no_verify is defined %}
+# Do not verify git SSL
+AWX_TASK_ENV['GIT_SSL_NO_VERIFY'] = True
+{% endif %}
 
 CLUSTER_HOST_ID = "awx"
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'

--- a/installer/roles/kubernetes/templates/configmap.yml.j2
+++ b/installer/roles/kubernetes/templates/configmap.yml.j2
@@ -14,6 +14,11 @@ data:
     # Automatically deprovision pods that go offline
     AWX_AUTO_DEPROVISION_INSTANCES = True
 
+{% if git_ssl_no_verify is defined %}
+    # Do not verify git SSL
+    AWX_TASK_ENV['GIT_SSL_NO_VERIFY'] = True
+{% endif %}
+
     SYSTEM_TASK_ABS_CPU = {{ ((task_cpu_request|int / 1000) * 4)|int }}
     SYSTEM_TASK_ABS_MEM = {{ ((task_mem_request|int * 1024) / 100)|int }}
 

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -143,7 +143,7 @@ spec:
           volumeMounts:
 {% if ca_trust_dir is defined %}
             - name: {{ kubernetes_deployment_name }}-ca-trust-dir
-              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              mountPath: "/etc/pki/ca-trust"
               readOnly: true
 {% endif %}
 {% if project_data_dir is defined %}
@@ -188,7 +188,7 @@ spec:
           volumeMounts:
 {% if ca_trust_dir is defined %}
             - name: {{ kubernetes_deployment_name }}-ca-trust-dir
-              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              mountPath: "/etc/pki/ca-trust"
               readOnly: true
 {% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -26,8 +26,11 @@ services:
     {% if project_data_dir is defined %}
       - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
     {% endif %}
+    {% if ca_trust_anchors_dir is defined %}
+      - "{{ ca_trust_anchors_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
+    {% endif %}
     {% if ca_trust_dir is defined %}
-      - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
+      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
     {% endif %}
     {% if ssl_certificate is defined %}
       - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
@@ -75,8 +78,11 @@ services:
     {% if project_data_dir is defined %}
       - "{{ project_data_dir +':/var/lib/awx/projects:rw' }}"
     {% endif %}
+    {% if ca_trust_anchors_dir is defined %}
+      - "{{ ca_trust_anchors_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
+    {% endif %}
     {% if ca_trust_dir is defined %}
-      - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
+      - "{{ ca_trust_dir +':/etc/pki/ca-trust:ro' }}"
     {% endif %}
     {% if ssl_certificate is defined %}
       - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"


### PR DESCRIPTION
##### SUMMARY
Whenever deploying AWX with official images, just mounting the `/etc/pki/ca-trust/source/anchors` is not sufficient to trust in 3rd party Certificate Authorities as the `awx` user has no privileges to run the `update-ca-trust` command. 

In the `update-ca-trust` is just performed in the `local_docker` installs, this patch provides the ability to export the full `/etc/pki/ca-trust` directory from the host node to the `awx_web` and `awx_task`  containers. 

It also maintained the ability to export only the `/etc/pki/ca-trust/source/anchors`  for custom images built in the `local_docker` installs. 

Furthermore, this patch also includes the option to the user to enable the `AWX_TASK_ENV['GIT_SSL_NO_VERIFY']` for testing purposes. 

Fixes: #3318 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 5.0.0.0
```


