### PR TITLE
Fix display of indirect access permissions.

### DIFF
--- a/awx/ui/client/src/access/rbac-role-column/roleList.directive.js
+++ b/awx/ui/client/src/access/rbac-role-column/roleList.directive.js
@@ -26,13 +26,10 @@ export default
                                 //
                                 // If the user has indirect admin access, they are system admin, org admin,
                                 // or a <resource_type>_admin. Return the role name directly.
-                                if (i.descendant_roles.includes('admin_role')) {
+                                // Similarly, if they are an auditor, return that instead of a read role.
+                                if (i.descendant_roles.includes('admin_role') || i.role.name.includes('Auditor')) {
                                     i.role.explicit = false;
-                                    return i.role;
-                                }
-                                // Return other specific roles that grant read access
-                                if (i.role.name.includes('Auditor')) {
-                                    i.role.explicit = false;
+                                    i.role.parent_role_name = i.role.name;
                                     return i.role;
                                 }
                                 // Handle more complex cases
@@ -45,6 +42,7 @@ export default
                                 let indirect_roles = [];
                                 i.descendant_roles.forEach((descendant_role) => {
                                     let r = _.cloneDeep(i.role);
+                                    r.parent_role_name = r.name;
                                     r.name = descendant_role.replace('_role','');
                                     r.explicit = false;
                                     // Do not include the read role unless it is the only descendant role.

--- a/awx/ui/client/src/access/rbac-role-column/roleList.directive.js
+++ b/awx/ui/client/src/access/rbac-role-column/roleList.directive.js
@@ -21,9 +21,40 @@ export default
                         }))
                         .concat(scope.deleteTarget.summary_fields
                             .indirect_access.map((i) => {
-                                i.role.explicit = false;
-                                return i.role;
+                                // Indirect access roles describe the role on another object that
+                                // gives the user access to this object, so we must introspect them.
+                                //
+                                // If the user has indirect admin access, they are system admin, org admin,
+                                // or a <resource_type>_admin. Return the role name directly.
+                                if (i.descendant_roles.includes('admin_role')) {
+                                    i.role.explicit = false;
+                                    return i.role;
+                                }
+                                // Return other specific roles that grant read access
+                                if (i.role.name.includes('Auditor')) {
+                                    i.role.explicit = false;
+                                    return i.role;
+                                }
+                                // Handle more complex cases
+                                // This includes roles team<->team roles, and roles an org admin
+                                // inherits from teams in their organization.
+                                //
+                                // For these, we want to describe the actual permissions for the
+                                // object we are retrieving the access_list for, so replace
+                                // the role name with the descendant_roles.
+                                let indirect_roles = [];
+                                i.descendant_roles.forEach((descendant_role) => {
+                                    let r = _.cloneDeep(i.role);
+                                    r.name = descendant_role.replace('_role','');
+                                    r.explicit = false;
+                                    // Do not include the read role unless it is the only descendant role.
+                                    if (r.name !== 'read' || i.descendant_roles.length === 1) {
+                                        indirect_roles.push(r);
+                                    }
+                                });
+                                return indirect_roles;
                         }))
+                        .flat()
                         .filter((role) => {
                             return Boolean(attrs.teamRoleList) === Boolean(role.team_id);
                         })

--- a/awx/ui/client/src/access/rbac-role-column/roleList.partial.html
+++ b/awx/ui/client/src/access/rbac-role-column/roleList.partial.html
@@ -18,7 +18,16 @@
     <div class="RoleList-tag"
         ng-class="{'RoleList-tag--deletable': entry.explicit && entry.user_capabilities.unattach,
             'RoleList-tag--team': entry.team_id}"
-        ng-if="!entry.team_id">
+        ng-if="!entry.team_id && (entry.explicit || !entry.resource_type)">
         <span class="RoleList-name">{{ entry.name }}</span>
+    </div>
+
+    <div class="RoleList-tag"
+        ng-class="{'RoleList-tag--deletable': entry.explicit && entry.user_capabilities.unattach,
+            'RoleList-tag--team': entry.team_id}"
+        aw-tool-tip='<div>Via {{ entry.parent_role_name | sanitize }} role on {{ entry.resource_type | sanitize }} {{entry.resource_name | sanitize}}</div>' aw-tip-placement='bottom'
+        ng-if="!entry.team_id && !entry.explicit && entry.resource_type">
+        <span class="RoleList-name">{{ entry.name }}</span>
+        <i class="fa fa-sitemap"></i>
     </div>
 </div>


### PR DESCRIPTION
For indirect roles, we need to actually show the derived roles, not the
details of the role that gives us the derived roles. This means that
we can get multiple derived roles from a single indirect role, so
we have to expand the list.

UI-only implementation of https://github.com/ansible/awx/pull/4514

Will help with #3903 and #4108.

Example for an inventory:
'admin' has indirect access by being the sysadmin.
'joe' has indirect access by being an admin of the org the inventory belongs to.
'fred', from outside the org, has been granted 'read' and 'update' explicitly to his outside-the-org team.
'fred' and 'bob' are org admins of fred's org, and therefore get indirect access to the team permission of fred's team.

![Screenshot from 2019-08-20 12-19-40](https://user-images.githubusercontent.com/5208768/63365302-68cdfa80-c345-11e9-8af2-e69c7306ba7e.png)
