### PR TITLE
clean up old v2 versioning in API tests

### DIFF
--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -32,83 +32,78 @@ def test_idempotent_credential_type_setup():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_user_credential_via_credentials_list(post, get, alice, credentialtype_ssh, version, params):
-    params['user'] = alice.id
-    params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        alice
-    )
+def test_create_user_credential_via_credentials_list(post, get, alice, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'user': alice.id,
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, alice)
     assert response.status_code == 201
 
-    response = get(reverse('api:credential_list', kwargs={'version': version}), alice)
+    response = get(reverse('api:credential_list'), alice)
     assert response.status_code == 200
     assert response.data['count'] == 1
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_credential_validation_error_with_bad_user(post, admin, version, credentialtype_ssh, params):
-    params['user'] = 'asdf'
-    params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+def test_credential_validation_error_with_bad_user(post, admin, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'user': 'asdf',
+        'name': 'Some name'
+    }
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 400
     assert response.data['user'][0] == 'Incorrect type. Expected pk value, received str.'
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_user_credential_via_user_credentials_list(post, get, alice, credentialtype_ssh, version, params):
-    params['user'] = alice.id
-    params['name'] = 'Some name'
+def test_create_user_credential_via_user_credentials_list(post, get, alice, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'user': alice.id,
+        'name': 'Some name',
+    }
     response = post(
-        reverse('api:user_credentials_list', kwargs={'version': version, 'pk': alice.pk}),
+        reverse('api:user_credentials_list', kwargs={'pk': alice.pk}),
         params,
         alice
     )
     assert response.status_code == 201
 
-    response = get(reverse('api:user_credentials_list', kwargs={'version': version, 'pk': alice.pk}), alice)
+    response = get(reverse('api:user_credentials_list', kwargs={'pk': alice.pk}), alice)
     assert response.status_code == 200
     assert response.data['count'] == 1
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_user_credential_via_credentials_list_xfail(post, alice, bob, version, params):
+def test_create_user_credential_via_credentials_list_xfail(post, alice, bob):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'user': bob.id,
+        'name': 'Some name',
+    }
     params['user'] = bob.id
     params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        alice
-    )
+    response = post(reverse('api:credential_list'), params, alice)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_user_credential_via_user_credentials_list_xfail(post, alice, bob, version, params):
-    params['user'] = bob.id
-    params['name'] = 'Some name'
+def test_create_user_credential_via_user_credentials_list_xfail(post, alice, bob):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'user': bob.id,
+        'name': 'Some name',
+    }
     response = post(
-        reverse('api:user_credentials_list', kwargs={'version': version, 'pk': bob.pk}),
+        reverse('api:user_credentials_list', kwargs={'pk': bob.pk}),
         params,
         alice
     )
@@ -121,21 +116,18 @@ def test_create_user_credential_via_user_credentials_list_xfail(post, alice, bob
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_team_credential(post, get, team, organization, org_admin, team_member, credentialtype_ssh, version, params):
-    params['team'] = team.id
-    params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        org_admin
-    )
+def test_create_team_credential(post, get, team, organization, org_admin, team_member, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'team': team.id,
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, org_admin)
     assert response.status_code == 201
 
     response = get(
-        reverse('api:team_credentials_list', kwargs={'version': version, 'pk': team.pk}),
+        reverse('api:team_credentials_list', kwargs={'pk': team.pk}),
         team_member
     )
     assert response.status_code == 200
@@ -146,21 +138,22 @@ def test_create_team_credential(post, get, team, organization, org_admin, team_m
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_team_credential_via_team_credentials_list(post, get, team, org_admin, team_member, credentialtype_ssh, version, params):
-    params['team'] = team.id
-    params['name'] = 'Some name'
+def test_create_team_credential_via_team_credentials_list(post, get, team, org_admin, team_member, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'team': team.id,
+        'name': 'Some name',
+    }
     response = post(
-        reverse('api:team_credentials_list', kwargs={'version': version, 'pk': team.pk}),
+        reverse('api:team_credentials_list', kwargs={'pk': team.pk}),
         params,
         org_admin
     )
     assert response.status_code == 201
 
     response = get(
-        reverse('api:team_credentials_list', kwargs={'version': version, 'pk': team.pk}),
+        reverse('api:team_credentials_list', kwargs={'pk': team.pk}),
         team_member
     )
     assert response.status_code == 200
@@ -168,35 +161,29 @@ def test_create_team_credential_via_team_credentials_list(post, get, team, org_a
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_team_credential_by_urelated_user_xfail(post, team, organization, alice, team_member, version, params):
-    params['team'] = team.id
-    params['organization'] = organization.id
-    params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        alice
-    )
+def test_create_team_credential_by_urelated_user_xfail(post, team, organization, alice, team_member):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'team': team.id,
+        'organization': organization.id,
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, alice)
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_team_credential_by_team_member_xfail(post, team, organization, alice, team_member, version, params):
+def test_create_team_credential_by_team_member_xfail(post, team, organization, alice, team_member):
     # Members can't add credentials, only org admins.. for now?
-    params['team'] = team.id
-    params['organization'] = organization.id
-    params['name'] = 'Some name'
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        team_member
-    )
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'team': team.id,
+        'organization': organization.id,
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, team_member)
     assert response.status_code == 403
 
 
@@ -206,120 +193,109 @@ def test_create_team_credential_by_team_member_xfail(post, team, organization, a
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_org_user_through_role_users(post, credential, organization, org_admin, org_member, version):
+def test_grant_org_credential_to_org_user_through_role_users(post, credential, organization, org_admin, org_member):
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:role_users_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_users_list', kwargs={'pk': credential.use_role.id}), {
         'id': org_member.id
     }, org_admin)
     assert response.status_code == 204
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_org_user_through_user_roles(post, credential, organization, org_admin, org_member, version):
+def test_grant_org_credential_to_org_user_through_user_roles(post, credential, organization, org_admin, org_member):
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:user_roles_list', kwargs={'version': version, 'pk': org_member.id}), {
+    response = post(reverse('api:user_roles_list', kwargs={'pk': org_member.id}), {
         'id': credential.use_role.id
     }, org_admin)
     assert response.status_code == 204
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_non_org_user_through_role_users(post, credential, organization, org_admin, alice, version):
+def test_grant_org_credential_to_non_org_user_through_role_users(post, credential, organization, org_admin, alice):
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:role_users_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_users_list', kwargs={'pk': credential.use_role.id}), {
         'id': alice.id
     }, org_admin)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_non_org_user_through_user_roles(post, credential, organization, org_admin, alice, version):
