### PR TITLE
Detect possible inventory plugin files

### DIFF
--- a/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.json
+++ b/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.json
@@ -1,0 +1,3 @@
+{
+  "purpose": "not_an_inventory"
+}

--- a/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.yml
+++ b/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.yml
@@ -1,0 +1,1 @@
+purpose: not_an_inventory

--- a/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.yml
+++ b/awx/main/tests/data/ansible_utils/inventories/invalid/not_an_inventory.yml
@@ -1,1 +1,0 @@
-purpose: not_an_inventory

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory.json
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory.json
@@ -1,0 +1,36 @@
+{
+  "all": {
+    "hosts": {
+      "test1": null, 
+      "test2": {
+        "var1": "value1"
+      }
+    }, 
+    "children": {
+      "other_group": {
+        "hosts": {
+          "test4": {
+            "ansible_host": "127.0.0.1"
+          }
+        }, 
+        "children": {
+          "group_x": {
+            "hosts": "test5"
+          }
+        }, 
+        "vars": {
+          "g2_var2": "value3"
+        }
+      }, 
+      "last_group": {
+        "hosts": "test1", 
+        "vars": {
+          "last_var": "MYVALUE"
+        }
+      }
+    }, 
+    "vars": {
+      "group_var1": "value2"
+    }
+  }
+}

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
@@ -1,24 +1,22 @@
 ---
-all: # keys must be unique, i.e. only one 'hosts' per group
-    hosts:
-        test1:
-        test2:
-            var1: value1
-    vars:
-        group_var1: value2
-    children:   # key order does not matter, indentation does
-        other_group:
-            children:
-                group_x:
-                    hosts:
-                        test5
-            vars:
-                g2_var2: value3
-            hosts:
-                test4:
-                    ansible_host: 127.0.0.1
-        last_group:
-            hosts:
-                test1 # same host as above, additional group membership
-            vars:
-                last_var: MYVALUE
+all:  # keys must be unique, i.e. only one 'hosts' per group
+  hosts:
+    test1:
+    test2:
+      var1: value1
+  vars:
+    group_var1: value2
+  children:  # key order does not matter, indentation does
+    other_group:
+      children:
+        group_x:
+          hosts: test5
+      vars:
+        g2_var2: value3
+      hosts:
+        test4:
+          ansible_host: 127.0.0.1
+    last_group:
+      hosts: test1  # same host as above, additional group membership
+      vars:
+        last_var: MYVALUE

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
@@ -1,3 +1,4 @@
+---
 all: # keys must be unique, i.e. only one 'hosts' per group
     hosts:
         test1:

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory.yaml
@@ -1,0 +1,23 @@
+all: # keys must be unique, i.e. only one 'hosts' per group
+    hosts:
+        test1:
+        test2:
+            var1: value1
+    vars:
+        group_var1: value2
+    children:   # key order does not matter, indentation does
+        other_group:
+            children:
+                group_x:
+                    hosts:
+                        test5
+            vars:
+                g2_var2: value3
+            hosts:
+                test4:
+                    ansible_host: 127.0.0.1
+        last_group:
+            hosts:
+                test1 # same host as above, additional group membership
+            vars:
+                last_var: MYVALUE

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory_plugin.yaml
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory_plugin.yaml
@@ -1,0 +1,6 @@
+# This inventory is designed to be processed by an inventory plugin
+plugin: custom_inventory_plugin
+parameters:
+  - first
+  - second
+  - third

--- a/awx/main/tests/data/ansible_utils/inventories/valid/inventory_plugin.yaml
+++ b/awx/main/tests/data/ansible_utils/inventories/valid/inventory_plugin.yaml
@@ -1,3 +1,4 @@
+---
 # This inventory is designed to be processed by an inventory plugin
 plugin: custom_inventory_plugin
 parameters:

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -18,7 +18,7 @@ __all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory']
 
 
 valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|(ansible\.builtin\.)?include|(ansible\.builtin\.)?import_playbook):\s*?.*?$')
