### PR TITLE
Removing job_status from the docs because it doesn't exist.

### DIFF
--- a/docs/logging_integration.md
+++ b/docs/logging_integration.md
@@ -15,9 +15,6 @@ deliver a large amount of information in a predictable structured format,
 following the same structure as one would expect if obtaining the data
 from the API. These data loggers are the following.
 
- - awx.analytics.job_status
-     - Summaries of status changes for jobs, project updates, inventory
-       updates, and others
  - awx.analytics.job_events
      - Data returned from the Ansible callback module
  - awx.analytics.activity_stream


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Per #3226 this removes the notion of job_status in the docs since it doesn't exist.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```

##### ADDITIONAL INFORMATION
The only useful information present is in the issue or evident from viewing the diff.
