### PR TITLE
Fixes issues with extra var prompting in workflow nodes

### DIFF
--- a/awx/ui/client/legacy/styles/forms.less
+++ b/awx/ui/client/legacy/styles/forms.less
@@ -613,6 +613,10 @@ input[type='radio']:checked:before {
     button {
         margin-left: 20px;
     }
+
+    .at-Tab {
+        margin-left: 0px;
+    }
 }
 
 .Form-button {

--- a/awx/ui/client/src/templates/prompt/prompt.service.js
+++ b/awx/ui/client/src/templates/prompt/prompt.service.js
@@ -26,10 +26,23 @@ function PromptService (Empty, $filter)  {
               hasDefaultExtraVars = _.get(params, 'launchConf.defaults.extra_vars');
 
         if(hasCurrentExtraVars && hasDefaultExtraVars) {
-            extraVars = jsyaml.safeDump(_.merge(jsyaml.safeLoad(params.launchConf.defaults.extra_vars), params.currentValues.extra_data));
+            let currentExtraVars = {};
+            let defaultExtraVars = {};
+            if (typeof params.currentValues.extra_data === 'object') {
+                currentExtraVars = params.currentValues.extra_data;
+            } else if (typeof params.currentValues.extra_data === 'string') {
+                currentExtraVars = jsyaml.safeDump(params.currentValues.extra_data);
+            }
+
+            if (typeof params.launchConf.defaults.extra_vars === 'object') {
+                defaultExtraVars = params.launchConf.defaults.extra_vars;
+            } else if (typeof params.launchConf.defaults.extra_vars === 'string') {
+                defaultExtraVars = jsyaml.safeLoad(params.launchConf.defaults.extra_vars);
+            }
+            extraVars = '---\n' + jsyaml.safeDump(_.merge(defaultExtraVars, currentExtraVars));
         } else if(hasCurrentExtraVars) {
             if (typeof params.currentValues.extra_data === 'object') {
-                extraVars = jsyaml.safeDump(params.currentValues.extra_data);
+                extraVars = '---\n' + jsyaml.safeDump(params.currentValues.extra_data);
             } else if (typeof params.currentValues.extra_data === 'string') {
                 extraVars = params.currentValues.extra_data;
             }

--- a/awx/ui/client/src/templates/prompt/prompt.service.js
+++ b/awx/ui/client/src/templates/prompt/prompt.service.js
@@ -28,7 +28,11 @@ function PromptService (Empty, $filter)  {
         if(hasCurrentExtraVars && hasDefaultExtraVars) {
             extraVars = jsyaml.safeDump(_.merge(jsyaml.safeLoad(params.launchConf.defaults.extra_vars), params.currentValues.extra_data));
         } else if(hasCurrentExtraVars) {
-            extraVars = jsyaml.safeDump(params.currentValues.extra_data);
+            if (typeof params.currentValues.extra_data === 'object') {
+                extraVars = jsyaml.safeDump(params.currentValues.extra_data);
+            } else if (typeof params.currentValues.extra_data === 'string') {
+                extraVars = params.currentValues.extra_data;
+            }
         } else if(hasDefaultExtraVars) {
             extraVars = params.launchConf.defaults.extra_vars;
         }

--- a/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/forms/workflow-node-form.controller.js
@@ -328,12 +328,18 @@ export default ['$scope', 'TemplatesService', 'JobTemplateModel', 'PromptService
 
                                             let processed = PromptService.processSurveyQuestions({
                                                 surveyQuestions: surveyQuestionRes.data.spec,
-                                                extra_data: _.cloneDeep($scope.nodeConfig.node.originalNodeObject.extra_data)
+                                                extra_data: jsyaml.safeLoad(prompts.variables.value)
                                             });
 
                                             $scope.missingSurveyValue = processed.missingSurveyValue;
 
                                             $scope.extraVars = (processed.extra_data === '' || _.isEmpty(processed.extra_data)) ? '---' : '---\n' + jsyaml.safeDump(processed.extra_data);
+
+                                            // PromptService.processSurveyQuestions will strip the survey answers out of the extra
+                                            // vars so we should update the prompt value
+                                            prompts.variables = {
+                                                value: $scope.extraVars
+                                            };
 
                                             $scope.nodeConfig.node.promptData = $scope.promptData = {
                                                 launchConf: launchConf,

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
@@ -100,12 +100,15 @@ export default ['$scope', 'TemplatesService',
                 }
 
                 if (_.has(node, 'promptData.extraVars')) {
+                    const formVars = node.promptData.extraVars;
+                    const formVarsJSON = typeof formVars === 'string' ? jsyaml.safeLoad(formVars) : formVars;
                     if (_.get(node, 'promptData.launchConf.defaults.extra_vars')) {
-                        const defaultVars = jsyaml.safeLoad(node.promptData.launchConf.defaults.extra_vars);
+                        const defaultVars = node.promptData.launchConf.defaults.extra_vars;
+                        const defaultVarsJSON = typeof defaultVars === 'string' ? jsyaml.safeLoad(defaultVars) : defaultVars;
 
                         // Only include extra vars that differ from the template default vars
-                        _.forOwn(node.promptData.extraVars, (value, key) => {
-                            if (!defaultVars[key] || defaultVars[key] !== value) {
+                        _.forOwn(formVarsJSON, (value, key) => {
+                            if (!defaultVarsJSON[key] || defaultVarsJSON[key] !== value) {
                                 sendableNodeData.extra_data[key] = value;
                             }
                         });
@@ -113,8 +116,8 @@ export default ['$scope', 'TemplatesService',
                             delete sendableNodeData.extra_data;
                         }
                     } else {
-                        if (_.has(node, 'promptData.extraVars') && !_.isEmpty(node.promptData.extraVars)) {
-                            sendableNodeData.extra_data = node.promptData.extraVars;
+                        if (_.has(node, 'promptData.extraVars') && !_.isEmpty(formVarsJSON)) {
+                            sendableNodeData.extra_data = formVarsJSON;
                         }
                     }
                 }


### PR DESCRIPTION
##### SUMMARY
link #4293 

The easiest way to reproduce the `pipe` in the extra vars was to:
1) Create a JT that prompted for extra vars with no default values
2) Create a WFJT and select the JT from step 1 as a node
3) While creating the node in step 2, click on the prompt button and go through the prompts without selecting anything
4) Save the WFJT
5) Open the WFJT back up and edit the node
6) Click the prompt button and navigate to the extra vars prompt section

Here's a gif of part of that process:

![extra_vars](https://user-images.githubusercontent.com/9889020/63353596-f9e6a680-c330-11e9-9a6c-6065066cf846.gif)

This bug got introduced by https://github.com/ansible/awx/pull/3669 which was a fix for a bug introduced by https://github.com/ansible/awx/pull/3359.

The short of it is that `params.currentValues.extra_data` can be an object (json) or a string (yaml) when being processed and we need to be able to handle both scenarios.

I went back and doubled checked that yaml comments were still being presented to the user on launch (see https://github.com/ansible/awx/pull/3359#issue-258102793 for more info on that).

I also dropped a commit in here to address the prompt tab spacing issues seen when launching a job from the job template form.

Before:
<img width="822" alt="Screen Shot 2019-08-20 at 9 48 17 AM" src="https://user-images.githubusercontent.com/9889020/63352931-f56dbe00-c32f-11e9-9d5d-8d6c28fce1fe.png">

After:
<img width="863" alt="Screen Shot 2019-08-20 at 9 48 40 AM" src="https://user-images.githubusercontent.com/9889020/63352946-f999db80-c32f-11e9-8593-5df6fad370f9.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
awx: 6.1.0

##### ADDITIONAL INFORMATION
In addition to testing out the cases listed in #4293 and #3359 I've done some manual regression testing in the other places where extra variables are prompted.  Schedules is one place that can be impacted by prompting changes.  I double checked to make sure that promptable extra vars display properly when prompted for a schedule (both add and edit).
