### PR TITLE
Update job status comments

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -65,8 +65,8 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, Notificatio
     # status inherits from related jobs. Thus, status must be able to be set to any status that a job status is settable to.
     JOB_STATUS_CHOICES = [
         ('new', _('New')),                  # Job has been created, but not started.
-        ('pending', _('Pending')),          # Job has been queued, but is not yet running.
-        ('waiting', _('Waiting')),          # Job is waiting on an update/dependency.
+        ('pending', _('Pending')),          # Job is pending Task Manager processing (blocked by dependency req, capacity or a concurrent job)
+        ('waiting', _('Waiting')),          # Job has been assigned to run on a specific node (and is about to run).
         ('running', _('Running')),          # Job is currently running.
         ('successful', _('Successful')),    # Job completed successfully.
         ('failed', _('Failed')),            # Job completed, but with failures.


### PR DESCRIPTION
  - waiting and pending job descriptions were not accurate

##### SUMMARY
Update in line documentation for unified job statuses.  

Jobs in the "pending" status are actually awaiting processing by the Task Manager to determine the dependencies and order of job execution.  By processing, we mean that the Task Manager is checking the following conditions:
* If the job is blocked because it has a dependency that has to be run first
* if the job is blocked because `allow_simultaneous` is not checked and there is another job running already
* there is not enough capacity to schedule another job at that time.  

Jobs in the "waiting" status have been submitted to the RabbitMQ queue and are waiting to be assigned an execution node.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


