### PR TITLE
Makes workflow start node width dynamic to account for languages other than English

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -23,9 +23,16 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
         restrict: 'E',
         link: function(scope, element) {
 
+            // Quickly render the start text so we see how wide it is and know how wide to make the start
+            // node element.
+            const startNodeText = $(`<span class="WorkflowChart-node" style="visibility:hidden;"><span class="WorkflowChart-startText">${TemplatesStrings.get('workflow_maker.START')}</span></span>`);
+            startNodeText.appendTo(document.body);
+            const startNodeTextWidth = startNodeText.width();
+            startNodeText.remove();
+
             let nodeW = 180,
                 nodeH = 60,
-                rootW = 60,
+                rootW = startNodeTextWidth + 25,
                 rootH = 40,
                 startNodeOffsetY = scope.mode === 'details' ? 17 : 10,
                 maxNodeTextLength = 27,


### PR DESCRIPTION
##### SUMMARY
Since the workflow visualizer is a series of svg elements under the hood we need to be explicit about sizing and placement.  The start node's width was originally defined based on the English `START`.  This doesn't scale out particularly well with other languages.  To fix this, we need to dynamically calculate the width of the start node text (whatever that may be) and take that into account when defining the width of the start node itself.  We do this by quickly attaching a dummy element to the page using the same classes and text as the real start node.  After calculating the width we use that variable throughout the directive.

Note that this shouldn't impact the start node for workflow _details_ which is a small, statically sized blue box.

<img width="789" alt="Screen Shot 2019-08-01 at 10 27 25 AM" src="https://user-images.githubusercontent.com/9889020/62301883-631c7d80-b447-11e9-82a7-14e42e87834c.png">
<img width="854" alt="Screen Shot 2019-08-01 at 10 26 53 AM" src="https://user-images.githubusercontent.com/9889020/62301885-631c7d80-b447-11e9-8bd5-c4d0b2b05221.png">
<img width="876" alt="Screen Shot 2019-08-01 at 10 26 14 AM" src="https://user-images.githubusercontent.com/9889020/62301886-631c7d80-b447-11e9-8cd4-7320eb8f8bd1.png">
<img width="1036" alt="Screen Shot 2019-08-01 at 10 25 39 AM" src="https://user-images.githubusercontent.com/9889020/62301887-631c7d80-b447-11e9-8412-ec0efbdfa9e4.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI