### PR TITLE
Re-create lost data in Azure_rm imports

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -2048,8 +2048,10 @@ class azure_rm(PluginFileInjector):
             'provisioning_state': 'provisioning_state | title',
             'computer_name': 'name',
             'type': 'resource_type',
-            'private_ip': 'private_ipv4_addresses[0]',
-            'public_ip': 'public_ipv4_addresses[0]',
+            'private_ip': 'private_ipv4_addresses[0] if private_ipv4_addresses else None',
+            'public_ip': 'public_ipv4_addresses[0] if public_ipv4_addresses else None',
+            'public_ip_name': 'public_ip_name if public_ip_name is defined else None',
+            'public_ip_id': 'public_ip_id if public_ip_id is defined else None',
             'tags': 'tags if tags else None'
         }
         # Special functionality from script

--- a/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
@@ -8,9 +8,11 @@ fail_on_template_errors: false
 hostvar_expressions:
   ansible_host: private_ipv4_addresses[0]
   computer_name: name
-  private_ip: private_ipv4_addresses[0]
+  private_ip: private_ipv4_addresses[0] if private_ipv4_addresses else None
   provisioning_state: provisioning_state | title
-  public_ip: public_ipv4_addresses[0]
+  public_ip: public_ipv4_addresses[0] if public_ipv4_addresses else None
+  public_ip_id: public_ip_id if public_ip_id is defined else None
+  public_ip_name: public_ip_name if public_ip_name is defined else None
   tags: tags if tags else None
   type: resource_type
 keyed_groups:


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/4353

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.0.0
```


##### ADDITIONAL INFORMATION
This just adds back in more content which was lost. We had a previous issue where errors were thrown in this case. We switched that to not show errors, but that meant the keys were not present in this case. This PR deals with the actual logic to fill in those keys for the particular situation of non-public hosts.
