### PR TITLE
Add host description to relevant lists

### DIFF
--- a/awx/ui/client/src/inventories-hosts/hosts/host.list.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/host.list.js
@@ -71,7 +71,6 @@ export default ['i18n', function(i18n) {
                 columnClass: 'col-sm-4',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
-                class: 'InventoryManage-breakWord'
             },
             inventory: {
                 label: i18n._('Inventory'),

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -43,8 +43,8 @@
                         <div></div>
                         <div></div>
                         <div class="d-flex h-100">
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3 col-md-6 col-sm-8 col-xs-7" query-set="host_queryset"></div>
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="col-lg-3" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3 col-md-3 col-sm-3 col-xs-7" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
                             <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
                             <div class="List-tableHeader List-tableHeader--actions actions-column col-lg-3 text-right" translate>Actions</div>
                         </div>
@@ -70,10 +70,10 @@
                                         <a ui-sref="hosts.edit({host_id:host.id})">{{host.name }}</a>
                                     </div>
                                 </div>
-                                <div class="List-tableCell name-column InventoryManage-breakWord col-lg-3">
+                                <div class="List-tableCell name-column InventoryManage-breakWord d-none d-sm-flex col-sm-3 ellipsis">
                                     {{host.description }}
                                 </div>
-                                <div class="List-tableCell inventory_name-column col-lg-3 elllipsis">
+                                <div class="List-tableCell inventory_name-column d-none d-sm-flex col-sm-3 ellipsis">
                                     <div class="host-name">
                                         <a href="#/inventories/inventory/{{host.inventory}}">{{host.inventory_name}}</a>
                                     </div>

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -43,9 +43,9 @@
                         <div></div>
                         <div></div>
                         <div class="d-flex h-100">
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3 col-md-3 col-sm-3 col-xs-7" query-set="host_queryset"></div>
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3 col-md-4" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="d-none d-lg-flex col-lg-3" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="col-lg-3 col-md-4" query-set="host_queryset"></div>
                             <div class="List-tableHeader List-tableHeader--actions actions-column col-lg-3 text-right" translate>Actions</div>
                         </div>
                     </div>
@@ -64,21 +64,23 @@
                                     </a>
                                 </div>
                             </div>
-                            <div class="d-flex h-100">
-                                <div class="List-tableCell name-column InventoryManage-breakWord col-lg-3">
+                            <div class="d-flex h-100" style="min-width: 0;">
+                                <div class="List-tableCell name-column col-lg-3 col-md-4">
                                     <div class="host-name">
-                                        <a ui-sref="hosts.edit({host_id:host.id})">{{host.name }}</a>
+                                        <a ui-sref="hosts.edit({host_id:host.id})">{{ host.name }}</a>
                                     </div>
                                 </div>
-                                <div class="List-tableCell name-column InventoryManage-breakWord d-none d-sm-flex col-sm-3 ellipsis">
-                                    {{host.description }}
-                                </div>
-                                <div class="List-tableCell inventory_name-column d-none d-sm-flex col-sm-3 ellipsis">
-                                    <div class="host-name">
-                                        <a href="#/inventories/inventory/{{host.inventory}}">{{host.inventory_name}}</a>
+                                <div class="List-tableCell description-column d-none d-lg-flex col-lg-3">
+                                    <div class="d-inline-block text-truncate">
+                                        {{ host.description }}
                                     </div>
                                 </div>
-                                <div class="List-actionsContainer col-lg-3">
+                                <div class="List-tableCell inventory_name-column col-lg-3 col-md-4">
+                                    <div class="host-name d-inline-block text-truncate">
+                                        <a href="#/inventories/inventory/{{host.inventory}}">{{ host.inventory_name }}</a>
+                                    </div>
+                                </div>
+                                <div class="List-actionsContainer col-md-3 col-sm-4">
                                     <div class="List-actionButtonCell List-tableCell">
                                         <button id="insights-action" class="List-actionButton " ng-class="{'List-actionButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit.insights')}" data-placement="top" ng-click="goToInsights(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_INSIGHTS')}}" data-tip-watch="strings.get('inventory.VIEW_INSIGHTS')" ng-show="host.insights_system_id && host.summary_fields.inventory.hasOwnProperty('insights_credential_id')">
                                             <i class="fa fa-info"></i>

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -43,7 +43,7 @@
                         <div></div>
                         <div></div>
                         <div class="d-flex h-100">
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3 col-md-6 col-sm-8 col-xs-7" query-set="host_queryset"></div>
                             <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="col-lg-3" query-set="host_queryset"></div>
                             <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
                             <div class="List-tableHeader List-tableHeader--actions actions-column col-lg-3 text-right" translate>Actions</div>
@@ -71,9 +71,7 @@
                                     </div>
                                 </div>
                                 <div class="List-tableCell name-column InventoryManage-breakWord col-lg-3">
-                                    <div class="host-name">
-                                        <a ui-sref="hosts.edit({host_id:host.id})">{{host.description }}</a>
-                                    </div>
+                                    {{host.description }}
                                 </div>
                                 <div class="List-tableCell inventory_name-column col-lg-3 elllipsis">
                                     <div class="host-name">

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -43,9 +43,10 @@
                         <div></div>
                         <div></div>
                         <div class="d-flex h-100">
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-4" query-set="host_queryset"></div>
-                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="d-none d-sm-flex col-sm-4 ellipsis" query-set="host_queryset"></div>
-                            <div class="List-tableHeader List-tableHeader--actions actions-column col-lg-4 text-right" translate>Actions</div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="name" column-iterator="host" column-no-sort="undefined" column-label="Name" column-custom-class="col-lg-3" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="description" column-iterator="host" column-no-sort="undefined" column-label="Description" column-custom-class="col-lg-3" query-set="host_queryset"></div>
+                            <div class="List-tableHeader" base-path="hosts" collection="hosts" dataset="host_dataset" column-sort="" column-field="inventory" column-iterator="host" column-no-sort="undefined" column-label="Inventory" column-custom-class="d-none d-sm-flex col-sm-3 ellipsis" query-set="host_queryset"></div>
+                            <div class="List-tableHeader List-tableHeader--actions actions-column col-lg-3 text-right" translate>Actions</div>
                         </div>
                     </div>
                     <div class="List-staticColumnLayout--hosts List-tableRow" ng-repeat="host in hosts track by host.id">
@@ -64,17 +65,22 @@
                                 </div>
                             </div>
                             <div class="d-flex h-100">
-                                <div class="List-tableCell name-column InventoryManage-breakWord col-lg-4">
+                                <div class="List-tableCell name-column InventoryManage-breakWord col-lg-3">
                                     <div class="host-name">
                                         <a ui-sref="hosts.edit({host_id:host.id})">{{host.name }}</a>
                                     </div>
                                 </div>
-                                <div class="List-tableCell inventory_name-column col-lg-4 elllipsis">
+                                <div class="List-tableCell name-column InventoryManage-breakWord col-lg-3">
+                                    <div class="host-name">
+                                        <a ui-sref="hosts.edit({host_id:host.id})">{{host.description }}</a>
+                                    </div>
+                                </div>
+                                <div class="List-tableCell inventory_name-column col-lg-3 elllipsis">
                                     <div class="host-name">
                                         <a href="#/inventories/inventory/{{host.inventory}}">{{host.inventory_name}}</a>
                                     </div>
                                 </div>
-                                <div class="List-actionsContainer col-lg-4">
+                                <div class="List-actionsContainer col-lg-3">
                                     <div class="List-actionButtonCell List-tableCell">
                                         <button id="insights-action" class="List-actionButton " ng-class="{'List-actionButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit.insights')}" data-placement="top" ng-click="goToInsights(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_INSIGHTS')}}" data-tip-watch="strings.get('inventory.VIEW_INSIGHTS')" ng-show="host.insights_system_id && host.summary_fields.inventory.hasOwnProperty('insights_credential_id')">
                                             <i class="fa fa-info"></i>

--- a/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.list.js
@@ -38,7 +38,6 @@ export default ['i18n', function(i18n) {
                 key: true,
                 ngClick: "goToGroupGroups(group.id)",
                 columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
-                class: 'InventoryManage-breakWord',
             }
         },
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/groups.list.js
@@ -40,7 +40,6 @@
                 key: true,
                 uiSref: "inventories.edit.groups.edit({group_id:group.id})",
                 columnClass: 'col-lg-10 col-md-10 col-sm-10 col-xs-10',
-                class: 'InventoryManage-breakWord',
             }
         },
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups.list.js
@@ -39,7 +39,6 @@
                 key: true,
                 uiSref: "inventories.edit.groups.edit({group_id:nested_group.id})",
                 columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
