### PR TITLE
Add dynamic custom venv setup

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -46,3 +46,6 @@ kubernetes_deployment_replica_size: 1
 postgress_activate_wait: 60
 
 insights_url_base: "https://example.org"
+
+custom_venvs_path: "/opt/custom-venvs"
+custom_venvs_python: "python2"

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -134,6 +134,35 @@ spec:
     spec:
       serviceAccountName: awx
       terminationGracePeriodSeconds: 10
+{% if custom_venvs is defined %}
+      initContainers:
+        - image: 'centos:7'
+          name: init-custom-venvs
+          command:
+            - sh
+            - '-c'
+            - >-
+              yum install -y ansible curl python-setuptools epel-release \
+                openssl openssl-devel gcc python-devel &&
+              yum install -y python-virtualenv python36 python36-devel &&
+              mkdir -p {{ custom_venvs_path }} &&
+{% for custom_venv in custom_venvs %}
+              virtualenv -p {{ custom_venv.python | default(custom_venvs_python) }} \
+                {{ custom_venvs_path }}/{{ custom_venv.name }} &&
+              source {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/activate &&
+              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install -U psutil \
+                "ansible=={{ custom_venv.python_ansible_version }}" &&
+{% if custom_venv.python_modules is defined %}
+              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install -U \
+                {% for module in custom_venv.python_modules %}{{ module }} {% endfor %} &&
+{% endif %}
+              deactivate && 
+{% endfor %}
+              :
+          volumeMounts:
+            - name: custom-venvs
+              mountPath: {{ custom_venvs_path }}
+{% endif %}
       containers:
         - name: {{ kubernetes_deployment_name }}-web
           image: "{{ kubernetes_web_image }}:{{ kubernetes_web_version }}"
@@ -150,6 +179,10 @@ spec:
             - name: {{ kubernetes_deployment_name }}-project-data-dir
               mountPath: "/var/lib/awx/projects"
               readOnly: false
+{% endif %}
+{% if custom_venvs is defined %}
+            - name: custom-venvs
+              mountPath: {{ custom_venvs_path }}
 {% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config
               mountPath: "/etc/tower/settings.py"
@@ -190,6 +223,10 @@ spec:
             - name: {{ kubernetes_deployment_name }}-ca-trust-dir
               mountPath: "/etc/pki/ca-trust/source/anchors/"
               readOnly: true
+{% endif %}
+{% if custom_venvs is defined %}
+            - name: custom-venvs
+              mountPath: {{ custom_venvs_path }}
 {% endif %}
             - name: {{ kubernetes_deployment_name }}-application-config
               mountPath: "/etc/tower/settings.py"
@@ -300,6 +337,10 @@ spec:
           hostPath:
             path: "{{ project_data_dir }}"
             type: Directory
+{% endif %}
+{% if custom_venvs is defined %}
+        - name: custom-venvs 
+          emptyDir: {}
 {% endif %}
         - name: {{ kubernetes_deployment_name }}-application-config
           configMap:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change allows for custom virtual environments and their required modules to be specified as a list under the `custom_venvs` variable in the following format when deploying to Kubernetes:
```yaml
custom_venvs:
  - name: my_first_venv
    python_ansible_version: 2.8.1
    python_modules:
      - dnspython
      - pyvmomi
      - infoblox-client 
  - name: second_venv
    python_ansible_version: 2.7.10
    python_modules:
      - etc
```
The rationale behind this is to allow users to avoid modifying the deployment template when adding custom virtual environments. This makes it easier to separate and preserve their customizations between new version deployments.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.0.0
```
##### ADDITIONAL INFORMATION

This was adapted from these instructions: https://github.com/ansible/awx/blob/devel/docs/custom_virtualenvs.md#kubernetes-custom-virtualenvs
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