+def test_grant_org_credential_to_non_org_user_through_user_roles(post, credential, organization, org_admin, alice):
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:user_roles_list', kwargs={'version': version, 'pk': alice.id}), {
+    response = post(reverse('api:user_roles_list', kwargs={'pk': alice.id}), {
         'id': credential.use_role.id
     }, org_admin)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_private_credential_to_user_through_role_users(post, credential, alice, bob, version):
+def test_grant_private_credential_to_user_through_role_users(post, credential, alice, bob):
     # normal users can't do this
     credential.admin_role.members.add(alice)
-    response = post(reverse('api:role_users_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_users_list', kwargs={'pk': credential.use_role.id}), {
         'id': bob.id
     }, alice)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_private_credential_to_org_user_through_role_users(post, credential, org_admin, org_member, version):
+def test_grant_private_credential_to_org_user_through_role_users(post, credential, org_admin, org_member):
     # org admins can't either
     credential.admin_role.members.add(org_admin)
-    response = post(reverse('api:role_users_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_users_list', kwargs={'pk': credential.use_role.id}), {
         'id': org_member.id
     }, org_admin)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_sa_grant_private_credential_to_user_through_role_users(post, credential, admin, bob, version):
+def test_sa_grant_private_credential_to_user_through_role_users(post, credential, admin, bob):
     # but system admins can
-    response = post(reverse('api:role_users_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_users_list', kwargs={'pk': credential.use_role.id}), {
         'id': bob.id
     }, admin)
     assert response.status_code == 204
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_private_credential_to_user_through_user_roles(post, credential, alice, bob, version):
+def test_grant_private_credential_to_user_through_user_roles(post, credential, alice, bob):
     # normal users can't do this
     credential.admin_role.members.add(alice)
