### PR TITLE
get more events on page down or up when needed

### DIFF
--- a/awx/ui/client/features/output/index.controller.js
+++ b/awx/ui/client/features/output/index.controller.js
@@ -422,10 +422,18 @@ function menuLast () {
 
 function down () {
     scroll.moveDown();
+
+    if (scroll.isBeyondLowerThreshold()) {
+        next();
+    }
 }
 
 function up () {
     scroll.moveUp();
+
+    if (scroll.isBeyondUpperThreshold()) {
+        previous();
+    }
 }
 
 function togglePanelExpand () {


### PR DESCRIPTION
##### SUMMARY
The up / down controls move the display up or down by exactly one visible page. We also want to retrieve the next / previous set of events if we move into the upper or lower limits of the visible results.



