### PR TITLE
Add link to organization inventory list

### DIFF
--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-inventories.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-inventories.controller.js
@@ -68,6 +68,7 @@ export default ['$scope', '$rootScope', '$location',
             }
 
             item.kind_label = item.kind === '' ? i18n._('Inventory') : (item.kind === 'smart' ? i18n._('Smart Inventory'): i18n._('Inventory'));
+            item.linkToDetails = (item.kind && item.kind === 'smart') ? `inventories.editSmartInventory({smartinventory_id:${item.id}})` : `inventories.edit({inventory_id:${item.id}})`;
 
             return item;
         }


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/4392

* Add `ui-sref` link to the organization inventory list 
* Routes to regular and smart inventory states

![org inv linkout](https://user-images.githubusercontent.com/15881645/62065842-daf76780-b1fd-11e9-8cd4-4acdca2fc632.gif)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```