### PR TITLE
Show notification menu to users with notification_admin team role

### DIFF
--- a/awx/ui/client/lib/components/layout/layout.directive.js
+++ b/awx/ui/client/lib/components/layout/layout.directive.js
@@ -61,8 +61,8 @@ function AtLayoutController ($scope, $http, strings, ProcessErrors, $transitions
     }
 
     function checkNotificationAdmin () {
-        const usersPath = `/api/v2/users/${vm.currentUserId}/roles/?role_field=notification_admin_role`;
-        $http.get(usersPath)
+        const notifAdminOrgsPath = 'api/v2/organizations/?role_level=notification_admin_role';
+        $http.get(notifAdminOrgsPath)
             .then(({ data }) => {
                 if (data.count > 0) {
                     vm.isNotificationAdmin = true;
@@ -73,7 +73,7 @@ function AtLayoutController ($scope, $http, strings, ProcessErrors, $transitions
             .catch(({ data, status }) => {
                 ProcessErrors(null, data, status, null, {
                     hdr: strings.get('error.HEADER'),
-                    msg: strings.get('error.CALL', { path: usersPath, action: 'GET', status })
+                    msg: strings.get('error.CALL', { path: notifAdminOrgsPath, action: 'GET', status })
                 });
             });
     }

--- a/awx/ui/test/unit/components/layout.unit.js
+++ b/awx/ui/test/unit/components/layout.unit.js
@@ -46,7 +46,7 @@ describe('Components | Layout', () => {
             $httpBackend.when('GET', /admin_of_organizations/)
                 .respond(mockOrgAdminResponse);
 
-            $httpBackend.when('GET', /roles\/\?role_field=notification_admin_role/)
+            $httpBackend.when('GET', /organizations\/\?role_level=notification_admin_role/)
                 .respond(mockNotificationAdminResponse);
         });
 


### PR DESCRIPTION
##### SUMMARY
Notifications (in the side nav) was hidden from users who were granted the notification admin role through a team permission.  This PR fixes that.

The previous endpoint only returns whether or not the user has been explicitly granted the notification admin role on the org.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
