### PR TITLE
fix awkit shell init when no credential config is provided

### DIFF
--- a/awxkit/awxkit/scripts/basic_session.py
+++ b/awxkit/awxkit/scripts/basic_session.py
@@ -60,13 +60,17 @@ def main():
         if akit_args.credential_file != utils.not_provided:
             config.credentials = utils.load_credentials(
                 akit_args.credential_file)
+        else:
+            config.credentials = utils.PseudoNamespace({
+                'default': {
+                    'username': os.getenv('AWXKIT_USER', 'admin'),
+                    'password': os.getenv('AWXKIT_USER_PASSWORD', 'password')
+                }
+            })
 
         if akit_args.project_file != utils.not_provided:
             config.project_urls = utils.load_projects(
                 akit_args.project_file)
-        else:
-            config.credentials = utils.PseudoNamespace({'default': {'username': os.getenv(
-                'AWXKIT_USER', 'admin'), 'password': os.getenv('AWXKIT_USER_PASSWORD', 'password')}})
 
         global root
         root = api.Api()


### PR DESCRIPTION
##### SUMMARY

This should drop you into an interactive shell with an authenticated `v2` client:

```shell
AWXKIT_BASE_URL='http://awxhost' AWXKIT_USER='username' AWXKIT_USER_PASSWORD='password' akit
```

Currently, if you do this you'll get some errors. This PR is to fix this.


##### ISSUE TYPE

##### COMPONENT NAME
 - API
