### PR TITLE
specify a ng-csp attribute so Angular doesn't autodetect

### DIFF
--- a/awx/ui/client/index.template.ejs
+++ b/awx/ui/client/index.template.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html ng-csp="no-unsafe-eval">
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
without this, we're getting a false positive log message about an unsafe
eval (which is *actually* just angular auto-detecting whether or not
eval is supported):

```
awx_1        | 2019-07-08 20:40:19,141 ERROR    awx {'csp-report': {'document-uri': 'https://localhost:8043/', 'referrer': '', 'violated-directive': 'script-src', 'effective-directive': 'script-src', 'original-policy': "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' cdn.pendo.io; img-src 'self' data:; report-uri /csp-violation/", 'disposition': 'enforce', 'blocked-uri': 'eval', 'line-number': 116711, 'column-number': 7, 'source-file': 'https://localhost:8043/static/js/vendor.8778ab7be905d20927b3.js', 'status-code': 0, 'script-sample': ''}}
```

see: https://www.w3schools.com/angular/ng_ng-csp.asp