### PR TITLE
fix a 500 error for Activity Stream job records w/ a missing JT

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4687,10 +4687,10 @@ class ActivityStreamSerializer(BaseSerializer):
         if fk not in summary_keys:
             return
         related_obj = getattr(obj, summary_keys[fk], None)
-        summary_fields[get_type_for_model(related_obj)] = []
         item = {}
         fields = SUMMARIZABLE_FK_FIELDS[summary_keys[fk]]
         if related_obj is not None:
+            summary_fields[get_type_for_model(related_obj)] = []
             for field in fields:
                 fval = getattr(related_obj, field, None)
                 if fval is not None:


### PR DESCRIPTION
1.  Create a Job Template.
2.  Launch it and get a job.
3.  Delete the Job Template.
4.  View the global activity stream.
5.  💥

<img width="618" alt="image" src="https://user-images.githubusercontent.com/214912/61383564-ee5d1700-a87c-11e9-95d8-2f83cda1d012.png">
<img width="767" alt="image" src="https://user-images.githubusercontent.com/214912/61383578-f5842500-a87c-11e9-8336-8cc388f8e94c.png">
