### PR TITLE
Fix #3857. More informative error message for job templates

### DIFF
--- a/awx/ui/client/src/templates/main.js
+++ b/awx/ui/client/src/templates/main.js
@@ -124,7 +124,7 @@ angular.module('templates', [surveyMaker.name, jobTemplates.name, labels.name, p
                                         .then(function(data) {
                                             if (!data.actions.POST) {
                                                 $state.go("^");
-                                                Alert(i18n._('Permission Error'), i18n._('You do not have permission to add a job template.'), 'alert-info');
+                                                Alert(i18n._('Permission Error'), i18n._('You do not have permission to add a job template, or there are no projects available.'), 'alert-info');
                                             }
                                         }).catch(function(response){
                                             ProcessErrors(null, response.data, response.status, null, {


### PR DESCRIPTION
##### SUMMARY
When the user try to create a job template and there are no projects available a misleading error message is is displayed in a modal "You do not have permission to add a job template.".

This change the error message to "You do not have permission to add a job template, or there are no projects available."

Related #3857 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
I'm unable to run a make on my current machine due to work. Hoping that someone else can do it, since this is just a change of an error message.

##### ADDITIONAL INFORMATION
