### PR TITLE
Remove extra warning when using garbage credentials

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -688,16 +688,18 @@ class CredentialInputField(JSONSchemaField):
                 model_instance.inputs['ssh_key_data'] = model_instance.__class__.objects.get(
                     pk=model_instance.pk
                 ).inputs.get('ssh_key_data')
-
+            
             if model_instance.has_encrypted_ssh_key_data and not value.get('ssh_key_unlock'):
                 errors['ssh_key_unlock'] = [_('must be set when SSH key is encrypted.')]
+            
             if all([
                 model_instance.inputs.get('ssh_key_data'),
                 value.get('ssh_key_unlock'),
-                not model_instance.has_encrypted_ssh_key_data
+                not model_instance.has_encrypted_ssh_key_data,
+                'ssh_key_data' not in errors
             ]):
                 errors['ssh_key_unlock'] = [_('should not be set when SSH key is not encrypted.')]
-
+        
         if errors:
             raise serializers.ValidationError({
                 'inputs': errors

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -688,7 +688,7 @@ class CredentialInputField(JSONSchemaField):
                 model_instance.inputs['ssh_key_data'] = model_instance.__class__.objects.get(
                     pk=model_instance.pk
                 ).inputs.get('ssh_key_data')
-            
+
             if model_instance.has_encrypted_ssh_key_data and not value.get('ssh_key_unlock'):
                 errors['ssh_key_unlock'] = [_('must be set when SSH key is encrypted.')]
             

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -699,7 +699,7 @@ class CredentialInputField(JSONSchemaField):
                 'ssh_key_data' not in errors
             ]):
                 errors['ssh_key_unlock'] = [_('should not be set when SSH key is not encrypted.')]
-        
+
         if errors:
             raise serializers.ValidationError({
                 'inputs': errors


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Added logic into the fields check that removes a secondary check of the ssh_key_unlock if the already checked ssh_key_data is invalid.
- Additionally added a test to verify that this is functioning as expected.
- Pertains to #3762 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The most helpful way to recreate the bug is documented in #3762 , although if you do not have more than 1 organization in your test instance you either need to create an additional one (minimum of 2) or  simply change the input for organization from 2 to 1 (example below).
```"organization": 2,``` --> ```"organization": 1,```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Output before:
```
{
   "inputs": {
       "ssh_key_data":[
           "Invalid certificate or key: thisisobviouslynotakey..."
       ],
       "ssh_key_unlock":[
           "should not be set when SSH key is not encrypted."
      ]
   }
}
```
Output after:
```
{
    "inputs": {
        "ssh_key_data": [
            "Invalid certificate or key: thisisobviouslynotakey..."
        ]
    }
}
```
