### PR TITLE
Add description to template and project list view

### DIFF
--- a/awx/ui/client/features/projects/projects.strings.js
+++ b/awx/ui/client/features/projects/projects.strings.js
@@ -6,6 +6,7 @@ function ProjectsStrings (BaseString) {
 
     ns.list = {
         PANEL_TITLE: t.s('PROJECTS'),
+        ROW_ITEM_LABEL_DESCRIPTION: t.s('DESCRIPTION'),
         ROW_ITEM_LABEL_REVISION: t.s('REVISION'),
         ROW_ITEM_LABEL_ORGANIZATION: t.s('ORGANIZATION'),
         ROW_ITEM_LABEL_MODIFIED: t.s('LAST MODIFIED'),

--- a/awx/ui/client/features/projects/projectsList.view.html
+++ b/awx/ui/client/features/projects/projectsList.view.html
@@ -81,6 +81,10 @@
                         <at-truncate string="{{ project.scm_revision }}" maxLength="7"></at-truncate>
                     </div>
                     <at-row-item
+                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_DESCRIPTION')}}"
+                        value="{{ project.description | sanitize }}">
+                    </at-row-item>
+                    <at-row-item
                         label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_ORGANIZATION')}}"
                         value="{{ project.summary_fields.organization.name }}"
                         value-link="/#/organizations/{{ project.organization }}">

--- a/awx/ui/client/features/templates/templates.strings.js
+++ b/awx/ui/client/features/templates/templates.strings.js
@@ -13,6 +13,7 @@ function TemplatesStrings (BaseString) {
         ADD_DD_JT_LABEL: t.s('Job Template'),
         ADD_DD_WF_LABEL: t.s('Workflow Template'),
         OPEN_WORKFLOW_VISUALIZER: t.s('Click here to open the workflow visualizer'),
+        ROW_ITEM_LABEL_DESCRIPTION: t.s('Description'),
         ROW_ITEM_LABEL_ACTIVITY: t.s('Activity'),
         ROW_ITEM_LABEL_INVENTORY: t.s('Inventory'),
         ROW_ITEM_LABEL_PROJECT: t.s('Project'),

--- a/awx/ui/client/features/templates/templatesList.view.html
+++ b/awx/ui/client/features/templates/templatesList.view.html
@@ -88,6 +88,10 @@
                 </div>
                 <div class="at-Row-container--wrapped">
                     <at-row-item
+                        label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_DESCRIPTION') }}"
+                        value="{{ template.description | sanitize }}">
+                    </at-row-item>
+                    <at-row-item
                         label-value="{{:: vm.strings.get('list.ROW_ITEM_LABEL_INVENTORY') }}"
                         value="{{ template.summary_fields.inventory.name }}"
                         value-link="/#/inventories/{{template.summary_fields.inventory.kind === 'smart' ? 'smart' : 'inventory'}}/{{ template.summary_fields.inventory.id }}">


### PR DESCRIPTION
##### SUMMARY
Added a description to the template and the project list view to fix the issue #4359

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
After applying this patch, `DESCRIPTION` visible to the template and the project list view as follows:

- Template List VIew

![template_list](https://user-images.githubusercontent.com/7360578/61940029-95edee00-afcf-11e9-91c3-7e2791ef67b9.png)

- Project List View

![project_list](https://user-images.githubusercontent.com/7360578/61940047-9edebf80-afcf-11e9-834f-17814abd44d8.png)
