### PR TITLE
Introduces the ability to pass annotations to the Kubernetes Ingress Controllers

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -26,6 +26,12 @@ dockerhub_base=ansible
 # pg_cpu_limit=1000
 # pg_mem_limit=2
 
+# Kubernetes Ingress Annotations
+# You can use the variables below to pass annotations to Kubernetes Ingress
+# The example below shows an annotation to be used with Traefik but other Ingress controllers are also supported.
+#kubernetes_ingress_hostname=awx.example.org
+#kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
+
 # Kubernetes and Openshift Install Resource Requests
 # These are the request and limit values for a pod's container for task/web/rabbitmq/memcached/management.
 # The total amount of requested resources for a pod is the sum of all

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -373,10 +373,27 @@ kind: Ingress
 metadata:
   name: {{ kubernetes_deployment_name }}-web-svc
   namespace: {{ kubernetes_namespace }}
+{% if kubernetes_ingress_annotations is defined %}
+  annotations:
+{% for key, value in kubernetes_ingress_annotations.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
+
+spec:
+  rules:
+  - host: {{ kubernetes_ingress_hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ kubernetes_deployment_name }}-web-svc
+          servicePort: 80
+{% else %}
 spec:
   backend:
     serviceName: {{ kubernetes_deployment_name }}-web-svc
     servicePort: 80
+{% endif %}
 {% endif %}
 {% if openshift_host is defined %}
 ---


### PR DESCRIPTION
##### SUMMARY
This PR introduces the ability to configure annotations to Ingress controllers. 

This is applicable when you want to serve AWX behind a reverse proxy (using Nginx or Traefik) ingress controllers. 

Setting the variables on the `inventory` file will automatically configure the Ingress controller. 
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
AWX 5.0.0.0
```


##### ADDITIONAL INFORMATION
* To test this scenario, I'm using a Traefik on my k8s cluster. So basically the steps performed were:
```
# inventory
kubernetes_ingress_hostname=tower.tatu.home
kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
```

* Then running the playbook I ended up with the following ingress controller:
```yaml
# kubectl edit ingress awx-web-svc
apiVersion: extensions/v1beta1                                                                                                                                                                                                                                     
kind: Ingress                                                                                                                                                                                                                                                      
metadata:                                                                                                                                                                                                                                                          
  annotations:                                                                                                                                                                                                                                                     
    kubectl.kubernetes.io/last-applied-configuration: |                                                                                                                                                                                                            
      {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.class":"traefik","traefik.ingress.kubernetes.io/redirect-entry-point":"https"},"name":"awx-web-svc","namespace":"default"},"spec":{"rules":[{"host":"to
    kubernetes.io/ingress.class: traefik                                                                                                                                                                                                                           
    traefik.ingress.kubernetes.io/redirect-entry-point: https                                                                                                                                                                                                      
  creationTimestamp: "2019-06-20T20:45:02Z"                                                                                                                                                                                                                        
  generation: 1                                                                                                                                                                                                                                                    
  name: awx-web-svc                                                                                                                                                                                                                                                
  namespace: default                                                                                                                                                                                                                                               
  resourceVersion: "2404506"                                                                                                                                                                                                                                       
  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/awx-web-svc                                                                                                                                                                                      
  uid: 46c1db5d-939c-11e9-b87e-507b9d7d97d9                                                                                                                                                                                                                        
spec:                                                                                                                                                                                                                                                              
  rules:                                                                                                                                                                                                                                                           
  - host: tower.tatu.home                                                                                                                                                                                                                                          
    http:                                                                                                                                                                                                                                                          
      paths:                                                                                                                                                                                                                                                       
      - backend:                                                                                                                                                                                                                                                   
          serviceName: awx-web-svc                                                                                                                                                                                                                                 
          servicePort: 80                                                                                                                                                                                                                                          
        path: /                                                                                                                                                                                                                                                    
status:                                                                                                                                                                                                                                                            
  loadBalancer:                                                                                                                                                                                                                                                    
    ingress:                                                                                                                                                                                                                                                       
    - ip: 192.168.168.55  
```
* Then we can see the Traefik automatically recognizes it

![image](https://user-images.githubusercontent.com/809840/59881403-800c5e00-937d-11e9-914f-e27147d35b98.png)

* And finally the AWX is working behind Traefik using a custom SSL certificate and custom FQDN
![image](https://user-images.githubusercontent.com/809840/59881471-a9c58500-937d-11e9-9aca-d08ba44843fb.png)
