### PR TITLE
fix typo in migration name

### DIFF
--- a/awx/main/migrations/0084_v360_token_description.py
+++ b/awx/main/migrations/0084_v360_token_description.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('main', '0083_v360_job_branch_overrirde'),
+        ('main', '0083_v360_job_branch_override'),
     ]
 
     operations = [


### PR DESCRIPTION
##### SUMMARY
There is a typo in this migration pointer that django is rightfully complaining about.  


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

