### PR TITLE
Remove deprecated WFJT node credential field

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -920,27 +920,6 @@ class LaunchTimeConfigBase(BaseModel):
     def display_extra_data(self):
         return self.display_extra_vars()
 
-    @property
-    def _credential(self):
-        '''
-        Only used for workflow nodes to support backward compatibility.
-        '''
-        try:
-            return [cred for cred in self.credentials.all() if cred.credential_type.kind == 'ssh'][0]
-        except IndexError:
-            return None
-
-    @property
-    def credential(self):
-        '''
-        Returns an integer so it can be used as IntegerField in serializer
-        '''
-        cred = self._credential
-        if cred is not None:
-            return cred.pk
-        else:
-            return None
-
 
 class LaunchTimeConfig(LaunchTimeConfigBase):
     '''

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -149,7 +149,7 @@ The resulting state of the workflow job run above would be 'successful'. Althoug
 * Verify that a subtree of execution will never start if its root node is successfully canceled.
 * Verify that cancelling a workflow job that is cancellable will consequently cancel any of its cancellable spawned jobs and thus interrupts the whole workflow execution.
 * Verify that during a workflow job run, deleting its spawned jobs are prohibited.
-* Verify that at the beginning of each spawned job run, its prompted fields will be populated by the wrapping workflow job node with corrected values. For example, `credential` field of workflow job node goes to `credential` field of spawned job.
+* Verify that at the beginning of each spawned job run, its prompted fields will be populated by the wrapping workflow job node with corrected values. For example, related `credentials` of workflow job node go to `credentials` of spawned job.
 * Verify that notification templates can be successfully (dis)associated with a workflow job template. Later when its spawned workflow jobs finish running, verify that the correct type of notifications will be sent according to the job status.
 * Verify that a workflow job can be successfully relaunched.
 


### PR DESCRIPTION
##### SUMMARY
Maintaining this field here does not make any sense after it has been removed from the job template model.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```

```


##### ADDITIONAL INFORMATION
WFJT nodes hold prompts only for job templates. The singular `credential` field was removed from job templates. Keeping it on the WFJT node would only create more confusion, because the congruency between the two would be broken.
