### PR TITLE
Azure config currently errors if instance does not have a public IP

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -2049,14 +2049,17 @@ class azure_rm(PluginFileInjector):
             'computer_name': 'name',
             'type': 'resource_type',
             'private_ip': 'private_ipv4_addresses[0] if private_ipv4_addresses else None',
-            'public_ip': 'public_ipv4_addresses[0] if public_ipv4_addresses else None',
-            'public_ip_name': 'public_ip_name if public_ip_name is defined else None',
-            'public_ip_id': 'public_ip_id if public_ip_id is defined else None',
             'tags': 'tags if tags else None'
         }
         # Special functionality from script
         if source_vars.get('use_private_ip', False):
             ret['hostvar_expressions']['ansible_host'] = 'private_ipv4_addresses[0]'
+        else:
+            ret['hostvar_expressions'] = {
+                'public_ip': 'public_ipv4_addresses[0] if public_ipv4_addresses else None',
+                'public_ip_name': 'public_ip_name if public_ip_name is defined else None',
+                'public_ip_id': 'public_ip_id if public_ip_id is defined else None'
+            }
         # end compatibility content
 
         if inventory_update.source_regions and 'all' not in inventory_update.source_regions:


### PR DESCRIPTION
Signed-off-by: willtome <willtome@gmail.com>

##### SUMMARY
The Azure dynamic inventory plugin uses an `azure_rm.yml` config written by awx to provide backwards compatibility with script behavior. Currently, if an instance does not have a public IP, the inventory load fails with
```
File "/usr/lib/python2.7/site-packages/ansible/inventory/manager.py", line 268, in parse_source
51
plugin.parse(self._inventory, self._loader, source, cache=cache)
52
File "/usr/lib/python2.7/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
53
plugin.parse(inventory, loader, path, cache=cache)
54
File "/usr/lib/python2.7/site-packages/ansible/plugins/inventory/azure_rm.py", line 265, in parse
55
self._get_hosts()
56
File "/usr/lib/python2.7/site-packages/ansible/plugins/inventory/azure_rm.py", line 344, in _get_hosts
57
self._set_composite_vars(constructable_config_compose, h.hostvars, inventory_hostname, strict=constructable_config_strict)
58
File "/usr/lib/python2.7/site-packages/ansible/plugins/inventory/__init__.py", line 363, in _set_composite_vars
59
raise AnsibleError("Could not set %s for host %s: %s" % (varname, host, to_native(e)))
```

##### AWX VERSION
This issue was observed on Ansible Tower 3.5 with Ansible 2.8


