### PR TITLE
Change to docker_service for compatibility

### DIFF
--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -23,7 +23,7 @@
   register: awx_secret_key
 
 - name: Start the containers
-  docker_compose:
+  docker_service:
     project_src: "{{ docker_compose_dir }}"
     restarted: "{{ awx_compose_config is changed or awx_secret_key is changed }}"
   register: awx_compose_start


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change the `docker_compose` module name to its alias, `docker_service`, which was the name of the module before Ansible 2.8.  Since the requirements for AWX installation reference Ansible 2.4+, this should be made compatible with older versions that only recognize `docker_service`. Otherwise, installation will error out with an unrecognized module name.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Before change error message with ansible 2.7.9:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[ashley@ansible installer]$ ansible-playbook -i inventory-sand install.yml -e openshift_token=<my_token>
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '~/awx-6.0.0/installer/roles/local_docker/tasks/compose.yml': line 25, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Start the containers
  ^ here
```
