### PR TITLE
suppress urllib3 insecure warnings in the CLI

### DIFF
--- a/awxkit/awxkit/cli/__init__.py
+++ b/awxkit/awxkit/cli/__init__.py
@@ -2,6 +2,7 @@ import json
 import sys
 import traceback
 import yaml
+import urllib3
 
 from requests.exceptions import ConnectionError, SSLError
 
@@ -9,6 +10,11 @@ from .client import CLI
 from awxkit.utils import to_str
 from awxkit.exceptions import Unauthorized, Common
 from awxkit.cli.utils import cprint
+
+
+# you'll only see these warnings if you've explicitly *disabled* SSL
+# verification, so they're a little annoying, redundant
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def run(stdout=sys.stdout, stderr=sys.stderr, argv=[]):


### PR DESCRIPTION
this message only shows up if you've specified `-k` or `TOWER_SSL_VERIFY=f`, so it seems unnecessary