### PR TITLE
Document UI building process for development environment to cover I18N static contents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,8 @@ Run the following to build the AWX UI:
 ```bash
 (host) $ make ui-devel
 ```
+See [the ui development documentation](awx/ui/README.md) for more information on using the frontend development, build, and test tooling.
+
 ### Running the environment
 
 #### Start the containers

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ I18N_FLAG_FILE = .i18n_built
 	ui-test ui-deps ui-test-ci VERSION
 
 # remove ui build artifacts
-clean-ui:
+clean-ui: clean-languages
 	rm -rf awx/ui/static/
 	rm -rf awx/ui/node_modules/
 	rm -rf awx/ui/test/unit/reports/
@@ -93,6 +93,10 @@ clean-schema:
 	rm -rf swagger.json
 	rm -rf schema.json
 	rm -rf reference-schema.json
+
+clean-languages:
+	rm -f $(I18N_FLAG_FILE)
+	find . -type f -regex ".*\.mo$$" -delete
 
 # Remove temporary build files, compiled Python files.
 clean: clean-ui clean-dist

--- a/awx/ui/README.md
+++ b/awx/ui/README.md
@@ -60,6 +60,7 @@ npm --prefix awx/ui run e2e
 ```shell
 # add an exact development or build dependency
 npm install --prefix awx/ui --save-dev --save-exact dev-package@1.2.3
+
 # add an exact production dependency
 npm install --prefix awx/ui --save --save-exact prod-package@1.23
 
@@ -81,3 +82,22 @@ npm uninstall --prefix awx/ui --save prod-package
 # built files are placed in awx/ui/static
 make ui-release
 ```
+
+## Internationalization
+Application strings marked for translation are extracted and used to generate `.pot` files using the following command:
+```shell
+# extract strings and generate .pot files
+make pot
+```
+To include the translations in the development environment, we compile them prior to building the ui:
+```shell
+# remove any prior ui builds
+make clean-ui
+
+# compile the .pot files to javascript files usable by the application
+make languages
+
+# build the ui with translations included
+make ui-devel
+```
+**Note**: Python 3.6 is required to compile the `.pot` files.


### PR DESCRIPTION
##### SUMMARY
For a development environment, if we want to generate language files like `awx/locale/ja/LC_MESSAGES/django.mo`, we need to exec make languages before `make ui-devel`.
If the building process of those files have finished before ui-devel target, *.mo and <LANG>.json files will be copied to the static contents directory by collectstatic.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
 - Installer

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
This pull request is a re-creation for #4271