### PR TITLE
fix the hashivault v2 lookup

### DIFF
--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -89,6 +89,7 @@ def kv_backend(**kwargs):
             params['version'] = kwargs['secret_version']
         try:
             mount_point, *path = pathlib.Path(secret_path.lstrip(os.sep)).parts
+            '/'.join(path)
         except Exception:
             mount_point, path = secret_path, []
         # https://www.vaultproject.io/api/secret/kv/kv-v2.html#read-secret-version

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -89,7 +89,6 @@ def kv_backend(**kwargs):
             params['version'] = kwargs['secret_version']
         try:
             mount_point, *path = pathlib.Path(secret_path.lstrip(os.sep)).parts
-            '/'.join(*path)
         except Exception:
             mount_point, path = secret_path, []
         # https://www.vaultproject.io/api/secret/kv/kv-v2.html#read-secret-version


### PR DESCRIPTION
##### SUMMARY
Currently if you have api version 2 nested secret for hashi vault like kv/test/folder, the lookup doesnt work. It gives an 404 error 

```
HashiCorp Vault Secret Lookup: HTTP 404 {"request_id":"25568b99-3dd9-62fe-336f-b3f4f6a8e6f5","lease_id":"","renewable":false,"lease_duration":0,"data":null,"wrap_info":null,"warnings":["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use 'vault kv get' for this operation."],"auth":null} 
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

hashivault

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX version: 4.0.0
Ansible Version: 2.8.0
```


##### ADDITIONAL INFORMATION
The issue is because of this line in the hashivault plugin:

https://github.com/ansible/awx/blob/devel/awx/main/credential_plugins/hashivault.py#L92

We are doing a join on *path, which will make it 2 arguments for the join if the secret is nested like /kv/test/folder. That will throw an exception of `TypeError: join() takes exactly one argument (2 given)`. In the plugin we are catching the exception and making mount_point as secret path, which leads to wrong path while doing the lookup.

We dont need to join there because we are anyways doing a join later at

https://github.com/ansible/awx/blob/devel/awx/main/credential_plugins/hashivault.py#L97


