### PR TITLE
Prevent clicks outside of prompt modal from closing the modal without saving

### DIFF
--- a/awx/ui/client/lib/components/dialog/dialog.component.js
+++ b/awx/ui/client/lib/components/dialog/dialog.component.js
@@ -1,30 +1,7 @@
 const templateUrl = require('~components/dialog/dialog.partial.html');
 
-const overlayClass = 'at-Dialog';
-
-function DialogController () {
-    const vm = this || {};
-
-    vm.handleClick = ({ target }) => {
-        if (!vm.onClose) {
-            return;
-        }
-
-        const targetElement = $(target);
-
-        if (targetElement.hasClass(overlayClass)) {
-            vm.onClose();
-        }
-    };
-}
-
-DialogController.$inject = [
-    '$element',
-];
-
 export default {
     templateUrl,
-    controller: DialogController,
     controllerAs: 'vm',
     transclude: true,
     bindings: {

--- a/awx/ui/client/lib/components/modal/modal.directive.js
+++ b/awx/ui/client/lib/components/modal/modal.directive.js
@@ -44,7 +44,6 @@ function AtModalController ($timeout, eventService, strings) {
     };
 
     vm.hide = () => {
-        console.log('hide');
         overlay.style.opacity = 0;
 
         if (!vm.modal.preventOutsideClick) {

--- a/awx/ui/client/lib/components/modal/modal.directive.js
+++ b/awx/ui/client/lib/components/modal/modal.directive.js
@@ -12,11 +12,10 @@ function atModalLink (scope, el, attrs, controllers) {
     });
 }
 
-function AtModalController ($timeout, eventService, strings) {
+function AtModalController (strings) {
     const vm = this;
 
     let overlay;
-    let listeners;
 
     vm.strings = strings;
 
@@ -33,22 +32,12 @@ function AtModalController ($timeout, eventService, strings) {
         vm.modal.title = title;
         vm.modal.message = message;
 
-        if (!vm.modal.preventOutsideClick) {
-            listeners = eventService.addListeners([
-                [overlay, 'click', vm.clickToHide]
-            ]);
-        }
-
         overlay.style.display = 'block';
         overlay.style.opacity = 1;
     };
 
     vm.hide = () => {
         overlay.style.opacity = 0;
-
-        if (!vm.modal.preventOutsideClick) {
-            eventService.remove(listeners);
-        }
 
         setTimeout(() => {
             overlay.style.display = 'none';
@@ -67,8 +56,6 @@ function AtModalController ($timeout, eventService, strings) {
 }
 
 AtModalController.$inject = [
-    '$timeout',
-    'EventService',
     'ComponentsStrings'
 ];
 

--- a/awx/ui/client/lib/components/modal/modal.directive.js
+++ b/awx/ui/client/lib/components/modal/modal.directive.js
@@ -33,18 +33,23 @@ function AtModalController ($timeout, eventService, strings) {
         vm.modal.title = title;
         vm.modal.message = message;
 
-        listeners = eventService.addListeners([
-            [overlay, 'click', vm.clickToHide]
-        ]);
+        if (!vm.modal.preventOutsideClick) {
+            listeners = eventService.addListeners([
+                [overlay, 'click', vm.clickToHide]
+            ]);
+        }
 
         overlay.style.display = 'block';
         overlay.style.opacity = 1;
     };
 
     vm.hide = () => {
+        console.log('hide');
         overlay.style.opacity = 0;
 
-        eventService.remove(listeners);
+        if (!vm.modal.preventOutsideClick) {
+            eventService.remove(listeners);
+        }
 
         setTimeout(() => {
             overlay.style.display = 'none';

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -13,6 +13,8 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
             scope = _scope_;
             ({ modal } = scope[scope.ns]);
 
+            modal.preventOutsideClick = true;
+
             scope.$watch('vm.promptData.triggerModalOpen', () => {
                 vm.actionButtonClicked = false;
                 if(vm.promptData && vm.promptData.triggerModalOpen) {

--- a/awx/ui/client/src/templates/prompt/prompt.controller.js
+++ b/awx/ui/client/src/templates/prompt/prompt.controller.js
@@ -13,8 +13,6 @@ export default [ 'ProcessErrors', 'CredentialTypeModel', 'TemplatesStrings', '$f
             scope = _scope_;
             ({ modal } = scope[scope.ns]);
 
-            modal.preventOutsideClick = true;
-
             scope.$watch('vm.promptData.triggerModalOpen', () => {
                 vm.actionButtonClicked = false;
                 if(vm.promptData && vm.promptData.triggerModalOpen) {


### PR DESCRIPTION
##### SUMMARY
User will now need to explicitly hit the X or Cancel buttons to close the modal without actually saving/launching.  These changes should not impact any other modals.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Tested locally by:

1. Create a Survey
2. Launch the Job Template with the survey
3. Enter the values in Survey
4. Click outside the Survey window

and confirming that the modal does not close.  Also confirmed that clicking the X button/Cancel button still close the modal as expected.
