### PR TITLE
Fix asserts in test_project.py to use the id directly off of the job template

### DIFF
--- a/awx/main/tests/functional/api/test_project.py
+++ b/awx/main/tests/functional/api/test_project.py
@@ -59,7 +59,7 @@ def test_no_changing_overwrite_behavior_if_used(post, patch, organization, admin
         user=admin_user,
         expect=201
     )
-    JobTemplate.objects.create(
+    jt = JobTemplate.objects.create(
         name='provides branch', project_id=r1.data['id'],
         playbook='helloworld.yml',
         scm_branch='foobar'
@@ -70,9 +70,10 @@ def test_no_changing_overwrite_behavior_if_used(post, patch, organization, admin
         user=admin_user,
         expect=400
     )
+    p = Project.objects.get(pk=r1.data['id'])
     assert 'job templates depend on branch override behavior for this project' in str(r2.data['allow_override'])
-    assert 'ids: 2' in str(r2.data['allow_override'])
-    assert Project.objects.get(pk=r1.data['id']).allow_override is True
+    assert 'ids: {}'.format(jt.id) in str(r2.data['allow_override'])
+    assert p.allow_override is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change a test assertion making use of a hard-coded job template id to instead use the id off of the created job template object.  This test has been occasionally, if infrequently, flaking out.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```