### PR TITLE
Ignore Azure templating errors

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1991,6 +1991,8 @@ class azure_rm(PluginFileInjector):
 
         source_vars = inventory_update.source_vars_dict
 
+        ret['fail_on_template_errors'] = False
+
         group_by_hostvar = {
             'location': {'prefix': '', 'separator': '', 'key': 'location'},
             'tag': {'prefix': '', 'separator': '', 'key': 'tags.keys() | list if tags else []'},

--- a/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
@@ -4,6 +4,7 @@ default_host_filters: []
 exclude_host_filters:
 - resource_group not in ['foo_resources', 'bar_resources']
 - location not in ['southcentralus', 'westus']
+fail_on_template_errors: false
 hostvar_expressions:
   ansible_host: private_ipv4_addresses[0]
   computer_name: name


### PR DESCRIPTION
I'm going to be doing more validation of this, but the first-layer of validation I find by doing this:

```diff
diff --git a/awx/main/models/inventory.py b/awx/main/models/inventory.py
index 5c1f4ef8eb..1d78b466d1 100644
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1991,12 +1991,15 @@ class azure_rm(PluginFileInjector):
 
         source_vars = inventory_update.source_vars_dict
 
+        ret['fail_on_template_errors'] = False
+
         group_by_hostvar = {
             'location': {'prefix': '', 'separator': '', 'key': 'location'},
             'tag': {'prefix': '', 'separator': '', 'key': 'tags.keys() | list if tags else []'},
             # Introduced with https://github.com/ansible/ansible/pull/53046
             'security_group': {'prefix': '', 'separator': '', 'key': 'security_group'},
             'resource_group': {'prefix': '', 'separator': '', 'key': 'resource_group'},
+            'foobar': {'prefix': '', 'separator': '', 'key': 'bar_foo'},
             # Note, os_family was not documented correctly in script, but defaulted to grouping by it
             'os_family': {'prefix': '', 'separator': '', 'key': 'os_disk.operating_system_type'}
         }
@@ -2048,6 +2051,7 @@ class azure_rm(PluginFileInjector):
             'type': 'resource_type',
             'private_ip': 'private_ipv4_addresses[0]',
             'public_ip': 'public_ipv4_addresses[0]',
+            'foobar2': 'barfoo2',
             'tags': 'tags if tags else None'
         }
         # Special functionality from script
```

Without the `fail_on_template_errors` line, Azure imports fail with templating errors of a similar variety that was reported ('barfoo2' is undefined). By putting it back in, that passes. The idea is to confirm that errors are ignored for both types of entries.