### PR TITLE
Fix NoneType path error with analytics collection

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -330,10 +330,12 @@ def send_notifications(notification_list, job_id=None):
 
 @task()
 def gather_analytics():
-    if settings.PENDO_TRACKING_STATE == 'off':
+    if not settings.INSIGHTS_TRACKING_STATE:
         return
     try:
         tgz = analytics.gather()
+        if not tgz:
+            return
         logger.debug('gathered analytics: {}'.format(tgz))
         analytics.ship(tgz)
     finally:


### PR DESCRIPTION
##### SUMMARY
The analytics collection tar.gz path was being set to "None" when the `INSIGHTS_TRACKING_STATE` was set to False, but not being caught properly when called in tasks.py

This is currently an issue for users with:

```
"PENDO_TRACKING_STATE": "off"
and
"INSIGHTS_TRACKING_STATE": false
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 
