### PR TITLE
E2E websocket cleanup

### DIFF
--- a/awx/ui/test/e2e/tests/test-websockets.js
+++ b/awx/ui/test/e2e/tests/test-websockets.js
@@ -163,23 +163,6 @@ module.exports = {
         client.useXpath().expect.element(`${splitJt}${sparklineIcon}[1]${success}`)
             .to.be.present.before(AWX_E2E_TIMEOUT_ASYNC);
     },
-    'Test pending deletion of inventories': client => {
-        const uniqueID = uuid().substr(0, 8);
-        getInventorySource(`test-pending-delete-${uniqueID}`);
-        client
-            .useCss()
-            .navigateTo(`${AWX_E2E_URL}/#/inventories`, false)
-            .waitForElementVisible('.SmartSearch-input')
-            .clearValue('.SmartSearch-input')
-            .setValue('.SmartSearch-input', [`test-pending-delete-${uniqueID}`, client.Keys.ENTER])
-            .pause(AWX_E2E_TIMEOUT_SHORT) // helps prevent flake
-            .findThenClick('.fa-trash-o', 'css')
-            .waitForElementVisible('#prompt_action_btn')
-            .pause(AWX_E2E_TIMEOUT_SHORT) // animation catches us sometimes
-            .click('#prompt_action_btn');
-        client.useCss().expect.element('[ng-if="inventory.pending_deletion"]')
-            .to.be.visible.before(AWX_E2E_TIMEOUT_LONG);
-    },
     after: client => {
         client.end();
     }


### PR DESCRIPTION
##### SUMMARY
When inventories are deleted, they can be somewhat large and take a while to delete, so the deletion is launched as a background task to ensure that operation does not hang. When done with localhost, or even a fairly large number of dummy hosts, the signal isn't deterministic enough for E2E runs without significant flakiness rates. 