-valid_inventory_re = re.compile(r'^[# {},a-zA-Z0-9_.=\[\]]')
+valid_inventory_re = re.compile(r'^[a-zA-Z0-9_.=\[\]]')
 
 
 def skip_directory(relative_directory_path):

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -87,38 +87,17 @@ def could_be_inventory(project_path, dir_path, filename):
     matched = False
     try:
         # only read through first 10 lines for performance
-<<<<<<< HEAD
         with open(inventory_path, encoding='utf-8', errors='ignore') as inv_file:
             for i, line in enumerate(inv_file):
                 if i > 10:
                     break
+                elif 'plugin:' in line or 'all' in line:
+                    matched = True
+                    break
+                    # Probably an inventory file
                 elif valid_inventory_re.match(line):
                     matched = True
                     break
-||||||| parent of ebc51d22fb (Detect possible inventory plugin files)
-        with codecs.open(
-            inventory_path,
-            'r',
-            encoding='utf-8',
-            errors='ignore'
-        ) as inv_file:
-            for line in islice(inv_file, 10):
-                if not valid_inventory_re.match(line):
-                    return None
-=======
-        with codecs.open(
-            inventory_path,
-            'r',
-            encoding='utf-8',
-            errors='ignore'
-        ) as inv_file:
-            for line in islice(inv_file, 10):
-                if 'plugin:' in line or 'all' in line:
-                    # Probably an inventory file
-                    return inventory_rel_path
-                if not valid_inventory_re.match(line):
-                    return None
->>>>>>> ebc51d22fb (Detect possible inventory plugin files)
     except IOError:
         return None
     if not matched:

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -18,7 +18,7 @@ __all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory']
 
 
 valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|(ansible\.builtin\.)?include|(ansible\.builtin\.)?import_playbook):\s*?.*?$')
-valid_inventory_re = re.compile(r'^[a-zA-Z0-9_.=\[\]]')
+valid_inventory_re = re.compile(r'^[# {},a-zA-Z0-9_.=\[\]]')
 
 
 def skip_directory(relative_directory_path):
@@ -75,6 +75,9 @@ def could_be_inventory(project_path, dir_path, filename):
     elif suspected_ext == '.ini' or os.access(inventory_path, os.X_OK):
         # Files with any of these extensions are always included
         return inventory_rel_path
+    elif suspected_ext in ['.yaml', '.yml', '.json']:
+        # Might be an inventory plugin file
+        pass
     elif '.' in suspected_ext:
         # If not using those extensions, inventory must have _no_ extension
         return None
@@ -84,6 +87,7 @@ def could_be_inventory(project_path, dir_path, filename):
     matched = False
     try:
         # only read through first 10 lines for performance
+<<<<<<< HEAD
         with open(inventory_path, encoding='utf-8', errors='ignore') as inv_file:
             for i, line in enumerate(inv_file):
                 if i > 10:
@@ -91,6 +95,30 @@ def could_be_inventory(project_path, dir_path, filename):
                 elif valid_inventory_re.match(line):
                     matched = True
                     break
+||||||| parent of ebc51d22fb (Detect possible inventory plugin files)
+        with codecs.open(
+            inventory_path,
+            'r',
+            encoding='utf-8',
+            errors='ignore'
+        ) as inv_file:
+            for line in islice(inv_file, 10):
+                if not valid_inventory_re.match(line):
+                    return None
+=======
+        with codecs.open(
+            inventory_path,
+            'r',
+            encoding='utf-8',
+            errors='ignore'
+        ) as inv_file:
+            for line in islice(inv_file, 10):
+                if 'plugin:' in line or 'all' in line:
+                    # Probably an inventory file
+                    return inventory_rel_path
+                if not valid_inventory_re.match(line):
+                    return None
+>>>>>>> ebc51d22fb (Detect possible inventory plugin files)
     except IOError:
         return None
     if not matched:


### PR DESCRIPTION
##### SUMMARY
AWX ignores inventory plugin files when choosing inventory files from a Project source. This PR lets yaml and json files slip through after a very basic check for a couple of keywords that would be in a yaml or json inventory file or an inventory plugin file.

related #3491

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 5.0.0
```

##### ADDITIONAL INFORMATION

