### PR TITLE
Insert signed public key in artifact_dir, fix for issue #4139

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -828,8 +828,10 @@ class BaseTask(object):
                     os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
                 private_data_files['credentials'][credential] = path
             for credential, data in private_data.get('certificates', {}).items():
-                name = 'credential_%d-cert.pub' % credential.pk
-                path = os.path.join(private_data_dir, name)
+                artifact_dir = os.path.join(private_data_dir, 'artifacts', str(self.instance.id))
+                if not os.path.exists(artifact_dir):
+                    os.makedirs(artifact_dir, mode=0o700)
+                path = os.path.join(artifact_dir, 'ssh_key_data-cert.pub')
                 with open(path, 'w') as f:
                     f.write(data)
                     f.close()


### PR DESCRIPTION
Signed-off-by: Jaap de Koning <jaap.de.koning@bigdatarepublic.nl>

##### SUMMARY
Resolving the topic covered in/related #4139
Although i understand that this is not a pretty fix at all, it simply writes the public key at a location where Ansible runner expects it to be, so that it can correctly feed it to the ssh-agent.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.0.0
```

##### ADDITIONAL INFORMATION
Ansible runner expects the private key as (see path created in [runner_config#L99](https://github.com/ansible/ansible-runner/blob/master/ansible_runner/runner_config.py#L99)):
`private_data_dir/env/ssh_key` and writes it back under:
`private_data_dir/artifacts/self.instance.id/ssh_key_data`

It then also expects any public key there as:
`private_data_dir/artifacts/self.instance.id/ssh_key_data-cert.pub`

It would be nicer to instruct Ansible runner to find the keys in a certain location, or load the ssh-agent from awx tasks.