### PR TITLE
[RFC] Allow enable/disable of hosts in dynamic inventory from the UI.

### DIFF
--- a/awx/ui/client/src/inventories-hosts/hosts/host.form.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/host.form.js
@@ -34,11 +34,10 @@ function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataTitle: i18n._('Host Enabled'),
-                    ngDisabled: 'host.has_inventory_sources'
                 }
             },
             fields: {

--- a/awx/ui/client/src/inventories-hosts/hosts/host.list.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/host.list.js
@@ -27,7 +27,6 @@ export default ['i18n', function(i18n) {
             {
                 field: 'toggleHost',
                 content: {
-                    ngDisabled: 'host.has_inventory_sources',
                     label: '',
                     columnClass: 'List-staticColumn--toggle',
                     type: "toggle",
@@ -36,8 +35,8 @@ export default ['i18n', function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this flag may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataPlacement: "right",
                     nosort: true,

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -52,9 +52,9 @@
                     <div class="List-staticColumnLayout--hosts List-tableRow" ng-repeat="host in hosts track by host.id">
                             <div></div>
                             <div class="List-tableCell toggleHost-column List-staticColumn--toggle">
-                                <div class="ScheduleToggle" ng-class="{'is-on': host.enabled, 'ScheduleToggle--disabled': host.has_inventory_sources}" aw-tool-tip="{{strings.get('hostList.DISABLED_TOGGLE_TOOLTIP')}}" data-placement="right" data-tip-watch="undefined">
-                                    <button type="button" ng-disabled="host.has_inventory_sources" ng-show="host.enabled" class="ScheduleToggle-switch is-on" ng-click="toggleHost($event, host)" translate>ON</button>
-                                    <button type="button" ng-disabled="host.has_inventory_sources" ng-show="!host.enabled" class="ScheduleToggle-switch" ng-click="toggleHost($event, host)" translate>OFF</button>
+                                <div class="ScheduleToggle" ng-class="{'is-on': host.enabled}" aw-tool-tip="{{strings.get('hostList.DISABLED_TOGGLE_TOOLTIP')}}" data-placement="right" data-tip-watch="undefined">
+                                    <button type="button" ng-show="host.enabled" class="ScheduleToggle-switch is-on" ng-click="toggleHost($event, host)" translate>ON</button>
+                                    <button type="button" ng-show="!host.enabled" class="ScheduleToggle-switch" ng-click="toggleHost($event, host)" translate>OFF</button>
                                 </div>
                             </div>
                             <div class="List-tableCell active_failures-column status-column List-staticColumn--smallStatus">

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.form.js
@@ -33,11 +33,10 @@ function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataTitle: i18n._('Host Enabled'),
-                    ngDisabled: 'host.has_inventory_sources'
                 }
             },
             fields: {

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts.list.js
@@ -23,7 +23,7 @@ export default ['i18n', function(i18n) {
             {
                 field: 'toggleHost',
                 content: {
-                    ngDisabled: '!nested_host.summary_fields.user_capabilities.edit || nested_host.has_inventory_sources',
+                    ngDisabled: '!nested_host.summary_fields.user_capabilities.edit',
                     label: '',
                     columnClass: 'List-staticColumn--toggle',
                     type: "toggle",
@@ -32,8 +32,8 @@ export default ['i18n', function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this flag may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataPlacement: "right",
                     nosort: true,

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.form.js
@@ -33,12 +33,12 @@ function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataTitle: i18n._('Host Enabled'),
                     dataPlacement: "right",
-                    ngDisabled: '!host.summary_fields.user_capabilities.edit || host.has_inventory_sources || isSmartInvHost'
+                    ngDisabled: '!host.summary_fields.user_capabilities.edit || isSmartInvHost'
                 }
             },
             fields: {

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related-host.list.js
@@ -22,7 +22,7 @@ export default ['i18n', function(i18n) {
             {
                 field: 'toggleHost',
                 content: {
-                    ngDisabled: '!host.summary_fields.user_capabilities.edit || host.has_inventory_sources',
+                    ngDisabled: '!host.summary_fields.user_capabilities.edit',
                     label: '',
                     type: "toggle",
                     ngClick: "toggleHost($event, host)",
@@ -30,8 +30,8 @@ export default ['i18n', function(i18n) {
                         i18n._("Indicates if a host is available and should be included in running jobs.") +
                         "</p><p>" +
                         i18n._("For hosts that are part of an external" +
-                               " inventory, this flag cannot be changed. It will be" +
-                               " set by the inventory sync process.") +
+                               " inventory, this may be" +
+                               " reset by the inventory sync process.") +
                         "</p>",
                     dataPlacement: "right",
                     nosort: true,

--- a/awx/ui/client/src/inventories-hosts/inventory-hosts.strings.js
+++ b/awx/ui/client/src/inventories-hosts/inventory-hosts.strings.js
@@ -30,7 +30,7 @@ function InventoryHostsStrings (BaseString) {
     ns.hostList = {
         DISABLED_TOGGLE_TOOLTIP: () => t.s('{{ str1 }}</p><p>{{ str2 }}</p>', {
             str1: t.s('Indicates if a host is available and should be included in running jobs.'), 
-            str2: t.s('For hosts that are part of an external inventory, this flag cannot be changed. It will be set by the inventory sync process.')
+            str2: t.s('For hosts that are part of an external inventory, this may be reset by the inventory sync process.')
         })
     };
 


### PR DESCRIPTION
The API lets you do it, so we shouldn't block it from the UI.

I believe this restriction was because we we didn't want people setting it and thinking it was persistent with future inventory syncs... but we already allow you to *delete* from the UI (which will then be overwritten by a future inventory sync.)