### PR TITLE
Fix error with rejoining node to cluster after lost connection to postgres

### DIFF
--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -33,7 +33,11 @@ def reap(instance=None, status='failed', excluded_uuids=[]):
     '''
     Reap all jobs in waiting|running for this instance.
     '''
-    me = instance or Instance.objects.me()
+    me = instance
+    if me is None:
+        (changed, me) = Instance.objects.get_or_register()
+        if changed:
+            logger.info("Registered tower node '{}'".format(me.hostname))
     now = tz_now()
     workflow_ctype_id = ContentType.objects.get_for_model(WorkflowJob).id
     jobs = UnifiedJob.objects.filter(


### PR DESCRIPTION
##### SUMMARY
This commit will fix the error with rejoining node to cluster after lost connection to postgres.
Rejoining was introduced here: https://github.com/ansible/awx/commit/7ce8907b7b49df5fe9375a81de166bc9f0ce45b2

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
6.0.0
```

##### ADDITIONAL INFORMATION
When node(1.awx.node.dc1 on this example) lost connection to postgres, other nodes deprovision it(and delete from PG database):

```
Jul  4 17:16:59 1.awx.node.dc2 dispatcher[207]: 2019-07-04 14:16:59,220 INFO     awx.main.tasks Host 1.awx.node.dc1 Automatically Deprovisioned.
```

But when connection recover, dispatcher can't rejoining node to cluster, cause he can't get node id from database:

```
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: 2019-07-04 14:20:39,433 ERROR    awx.main.dispatch failed to write inbound message
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: Traceback (most recent call last):
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/dispatch/pool.py", line 388, in write
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: self.cleanup()
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/dispatch/pool.py", line 373, in cleanup
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: reaper.reap(excluded_uuids=running_uuids)
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/dispatch/reaper.py", line 35, in reap
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: me = instance or Instance.objects.me()
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/managers.py", line 88, in me
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: raise RuntimeError("No instance found with the current cluster host id")
Jul  4 17:20:39 1.awx.node.dc1 dispatcher[505]: RuntimeError: No instance found with the current cluster host id
```
We should register instance on database before trying to get it's id.