-    response = post(reverse('api:user_roles_list', kwargs={'version': version, 'pk': bob.id}), {
+    response = post(reverse('api:user_roles_list', kwargs={'pk': bob.id}), {
         'id': credential.use_role.id
     }, alice)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_private_credential_to_org_user_through_user_roles(post, credential, org_admin, org_member, version):
+def test_grant_private_credential_to_org_user_through_user_roles(post, credential, org_admin, org_member):
     # org admins can't either
     credential.admin_role.members.add(org_admin)
-    response = post(reverse('api:user_roles_list', kwargs={'version': version, 'pk': org_member.id}), {
+    response = post(reverse('api:user_roles_list', kwargs={'pk': org_member.id}), {
         'id': credential.use_role.id
     }, org_admin)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_sa_grant_private_credential_to_user_through_user_roles(post, credential, admin, bob, version):
+def test_sa_grant_private_credential_to_user_through_user_roles(post, credential, admin, bob):
     # but system admins can
-    response = post(reverse('api:user_roles_list', kwargs={'version': version, 'pk': bob.id}), {
+    response = post(reverse('api:user_roles_list', kwargs={'pk': bob.id}), {
         'id': credential.use_role.id
     }, admin)
     assert response.status_code == 204
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_team_through_role_teams(post, credential, organization, org_admin, org_auditor, team, version):
+def test_grant_org_credential_to_team_through_role_teams(post, credential, organization, org_admin, org_auditor, team):
     assert org_auditor not in credential.read_role
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:role_teams_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {
         'id': team.id
     }, org_admin)
     assert response.status_code == 204
@@ -327,12 +303,11 @@ def test_grant_org_credential_to_team_through_role_teams(post, credential, organ
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_grant_org_credential_to_team_through_team_roles(post, credential, organization, org_admin, org_auditor, team, version):
+def test_grant_org_credential_to_team_through_team_roles(post, credential, organization, org_admin, org_auditor, team):
     assert org_auditor not in credential.read_role
     credential.organization = organization
     credential.save()
-    response = post(reverse('api:team_roles_list', kwargs={'version': version, 'pk': team.id}), {
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {
         'id': credential.use_role.id
     }, org_admin)
     assert response.status_code == 204
@@ -340,20 +315,18 @@ def test_grant_org_credential_to_team_through_team_roles(post, credential, organ
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_sa_grant_private_credential_to_team_through_role_teams(post, credential, admin, team, version):
+def test_sa_grant_private_credential_to_team_through_role_teams(post, credential, admin, team):
     # not even a system admin can grant a private cred to a team though
-    response = post(reverse('api:role_teams_list', kwargs={'version': version, 'pk': credential.use_role.id}), {
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {
         'id': team.id
     }, admin)
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version', ['v2'])
-def test_sa_grant_private_credential_to_team_through_team_roles(post, credential, admin, team, version):
+def test_sa_grant_private_credential_to_team_through_team_roles(post, credential, admin, team):
     # not even a system admin can grant a private cred to a team though
-    response = post(reverse('api:role_teams_list', kwargs={'version': version, 'pk': team.id}), {
+    response = post(reverse('api:role_teams_list', kwargs={'pk': team.id}), {
         'id': credential.use_role.id
     }, admin)
     assert response.status_code == 400
@@ -365,12 +338,13 @@ def test_sa_grant_private_credential_to_team_through_team_roles(post, credential
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_org_credential_as_not_admin(post, organization, org_member, credentialtype_ssh, version, params):
-    params['name'] = 'Some name'
-    params['organization'] = organization.id
+def test_create_org_credential_as_not_admin(post, organization, org_member, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'name': 'Some name',
+        'organization': organization.id,
+    }
     response = post(
         reverse('api:credential_list'),
         params,
@@ -380,35 +354,33 @@ def test_create_org_credential_as_not_admin(post, organization, org_member, cred
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_create_org_credential_as_admin(post, organization, org_admin, credentialtype_ssh, version, params):
-    params['name'] = 'Some name'
-    params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        org_admin
-    )
+def test_create_org_credential_as_admin(post, organization, org_admin, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'name': 'Some name',
+        'organization': organization.id,
+    }
+    response = post(reverse('api:credential_list'), params, org_admin)
     assert response.status_code == 201
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_credential_detail(post, get, organization, org_admin, credentialtype_ssh, version, params):
-    params['name'] = 'Some name'
-    params['organization'] = organization.id
+def test_credential_detail(post, get, organization, org_admin, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'name': 'Some name',
+        'organization': organization.id,
+    }
     response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
+        reverse('api:credential_list'),
         params,
         org_admin
     )
     assert response.status_code == 201
     response = get(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': response.data['id']}),
+        reverse('api:credential_detail', kwargs={'pk': response.data['id']}),
         org_admin
     )
     assert response.status_code == 200
@@ -419,42 +391,43 @@ def test_credential_detail(post, get, organization, org_admin, credentialtype_ss
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
-def test_list_created_org_credentials(post, get, organization, org_admin, org_member, credentialtype_ssh, version, params):
-    params['name'] = 'Some name'
-    params['organization'] = organization.id
+def test_list_created_org_credentials(post, get, organization, org_admin, org_member, credentialtype_ssh):
+    params = {
+        'credential_type': 1,
+        'inputs': {'username': 'someusername'},
+        'name': 'Some name',
+        'organization': organization.id,
+    }
     response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
+        reverse('api:credential_list'),
         params,
         org_admin
     )
     assert response.status_code == 201
 
     response = get(
-        reverse('api:credential_list', kwargs={'version': version}),
+        reverse('api:credential_list'),
         org_admin
     )
     assert response.status_code == 200
     assert response.data['count'] == 1
 
     response = get(
-        reverse('api:credential_list', kwargs={'version': version}),
+        reverse('api:credential_list'),
         org_member
     )
     assert response.status_code == 200
     assert response.data['count'] == 0
 
     response = get(
-        reverse('api:organization_credential_list', kwargs={'version': version, 'pk': organization.pk}),
+        reverse('api:organization_credential_list', kwargs={'pk': organization.pk}),
         org_admin
     )
     assert response.status_code == 200
     assert response.data['count'] == 1
 
     response = get(
-        reverse('api:organization_credential_list', kwargs={'version': version, 'pk': organization.pk}),
+        reverse('api:organization_credential_list', kwargs={'pk': organization.pk}),
         org_member
     )
     assert response.status_code == 200
@@ -466,7 +439,7 @@ def test_list_created_org_credentials(post, get, organization, org_admin, org_me
 def test_list_cannot_order_by_encrypted_field(post, get, organization, org_admin, credentialtype_ssh, order_by):
     for i, password in enumerate(('abc', 'def', 'xyz')):
         response = post(
-            reverse('api:credential_list', kwargs={'version': 'v2'}),
+            reverse('api:credential_list'),
             {
                 'organization': organization.id,
                 'name': 'C%d' % i,
@@ -476,7 +449,7 @@ def test_list_cannot_order_by_encrypted_field(post, get, organization, org_admin
         )
 
     response = get(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
+        reverse('api:credential_list'),
         org_admin,
         QUERY_STRING='order_by=%s' % order_by,
         status=400
@@ -494,11 +467,7 @@ def test_inputs_cannot_contain_extra_fields(get, post, organization, admin, cred
             'invalid_field': 'foo'
         },
     }
-    response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 400
     assert "'invalid_field' was unexpected" in response.data['inputs'][0]
 
@@ -517,11 +486,7 @@ def test_falsey_field_data(get, post, organization, admin, field_value):
             'authorize': field_value
         }
     }
-    response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -545,11 +510,7 @@ def test_field_dependencies(get, post, organization, admin, kind, extraneous):
         'organization': organization.id,
         'inputs': {extraneous: 'not needed'}
     }
-    response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 400
     assert re.search('cannot be set unless .+ is set.', smart_str(response.content))
 
@@ -560,8 +521,8 @@ def test_field_dependencies(get, post, organization, admin, kind, extraneous):
 # SCM Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_scm_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -570,17 +531,11 @@ def test_field_dependencies(get, post, organization, admin, kind, extraneous):
             'ssh_key_data': EXAMPLE_ENCRYPTED_PRIVATE_KEY,
             'ssh_key_unlock': 'some_key_unlock',
         }
-    }]
-])
-def test_scm_create_ok(post, organization, admin, version, params):
+    }
     scm = CredentialType.defaults['scm']()
     scm.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -592,24 +547,18 @@ def test_scm_create_ok(post, organization, admin, version, params):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_ssh_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
             'password': 'secret',
         }
-    }]
-])
-def test_ssh_create_ok(post, organization, admin, version, params):
+    }
     ssh = CredentialType.defaults['ssh']()
     ssh.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -622,24 +571,18 @@ def test_ssh_create_ok(post, organization, admin, version, params):
 # Vault Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_vault_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
             'vault_password': 'some_password',
         }
-    }]
-])
-def test_vault_create_ok(post, organization, admin, version, params):
+    }
     vault = CredentialType.defaults['vault']()
     vault.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -652,7 +595,7 @@ def test_vault_password_required(post, organization, admin):
     vault = CredentialType.defaults['vault']()
     vault.save()
     response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
+        reverse('api:credential_list'),
         {
             'credential_type': vault.pk,
             'organization': organization.id,
@@ -676,8 +619,8 @@ def test_vault_password_required(post, organization, admin):
 # Net Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_net_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -688,17 +631,11 @@ def test_vault_password_required(post, organization, admin):
             'authorize': True,
             'authorize_password': 'some_authorize_password',
         }
-    }]
-])
-def test_net_create_ok(post, organization, admin, version, params):
+    }
     net = CredentialType.defaults['net']()
     net.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -715,8 +652,8 @@ def test_net_create_ok(post, organization, admin, version, params):
 # Cloudforms Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_cloudforms_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -724,17 +661,11 @@ def test_net_create_ok(post, organization, admin, version, params):
             'username': 'some_username',
             'password': 'some_password',
         }
-    }]
-])
-def test_cloudforms_create_ok(post, organization, admin, version, params):
+    }
     cloudforms = CredentialType.defaults['cloudforms']()
     cloudforms.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -748,8 +679,8 @@ def test_cloudforms_create_ok(post, organization, admin, version, params):
 # GCE Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_gce_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -757,17 +688,11 @@ def test_cloudforms_create_ok(post, organization, admin, version, params):
             'project': 'some_project',
             'ssh_key_data': EXAMPLE_PRIVATE_KEY,
         }
