### PR TITLE
Prevent ovirt4.py to fail if no VMs have stats returned

### DIFF
--- a/awx/plugins/inventory/ovirt4.py
+++ b/awx/plugins/inventory/ovirt4.py
@@ -179,7 +179,7 @@ def get_dict_of_struct(connection, vm):
             if vm.name in [vm.name for vm in connection.follow_link(group.vms)]
         ],
         'statistics': dict(
-            (stat.name, stat.values[0].datum) for stat in stats
+            (stat.name, stat.values[0].datum) for stat in stats if stat.values
         ),
         'devices': dict(
             (device.name, [ip.address for ip in device.ips]) for device in devices if device.ips


### PR DESCRIPTION
Signed-off-by: Thomas Dannenmuller <tromatik@gmail.com>

##### SUMMARY
Just add a condition to skip statistics dict, in case ovirt API return empty statistics for a VM. This prevent the inventory script to fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
