### PR TITLE
Fix 254 delete last elem list page

### DIFF
--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
@@ -38,7 +38,15 @@ class PaginatedDataList extends React.Component {
     this.handleSort = this.handleSort.bind(this);
   }
 
-  getSortOrder() {
+  componentDidUpdate(prevProps) {
+    const { itemCount: prevItemCount } = prevProps;
+    const { itemCount } = this.props
+    if (prevItemCount !== itemCount) {
+      this.getCurrPage(itemCount);
+    }
+  }
+
+  getSortOrder () {
     const { qsConfig, location } = this.props;
     const queryParams = parseNamespacedQueryString(qsConfig, location.search);
     if (queryParams.order_by && queryParams.order_by.startsWith('-')) {
@@ -47,7 +55,20 @@ class PaginatedDataList extends React.Component {
     return [queryParams.order_by, 'ascending'];
   }
 
-  handleSetPage(event, pageNumber) {
+  getCurrPage (itemCount) {
+    if (itemCount < 0) {
+      return;
+    }
+    const { qsConfig, location } = this.props;
+    const queryParams = parseNamespacedQueryString(qsConfig, location.search);
+    const maxPages = Math.ceil(itemCount / queryParams.page_size);
+    const currPage = queryParams.page;
+    if (currPage > maxPages) {
+      this.pushHistoryState({ page: (currPage + (maxPages - currPage)) || 1 })
+    }
+  }
+
+  handleSetPage (event, pageNumber) {
     this.pushHistoryState({ page: pageNumber });
   }
 

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
@@ -40,13 +40,13 @@ class PaginatedDataList extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { itemCount: prevItemCount } = prevProps;
-    const { itemCount } = this.props
+    const { itemCount } = this.props;
     if (prevItemCount !== itemCount) {
       this.getCurrPage(itemCount);
     }
   }
 
-  getSortOrder () {
+  getSortOrder() {
     const { qsConfig, location } = this.props;
     const queryParams = parseNamespacedQueryString(qsConfig, location.search);
     if (queryParams.order_by && queryParams.order_by.startsWith('-')) {
@@ -55,20 +55,22 @@ class PaginatedDataList extends React.Component {
     return [queryParams.order_by, 'ascending'];
   }
 
-  getCurrPage (itemCount) {
+  getCurrPage(itemCount) {
     if (itemCount < 0) {
       return;
     }
     const { qsConfig, location } = this.props;
-    const queryParams = parseNamespacedQueryString(qsConfig, location.search);
-    const maxPages = Math.ceil(itemCount / queryParams.page_size);
-    const currPage = queryParams.page;
-    if (currPage > maxPages) {
-      this.pushHistoryState({ page: (currPage + (maxPages - currPage)) || 1 })
+    const { page_size, page: currPage } = parseNamespacedQueryString(
+      qsConfig,
+      location.search
+    );
+    const lastPage = Math.ceil(itemCount / page_size);
+    if (currPage > lastPage) {
+      this.pushHistoryState({ page: lastPage || 1 });
     }
   }
 
-  handleSetPage (event, pageNumber) {
+  handleSetPage(event, pageNumber) {
     this.pushHistoryState({ page: pageNumber });
   }
 

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
@@ -132,7 +132,7 @@ describe('<PaginatedDataList />', () => {
       integerFields: [],
     };
     const testParams = [5, 25, 0, -1]; // number of items
-    const expected = [5, 5, 1, 1] // expected current page
+    const expected = [5, 5, 1, 1]; // expected current page
     const history = createMemoryHistory({
       initialEntries: ['/organizations/1/teams'],
     });
@@ -146,13 +146,16 @@ describe('<PaginatedDataList />', () => {
           order_by: 'name',
         }}
         qsConfig={customQSConfig}
-      />, { context: { router: { history } } }
+      />,
+      { context: { router: { history } } }
     );
     testParams.forEach((param, i) => {
       wrapper.setProps({ itemCount: param });
-      expect(history.location.search).toEqual(`?${customQSConfig.namespace}.page=${expected[i]}`)
+      expect(history.location.search).toEqual(
+        `?${customQSConfig.namespace}.page=${expected[i]}`
+      );
       wrapper.update();
-    })
+    });
     wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
@@ -10,6 +10,8 @@ const mockData = [
   { id: 3, name: 'three', url: '/org/team/3' },
   { id: 4, name: 'four', url: '/org/team/4' },
   { id: 5, name: 'five', url: '/org/team/5' },
+  { id: 6, name: 'six', url: '/org/team/6' },
+  { id: 7, name: 'seven', url: '/org/team/7' },
 ];
 
 const qsConfig = {
@@ -122,5 +124,35 @@ describe('<PaginatedDataList />', () => {
     wrapper.update();
     pagination.prop('onPerPageSelect')(null, 25);
     expect(history.location.search).toEqual('?item.page_size=25');
+  });
+  test('should navigate to correct current page when list items change', () => {
+    const customQSConfig = {
+      namespace: 'foo',
+      defaultParams: { page: 7, page_size: 1 }, // show only 1 item per page
+      integerFields: [],
+    };
+    const testParams = [5, 25, 0, -1]; // number of items
+    const expected = [5, 5, 1, 1] // expected current page
+    const history = createMemoryHistory({
+      initialEntries: ['/organizations/1/teams'],
+    });
+    const wrapper = mountWithContexts(
+      <PaginatedDataList
+        items={mockData}
+        itemCount={7}
+        queryParams={{
+          page: 1,
+          page_size: 5,
+          order_by: 'name',
+        }}
+        qsConfig={customQSConfig}
+      />, { context: { router: { history } } }
+    );
+    testParams.forEach((param, i) => {
+      wrapper.setProps({ itemCount: param });
+      expect(history.location.search).toEqual(`?${customQSConfig.namespace}.page=${expected[i]}`)
+      wrapper.update();
+    })
+    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -75,12 +75,13 @@ class OrganizationsList extends Component {
     this.setState({ deletionError: null });
   }
 
-  async handleOrgDelete() {
-    const { selected } = this.state;
+  async handleOrgDelete () {
+    const { selected, itemCount } = this.state;
 
     this.setState({ hasContentLoading: true });
     try {
-      await Promise.all(selected.map(org => OrganizationsAPI.destroy(org.id)));
+      await Promise.all(selected.map((org) => OrganizationsAPI.destroy(org.id)));
+      this.setState({ itemCount: itemCount - selected.length });
     } catch (err) {
       this.setState({ deletionError: err });
     } finally {

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -75,12 +75,12 @@ class OrganizationsList extends Component {
     this.setState({ deletionError: null });
   }
 
-  async handleOrgDelete () {
+  async handleOrgDelete() {
     const { selected, itemCount } = this.state;
 
     this.setState({ hasContentLoading: true });
     try {
-      await Promise.all(selected.map((org) => OrganizationsAPI.destroy(org.id)));
+      await Promise.all(selected.map(org => OrganizationsAPI.destroy(org.id)));
       this.setState({ itemCount: itemCount - selected.length });
     } catch (err) {
       this.setState({ deletionError: err });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -77,20 +77,22 @@ class TemplatesList extends Component {
     }
   }
 
-  async handleTemplateDelete () {
+  async handleTemplateDelete() {
     const { selected, itemCount } = this.state;
 
     this.setState({ hasContentLoading: true });
     try {
-      await Promise.all(selected.map(({ type, id }) => {
-        let deletePromise;
-        if (type === 'job_template') {
-          deletePromise = JobTemplatesAPI.destroy(id);
-        } else if (type === 'workflow_job_template') {
-          deletePromise = WorkflowJobTemplatesAPI.destroy(id);
-        }
-        return deletePromise;
-      }));
+      await Promise.all(
+        selected.map(({ type, id }) => {
+          let deletePromise;
+          if (type === 'job_template') {
+            deletePromise = JobTemplatesAPI.destroy(id);
+          } else if (type === 'workflow_job_template') {
+            deletePromise = WorkflowJobTemplatesAPI.destroy(id);
+          }
+          return deletePromise;
+        })
+      );
       this.setState({ itemCount: itemCount - selected.length });
     } catch (err) {
       this.setState({ deletionError: err });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -77,22 +77,21 @@ class TemplatesList extends Component {
     }
   }
 
-  async handleTemplateDelete() {
-    const { selected } = this.state;
+  async handleTemplateDelete () {
+    const { selected, itemCount } = this.state;
 
     this.setState({ hasContentLoading: true });
     try {
-      await Promise.all(
-        selected.map(({ type, id }) => {
-          let deletePromise;
-          if (type === 'job_template') {
-            deletePromise = JobTemplatesAPI.destroy(id);
-          } else if (type === 'workflow_job_template') {
-            deletePromise = WorkflowJobTemplatesAPI.destroy(id);
-          }
-          return deletePromise;
-        })
-      );
+      await Promise.all(selected.map(({ type, id }) => {
+        let deletePromise;
+        if (type === 'job_template') {
+          deletePromise = JobTemplatesAPI.destroy(id);
+        } else if (type === 'workflow_job_template') {
+          deletePromise = WorkflowJobTemplatesAPI.destroy(id);
+        }
+        return deletePromise;
+      }));
+      this.setState({ itemCount: itemCount - selected.length });
     } catch (err) {
       this.setState({ deletionError: err });
     } finally {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #4239 

This PR does the following:

Updates the itemCount of the Orgs and Templates list page when an org/template has been successfully deleted.
Add a new method `getCurrPage()` to `PaginatedDataList` that updates pagination and query params accordingly when the current page a user is on is greater than the total pages the component is supposed to display.
Add unit test for `getCurrPage()` functionality.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
