### PR TITLE
fix a bug that breaks OPT_X_TLS_REQUIRE_CERT=0 for LDAP authentication

### DIFF
--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -66,7 +66,7 @@ class LDAPSettings(BaseLDAPSettings):
         # see: https://github.com/python-ldap/python-ldap/issues/55
         newctx_option = self.CONNECTION_OPTIONS.pop(ldap.OPT_X_TLS_NEWCTX, None)
         self.CONNECTION_OPTIONS = OrderedDict(self.CONNECTION_OPTIONS)
-        if newctx_option:
+        if newctx_option is not None:
             self.CONNECTION_OPTIONS[ldap.OPT_X_TLS_NEWCTX] = newctx_option
 
 


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/4267