### PR TITLE
[WIP] disable basic auth by default

### DIFF
--- a/awx/conf/migrations/0007_v360_copy_basic_auth_setting.py
+++ b/awx/conf/migrations/0007_v360_copy_basic_auth_setting.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations
+from awx.conf.migrations import _rename_setting
+    
+    
+def copy_basic_auth_setting(apps, schema_editor):
+    _rename_setting.copy_setting(apps, schema_editor, old_key='AUTH_BASIC_ENABLED')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('conf', '0006_v331_ldap_group_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_basic_auth_setting, None),
+    ]
+    

--- a/awx/conf/migrations/_rename_setting.py
+++ b/awx/conf/migrations/_rename_setting.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import logging
 from django.utils.timezone import now
 from django.conf import settings
+from awx.conf.models import Setting
 
 logger = logging.getLogger('awx.conf.settings')
 
@@ -30,3 +31,15 @@ def rename_setting(apps, schema_editor, old_key, new_key):
                                modified=now()
                                )
         
+        
+def copy_setting(apps, schema_editor, old_key):
+
+    # If old_key has been set local_settings.py, then set it in Tower Settings (CTinT)
+    if hasattr(settings, old_key):
+        old_setting = getattr(settings, 'AUTH_BASIC_ENABLED')
+        Setting.objects.create(key=old_key, 
+                               value=old_setting, 
+                               created=now(),
+                               modified=now()
+                               )
+

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -63,6 +63,11 @@ SESSION_COOKIE_SECURE = False
 # Disallow sending csrf cookies over insecure connections
 CSRF_COOKIE_SECURE = False
 
+# Enable / Disable HTTP Basic Authentication used in the API browser
+# Note: Session limits are not enforced when using HTTP Basic Authentication.
+# Note: This setting may be overridden by database settings.
+AUTH_BASIC_ENABLED = True
+
 # Override django.template.loaders.cached.Loader in defaults.py
 template = next((tpl_backend for tpl_backend in TEMPLATES if tpl_backend['NAME'] == 'default'), None) # noqa
 template['OPTIONS']['loaders'] = (


### PR DESCRIPTION
##### SUMMARY
Related: https://github.com/ansible/awx/issues/4143

Disables Basic Auth by default and maintains previous setting via a migration.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


