### PR TITLE
[4362] git version is old and does not work with x509 certificates

### DIFF
--- a/awx/ui/test/e2e/cluster/Dockerfile
+++ b/awx/ui/test/e2e/cluster/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
 
-RUN yum install -y epel-release
+RUN yum -y update && yum -y install epel-release && yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 
 RUN yum install -y \
     bzip2 \
     gcc-c++ \
-    git \
+    git2u \
+    git2u-core \
     make \
     nodejs \
     npm

--- a/installer/roles/image_build/files/Dockerfile.sdist
+++ b/installer/roles/image_build/files/Dockerfile.sdist
@@ -1,11 +1,12 @@
 FROM centos:7
 
-RUN yum install -y epel-release
+RUN yum -y update && yum -y install epel-release && yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 
 RUN yum install -y bzip2 \
     gcc-c++ \
     gettext \
-    git \
+    git2u \
+    git2u-core \
     make \
     nodejs \
     python36-setuptools

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -5,7 +5,7 @@ USER root
 ADD ansible.repo /etc/yum.repos.d/ansible.repo
 ADD RPM-GPG-KEY-ansible-release /etc/pki/rpm-gpg/RPM-GPG-KEY-ansible-release
 
-RUN yum -y update && yum -y install epel-release
+RUN yum -y update && yum -y install epel-release && yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 
 # sync with tools/docker-compose/Dockerfile
 RUN yum -y install acl \
@@ -16,7 +16,8 @@ RUN yum -y install acl \
   cyrus-sasl-devel \
   gcc \
   gcc-c++ \
-  git \
+  git2u \
+  git2u-core \
   krb5-devel \
   krb5-libs \
   krb5-workstation \

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 ARG UID=0
 
-RUN yum -y update && yum -y install epel-release
+RUN yum -y update && yum -y install epel-release && yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 
 # sync with installer/roles/image_build/templates/Dockerfile.j2
 RUN yum -y install acl \
@@ -17,7 +17,8 @@ RUN yum -y install acl \
   gcc \
   gcc-c++ \
   GConf2 \
-  git \
+  git2u \
+  git2u-core \
   gtk3 \
   ipa-gothic-fonts \
   krb5-devel \


### PR DESCRIPTION
* upgrade from git on containers

##### SUMMARY
Fixes #4362 
Upgrade of the git version

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 6.1.0
```