### PR TITLE
Addition of inventory value for memcached image, allows for custom im…

### DIFF
--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -13,6 +13,9 @@ rabbitmq_password: "guest"
 postgresql_version: "9.6"
 postgresql_image: "postgres:{{postgresql_version}}"
 
+
+memcached_image: "memcached"
+memcached_version: "alpine"
 memcached_host: "memcached"
 memcached_port: "11211"
 

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -118,7 +118,7 @@ services:
       no_proxy: {{ no_proxy | default('') }}
 
   memcached:
-    image: memcached:alpine
+    image: "{{ memcached_image }}:{{ memcached_version }}"
     container_name: awx_memcached
     restart: unless-stopped
     environment:


### PR DESCRIPTION
…age locations for memcached to match other images

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows for Dynamic image calls for memcached.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Adding this allows for Ansible inventory calls for memcached if needed to append things like local docker repositories if access to external docker is not allowed. This is handled in Kubernetes / Openshift deployments as that is configured on the individual Kube/OCP for additional registries.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
