### PR TITLE
Remove restriction on toggling dynamic hosts on/off from the host form view

### DIFF
--- a/awx/ui/client/src/inventories-hosts/hosts/edit/host-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/edit/host-edit.controller.js
@@ -5,16 +5,13 @@
  *************************************************/
 
  export default
- 	['$scope', '$state', '$stateParams', 'GenerateForm', 'HostsService', 'host', '$rootScope',
- 	function($scope, $state, $stateParams, GenerateForm, HostsService, host, $rootScope){
+ 	['$scope', '$state', 'HostsService', 'host', '$rootScope',
+ 	function($scope, $state, HostsService, host, $rootScope){
  		$scope.parseType = 'yaml';
  		$scope.formCancel = function(){
  			$state.go('^', null, {reload: true});
  		};
  		$scope.toggleHostEnabled = function(){
-			if ($scope.host.has_inventory_sources){
-				return;
-			}
  			$scope.host.enabled = !$scope.host.enabled;
  		};
  		$scope.toggleEnabled = function(){

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts-add.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts-add.controller.js
@@ -5,9 +5,9 @@
  *************************************************/
 
 export default ['$state', '$stateParams', '$scope', 'RelatedHostsFormDefinition', 'ParseTypeChange',
-                'GenerateForm', 'HostsService', 'rbacUiControlService', 'GetBasePath', 'ToJSON', 'canAdd', 'GroupsService',
+                'GenerateForm', 'HostsService', 'ToJSON', 'canAdd', 'GroupsService',
                 function($state, $stateParams, $scope, RelatedHostsFormDefinition, ParseTypeChange,
-                         GenerateForm, HostsService, rbacUiControlService, GetBasePath, ToJSON, canAdd, GroupsService) {
+                         GenerateForm, HostsService, ToJSON, canAdd, GroupsService) {
 
         init();
 
@@ -29,9 +29,6 @@ export default ['$state', '$stateParams', '$scope', 'RelatedHostsFormDefinition'
             $state.go('^');
         };
         $scope.toggleHostEnabled = function() {
-            if ($scope.host.has_inventory_sources){
-                return;
-            }
             $scope.host.enabled = !$scope.host.enabled;
         };
         $scope.formSave = function(){

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/add/host-add.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/add/host-add.controller.js
@@ -5,9 +5,9 @@
  *************************************************/
 
 export default ['$state', '$stateParams', '$scope', 'RelatedHostsFormDefinition',
-                'GenerateForm', 'HostsService', 'GetBasePath', 'ToJSON', 'canAdd',
+                'GenerateForm', 'HostsService', 'ToJSON', 'canAdd',
                 function($state, $stateParams, $scope, RelatedHostsFormDefinition,
-                         GenerateForm, HostsService, GetBasePath, ToJSON, canAdd) {
+                         GenerateForm, HostsService, ToJSON, canAdd) {
 
         init();
 
@@ -21,9 +21,6 @@ export default ['$state', '$stateParams', '$scope', 'RelatedHostsFormDefinition'
             $state.go('^');
         };
         $scope.toggleHostEnabled = function() {
-            if ($scope.host.has_inventory_sources){
-                return;
-            }
             $scope.host.enabled = !$scope.host.enabled;
         };
         $scope.formSave = function(){

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/edit/host-edit.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/edit/host-edit.controller.js
@@ -5,17 +5,14 @@
  *************************************************/
 
  export default
- 	['$scope', '$state', '$stateParams', 'GenerateForm', 'ParseTypeChange', 'HostsService', 'host', '$rootScope',
- 	function($scope, $state, $stateParams, GenerateForm, ParseTypeChange, HostsService, host, $rootScope){
+ 	['$scope', '$state', 'HostsService', 'host', '$rootScope',
+ 	function($scope, $state, HostsService, host, $rootScope){
         $scope.isSmartInvHost = $state.includes('inventories.editSmartInventory.hosts.edit');
  		$scope.parseType = 'yaml';
  		$scope.formCancel = function(){
  			$state.go('^', null, {reload: true});
  		};
  		$scope.toggleHostEnabled = function(){
-			if ($scope.host.has_inventory_sources){
-				return;
-			}
  			$scope.host.enabled = !$scope.host.enabled;
  		};
  		$scope.toggleEnabled = function(){


### PR DESCRIPTION
##### SUMMARY
Follow on to https://github.com/ansible/awx/pull/4420.  Since we expose a toggle on the host form(s) to all the user to toggle the host on/off from that view we should remove the dynamic host restriction there too.  Ping @wenottingham for confirmation.

<img width="691" alt="Screen Shot 2019-08-07 at 11 16 13 AM" src="https://user-images.githubusercontent.com/9889020/62635093-0caab580-b905-11e9-9432-340a97df6113.png">

Also removed some unused dep injections

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
