### PR TITLE
Remove pexpect, etc, from the ansible venv, that's now runner's problem.

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -1,5 +1,6 @@
 # GCE
 apache-libcloud==2.5.0
+google-auth==1.6.2    # needed for gce inventory imports
 # Azure
 # azure deps from https://github.com/ansible/ansible/blob/stable-2.8/packaging/requirements/requirements-azure.txt
 packaging
@@ -40,7 +41,6 @@ azure-mgmt-loganalytics==0.2.0
 # AWS
 boto==2.47.0    # last which does not break ec2 scripts
 boto3==1.6.2
-google-auth==1.6.2    # needed for gce inventory imports
 jinja2==2.10.1  # required for native jinja2 types for inventory compat mode
 # netconf for network modules
 ncclient==0.6.3
@@ -50,9 +50,7 @@ netaddr
 ovirt-engine-sdk-python==4.3.0    # minimum set inside Ansible facts module requirements
 pycurl==7.43.0.1    # higher versions will not install without SSL backend specified
 # AWX usage
-pexpect==4.6.0    # same as AWX requirement
 psutil==5.4.3    # same as AWX requirement
-ptyprocess==0.5.2 # via pexpect, but needs to be pinned. Read the blame.
 setuptools==36.0.1
 pip==9.0.1
 # VMware

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -81,9 +81,7 @@ ovirt-engine-sdk-python==4.3.0
 packaging==19.0
 paramiko==2.6.0           # via azure-cli-core, ncclient
 pbr==5.2.0                # via keystoneauth1, openstacksdk, os-service-types, stevedore
-pexpect==4.6.0
 psutil==5.4.3
-ptyprocess==0.5.2
 pyasn1-modules==0.2.5     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, requests-credssp, rsa
 pycparser==2.19           # via cffi


### PR DESCRIPTION
##### SUMMARY

AWX doesn't need this in the ansible venv any more.