### PR TITLE
fixed problem with hashicorp vault kv2 mount_points that contain a '/'

### DIFF
--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -102,12 +102,12 @@ def kv_backend(**kwargs):
         if kwargs.get('secret_version'):
             request_kwargs['params'] = {'version': kwargs['secret_version']}
         try:
-            mount_point, *path = pathlib.Path(secret_path.lstrip(os.sep)).parts
+            *mount_point, path = pathlib.Path(secret_path.lstrip(os.sep)).parts
             '/'.join(path) 
         except Exception:
             mount_point, path = secret_path, []
         # https://www.vaultproject.io/api/secret/kv/kv-v2.html#read-secret-version
-        request_url = '/'.join([url, mount_point, 'data'] + path).rstrip('/')
+        request_url = '/'.join([url] + mount_point + ['data', path]).rstrip('/')
         response = sess.get(request_url, **request_kwargs)
 
         response.raise_for_status()


### PR DESCRIPTION
##### SUMMARY
Fixes the issue described by @jakemcdermott in https://github.com/ansible/awx/pull/4175#issuecomment-507307284

It changes the logic to detect the mount_point and path of the KV2 secret, to add the '/data/' at the correct point of the URL for the vault api call.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 6.0.0
```


##### ADDITIONAL INFORMATION

Before this, the following path to a KV2 secret would not work:
```
team/application/secret_name
```
because the actual API call to vault would be:
```
https://vault:8200/v1/team/data/application/secret_name
```
After this change the correct API call would be used:
```
https://vault:8200/v1/team/application/data/secret_name
```

Couple more thoughts:

1. Add a check for /data/ in the secret_path, and only add if it is not present
2. Write a validator for secret_path, so that it requires at least "value1/value2"
