### PR TITLE
don't ship external logs from the main thread of the dispatcher

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -6,6 +6,7 @@ import logging
 import json
 import requests
 import time
+import threading
 import socket
 import select
 from urllib import parse as urlparse
@@ -286,6 +287,8 @@ class AWXProxyHandler(logging.Handler):
     Parameters match same parameters in the actualized handler classes.
     '''
 
+    thread_local = threading.local()
+
     def __init__(self, **kwargs):
         # TODO: process 'level' kwarg
         super(AWXProxyHandler, self).__init__(**kwargs)
@@ -322,8 +325,9 @@ class AWXProxyHandler(logging.Handler):
         return self._handler
 
     def emit(self, record):
-        actual_handler = self.get_handler()
-        return actual_handler.emit(record)
+        if AWXProxyHandler.thread_local.enabled:
+            actual_handler = self.get_handler()
+            return actual_handler.emit(record)
 
     def perform_test(self, custom_settings):
         """
@@ -352,6 +356,13 @@ class AWXProxyHandler(logging.Handler):
                         )
             except RequestException as e:
                 raise LoggingConnectivityException(str(e))
+
+    @classmethod
+    def disable(cls):
+        cls.thread_local.enabled = False
+
+
+AWXProxyHandler.thread_local.enabled = True
 
 
 ColorHandler = logging.StreamHandler


### PR DESCRIPTION
this is a fairly esoteric change that attempts to work around a bug
we've discovered in cpython itself

context: https://github.com/ansible/awx/issues/4181