### PR TITLE
Add playbook select and project field validation

### DIFF
--- a/awx/ui_next/src/api/models/Projects.js
+++ b/awx/ui_next/src/api/models/Projects.js
@@ -4,6 +4,12 @@ class Projects extends Base {
   constructor(http) {
     super(http);
     this.baseUrl = '/api/v2/projects/';
+
+    this.readPlaybooks = this.readPlaybooks.bind(this);
+  }
+
+  readPlaybooks(id) {
+    return this.http.get(`${this.baseUrl}${id}/playbooks/`);
   }
 }
 

--- a/awx/ui_next/src/components/AnsibleSelect/AnsibleSelect.jsx
+++ b/awx/ui_next/src/components/AnsibleSelect/AnsibleSelect.jsx
@@ -17,13 +17,16 @@ class AnsibleSelect extends React.Component {
   }
 
   render() {
-    const { value, data, i18n } = this.props;
+    const { id, data, i18n, isValid, onBlur, value } = this.props;
 
     return (
       <FormSelect
+        id={id}
         value={value}
         onChange={this.onSelectChange}
+        onBlur={onBlur}
         aria-label={i18n._(t`Select Input`)}
+        isValid={isValid}
       >
         {data.map(datum => (
           <FormSelectOption
@@ -40,10 +43,15 @@ class AnsibleSelect extends React.Component {
 
 AnsibleSelect.defaultProps = {
   data: [],
+  isValid: true,
+  onBlur: () => {},
 };
 
 AnsibleSelect.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
+  id: PropTypes.string.isRequired,
+  isValid: PropTypes.bool,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
 };

--- a/awx/ui_next/src/components/AnsibleSelect/AnsibleSelect.test.jsx
+++ b/awx/ui_next/src/components/AnsibleSelect/AnsibleSelect.test.jsx
@@ -19,6 +19,7 @@ describe('<AnsibleSelect />', () => {
   test('initially renders succesfully', async () => {
     mountWithContexts(
       <AnsibleSelect
+        id="bar"
         value="foo"
         name="bar"
         onChange={() => {}}
@@ -31,6 +32,7 @@ describe('<AnsibleSelect />', () => {
     const spy = jest.spyOn(_AnsibleSelect.prototype, 'onSelectChange');
     const wrapper = mountWithContexts(
       <AnsibleSelect
+        id="bar"
         value="foo"
         name="bar"
         onChange={() => {}}
@@ -45,6 +47,7 @@ describe('<AnsibleSelect />', () => {
   test('Returns correct select options', () => {
     const wrapper = mountWithContexts(
       <AnsibleSelect
+        id="bar"
         value="foo"
         name="bar"
         onChange={() => {}}

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -186,6 +186,7 @@ class Lookup extends React.Component {
       columns,
       multiple,
       name,
+      onBlur,
       required,
       i18n,
     } = this.props;
@@ -209,7 +210,7 @@ class Lookup extends React.Component {
 
     return (
       <Fragment>
-        <InputGroup>
+        <InputGroup onBlur={onBlur}>
           <Button
             aria-label="Search"
             id={id}

--- a/awx/ui_next/src/screens/Organization/shared/OrganizationForm.jsx
+++ b/awx/ui_next/src/screens/Organization/shared/OrganizationForm.jsx
@@ -164,6 +164,7 @@ class OrganizationForm extends Component {
                           label={i18n._(t`Ansible Environment`)}
                         >
                           <AnsibleSelect
+                            id="org-custom-virtualenv"
                             data={[
                               defaultVenv,
                               ...custom_virtualenvs

--- a/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
@@ -106,13 +106,14 @@ class JobTemplateEdit extends Component {
       template: { id },
       history,
     } = this.props;
+    const { newLabels, removedLabels } = values;
+    delete values.newLabels;
+    delete values.removedLabels;
 
     this.setState({ formSubmitError: null });
     try {
-      await JobTemplatesAPI.update(id, { ...values });
-      await Promise.all([
-        this.submitLabels(values.newLabels, values.removedLabels),
-      ]);
+      await JobTemplatesAPI.update(id, values);
+      await Promise.all([this.submitLabels(newLabels, removedLabels)]);
       history.push(this.detailsUrl);
     } catch (formSubmitError) {
       this.setState({ formSubmitError });

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -427,7 +427,7 @@ const FormikApp = withFormik({
     const {
       name = '',
       description = '',
-      job_type = '',
+      job_type = 'run',
       inventory = '',
       playbook = '',
       project = '',

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mountWithContexts, waitForElement } from '@testUtils/enzymeHelpers';
 import { sleep } from '@testUtils/testUtils';
-import { shallow } from 'enzyme';
 import JobTemplateForm, { _JobTemplateForm } from './JobTemplateForm';
 import { LabelsAPI } from '@api';
 
@@ -42,13 +41,11 @@ describe('<JobTemplateForm />', () => {
 
   test('initially renders successfully', async done => {
     const wrapper = mountWithContexts(
-      shallow(
-        <JobTemplateForm
-          template={mockData}
-          handleSubmit={jest.fn()}
-          handleCancel={jest.fn()}
-        />
-      ).get(0)
+      <JobTemplateForm
+        template={mockData}
+        handleSubmit={jest.fn()}
+        handleCancel={jest.fn()}
+      />
     );
 
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
@@ -64,14 +61,13 @@ describe('<JobTemplateForm />', () => {
 
   test('should update form values on input changes', async done => {
     const wrapper = mountWithContexts(
-      shallow(
-        <JobTemplateForm
-          template={mockData}
-          handleSubmit={jest.fn()}
-          handleCancel={jest.fn()}
-        />
-      ).get(0)
+      <JobTemplateForm
+        template={mockData}
+        handleSubmit={jest.fn()}
+        handleCancel={jest.fn()}
+      />
     );
+
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
     const form = wrapper.find('Formik');
     wrapper.find('input#template-name').simulate('change', {
@@ -133,6 +129,27 @@ describe('<JobTemplateForm />', () => {
     expect(handleCancel).not.toHaveBeenCalled();
     wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
     expect(handleCancel).toBeCalled();
+    done();
+  });
+
+  test('should call loadRelatedProjectPlaybooks when project value changes', async done => {
+    const loadRelatedProjectPlaybooks = jest.spyOn(
+      _JobTemplateForm.prototype,
+      'loadRelatedProjectPlaybooks'
+    );
+    const wrapper = mountWithContexts(
+      <JobTemplateForm
+        template={mockData}
+        handleSubmit={jest.fn()}
+        handleCancel={jest.fn()}
+      />
+    );
+    await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
+    wrapper.find('ProjectLookup').prop('onChange')({
+      id: 10,
+      name: 'project',
+    });
+    expect(loadRelatedProjectPlaybooks).toHaveBeenCalledWith(10);
     done();
   });
 

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mountWithContexts, waitForElement } from '@testUtils/enzymeHelpers';
 import { sleep } from '@testUtils/testUtils';
+import { shallow } from 'enzyme';
 import JobTemplateForm, { _JobTemplateForm } from './JobTemplateForm';
 import { LabelsAPI } from '@api';
 
@@ -41,12 +42,15 @@ describe('<JobTemplateForm />', () => {
 
   test('initially renders successfully', async done => {
     const wrapper = mountWithContexts(
-      <JobTemplateForm
-        template={mockData}
-        handleSubmit={jest.fn()}
-        handleCancel={jest.fn()}
-      />
+      shallow(
+        <JobTemplateForm
+          template={mockData}
+          handleSubmit={jest.fn()}
+          handleCancel={jest.fn()}
+        />
+      ).get(0)
     );
+
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
     expect(LabelsAPI.read).toHaveBeenCalled();
     expect(
@@ -60,11 +64,13 @@ describe('<JobTemplateForm />', () => {
 
   test('should update form values on input changes', async done => {
     const wrapper = mountWithContexts(
-      <JobTemplateForm
-        template={mockData}
-        handleSubmit={jest.fn()}
-        handleCancel={jest.fn()}
-      />
+      shallow(
+        <JobTemplateForm
+          template={mockData}
+          handleSubmit={jest.fn()}
+          handleCancel={jest.fn()}
+        />
+      ).get(0)
     );
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
     const form = wrapper.find('Formik');
@@ -90,7 +96,7 @@ describe('<JobTemplateForm />', () => {
       name: 'project',
     });
     expect(form.state('values').project).toEqual(4);
-    wrapper.find('input#template-playbook').simulate('change', {
+    wrapper.find('AnsibleSelect[name="playbook"]').simulate('change', {
       target: { value: 'new baz type', name: 'playbook' },
     });
     expect(form.state('values').playbook).toEqual('new baz type');

--- a/awx/ui_next/src/screens/Template/shared/ProjectLookup.jsx
+++ b/awx/ui_next/src/screens/Template/shared/ProjectLookup.jsx
@@ -17,12 +17,23 @@ const loadProjects = async params => ProjectsAPI.read(params);
 
 class ProjectLookup extends React.Component {
   render() {
-    const { value, tooltip, onChange, required, i18n } = this.props;
+    const {
+      helperTextInvalid,
+      i18n,
+      isValid,
+      onChange,
+      required,
+      tooltip,
+      value,
+      onBlur,
+    } = this.props;
 
     return (
       <FormGroup
-        fieldId="project-lookup"
+        fieldId="project"
+        helperTextInvalid={helperTextInvalid}
         isRequired={required}
+        isValid={isValid}
         label={i18n._(t`Project`)}
       >
         {tooltip && (
@@ -31,10 +42,11 @@ class ProjectLookup extends React.Component {
           </Tooltip>
         )}
         <Lookup
-          id="project-lookup"
+          id="project"
           lookupHeader={i18n._(t`Projects`)}
           name="project"
           value={value}
+          onBlur={onBlur}
           onLookupSave={onChange}
           getItems={loadProjects}
           required={required}
@@ -47,15 +59,21 @@ class ProjectLookup extends React.Component {
 
 ProjectLookup.propTypes = {
   value: Project,
-  tooltip: string,
+  helperTextInvalid: string,
+  isValid: bool,
+  onBlur: func,
   onChange: func.isRequired,
   required: bool,
+  tooltip: string,
 };
 
 ProjectLookup.defaultProps = {
-  value: null,
-  tooltip: '',
+  helperTextInvalid: '',
+  isValid: true,
   required: false,
+  tooltip: '',
+  value: null,
+  onBlur: () => {},
 };
 
 export default withI18n()(ProjectLookup);


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/4233

* Add playbook select to job template form
* Refactored job template form to use `withFormik`
* Add validation and field level error messages to job template selects and project lookup

_Project never updated error_
![jt never updated](https://user-images.githubusercontent.com/15881645/63613259-59051f00-c5ae-11e9-8db6-4f3d1e894123.gif)

_Add job template field validation_
![jt add](https://user-images.githubusercontent.com/15881645/63613377-9ec1e780-c5ae-11e9-9e69-656f60373ffa.gif)

_Empty playbook field error_
![empty playbook select](https://user-images.githubusercontent.com/15881645/63613219-3e32aa80-c5ae-11e9-8d3e-06c35b7f0648.gif)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```
