### PR TITLE
Fix summary popover on inventory list

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.controller.js
@@ -25,16 +25,5 @@ export default [ '$scope', 'Empty', 'Wait', 'GetBasePath', 'Rest', 'ProcessError
                 }
             }
         };
-
-        $scope.viewJob = function(jobId, type) {
-            let outputType = 'playbook';
-
-            if (type === 'workflow_job') {
-                $state.go('workflowResults', { id: jobId}, { reload: true });
-            } else {
-                $state.go('output', { id: jobId, type: outputType });
-            }
-        };
-
     }
 ];

--- a/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.controller.js
@@ -1,5 +1,5 @@
-export default [ '$scope', 'Empty', 'Wait', 'GetBasePath', 'Rest', 'ProcessErrors', '$state',
-    function($scope, Empty, Wait, GetBasePath, Rest, ProcessErrors, $state) {
+export default [ '$scope', 'Empty', 'Wait', 'GetBasePath', 'Rest', 'ProcessErrors',
+    function($scope, Empty, Wait, GetBasePath, Rest, ProcessErrors) {
 
         $scope.gatherRecentJobs = function(event) {
             if (!Empty($scope.inventory.id)) {

--- a/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.directive.js
@@ -25,7 +25,7 @@ export default ['templateUrl', 'Wait', '$filter', '$compile', 'i18n', '$log',
                         elem.popover('dispose');
                     }
                     catch(err) {
-                        $log.debug(error);
+                        $log.debug(err);
                     }
                     $('.popover').each(function() {
                         // remove lingering popover <div>. Seems to be a bug in TB3 RC1

--- a/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/host-summary-popover/host-summary-popover.directive.js
@@ -1,5 +1,5 @@
-export default ['templateUrl', 'Wait', '$filter', '$compile', 'i18n',
-    function(templateUrl, Wait, $filter, $compile, i18n) {
+export default ['templateUrl', 'Wait', '$filter', '$compile', 'i18n', '$log',
+    function(templateUrl, Wait, $filter, $compile, i18n, $log) {
         return {
             restrict: 'E',
             replace: false,
@@ -19,19 +19,20 @@ export default ['templateUrl', 'Wait', '$filter', '$compile', 'i18n',
 
                 function attachElem(event, html, title) {
                     var elem = $(event.target).parent();
+
                     try {
                         elem.tooltip('hide');
-                        elem.popover('destroy');
+                        elem.popover('dispose');
                     }
                     catch(err) {
-                        //ignore
+                        $log.debug(error);
                     }
                     $('.popover').each(function() {
                         // remove lingering popover <div>. Seems to be a bug in TB3 RC1
                         $(this).remove();
                     });
                     $('.tooltip').each( function() {
-                        // close any lingering tool tipss
+                        // close any lingering tooltips
                         $(this).hide();
                     });
                     elem.attr({
@@ -44,36 +45,59 @@ export default ['templateUrl', 'Wait', '$filter', '$compile', 'i18n',
                 }
 
                 scope.generateTable = function(data, event){
-                    var html, title = (scope.inventory.has_active_failures) ? "Recent Failed Jobs" : "Recent Successful Jobs";
+                    var html, title = (scope.inventory.has_active_failures) ? i18n._("Recent Failed Jobs") : i18n._("Recent Successful Jobs");
                     Wait('stop');
                     if (data.count > 0) {
-                        html = "<table class=\"table table-condensed flyout\" style=\"width: 100%\">\n";
-                        html += "<thead>\n";
-                        html += "<tr>";
-                        html += "<th>" + i18n._("Status") + "</th>";
-                        html += "<th>" + i18n._("Finished") + "</th>";
-                        html += "<th>" + i18n._("Name") + "</th>";
-                        html += "</tr>\n";
-                        html += "</thead>\n";
-                        html += "<tbody>\n";
+                        html = `
+                            <table class="table table-condensed flyout" style="width: 100%">
+                                <thead>
+                                    <tr>
+                                        <th>${i18n._("Status")}</th>
+                                        <th>${i18n._("Finished")}</th>
+                                        <th>${i18n._("Name")}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                        `;
 
                         data.results.forEach(function(row) {
+                            let href = '';
+                            switch (row.type) {
+                                case 'job':
+                                case 'ad_hoc_command':
+                                case 'system_job':
+                                case 'project_update':
+                                case 'inventory_update':
+                                    href = `#/jobs/${row.id}`;
+                                    break;
+                                case 'workflow_job':
+                                    href = `#/workflows/${row.id}`;
+                                    break;
+                                default:
+                                    break;
+                            }
                             if ((scope.inventory.has_active_failures && row.status === 'failed') || (!scope.inventory.has_active_failures && row.status === 'successful')) {
-                                html += "<tr>\n";
-                                html += "<td><a href=\"\" ng-click=\"viewJob(" + row.id + "," + "'" + row.type + "'" + ")\" " + "aw-tool-tip=\"" + row.status.charAt(0).toUpperCase() + row.status.slice(1) +
-                                    ". Click for details\" aw-tip-placement=\"top\" data-tooltip-outer-class=\"Tooltip-secondary\"><i class=\"fa SmartStatus-tooltip--" + row.status + " icon-job-" + row.status + "\"></i></a></td>\n";
-                                html += "<td>" + ($filter('longDate')(row.finished)) + "</td>";
-                                html += "<td><a href=\"\" ng-click=\"viewJob(" + row.id + "," + "'" + row.type + "'" + ")\" " + "aw-tool-tip=\"" + row.status.charAt(0).toUpperCase() + row.status.slice(1) +
-                                    ". Click for details\" aw-tip-placement=\"top\" data-tooltip-outer-class=\"Tooltip-secondary\">" + $filter('sanitize')(ellipsis(row.name)) + "</a></td>";
-                                html += "</tr>\n";
+                                html += `
+                                    <tr>
+                                        <td>
+                                            <a href="${href}">
+                                                <i class="fa SmartStatus-tooltip--${row.status} icon-job-${row.status}"></i>
+                                            </a>
+                                        </td>
+                                        <td>${($filter('longDate')(row.finished))}</td>
+                                        <td>
+                                            <a href="${href}">${$filter('sanitize')(ellipsis(row.name))}</a>
+                                        </td>
+                                    </tr>
+                                `;
                             }
                         });
-                        html += "</tbody>\n";
-                        html += "</table>\n";
+                        html += `</tbody></table>`;
                     }
                     else {
-                        html = "<p>" + i18n._("No recent job data available for this inventory.") + "</p>\n";
+                        html = `<p>${i18n._("No recent job data available for this inventory.")}</p>`;
                     }
+
                     attachElem(event, html, title);
                 };
 

--- a/awx/ui/client/src/inventories-hosts/inventories/list/source-summary-popover/source-summary-popover.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/list/source-summary-popover/source-summary-popover.directive.js
@@ -21,7 +21,7 @@ export default ['templateUrl', '$compile', 'Wait', '$filter', 'i18n',
                     var elem = $(event.target).parent();
                     try {
                         elem.tooltip('hide');
-                        elem.popover('destroy');
+                        elem.popover('dispose');
                     }
                     catch(err) {
                         //ignore

--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-inventories.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-inventories.controller.js
@@ -84,7 +84,7 @@ export default ['$scope', '$rootScope', '$location',
             var elem = $(event.target).parent();
             try {
                 elem.tooltip('hide');
-                elem.popover('destroy');
+                elem.popover('dispose');
             } catch (err) {
                 //ignore
             }

--- a/awx/ui/client/src/vendor.js
+++ b/awx/ui/client/src/vendor.js
@@ -33,6 +33,7 @@ $.fn.btn = btn;
 
 // Whitelist table elements so they can be used in popovers
 $.fn.popover.Constructor.Default.whiteList.table = [];
+$.fn.popover.Constructor.Default.whiteList.th = [];
 $.fn.popover.Constructor.Default.whiteList.tr = [];
 $.fn.popover.Constructor.Default.whiteList.td = [];
 $.fn.popover.Constructor.Default.whiteList.tbody = [];


### PR DESCRIPTION
##### SUMMARY
Some of this was related to the bootstrap upgrade to v4.  Some of it was just lingering buggy behavior.

There were actually several different broken things in and around this popover that needed to be fixed.

1. We were using `.popover('destroy')` in a few places.  This method is no longer available in v4.  We need to use [dispose](https://getbootstrap.com/docs/4.1/components/popovers/#popoverdispose) instead.
2. We needed to whitelist another table element `th` which is used by this particular popover.
3. The links to jobs in the popover were broken and needed to be updated.

I also went ahead and cleaned up the templating of the popover a bit for readability as well as removing unused attributes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

![inv_popover](https://user-images.githubusercontent.com/9889020/62225269-191f9300-b386-11e9-847e-f5be27c41bb6.gif)
