### PR TITLE
docker login: s/-p/--password-stdin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -569,8 +569,8 @@ setup-bundle-build:
 	mkdir -p $@
 
 docker-auth:
-	if [ "$(IMAGE_REPOSITORY_AUTH)" ]; then \
-		docker login -u oauth2accesstoken -p "$(IMAGE_REPOSITORY_AUTH)" $(IMAGE_REPOSITORY_BASE); \
+	@if [ "$(IMAGE_REPOSITORY_AUTH)" ]; then \
+		echo "$(IMAGE_REPOSITORY_AUTH)" | docker login -u oauth2accesstoken --password-stdin $(IMAGE_REPOSITORY_BASE); \
 	fi;
 
 # Docker isolated rampart


### PR DESCRIPTION
Calling `docker-auth` target currently results in:
`WARNING! Using --password via the CLI is insecure. Use --password-stdin.`

Change pipes in password instead of using `-p` flag. Command's output is suppressed in Makefile.

https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin