### PR TITLE
Update the `make clean` command to clear out the parallelized sqlite3 files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ clean: clean-ui clean-dist
 	rm -rf awx/job_status
 	rm -rf awx/job_output
 	rm -rf reports
-	rm -f awx/awx_test.sqlite3
+	rm -f awx/awx_test.sqlite3*
 	rm -rf requirements/vendor
 	rm -rf tmp
 	rm -rf $(I18N_FLAG_FILE)


### PR DESCRIPTION
##### SUMMARY
We just noticed that the `make clean` command only looks for `awx/awx_test.sqlite3`, which does not take into account the multiprocess copies.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```
