### PR TITLE
 Fix to use "type" as the condition value for Machine credential to cover I18N

### DIFF
--- a/awx/ui/client/lib/models/Credential.js
+++ b/awx/ui/client/lib/models/Credential.js
@@ -55,7 +55,7 @@ function assignInputGroupValues (apiConfig, credentialType, sourceCredentials) {
         return input;
     });
 
-    if (credentialType.get('name') === 'Machine') {
+    if (credentialType.get('namespace') === 'ssh') {
         const become = inputs.find((field) => field.id === 'become_method');
         become._isDynamic = true;
         become._choices = Array.from(apiConfig.become_methods, method => method[0]);


### PR DESCRIPTION
##### SUMMARY
Fix the variable for checking the credential type from `name` to `kind` in order to correctly handle I18N.
Currently, it uses "name" but this value does not match the condition(`Machine`) because it gets a localized value like `マシン` or `Máquina`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
6.0.0
```

##### ADDITIONAL INFORMATION
- ansible/tower#3590
