### PR TITLE
awx/ui: fixed minor grammar error in Survey form

### DIFF
--- a/awx/ui/client/src/templates/survey-maker/shared/question-definition.form.js
+++ b/awx/ui/client/src/templates/survey-maker/shared/question-definition.form.js
@@ -96,7 +96,7 @@ export default ['i18n', function(i18n){
                             '</div>'+
                             '<div class="col-sm-6">'+
                                 '<label for="text_max"><span class="Form-inputLabel">' + i18n._('Maximum Length') + '</span></label><input id="text_max" name="text_max" ng-model="text_max" aw-min="text_min || 0" min=0 aw-spinner="text_max" integer>'+
-                                '<div class="error" ng-show="survey_question_form.text_max.$error.integer || survey_question_form.text_max.$error.number">' + i18n._('The maximum length you entered is not a valid number.  Please enter a whole nnumber.') + '</div>'+
+                                '<div class="error" ng-show="survey_question_form.text_max.$error.integer || survey_question_form.text_max.$error.number">' + i18n._('The maximum length you entered is not a valid number.  Please enter a whole number.') + '</div>'+
                                 '<div class="error" ng-show="survey_question_form.text_max.$error.awMin">' + i18n._('The maximum length is too low.  Please enter a number larger than the minimum length you set.') + '</div>'+
                             '</div>'+
                         '</div>',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixed minor grammar error in Survey form. Instead of `nnumber`, it's `number`.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI


