### PR TITLE
fix a bug in the API metrics endpoint

### DIFF
--- a/awx/api/renderers.py
+++ b/awx/api/renderers.py
@@ -109,6 +109,11 @@ class AnsiDownloadRenderer(PlainTextRenderer):
 class PrometheusJSONRenderer(renderers.JSONRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
+        if isinstance(data, dict):
+            # HTTP errors are {'detail': ErrorDetail(string='...', code=...)}
+            return super(PrometheusJSONRenderer, self).render(
+                data, accepted_media_type, renderer_context
+            )
         parsed_metrics = text_string_to_metric_families(data)
         data = {}
         for family in parsed_metrics:


### PR DESCRIPTION
The metrics JSON renderer shouldn't try to parse data that isn't
a string (generally, this represents things like HTTP 403)