-    }]
-])
-def test_gce_create_ok(post, organization, admin, version, params):
+    }
     gce = CredentialType.defaults['gce']()
     gce.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -781,8 +706,8 @@ def test_gce_create_ok(post, organization, admin, version, params):
 # Azure Resource Manager
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_azure_rm_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -793,17 +718,11 @@ def test_gce_create_ok(post, organization, admin, version, params):
             'secret': 'some_secret',
             'tenant': 'some_tenant'
         }
-    }]
-])
-def test_azure_rm_create_ok(post, organization, admin, version, params):
+    }
     azure_rm = CredentialType.defaults['azure_rm']()
     azure_rm.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -820,8 +739,8 @@ def test_azure_rm_create_ok(post, organization, admin, version, params):
 # RH Satellite6 Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_satellite6_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -829,17 +748,11 @@ def test_azure_rm_create_ok(post, organization, admin, version, params):
             'username': 'some_username',
             'password': 'some_password',
         }
-    }]
-])
-def test_satellite6_create_ok(post, organization, admin, version, params):
+    }
     sat6 = CredentialType.defaults['satellite6']()
     sat6.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -853,8 +766,8 @@ def test_satellite6_create_ok(post, organization, admin, version, params):
 # AWS Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_aws_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -862,17 +775,11 @@ def test_satellite6_create_ok(post, organization, admin, version, params):
             'password': 'some_password',
             'security_token': 'abc123'
         }
-    }]
-])
-def test_aws_create_ok(post, organization, admin, version, params):
+    }
     aws = CredentialType.defaults['aws']()
     aws.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -883,22 +790,16 @@ def test_aws_create_ok(post, organization, admin, version, params):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_aws_create_fail_required_fields(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {}
-    }]
-])
-def test_aws_create_fail_required_fields(post, organization, admin, version, params):
+    }
     aws = CredentialType.defaults['aws']()
     aws.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
     assert Credential.objects.count() == 1
 
@@ -914,8 +815,8 @@ def test_aws_create_fail_required_fields(post, organization, admin, version, par
 # VMware vCenter Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_vmware_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {
@@ -923,17 +824,11 @@ def test_aws_create_fail_required_fields(post, organization, admin, version, par
             'username': 'some_username',
             'password': 'some_password'
         }
-    }]
-])
-def test_vmware_create_ok(post, organization, admin, version, params):
+    }
     vmware = CredentialType.defaults['vmware']()
     vmware.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     assert Credential.objects.count() == 1
@@ -944,22 +839,16 @@ def test_vmware_create_ok(post, organization, admin, version, params):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_vmware_create_fail_required_fields(post, organization, admin):
+    params = {
         'credential_type': 1,
         'name': 'Best credential ever',
         'inputs': {}
-    }]
-])
-def test_vmware_create_fail_required_fields(post, organization, admin, version, params):
+    }
     vmware = CredentialType.defaults['vmware']()
     vmware.save()
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
     assert Credential.objects.count() == 1
 
@@ -975,8 +864,8 @@ def test_vmware_create_fail_required_fields(post, organization, admin, version, 
 # Openstack Credentials
 #
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_openstack_create_ok(post, organization, admin):
+    params = {
         'credential_type': 1,
         'inputs': {
             'username': 'some_user',
@@ -984,19 +873,13 @@ def test_vmware_create_fail_required_fields(post, organization, admin, version, 
             'project': 'some_project',
             'host': 'some_host',
         }
-    }]
-])
-def test_openstack_create_ok(post, organization, admin, version, params):
+    }
     openstack = CredentialType.defaults['openstack']()
     openstack.save()
     params['kind'] = 'openstack'
     params['name'] = 'Best credential ever'
     params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
 
@@ -1023,11 +906,7 @@ def test_openstack_verify_ssl(get, post, organization, admin, verify_ssl, expect
         'name': 'Best credential ever',
         'organization': organization.id
     }
-    response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     cred = Credential.objects.get(pk=response.data['id'])
@@ -1035,23 +914,17 @@ def test_openstack_verify_ssl(get, post, organization, admin, verify_ssl, expect
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
-        'credential_type': 1,
-        'inputs': {}
-    }]
-])
-def test_openstack_create_fail_required_fields(post, organization, admin, version, params):
+def test_openstack_create_fail_required_fields(post, organization, admin):
     openstack = CredentialType.defaults['openstack']()
     openstack.save()
-    params['kind'] = 'openstack'
-    params['name'] = 'Best credential ever'
-    params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    params = {
+        'credential_type': 1,
+        'inputs': {},
+        'kind': 'openstack',
+        'name': 'Best credential ever',
+        'organization': organization.id,
+    }
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
     # username, password, host, and project must be specified by launch time
