### PR TITLE
Kill off all model can_read access methods

### DIFF
--- a/awx/main/tests/functional/test_rbac_label.py
+++ b/awx/main/tests/functional/test_rbac_label.py
@@ -22,7 +22,7 @@ def test_label_get_queryset_su(label, user):
 @pytest.mark.django_db
 def test_label_access(label, user):
     access = LabelAccess(user('user', False))
-    assert not access.can_read(label)
+    assert access.can_read(label)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_rbac_notifications.py
+++ b/awx/main/tests/functional/test_rbac_notifications.py
@@ -87,7 +87,7 @@ def test_notification_template_access_admin(role, organization_factory, notifica
     assert access.can_change(notification_template, {'organization': present_org.id})
     assert access.can_delete(notification_template)
 
-    nf = notification_template_factory("test-orphaned")
+    nf = notification_template_factory("test-orphaned").notification_template
     assert not access.can_read(nf)
     assert not access.can_change(nf, None)
     assert not access.can_delete(nf)


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/2598

Manual testing confirms that this resolves that issue, and the user is able to associate the label (this may or may not be the intent).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
6.0.0
```


##### ADDITIONAL INFORMATION
`can_read` is redundant with `filtered_queryset`
