### PR TITLE
awx/ui: minor fix on Update on Project Update description

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
@@ -380,7 +380,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n){
                     ngDisabled: '!(inventory_source_obj.summary_fields.user_capabilities.edit || canAdd)'
                 }, {
                     name: 'update_on_project_update',
-                    label: i18n._('Update on Project Change'),
+                    label: i18n._('Update on Project Update'),
                     type: 'checkbox',
                     ngShow: "source.value === 'scm'",
                     awPopOver: "<p>" + i18n._("After every project update where the SCM revision changes, " +

--- a/awx/ui/po/ansible-tower-ui.pot
+++ b/awx/ui/po/ansible-tower-ui.pot
@@ -5629,10 +5629,6 @@ msgstr ""
 msgid "Update on Launch"
 msgstr ""
 
-#: client/src/inventories-hosts/inventories/related/sources/sources.form.js:388
-msgid "Update on Project Change"
-msgstr ""
-
 #: client/src/inventories-hosts/inventories/related/sources/sources.form.js:394
 msgid "Update on Project Update"
 msgstr ""

--- a/awx/ui/po/es.po
+++ b/awx/ui/po/es.po
@@ -6250,10 +6250,6 @@ msgstr "Actualización faltante. Haga clic para obtener más información."
 msgid "Update on Launch"
 msgstr "Actualizar al ejecutar"
 
-#: client/src/inventories-hosts/inventories/related/sources/sources.form.js:388
-msgid "Update on Project Change"
-msgstr "Actualizar en el cambio de proyecto"
-
 #: client/src/inventories-hosts/inventories/related/sources/sources.form.js:394
 msgid "Update on Project Update"
 msgstr "Actualizar en la actualización del proyecto"

--- a/awx/ui/po/fr.po
+++ b/awx/ui/po/fr.po
@@ -6258,10 +6258,6 @@ msgstr "Mise à jour manquante. Cliquer pour plus de détails."
 msgid "Update on Launch"
 msgstr "Mettre à jour au lancement"
 
-#: client/src/inventories-hosts/inventories/related/sources/sources.form.js:388
-msgid "Update on Project Change"
-msgstr "Mettre à jour lorsqu'une modification est apportée au projet"
-
 #: client/src/inventories-hosts/inventories/related/sources/sources.form.js:394
 msgid "Update on Project Update"
 msgstr "Mettre à jour lorsque le projet est actualisé"

--- a/awx/ui/po/ja.po
+++ b/awx/ui/po/ja.po
@@ -5963,10 +5963,6 @@ msgstr "更新がありません。クリックして詳細を確認してくだ
 msgid "Update on Launch"
 msgstr "起動時の更新"
 
-#: client/src/inventories-hosts/inventories/related/sources/sources.form.js:388
-msgid "Update on Project Change"
-msgstr "プロジェクト変更時の更新"
-
 #: client/src/inventories-hosts/inventories/related/sources/sources.form.js:394
 msgid "Update on Project Update"
 msgstr "プロジェクト更新時の更新"

--- a/awx/ui/po/nl.po
+++ b/awx/ui/po/nl.po
@@ -6216,10 +6216,6 @@ msgstr "Update ontbreekt. Klik voor meer informatie"
 msgid "Update on Launch"
 msgstr "Update bij opstarten"
 
-#: client/src/inventories-hosts/inventories/related/sources/sources.form.js:388
-msgid "Update on Project Change"
-msgstr "Update voor projectwijziging"
-
 #: client/src/inventories-hosts/inventories/related/sources/sources.form.js:394
 msgid "Update on Project Update"
 msgstr "Update voor projectupdate"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

In the Inventory Source settings, one of the update options is titled
`Update on Project Change`. However, the tooltip is titled
`Update on Project Update`. Looking at the overall AWX codebase, I think
the definitions are fitted more towards `Update on Project Update`.

Here's an example:

~~~
                    name: 'update_on_project_update',
                    label: i18n._('Update on Project Update'),
                    type: 'checkbox',
                    ngShow: "source.value === 'scm'",
                    awPopOver: "<p>" + i18n._("After every project update where the SCM revision changes, " +
                                "refresh the inventory from the selected source before executing job tasks. " +
                                "This is intended for static content, like the Ansible inventory .ini file format.") + "</p>",
                    dataTitle: i18n._('Update on Project Update'),
                    dataContainer: 'body',
                    dataPlacement: 'right',
                    ngDisabled: '!(inventory_source_obj.summary_fields.user_capabilities.edit || canAdd)'
                }]
            },
~~~

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
