### PR TITLE
Change `docker_service` to `docker_compose`.

### DIFF
--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -23,7 +23,7 @@
   register: awx_secret_key
 
 - name: Start the containers
-  docker_service:
+  docker_compose:
     project_src: "{{ docker_compose_dir }}"
     restarted: "{{ awx_compose_config is changed or awx_secret_key is changed }}"
   register: awx_compose_start


### PR DESCRIPTION
Signed-off-by: aubrel <red_clover@riseup.net>

##### SUMMARY

This is a tiny, pre-emptive fix that replaces the [soon-deprecated `docker_service`](https://docs.ansible.com/ansible/latest/modules/docker_service_module.html) with its replacement, the [`docker_compose` Ansible module](https://docs.ansible.com/ansible/latest/modules/docker_compose_module.html). This both gets rid of the warning telling us that `docker_service` will be deprecated in Ansible v. 2.12 (see below) and anticipates this module's deprecation. I just noticed this and figured it would be a quick easy patch.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

```
awx: 5.0.0
```

##### ADDITIONAL INFORMATION

Upon running the playbook prior to the fix, we see the following error message after the `Start the containers` task from `installer/roles/local_docker/tasks/compose.yml`

```
[DEPRECATION WARNING]: The 'docker_service' module has been renamed to 'docker_compose'.. This feature will be removed in version 2.12. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

After this fix, this warning goes away.