### PR TITLE
Make --help not try to connect

### DIFF
--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pkg_resources
 import sys
+from argparse import ArgumentParser
 
 from .custom import handle_custom_actions
 from .format import (add_authentication_arguments,
@@ -264,7 +265,7 @@ class CLI(object):
         self.parser = HelpfulArgumentParser(add_help=False)
         self.parser.add_argument(
             '--help',
-            action='store_true',
+            action='help',
             help='prints usage information for the awx tool',
         )
         self.parser.add_argument(

--- a/awxkit/awxkit/cli/utils.py
+++ b/awxkit/awxkit/cli/utils.py
@@ -44,14 +44,6 @@ class HelpfulArgumentParser(ArgumentParser):
         self._print_message('\n')
         self.exit(2, '%s: %s\n' % (self.prog, message))
 
-    def _parse_known_args(self, args, ns):
-        for arg in ('-h', '--help'):
-            # the -h argument is extraneous; if you leave it off,
-            # awx-cli will just print usage info
-            if arg in args:
-                args.remove(arg)
-        return super(HelpfulArgumentParser, self)._parse_known_args(args, ns)
-
 
 def color_enabled():
     return _color.enabled


### PR DESCRIPTION
##### SUMMARY
Currently, `awx --help` prints help but then tries to connect and emits error messages.  It should just print the help and exit.

##### COMPONENT NAME
CLI

##### AWX VERSION
```
6.1.0
```