### PR TITLE
Fix js error thrown preventing creation of grafana notification

### DIFF
--- a/awx/ui/client/src/notifications/add/add.controller.js
+++ b/awx/ui/client/src/notifications/add/add.controller.js
@@ -199,7 +199,7 @@ export default ['Rest', 'Wait', 'NotificationsFormObject',
                         $scope[i] = null;
                     }
                     else {
-                        $scope[i] = $scope[i].toString().split('\n');
+                        $scope[i] = $scope[i] ? $scope[i].toString().split('\n') : "";
                     }
                 }
                 if (field.type === 'checkbox') {


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/4113

The issue here was that we were calling toString() on a variable that was not defined.  This throws an error to the console and prevents the creation of the Grafana notification.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
Tested by successfully creating/editing Grafana notifications after patch.  Also created Slack and Email notifications to ensure that other notification types weren't negatively impacted by the change.