-                class: 'InventoryManage-breakWord',
             }
         },
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
@@ -66,16 +66,24 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Hosts'),
                 uiSref: "inventories.edit.hosts.edit({host_id: nested_host.id})",
                 ngClass: "{ 'host-disabled-label': !nested_host.enabled }",
-                columnClass: 'col-lg-6 col-md-8 col-sm-8 col-xs-7',
+                columnClass: 'col-lg-4 col-md-8 col-sm-8 col-xs-7',
                 dataHostId: "{{ nested_host.id }}",
                 dataType: "nested_host",
-                class: 'InventoryManage-breakWord'
-            }
+            },
+            description: {
+                label: i18n._('Description'),
+                columnClass: 'd-none d-lg-flex col-lg-4',
+                template: `
+                    <div class="d-inline-block text-truncate">
+                        {{ nested_host.description }}
+                    </div>
+                `
+            },
         },
 
         fieldActions: {
 
-            columnClass: 'col-lg-6 col-md-4 col-sm-4 col-xs-5 text-right',
+            columnClass: 'col-lg-4 col-md-4 col-sm-4 col-xs-5 text-right',
             edit: {
                 ngClick: "editHost(nested_host.id)",
                 icon: 'icon-edit',

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -64,7 +64,7 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Hosts'),
                 uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
                 ngClass: "{ 'host-disabled-label': !host.enabled }",
-                columnClass: 'col-lg-3 col-md-6 col-sm-8 col-xs-7',
+                columnClass: 'col-lg-3 col-md-3 col-sm-3 col-xs-7',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
                 class: 'InventoryManage-breakWord'

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -67,11 +67,15 @@ export default ['i18n', function(i18n) {
                 columnClass: 'col-lg-3 col-md-3 col-sm-3 col-xs-7',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
-                class: 'InventoryManage-breakWord'
             },
             description: {
                 label: i18n._('Description'),
-                columnClass: 'd-none d-lg-flex col-lg-3'
+                columnClass: 'd-none d-lg-flex col-lg-3',
+                template: `
+                    <div class="d-inline-block text-truncate">
+                        {{ host.description }}
+                    </div>
+                `
             },
             groups: {
                 label: i18n._("Related Groups"),

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -64,33 +64,27 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Hosts'),
                 uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
                 ngClass: "{ 'host-disabled-label': !host.enabled }",
-                columnClass: 'col-lg-3 col-md-3 col-sm-8 col-xs-7',
+                columnClass: 'col-lg-3 col-md-6 col-sm-8 col-xs-7',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
                 class: 'InventoryManage-breakWord'
             },
             description: {
-                key: true,
                 label: i18n._('Description'),
-                uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
-                ngClass: "{ 'host-disabled-label': !host.enabled }",
-                columnClass: 'col-lg-3 col-md-3 col-sm-8 col-xs-7',
-                dataHostId: "{{ host.id }}",
-                dataType: "host",
-                class: 'InventoryManage-breakWord'
+                columnClass: 'd-none d-lg-flex col-lg-3'
             },
             groups: {
                 label: i18n._("Related Groups"),
                 type: 'related_groups',
                 nosort: true,
                 showDelete: true,
-                columnClass: 'd-none d-md-flex List-tableCell col-lg-3 col-md-3'
+                columnClass: 'd-none d-lg-flex List-tableCell col-lg-3'
             }
         },
 
         fieldActions: {
 
-            columnClass: 'col-lg-2 col-sm-3 col-xs-5 text-right',
+            columnClass: 'col-lg-3 col-md-6 col-sm-4 col-xs-5 text-right',
             edit: {
                 ngClick: "editHost(host)",
                 icon: 'icon-edit',

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -64,7 +64,17 @@ export default ['i18n', function(i18n) {
                 label: i18n._('Hosts'),
                 uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
                 ngClass: "{ 'host-disabled-label': !host.enabled }",
-                columnClass: 'col-lg-5 col-md-4 col-sm-8 col-xs-7',
+                columnClass: 'col-lg-3 col-md-3 col-sm-8 col-xs-7',
+                dataHostId: "{{ host.id }}",
+                dataType: "host",
+                class: 'InventoryManage-breakWord'
+            },
+            description: {
+                key: true,
+                label: i18n._('Description'),
+                uiSref: ".edit({inventory_id: host.inventory_id,host_id: host.id})",
+                ngClass: "{ 'host-disabled-label': !host.enabled }",
+                columnClass: 'col-lg-3 col-md-3 col-sm-8 col-xs-7',
                 dataHostId: "{{ host.id }}",
                 dataType: "host",
                 class: 'InventoryManage-breakWord'
@@ -74,13 +84,13 @@ export default ['i18n', function(i18n) {
                 type: 'related_groups',
                 nosort: true,
                 showDelete: true,
-                columnClass: 'd-none d-md-flex List-tableCell col-lg-5 col-md-4'
+                columnClass: 'd-none d-md-flex List-tableCell col-lg-3 col-md-3'
             }
         },
 
         fieldActions: {
 
-            columnClass: 'col-lg-2 col-sm-4 col-xs-5 text-right',
+            columnClass: 'col-lg-2 col-sm-3 col-xs-5 text-right',
             edit: {
                 ngClick: "editHost(host)",
                 icon: 'icon-edit',

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups.list.js
@@ -39,7 +39,6 @@
                 key: true,
                 ngClick: "goToGroupGroups(nested_group.id)",
                 columnClass: 'col-lg-6 col-md-6 col-sm-6 col-xs-6',
-                class: 'InventoryManage-breakWord',
             }
         },
 

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.list.js
@@ -40,7 +40,6 @@
                 key: true,
                 uiSref: "inventories.edit.inventory_sources.edit({inventory_source_id:inventory_source.id})",
                 columnClass: 'col-lg-4 col-md-4 col-sm-4 col-xs-4',
-                class: 'InventoryManage-breakWord',
             },
             source: {
                 label: i18n._('Type'),

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -363,7 +363,7 @@ export default ['$compile', 'Attr', 'Icon',
                     innerTable += `</div>`;
                 }
 
-                innerTable += `<div class='d-flex h-100'>`;
+                innerTable += `<div class='d-flex h-100' style='min-width: 0;'>`;
 
                 if (list.index) {
                     innerTable += "<div class=\"d-none d-sm-flex index-column List-tableCell\">{{ $index + ((" + list.iterator + "_page - 1) * " + list.iterator + "_page_size) + 1 }}.</div>\n";


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/pull/3901 link #3348 

@jlariza I took your branch and extended it a bit.  

1. Added the description to the groups -> hosts list
2. Removed reference to `InventoryManage-breakWord` that class isn't actually defined anywhere
3. Fixed up the ellipsis on the description.  That was a bit of a pain inside a flex'd container but it should be working now
4. Tinkered with the responsiveness so that column is hidden on xs/sm/md screens
5. Rebased off of latest devel - this should fix up test failures

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
awx 6.0.0

##### ADDITIONAL INFORMATION
Screenshots of all the places:
<img width="1557" alt="Screen Shot 2019-07-10 at 11 42 07 AM" src="https://user-images.githubusercontent.com/9889020/60984137-2efee280-a309-11e9-867d-db88d7419b4f.png">
<img width="1526" alt="Screen Shot 2019-07-10 at 11 41 17 AM" src="https://user-images.githubusercontent.com/9889020/60984139-2efee280-a309-11e9-9c86-184ce7a584d5.png">
<img width="1515" alt="Screen Shot 2019-07-10 at 11 41 08 AM" src="https://user-images.githubusercontent.com/9889020/60984140-2efee280-a309-11e9-833b-368ab55d3864.png">