@@ -1063,17 +936,15 @@ def test_openstack_create_fail_required_fields(post, organization, admin, versio
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_field_removal(put, organization, admin, credentialtype_ssh):
+    params = {
         'name': 'Best credential ever',
         'credential_type': 1,
         'inputs': {
             'username': 'joe',
             'password': '',
         }
-    }]
-])
-def test_field_removal(put, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1087,7 +958,7 @@ def test_field_removal(put, organization, admin, credentialtype_ssh, version, pa
 
     params['organization'] = organization.id
     response = put(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1126,7 +997,7 @@ def test_credential_type_mutability(patch, organization, admin, credentialtype_s
 
     def _change_credential_type():
         return patch(
-            reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+            reverse('api:credential_detail', kwargs={'pk': cred.pk}),
             {
                 'credential_type': credentialtype_aws.pk,
                 'inputs': {
@@ -1144,7 +1015,7 @@ def test_credential_type_mutability(patch, organization, admin, credentialtype_s
     assert response.data['credential_type'] == expected
 
     response = patch(
-        reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         {'name': 'Worst credential ever'},
         admin
     )
@@ -1175,7 +1046,7 @@ def test_vault_credential_type_mutability(patch, organization, admin, credential
 
     def _change_credential_type():
         return patch(
-            reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+            reverse('api:credential_detail', kwargs={'pk': cred.pk}),
             {
                 'credential_type': credentialtype_ssh.pk,
                 'inputs': {
@@ -1193,7 +1064,7 @@ def test_vault_credential_type_mutability(patch, organization, admin, credential
     assert response.data['credential_type'] == expected
 
     response = patch(
-        reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         {'name': 'Worst credential ever'},
         admin
     )
@@ -1225,7 +1096,7 @@ def test_cloud_credential_type_mutability(patch, organization, admin, credential
 
     def _change_credential_type():
         return patch(
-            reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+            reverse('api:credential_detail', kwargs={'pk': cred.pk}),
             {
                 'credential_type': credentialtype_ssh.pk,
                 'inputs': {
@@ -1243,7 +1114,7 @@ def test_cloud_credential_type_mutability(patch, organization, admin, credential
     assert response.data['credential_type'] == expected
 
     response = patch(
-        reverse('api:credential_detail', kwargs={'version': 'v2', 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         {'name': 'Worst credential ever'},
         admin
     )
@@ -1256,17 +1127,15 @@ def test_cloud_credential_type_mutability(patch, organization, admin, credential
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_ssh_unlock_needed(put, organization, admin, credentialtype_ssh):
+    params = {
         'name': 'Best credential ever',
         'credential_type': 1,
         'inputs': {
             'username': 'joe',
             'ssh_key_data': '$encrypted$',
         }
-    }]
-])
-def test_ssh_unlock_needed(put, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1281,7 +1150,7 @@ def test_ssh_unlock_needed(put, organization, admin, credentialtype_ssh, version
 
     params['organization'] = organization.id
     response = put(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1290,8 +1159,8 @@ def test_ssh_unlock_needed(put, organization, admin, credentialtype_ssh, version
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_ssh_unlock_not_needed(put, organization, admin, credentialtype_ssh):
+    params = {
         'name': 'Best credential ever',
         'credential_type': 1,
         'inputs': {
@@ -1299,9 +1168,7 @@ def test_ssh_unlock_needed(put, organization, admin, credentialtype_ssh, version
             'ssh_key_data': '$encrypted$',
             'ssh_key_unlock': 'superfluous-key-unlock',
         }
-    }]
-])
-def test_ssh_unlock_not_needed(put, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1315,7 +1182,7 @@ def test_ssh_unlock_not_needed(put, organization, admin, credentialtype_ssh, ver
 
     params['organization'] = organization.id
     response = put(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1324,8 +1191,8 @@ def test_ssh_unlock_not_needed(put, organization, admin, credentialtype_ssh, ver
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_ssh_unlock_with_prior_value(put, organization, admin, credentialtype_ssh):
+    params = {
         'name': 'Best credential ever',
         'credential_type': 1,
         'inputs': {
@@ -1333,9 +1200,7 @@ def test_ssh_unlock_not_needed(put, organization, admin, credentialtype_ssh, ver
             'ssh_key_data': '$encrypted$',
             'ssh_key_unlock': 'new-unlock',
         }
-    }]
-])
-def test_ssh_unlock_with_prior_value(put, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1350,7 +1215,7 @@ def test_ssh_unlock_with_prior_value(put, organization, admin, credentialtype_ss
 
     params['organization'] = organization.id
     response = put(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1361,8 +1226,8 @@ def test_ssh_unlock_with_prior_value(put, organization, admin, credentialtype_ss
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_ssh_bad_key_unlock_not_checked(put, organization, admin, credentialtype_ssh):
+    params = {
         'name': 'Best credential ever',
         'credential_type': 1,
         'inputs': {
@@ -1370,9 +1235,7 @@ def test_ssh_unlock_with_prior_value(put, organization, admin, credentialtype_ss
             'ssh_key_data': 'invalid-key',
             'ssh_key_unlock': 'unchecked-unlock',
         }
-    }]
-])
-def test_ssh_bad_key_unlock_not_checked(put, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1387,7 +1250,7 @@ def test_ssh_bad_key_unlock_not_checked(put, organization, admin, credentialtype
 
     params['organization'] = organization.id
     response = put(
-        reverse('api:credential_detail', kwargs={'version': version, 'pk': cred.pk}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1401,29 +1264,20 @@ def test_ssh_bad_key_unlock_not_checked(put, organization, admin, credentialtype
 #
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_secret_encryption_on_create(get, post, organization, admin, credentialtype_ssh):
+    params = {
         'credential_type': 1,
         'inputs': {
             'username': 'joe',
             'password': 'secret',
-        }
-    }]
-])
-def test_secret_encryption_on_create(get, post, organization, admin, credentialtype_ssh, version, params):
-    params['name'] = 'Best credential ever'
-    params['organization'] = organization.id
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+        },
+        'name': 'Best credential ever',
+        'organization': organization.id,
+    }
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
-    response = get(
-        reverse('api:credential_list', kwargs={'version': version}),
-        admin
-    )
+    response = get(reverse('api:credential_list'), admin)
     assert response.status_code == 200
     assert response.data['count'] == 1
     cred = response.data['results'][0]
@@ -1436,12 +1290,10 @@ def test_secret_encryption_on_create(get, post, organization, admin, credentialt
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'inputs': {'username': 'joe', 'password': 'secret'}}]
-])
-def test_secret_encryption_on_update(get, post, patch, organization, admin, credentialtype_ssh, version, params):
+def test_secret_encryption_on_update(get, post, patch, organization, admin, credentialtype_ssh):
+    params = {'inputs': {'username': 'joe', 'password': 'secret'}}
     response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
+        reverse('api:credential_list'),
         {
             'name': 'Best credential ever',
             'organization': organization.id,
@@ -1455,16 +1307,13 @@ def test_secret_encryption_on_update(get, post, patch, organization, admin, cred
     assert response.status_code == 201
 
     response = patch(
-        reverse('api:credential_detail', kwargs={'pk': 1, 'version': version}),
+        reverse('api:credential_detail', kwargs={'pk': 1}),
         params,
         admin
     )
     assert response.status_code == 200
 
-    response = get(
-        reverse('api:credential_list', kwargs={'version': version}),
-        admin
-    )
+    response = get(reverse('api:credential_list'), admin)
     assert response.status_code == 200
     assert response.data['count'] == 1
     cred = response.data['results'][0]
@@ -1477,15 +1326,13 @@ def test_secret_encryption_on_update(get, post, patch, organization, admin, cred
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('version, params', [
-    ['v2', {
+def test_secret_encryption_previous_value(patch, organization, admin, credentialtype_ssh):
+    params = {
         'inputs': {
             'username': 'joe',
             'password': '$encrypted$',
         }
-    }]
-])
-def test_secret_encryption_previous_value(patch, organization, admin, credentialtype_ssh, version, params):
+    }
     cred = Credential(
         credential_type=credentialtype_ssh,
         name='Best credential ever',
@@ -1499,7 +1346,7 @@ def test_secret_encryption_previous_value(patch, organization, admin, credential
 
     assert decrypt_field(cred, 'password') == 'secret'
     response = patch(
-        reverse('api:credential_detail', kwargs={'pk': cred.pk, 'version': version}),
+        reverse('api:credential_detail', kwargs={'pk': cred.pk}),
         params,
         admin
     )
@@ -1534,17 +1381,10 @@ def test_custom_credential_type_create(get, post, organization, admin):
             'api_token': 'secret'
         }
     }
-    response = post(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 201
 
-    response = get(
-        reverse('api:credential_list', kwargs={'version': 'v2'}),
-        admin
-    )
+    response = get(reverse('api:credential_list'), admin)
     assert response.status_code == 200
     assert response.data['count'] == 1
     cred = response.data['results'][0]
@@ -1560,17 +1400,11 @@ def test_custom_credential_type_create(get, post, organization, admin):
 #
 
 
-@pytest.mark.parametrize('version, params', [
-    ['v2', {'name': 'Some name', 'credential_type': 1, 'inputs': {'username': 'someusername'}}]
-])
 @pytest.mark.django_db
-def test_create_credential_missing_user_team_org_xfail(post, admin, credentialtype_ssh, version, params):
+def test_create_credential_missing_user_team_org_xfail(post, admin, credentialtype_ssh):
+    params = {'name': 'Some name', 'credential_type': 1, 'inputs': {'username': 'someusername'}}
     # Must specify one of user, team, or organization
-    response = post(
-        reverse('api:credential_list', kwargs={'version': version}),
-        params,
-        admin
-    )
+    response = post(reverse('api:credential_list'), params, admin)
     assert response.status_code == 400
 
 
@@ -1603,7 +1437,7 @@ def test_create_credential_with_invalid_url_xfail(post, organization, admin, url
         'credential_type': credential_type.pk,
         'inputs': {'server_url': url}
     }
-    endpoint = reverse('api:credential_list', kwargs={'version': 'v2'})
+    endpoint = reverse('api:credential_list')
     response = post(endpoint, params, admin)
     assert response.status_code == status
     if status != 201:

--- a/awx/main/tests/functional/api/test_credential_input_sources.py
+++ b/awx/main/tests/functional/api/test_credential_input_sources.py
@@ -6,10 +6,7 @@ from awx.api.versioning import reverse
 
 @pytest.mark.django_db
 def test_associate_credential_input_source(get, post, delete, admin, vault_credential, external_credential):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
 
     # attach
     params = {
@@ -35,7 +32,7 @@ def test_associate_credential_input_source(get, post, delete, admin, vault_crede
     response = delete(
         reverse(
             'api:credential_input_source_detail',
-            kwargs={'version': 'v2', 'pk': detail.data['id']}
+            kwargs={'pk': detail.data['id']}
         ),
         admin
     )
@@ -55,10 +52,7 @@ def test_associate_credential_input_source(get, post, delete, admin, vault_crede
     {'extraneous': 'foo'},  # invalid parameter
 ])
 def test_associate_credential_input_source_with_invalid_metadata(get, post, admin, vault_credential, external_credential, metadata):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'},
-    )
+    list_url = reverse('api:credential_input_source_list')
 
     params = {
         'target_credential': vault_credential.pk,
@@ -81,7 +75,6 @@ def test_create_from_list(get, post, admin, vault_credential, external_credentia
     }
     assert post(reverse(
         'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
     ), params, admin).status_code == 201
     assert CredentialInputSource.objects.count() == 1
 
@@ -90,7 +83,6 @@ def test_create_from_list(get, post, admin, vault_credential, external_credentia
 def test_create_credential_input_source_with_external_target_returns_400(post, admin, external_credential, other_external_credential):
     list_url = reverse(
         'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
     )
     params = {
         'target_credential': other_external_credential.pk,
@@ -107,7 +99,6 @@ def test_create_credential_input_source_with_external_target_returns_400(post, a
 def test_input_source_rbac_associate(get, post, delete, alice, vault_credential, external_credential):
     list_url = reverse(
         'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
     )
     params = {
         'target_credential': vault_credential.pk,
@@ -142,7 +133,7 @@ def test_input_source_rbac_associate(get, post, delete, alice, vault_credential,
     # alice can't admin the target (so she can't remove the input source)
     delete_url = reverse(
         'api:credential_input_source_detail',
-        kwargs={'version': 'v2', 'pk': detail.data['id']}
+        kwargs={'pk': detail.data['id']}
     )
     response = delete(delete_url, alice)
     assert response.status_code == 403
@@ -159,7 +150,7 @@ def test_input_source_detail_rbac(get, post, patch, delete, admin, alice,
                                   other_external_credential):
     sublist_url = reverse(
         'api:credential_input_source_sublist',
-        kwargs={'version': 'v2', 'pk': vault_credential.pk}
+        kwargs={'pk': vault_credential.pk}
     )
     params = {
         'source_credential': external_credential.pk,
@@ -213,10 +204,7 @@ def test_input_source_detail_rbac(get, post, patch, delete, admin, alice,
 def test_input_source_create_rbac(get, post, patch, delete, alice,
                                   vault_credential, external_credential,
                                   other_external_credential):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     params = {
         'target_credential': vault_credential.pk,
         'source_credential': external_credential.pk,
@@ -248,10 +236,7 @@ def test_input_source_rbac_swap_target_credential(get, post, put, patch, admin, 
     # you have to have admin role on the *original* credential (so you can
     # remove the relationship) *and* on the *new* credential (so you can apply the
     # new relationship)
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     params = {
         'target_credential': vault_credential.pk,
         'source_credential': external_credential.pk,
@@ -292,10 +277,7 @@ def test_input_source_rbac_change_metadata(get, post, put, patch, admin, alice,
                                            machine_credential, external_credential):
     # To change an input source, a user must have admin permissions on the
     # target credential and use permissions on the source credential.
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     params = {
         'target_credential': machine_credential.pk,
         'source_credential': external_credential.pk,
@@ -328,10 +310,7 @@ def test_input_source_rbac_change_metadata(get, post, put, patch, admin, alice,
 
 @pytest.mark.django_db
 def test_create_credential_input_source_with_non_external_source_returns_400(post, admin, credential, vault_credential):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     params = {
         'target_credential': vault_credential.pk,
         'source_credential': credential.pk,
@@ -344,10 +323,7 @@ def test_create_credential_input_source_with_non_external_source_returns_400(pos
 
 @pytest.mark.django_db
 def test_create_credential_input_source_with_undefined_input_returns_400(post, admin, vault_credential, external_credential):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     params = {
         'target_credential': vault_credential.pk,
         'source_credential': external_credential.pk,
@@ -361,10 +337,7 @@ def test_create_credential_input_source_with_undefined_input_returns_400(post, a
 
 @pytest.mark.django_db
 def test_create_credential_input_source_with_already_used_input_returns_400(post, admin, vault_credential, external_credential, other_external_credential):
-    list_url = reverse(
-        'api:credential_input_source_list',
-        kwargs={'version': 'v2'}
-    )
+    list_url = reverse('api:credential_input_source_list')
     all_params = [{
         'target_credential': vault_credential.pk,
         'source_credential': external_credential.pk,

--- a/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
+++ b/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
@@ -32,7 +32,7 @@ def test_extra_credentials_filtering(get, job_template, admin,
     job_template.credentials.add(credential)
     url = reverse(
         'api:job_template_extra_credentials_list',
-        kwargs={'version': 'v2', 'pk': job_template.pk}
+        kwargs={'pk': job_template.pk}
     )
     resp = get(url, admin, expect=200)
     assert resp.data['count'] == 1
@@ -45,7 +45,7 @@ def test_extra_credentials_requires_cloud_or_net(get, post, job_template, admin,
                                                  net_credential):
     url = reverse(
         'api:job_template_extra_credentials_list',
-        kwargs={'version': 'v2', 'pk': job_template.pk}
+        kwargs={'pk': job_template.pk}
     )
 
     for cred in (machine_credential, vault_credential):
@@ -63,7 +63,7 @@ def test_extra_credentials_requires_cloud_or_net(get, post, job_template, admin,
 def test_prevent_multiple_machine_creds(get, post, job_template, admin, machine_credential):
     url = reverse(
         'api:job_template_credentials_list',
-        kwargs={'version': 'v2', 'pk': job_template.pk}
+        kwargs={'pk': job_template.pk}
     )
 
     def _new_cred(name):
@@ -120,7 +120,7 @@ def test_extra_credentials_unique_by_kind(get, post, job_template, admin,
                                           credentialtype_aws):
     url = reverse(
         'api:job_template_extra_credentials_list',
-        kwargs={'version': 'v2', 'pk': job_template.pk}
+        kwargs={'pk': job_template.pk}
     )
 
     def _new_cred(name):

--- a/awx/main/tests/functional/api/test_generic.py
+++ b/awx/main/tests/functional/api/test_generic.py
@@ -70,7 +70,7 @@ class TestDeleteViews:
         delete(
             reverse(
                 'api:inventory_source_hosts_list',
-                kwargs={'version': 'v2', 'pk': inventory_source.pk}
+                kwargs={'pk': inventory_source.pk}
             ), user=rando, expect=403
         )
 
@@ -80,7 +80,7 @@ class TestDeleteViews:
         delete(
             reverse(
                 'api:inventory_source_hosts_list',
-                kwargs={'version': 'v2', 'pk': inventory_source.pk}
+                kwargs={'pk': inventory_source.pk}
             ), user=rando, expect=204
         )
         assert inventory_source.hosts.count() == 0

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -600,7 +600,7 @@ class TestControlledBySCM:
         assert scm_inventory.inventory_sources.count() == 0
 
     def test_adding_inv_src_ok(self, post, scm_inventory, admin_user):
-        post(reverse('api:inventory_inventory_sources_list', kwargs={'version': 'v2', 'pk': scm_inventory.id}),
+        post(reverse('api:inventory_inventory_sources_list', kwargs={'pk': scm_inventory.id}),
              {'name': 'new inv src', 'update_on_project_update': False, 'source': 'scm', 'overwrite_vars': True},
              admin_user, expect=201)
 
@@ -611,7 +611,7 @@ class TestControlledBySCM:
 
     def test_two_update_on_project_update_inv_src_prohibited(self, patch, scm_inventory, factory_scm_inventory, project, admin_user):
         scm_inventory2 = factory_scm_inventory(name="scm_inventory2")
-        res = patch(reverse('api:inventory_source_detail', kwargs={'version': 'v2', 'pk': scm_inventory2.id}),
+        res = patch(reverse('api:inventory_source_detail', kwargs={'pk': scm_inventory2.id}),
                     {'update_on_project_update': True,},
                     admin_user, expect=400)
         content = json.loads(res.content)

--- a/awx/main/tests/functional/api/test_job.py
+++ b/awx/main/tests/functional/api/test_job.py
@@ -31,7 +31,7 @@ def test_extra_credentials(get, organization_factory, job_template_factory, cred
     jt.save()
     job = jt.create_unified_job()
 
-    url = reverse('api:job_extra_credentials_list', kwargs={'version': 'v2', 'pk': job.pk})
+    url = reverse('api:job_extra_credentials_list', kwargs={'pk': job.pk})
     response = get(url, user=objs.superusers.admin)
     assert response.data.get('count') == 1
 
@@ -225,19 +225,19 @@ def test_disallowed_http_update_methods(put, patch, post, inventory, project, ad
     )
     job = jt.create_unified_job()
     post(
-        url=reverse('api:job_detail', kwargs={'pk': job.pk, 'version': 'v2'}),
+        url=reverse('api:job_detail', kwargs={'pk': job.pk}),
         data={},
         user=admin_user,
         expect=405
     )
     put(
-        url=reverse('api:job_detail', kwargs={'pk': job.pk, 'version': 'v2'}),
+        url=reverse('api:job_detail', kwargs={'pk': job.pk}),
         data={},
         user=admin_user,
         expect=405
     )
     patch(
-        url=reverse('api:job_detail', kwargs={'pk': job.pk, 'version': 'v2'}),
+        url=reverse('api:job_detail', kwargs={'pk': job.pk}),
         data={},
         user=admin_user,
         expect=405

--- a/awx/main/tests/functional/api/test_job_template.py
+++ b/awx/main/tests/functional/api/test_job_template.py
@@ -46,7 +46,7 @@ def test_extra_credential_creation(get, post, organization_factory, job_template
     jt = job_template_factory("jt", organization=objs.organization,
                               inventory='test_inv', project='test_proj').job_template
 
-    url = reverse('api:job_template_extra_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_extra_credentials_list', kwargs={'pk': jt.pk})
     response = post(url, {
         'name': 'My Cred',
         'credential_type': credentialtype_aws.pk,
@@ -68,7 +68,7 @@ def test_invalid_credential_kind_xfail(get, post, organization_factory, job_temp
     jt = job_template_factory("jt", organization=objs.organization,
                               inventory='test_inv', project='test_proj').job_template
 
-    url = reverse('api:job_template_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_credentials_list', kwargs={'pk': jt.pk})
     cred_type = CredentialType.defaults[kind]()
     cred_type.save()
     response = post(url, {
@@ -88,7 +88,7 @@ def test_extra_credential_unique_type_xfail(get, post, organization_factory, job
     jt = job_template_factory("jt", organization=objs.organization,
                               inventory='test_inv', project='test_proj').job_template
 
-    url = reverse('api:job_template_extra_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_extra_credentials_list', kwargs={'pk': jt.pk})
     response = post(url, {
         'name': 'My Cred',
         'credential_type': credentialtype_aws.pk,
@@ -124,7 +124,7 @@ def test_attach_extra_credential(get, post, organization_factory, job_template_f
     jt = job_template_factory("jt", organization=objs.organization,
                               inventory='test_inv', project='test_proj').job_template
 
-    url = reverse('api:job_template_extra_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_extra_credentials_list', kwargs={'pk': jt.pk})
     response = post(url, {
         'associate': True,
         'id': credential.id,
@@ -143,7 +143,7 @@ def test_detach_extra_credential(get, post, organization_factory, job_template_f
     jt.credentials.add(credential)
     jt.save()
 
-    url = reverse('api:job_template_extra_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_extra_credentials_list', kwargs={'pk': jt.pk})
     response = post(url, {
         'disassociate': True,
         'id': credential.id,
@@ -161,7 +161,7 @@ def test_attach_extra_credential_wrong_kind_xfail(get, post, organization_factor
     jt = job_template_factory("jt", organization=objs.organization,
                               inventory='test_inv', project='test_proj').job_template
 
-    url = reverse('api:job_template_extra_credentials_list', kwargs={'version': 'v2', 'pk': jt.pk})
+    url = reverse('api:job_template_extra_credentials_list', kwargs={'pk': jt.pk})
     response = post(url, {
         'associate': True,
         'id': machine_credential.id,

--- a/awx/main/tests/functional/api/test_pagination.py
+++ b/awx/main/tests/functional/api/test_pagination.py
@@ -51,7 +51,7 @@ def test_pagination_cap_page_size(get, admin, inventory):
 
     def host_list_url(params):
         request_qs = '?' + urlencode(params)
-        return reverse('api:host_list', kwargs={'version': 'v2'}) + request_qs
+        return reverse('api:host_list') + request_qs
 
     with patch('awx.api.pagination.Pagination.max_page_size', 5):
         resp = get(host_list_url({'page': '2', 'page_size': '10'}), user=admin)

--- a/awx/main/tests/functional/api/test_script_endpoint.py
+++ b/awx/main/tests/functional/api/test_script_endpoint.py
@@ -11,7 +11,7 @@ def test_empty_inventory(post, get, admin_user, organization, group_factory):
                           kind='',
                           organization=organization)
     inventory.save()
-    resp = get(reverse('api:inventory_script_view', kwargs={'version': 'v2', 'pk': inventory.pk}), admin_user)
+    resp = get(reverse('api:inventory_script_view', kwargs={'pk': inventory.pk}), admin_user)
     jdata = json.loads(resp.content)
     jdata.pop('all')
 
@@ -27,7 +27,7 @@ def test_ungrouped_hosts(post, get, admin_user, organization, group_factory):
     inventory.save()
     Host.objects.create(name='first_host', inventory=inventory)
     Host.objects.create(name='second_host', inventory=inventory)
-    resp = get(reverse('api:inventory_script_view', kwargs={'version': 'v2', 'pk': inventory.pk}), admin_user)
+    resp = get(reverse('api:inventory_script_view', kwargs={'pk': inventory.pk}), admin_user)
     jdata = json.loads(resp.content)
     assert inventory.hosts.count() == 2
     assert len(jdata['all']['hosts']) == 2

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -55,7 +55,7 @@ def test_node_rejects_unprompted_fields(inventory, project, workflow_job_templat
         ask_limit_on_launch = False
     )
     url = reverse('api:workflow_job_template_workflow_nodes_list',
-                  kwargs={'pk': workflow_job_template.pk, 'version': 'v2'})
+                  kwargs={'pk': workflow_job_template.pk})
     r = post(url, {'unified_job_template': job_template.pk, 'limit': 'webservers'},
              user=admin_user, expect=400)
     assert 'limit' in r.data
@@ -71,7 +71,7 @@ def test_node_accepts_prompted_fields(inventory, project, workflow_job_template,
         ask_limit_on_launch = True
     )
     url = reverse('api:workflow_job_template_workflow_nodes_list',
-                  kwargs={'pk': workflow_job_template.pk, 'version': 'v2'})
+                  kwargs={'pk': workflow_job_template.pk})
     post(url, {'unified_job_template': job_template.pk, 'limit': 'webservers'},
          user=admin_user, expect=201)
 

--- a/awx/main/tests/functional/test_rbac_job_templates.py
+++ b/awx/main/tests/functional/test_rbac_job_templates.py
@@ -106,7 +106,7 @@ def test_job_template_extra_credentials_prompts_access(
     jt.credentials.add(machine_credential)
     jt.execute_role.members.add(rando)
     r = post(
-        reverse('api:job_template_launch', kwargs={'version': 'v2', 'pk': jt.id}),
+        reverse('api:job_template_launch', kwargs={'pk': jt.id}),
         {'credentials': [machine_credential.pk, vault_credential.pk]}, rando
     )
     assert r.status_code == 403


### PR DESCRIPTION
`/api/v1/` is dead, long live `/api/v1/`.

![QONVIyz](https://user-images.githubusercontent.com/214912/63543040-d61d8f00-c4ef-11e9-89c2-de3ac0776ea4.gif)
