### PR TITLE
Allow use of user-specified private galaxy server with fallback

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -816,7 +816,7 @@ def galaxy_validate(serializer, attrs):
                 # new auth is applied, so check if compatible with version
                 from awx.main.utils import get_ansible_version
                 current_version = get_ansible_version()
-                min_version = '2.9'
+                min_version = '2.10'
                 if Version(current_version) < Version(min_version):
                     errors.setdefault(setting_name, [])
                     errors[setting_name].append(_(

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -411,6 +411,15 @@ register(
 )
 
 register(
+    'PROJECT_UPDATE_VVV',
+    field_class=fields.BooleanField,
+    label=_('Run Project Updates With Higher Verbosity'),
+    help_text=_('Adds the CLI -vvv flag to ansible-playbook runs of project_update.yml used for project updates.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
     'AWX_ROLES_ENABLED',
     field_class=fields.BooleanField,
     default=True,
@@ -428,6 +437,52 @@ register(
     help_text=_('Allows collections to be dynamically downloaded from a requirements.yml file for SCM projects.'),
     category=_('Jobs'),
     category_slug='jobs',
+)
+
+register(
+    'PRIVATE_GALAXY_URL',
+    field_class=fields.URLField,
+    label=_('Private Galaxy Server Host'),
+    help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
+                'The URL of the galaxy instance to connect to, this is required if using a private galaxy server.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
+    'PRIVATE_GALAXY_USERNAME',
+    field_class=fields.CharField,
+    label=_('Private Galaxy Server Username'),
+    help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
+                'The username to use for basic authentication against the Galaxy instance, '
+                'this is mutually exclusive with PRIVATE_GALAXY_TOKEN.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+    depends_on=['PRIVATE_GALAXY_URL']
+)
+
+register(
+    'PRIVATE_GALAXY_PASSWORD',
+    field_class=fields.CharField,
+    label=_('Private Galaxy Server Password'),
+    help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
+                'The password to use for basic authentication against the Galaxy instance, '
+                'this is mutually exclusive with PRIVATE_GALAXY_TOKEN.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+    depends_on=['PRIVATE_GALAXY_URL']
+)
+
+register(
+    'PRIVATE_GALAXY_TOKEN',
+    field_class=fields.CharField,
+    label=_('Private Galaxy Server Token'),
+    help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
+                'The username to use for basic authentication against the Galaxy instance, '
+                'this is mutually exclusive with corresponding username and password settings.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+    depends_on=['PRIVATE_GALAXY_URL']
 )
 
 register(

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -816,7 +816,7 @@ def galaxy_validate(serializer, attrs):
                 # new auth is applied, so check if compatible with version
                 from awx.main.utils import get_ansible_version
                 current_version = get_ansible_version()
-                min_version = '2.10'
+                min_version = '2.9'
                 if Version(current_version) < Version(min_version):
                     errors.setdefault(setting_name, [])
                     errors[setting_name].append(_(

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -442,47 +442,54 @@ register(
 register(
     'PRIVATE_GALAXY_URL',
     field_class=fields.URLField,
-    label=_('Private Galaxy Server Host'),
+    required=False,
+    allow_blank=True,
+    label=_('Private Galaxy Server URL'),
     help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
                 'The URL of the galaxy instance to connect to, this is required if using a private galaxy server.'),
     category=_('Jobs'),
-    category_slug='jobs',
+    category_slug='jobs'
 )
 
 register(
     'PRIVATE_GALAXY_USERNAME',
     field_class=fields.CharField,
+    required=False,
+    allow_blank=True,
     label=_('Private Galaxy Server Username'),
     help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
                 'The username to use for basic authentication against the Galaxy instance, '
                 'this is mutually exclusive with PRIVATE_GALAXY_TOKEN.'),
     category=_('Jobs'),
-    category_slug='jobs',
-    depends_on=['PRIVATE_GALAXY_URL']
+    category_slug='jobs'
 )
 
 register(
     'PRIVATE_GALAXY_PASSWORD',
     field_class=fields.CharField,
+    encrypted=True,
+    required=False,
+    allow_blank=True,
     label=_('Private Galaxy Server Password'),
     help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
                 'The password to use for basic authentication against the Galaxy instance, '
                 'this is mutually exclusive with PRIVATE_GALAXY_TOKEN.'),
     category=_('Jobs'),
-    category_slug='jobs',
-    depends_on=['PRIVATE_GALAXY_URL']
+    category_slug='jobs'
 )
 
 register(
     'PRIVATE_GALAXY_TOKEN',
     field_class=fields.CharField,
+    encrypted=True,
+    required=False,
+    allow_blank=True,
     label=_('Private Galaxy Server Token'),
     help_text=_('For using a private galaxy server at higher precedence than the public Ansible Galaxy. '
-                'The username to use for basic authentication against the Galaxy instance, '
+                'The token to use for connecting with the Galaxy instance, '
                 'this is mutually exclusive with corresponding username and password settings.'),
     category=_('Jobs'),
-    category_slug='jobs',
-    depends_on=['PRIVATE_GALAXY_URL']
+    category_slug='jobs'
 )
 
 register(

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -51,3 +51,7 @@ LOGGER_BLACKLIST = (
     # loggers that may be called getting logging settings
     'awx.conf'
 )
+
+# these correspond to both AWX and Ansible settings to keep naming consistent
+# for instance, settings.PRIMARY_GALAXY_AUTH_URL vs env var ANSIBLE_GALAXY_SERVER_FOO_AUTH_URL
+GALAXY_SERVER_FIELDS = ('url', 'username', 'password', 'token', 'auth_url')

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -64,7 +64,7 @@ def build_safe_env(env):
     for k, v in safe_env.items():
         if k == 'AWS_ACCESS_KEY_ID':
             continue
-        elif k.startswith('ANSIBLE_') and not k.startswith('ANSIBLE_NET'):
+        elif k.startswith('ANSIBLE_') and not k.startswith('ANSIBLE_NET') and not k.startswith('ANSIBLE_GALAXY_SERVER'):
             continue
         elif hidden_re.search(k):
             safe_env[k] = HIDDEN_PASSWORD

--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -12,8 +12,8 @@ class UriCleaner(object):
 
     @staticmethod
     def remove_sensitive(cleartext):
-        if settings.PRIVATE_GALAXY_URL:
-            exclude_list = (settings.PUBLIC_GALAXY_URL, settings.PRIVATE_GALAXY_URL)
+        if settings.PRIMARY_GALAXY_URL:
+            exclude_list = (settings.PUBLIC_GALAXY_URL, settings.PRIMARY_GALAXY_URL)
         else:
             exclude_list = (settings.PUBLIC_GALAXY_URL,)
         redactedtext = cleartext

--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -15,7 +15,7 @@ class UriCleaner(object):
         if settings.PRIVATE_GALAXY_URL:
             exclude_list = (settings.PUBLIC_GALAXY_URL, settings.PRIVATE_GALAXY_URL)
         else:
-            exclude_list = (settings.PUBLIC_GALAXY_URL)
+            exclude_list = (settings.PUBLIC_GALAXY_URL,)
         redactedtext = cleartext
         text_index = 0
         while True:
@@ -25,7 +25,7 @@ class UriCleaner(object):
             uri_str = match.group(1)
             # Do not redact items from the exclude list
             if any(uri_str.startswith(exclude_uri) for exclude_uri in exclude_list):
-                text_index = match.start() + len(UriCleaner.REPLACE_STR)
+                text_index = match.start() + len(uri_str)
                 continue
             try:
                 # May raise a ValueError if invalid URI for one reason or another
@@ -62,7 +62,6 @@ class UriCleaner(object):
                 redactedtext = t
                 if text_index >= len(redactedtext):
                     text_index = len(redactedtext) - 1
-                print('URL string old: {} new: {}'.format(uri_str_old, uri_str))
             except ValueError:
                 # Invalid URI, redact the whole URI to be safe
                 redactedtext = redactedtext[:match.start()] + UriCleaner.REPLACE_STR + redactedtext[match.end():]

--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -13,9 +13,9 @@ class UriCleaner(object):
     @staticmethod
     def remove_sensitive(cleartext):
         if settings.PRIMARY_GALAXY_URL:
-            exclude_list = (settings.PUBLIC_GALAXY_URL, settings.PRIMARY_GALAXY_URL)
+            exclude_list = [settings.PRIMARY_GALAXY_URL] + [server['url'] for server in settings.FALLBACK_GALAXY_SERVERS]
         else:
-            exclude_list = (settings.PUBLIC_GALAXY_URL,)
+            exclude_list = [server['url'] for server in settings.FALLBACK_GALAXY_SERVERS]
         redactedtext = cleartext
         text_index = 0
         while True:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1883,6 +1883,19 @@ class RunProjectUpdate(BaseTask):
         env['TMP'] = settings.AWX_PROOT_BASE_PATH
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         env['ANSIBLE_CALLBACK_PLUGINS'] = self.get_path_to('..', 'plugins', 'callback')
+        private_galaxy_url = settings.PRIVATE_GALAXY_URL
+        if private_galaxy_url:
+            # set up the fallback server, which is the normal Ansible Galaxy
+            env['ANSIBLE_GALAXY_SERVER_GALAXY_URL'] = 'https://galaxy.ansible.com'
+            env['ANSIBLE_GALAXY_SERVER_PRIVATE_GALAXY_URL'] = private_galaxy_url
+            for key in ('url', 'username', 'password', 'token'):
+                setting_name = 'PRIVATE_GALAXY_{}'.format(key.upper())
+                value = getattr(settings, setting_name)
+                if value:
+                    env_key = 'ANSIBLE_GALAXY_SERVER_PRIVATE_GALAXY_{}'.format(key.upper())
+                    env[env_key] = value
+            # now set the precedence
+            env['ANSIBLE_GALAXY_SERVER_LIST'] = 'private_galaxy,galaxy'
         return env
 
     def _build_scm_url_extra_vars(self, project_update):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -52,7 +52,7 @@ import ansible_runner
 
 # AWX
 from awx import __version__ as awx_application_version
-from awx.main.constants import CLOUD_PROVIDERS, PRIVILEGE_ESCALATION_METHODS, STANDARD_INVENTORY_UPDATE_ENV
+from awx.main.constants import CLOUD_PROVIDERS, PRIVILEGE_ESCALATION_METHODS, STANDARD_INVENTORY_UPDATE_ENV, GALAXY_SERVER_FIELDS
 from awx.main.access import access_registry
 from awx.main.models import (
     Schedule, TowerScheduleState, Instance, InstanceGroup,
@@ -1883,18 +1883,24 @@ class RunProjectUpdate(BaseTask):
         env['TMP'] = settings.AWX_PROOT_BASE_PATH
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         env['ANSIBLE_CALLBACK_PLUGINS'] = self.get_path_to('..', 'plugins', 'callback')
+        env['ANSIBLE_GALAXY_IGNORE'] = True
+        # Set up the fallback server, which is the normal Ansible Galaxy by default
+        galaxy_servers = list(settings.FALLBACK_GALAXY_SERVERS)
         # If private galaxy URL is non-blank, that means this feature is enabled
         if settings.PRIMARY_GALAXY_URL:
-            # set up the fallback server, which is the normal Ansible Galaxy
-            env['ANSIBLE_GALAXY_SERVER_GALAXY_URL'] = settings.PUBLIC_GALAXY_URL
-            for key in ('url', 'username', 'password', 'token'):
-                setting_name = 'PRIMARY_GALAXY_{}'.format(key.upper())
-                value = getattr(settings, setting_name)
+            galaxy_servers = [{'id': 'primary_galaxy'}] + galaxy_servers
+            for key in GALAXY_SERVER_FIELDS:
+                value = getattr(settings, 'PRIMARY_GALAXY_{}'.format(key.upper()))
                 if value:
-                    env_key = 'ANSIBLE_GALAXY_SERVER_PRIMARY_GALAXY_{}'.format(key.upper())
-                    env[env_key] = value
-            # now set the precedence
-            env['ANSIBLE_GALAXY_SERVER_LIST'] = 'primary_galaxy,galaxy'
+                    galaxy_servers[0][key] = value
+        for server in galaxy_servers:
+            for key in GALAXY_SERVER_FIELDS:
+                if not server.get(key):
+                    continue
+                env_key = ('ANSIBLE_GALAXY_SERVER_{}_{}'.format(server.get('id', 'unnamed'), key)).upper()
+                env[env_key] = server[key]
+        # now set the precedence of galaxy servers
+        env['ANSIBLE_GALAXY_SERVER_LIST'] = ','.join([server.get('id', 'unnamed') for server in galaxy_servers])
         return env
 
     def _build_scm_url_extra_vars(self, project_update):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1884,18 +1884,17 @@ class RunProjectUpdate(BaseTask):
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         env['ANSIBLE_CALLBACK_PLUGINS'] = self.get_path_to('..', 'plugins', 'callback')
         # If private galaxy URL is non-blank, that means this feature is enabled
-        private_galaxy_url = settings.PRIVATE_GALAXY_URL
-        if private_galaxy_url:
+        if settings.PRIMARY_GALAXY_URL:
             # set up the fallback server, which is the normal Ansible Galaxy
-            env['ANSIBLE_GALAXY_SERVER_GALAXY_URL'] = 'https://galaxy.ansible.com'
+            env['ANSIBLE_GALAXY_SERVER_GALAXY_URL'] = settings.PUBLIC_GALAXY_URL
             for key in ('url', 'username', 'password', 'token'):
-                setting_name = 'PRIVATE_GALAXY_{}'.format(key.upper())
+                setting_name = 'PRIMARY_GALAXY_{}'.format(key.upper())
                 value = getattr(settings, setting_name)
                 if value:
-                    env_key = 'ANSIBLE_GALAXY_SERVER_PRIVATE_GALAXY_{}'.format(key.upper())
+                    env_key = 'ANSIBLE_GALAXY_SERVER_PRIMARY_GALAXY_{}'.format(key.upper())
                     env[env_key] = value
             # now set the precedence
-            env['ANSIBLE_GALAXY_SERVER_LIST'] = 'private_galaxy,galaxy'
+            env['ANSIBLE_GALAXY_SERVER_LIST'] = 'primary_galaxy,galaxy'
         return env
 
     def _build_scm_url_extra_vars(self, project_update):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1883,11 +1883,11 @@ class RunProjectUpdate(BaseTask):
         env['TMP'] = settings.AWX_PROOT_BASE_PATH
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         env['ANSIBLE_CALLBACK_PLUGINS'] = self.get_path_to('..', 'plugins', 'callback')
+        # If private galaxy URL is non-blank, that means this feature is enabled
         private_galaxy_url = settings.PRIVATE_GALAXY_URL
         if private_galaxy_url:
             # set up the fallback server, which is the normal Ansible Galaxy
             env['ANSIBLE_GALAXY_SERVER_GALAXY_URL'] = 'https://galaxy.ansible.com'
-            env['ANSIBLE_GALAXY_SERVER_PRIVATE_GALAXY_URL'] = private_galaxy_url
             for key in ('url', 'username', 'password', 'token'):
                 setting_name = 'PRIVATE_GALAXY_{}'.format(key.upper())
                 value = getattr(settings, setting_name)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -130,6 +130,8 @@ def test_send_notifications_list(mock_notifications_filter, mock_job_get, mocker
     ('VMWARE_PASSWORD', 'SECRET'),
     ('API_SECRET', 'SECRET'),
     ('CALLBACK_CONNECTION', 'amqp://tower:password@localhost:5672/tower'),
+    ('ANSIBLE_GALAXY_SERVER_PRIMARY_GALAXY_PASSWORD', 'SECRET'),
+    ('ANSIBLE_GALAXY_SERVER_PRIMARY_GALAXY_TOKEN', 'SECRET'),
 ])
 def test_safe_env_filtering(key, value):
     assert build_safe_env({key: value})[key] == tasks.HIDDEN_PASSWORD

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -623,10 +623,10 @@ AWX_ROLES_ENABLED = True
 AWX_COLLECTIONS_ENABLED = True
 
 # Settings for private galaxy server, should be set in the UI
-PRIVATE_GALAXY_URL = ''
-PRIVATE_GALAXY_USERNAME = ''
-PRIVATE_GALAXY_TOKEN = ''
-PRIVATE_GALAXY_PASSWORD = ''
+PRIMARY_GALAXY_URL = ''
+PRIMARY_GALAXY_USERNAME = ''
+PRIMARY_GALAXY_TOKEN = ''
+PRIMARY_GALAXY_PASSWORD = ''
 # Public Galaxy URL, not configurable outside of file-based settings
 PUBLIC_GALAXY_URL = 'https://galaxy.ansible.com'
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -627,6 +627,8 @@ PRIVATE_GALAXY_URL = None
 PRIVATE_GALAXY_USERNAME = None
 PRIVATE_GALAXY_TOKEN = None
 PRIVATE_GALAXY_PASSWORD = None
+# Public Galaxy URL, not configurable outside of file-based settings
+PUBLIC_GALAXY_URL = 'https://galaxy.ansible.com'
 
 # Enable bubblewrap support for running jobs (playbook runs only).
 # Note: This setting may be overridden by database settings.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -609,6 +609,9 @@ AWX_REBUILD_SMART_MEMBERSHIP = False
 # By default, allow arbitrary Jinja templating in extra_vars defined on a Job Template
 ALLOW_JINJA_IN_EXTRA_VARS = 'template'
 
+# Run project updates with extra verbosity
+PROJECT_UPDATE_VVV = False
+
 # Enable dynamically pulling roles from a requirement.yml file
 # when updating SCM projects
 # Note: This setting may be overridden by database settings.
@@ -618,6 +621,12 @@ AWX_ROLES_ENABLED = True
 # when updating SCM projects
 # Note: This setting may be overridden by database settings.
 AWX_COLLECTIONS_ENABLED = True
+
+# Settings for private galaxy server, should be set in the UI
+PRIVATE_GALAXY_URL = None
+PRIVATE_GALAXY_USERNAME = None
+PRIVATE_GALAXY_TOKEN = None
+PRIVATE_GALAXY_PASSWORD = None
 
 # Enable bubblewrap support for running jobs (playbook runs only).
 # Note: This setting may be overridden by database settings.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -622,13 +622,22 @@ AWX_ROLES_ENABLED = True
 # Note: This setting may be overridden by database settings.
 AWX_COLLECTIONS_ENABLED = True
 
-# Settings for private galaxy server, should be set in the UI
+# Settings for primary galaxy server, should be set in the UI
 PRIMARY_GALAXY_URL = ''
 PRIMARY_GALAXY_USERNAME = ''
 PRIMARY_GALAXY_TOKEN = ''
 PRIMARY_GALAXY_PASSWORD = ''
-# Public Galaxy URL, not configurable outside of file-based settings
-PUBLIC_GALAXY_URL = 'https://galaxy.ansible.com'
+PRIMARY_GALAXY_AUTH_URL = ''
+# Settings for the fallback galaxy server(s), normally this is the
+# actual Ansible Galaxy site.
+# server options: 'id', 'url', 'username', 'password', 'token', 'auth_url'
+# To not use any fallback servers set this to []
+FALLBACK_GALAXY_SERVERS = [
+    {
+        'id': 'galaxy',
+        'url': 'https://galaxy.ansible.com'
+    }
+]
 
 # Enable bubblewrap support for running jobs (playbook runs only).
 # Note: This setting may be overridden by database settings.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -623,10 +623,10 @@ AWX_ROLES_ENABLED = True
 AWX_COLLECTIONS_ENABLED = True
 
 # Settings for private galaxy server, should be set in the UI
-PRIVATE_GALAXY_URL = None
-PRIVATE_GALAXY_USERNAME = None
-PRIVATE_GALAXY_TOKEN = None
-PRIVATE_GALAXY_PASSWORD = None
+PRIVATE_GALAXY_URL = ''
+PRIVATE_GALAXY_USERNAME = ''
+PRIVATE_GALAXY_TOKEN = ''
+PRIVATE_GALAXY_PASSWORD = ''
 # Public Galaxy URL, not configurable outside of file-based settings
 PUBLIC_GALAXY_URL = 'https://galaxy.ansible.com'
 

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -71,6 +71,20 @@ export default ['i18n', function(i18n) {
                 type: 'text',
                 reset: 'PRIVATE_GALAXY_URL',
             },
+            PRIVATE_GALAXY_USERNAME: {
+                type: 'text',
+                reset: 'PRIVATE_GALAXY_USERNAME',
+            },
+            PRIVATE_GALAXY_PASSWORD: {
+                type: 'sensitive',
+                hasShowInputButton: true,
+                reset: 'PRIVATE_GALAXY_PASSWORD',
+            },
+            PRIVATE_GALAXY_TOKEN: {
+                type: 'sensitive',
+                hasShowInputButton: true,
+                reset: 'PRIVATE_GALAXY_TOKEN',
+            },
             AWX_TASK_ENV: {
                 type: 'textarea',
                 reset: 'AWX_TASK_ENV',

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -58,11 +58,18 @@ export default ['i18n', function(i18n) {
                 type: 'text',
                 reset: 'ANSIBLE_FACT_CACHE_TIMEOUT',
             },
+            PROJECT_UPDATE_VVV: {
+                type: 'toggleSwitch',
+            },
             AWX_ROLES_ENABLED: {
                 type: 'toggleSwitch',
             },
             AWX_COLLECTIONS_ENABLED: {
                 type: 'toggleSwitch',
+            },
+            PRIVATE_GALAXY_URL: {
+                type: 'text',
+                reset: 'PRIVATE_GALAXY_URL',
             },
             AWX_TASK_ENV: {
                 type: 'textarea',

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -85,6 +85,10 @@ export default ['i18n', function(i18n) {
                 hasShowInputButton: true,
                 reset: 'PRIMARY_GALAXY_TOKEN',
             },
+            PRIMARY_GALAXY_AUTH_URL: {
+                type: 'text',
+                reset: 'PRIMARY_GALAXY_AUTH_URL',
+            },
             AWX_TASK_ENV: {
                 type: 'textarea',
                 reset: 'AWX_TASK_ENV',

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -67,23 +67,23 @@ export default ['i18n', function(i18n) {
             AWX_COLLECTIONS_ENABLED: {
                 type: 'toggleSwitch',
             },
-            PRIVATE_GALAXY_URL: {
+            PRIMARY_GALAXY_URL: {
                 type: 'text',
-                reset: 'PRIVATE_GALAXY_URL',
+                reset: 'PRIMARY_GALAXY_URL',
             },
-            PRIVATE_GALAXY_USERNAME: {
+            PRIMARY_GALAXY_USERNAME: {
                 type: 'text',
-                reset: 'PRIVATE_GALAXY_USERNAME',
+                reset: 'PRIMARY_GALAXY_USERNAME',
             },
-            PRIVATE_GALAXY_PASSWORD: {
+            PRIMARY_GALAXY_PASSWORD: {
                 type: 'sensitive',
                 hasShowInputButton: true,
-                reset: 'PRIVATE_GALAXY_PASSWORD',
+                reset: 'PRIMARY_GALAXY_PASSWORD',
             },
-            PRIVATE_GALAXY_TOKEN: {
+            PRIMARY_GALAXY_TOKEN: {
                 type: 'sensitive',
                 hasShowInputButton: true,
-                reset: 'PRIVATE_GALAXY_TOKEN',
+                reset: 'PRIMARY_GALAXY_TOKEN',
             },
             AWX_TASK_ENV: {
                 type: 'textarea',

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -52,3 +52,31 @@ Example of `tmp` directory where job is running:
 └── tmp_6wod58k
 
 ```
+
+### Galaxy Server Selection
+
+Ansible core default settings will download collections from the public
+Galaxy server at `https://galaxy.ansible.com`. For details on
+how Galaxy servers are configured in Ansible in general see:
+
+https://docs.ansible.com/ansible/devel/user_guide/collections_using.html
+(if "devel" link goes stale in the future, it is for Ansible 2.9)
+
+You can set a different server to be the primary Galaxy server to download
+roles and collections from in AWX project updates.
+This is done via the setting `PRIMARY_GALAXY_URL` and similar
+`PRIMARY_GALAXY_xxxx` settings for authentication.
+
+If the `PRIMARY_GALAXY_URL` setting is not blank, then the server list is defined
+to be `primary_galaxy,galaxy`. The `primary_galaxy` server definition uses the URL
+from those settings, as well as username, password, and/or token if applicable.
+the `galaxy` server definition uses public Galaxy (`https://galaxy.ansible.com`)
+with no authentication.
+
+This configuration causes requirements to be downloaded from the user-specified
+primary galaxy server if they are available there. If a requirement is
+not available from the primary galaxy server, then it will fallback to
+downloading it from the public Galaxy server.
+
+Even when these settings are enabled, this can still be bypassed for a specific
+requirement by using the `source:` option, as described in Ansible documentation.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -5,14 +5,14 @@ AWX supports the use of Ansible Collections. This section will give ways to use 
 ### Project Collections Requirements
 
 If you specify a Collections requirements file in SCM at `collections/requirements.yml`,
-then AWX will install Collections in that file in the implicit project sync
-before a job run. The invocation is:
+then AWX will install Collections from that file in the implicit project sync
+before a job run. The invocation looks like:
 
 ```
-ansible-galaxy collection install -r requirements.yml -p <job tmp location>
+ansible-galaxy collection install -r requirements.yml -p <job tmp location>/requirements_collections
 ```
 
-Example of `tmp` directory where job is running:
+Example of the resultant `tmp` directory where job is running:
 
 ```
 ├── project
@@ -69,7 +69,7 @@ This is done via the setting `PRIMARY_GALAXY_URL` and similar
 
 If the `PRIMARY_GALAXY_URL` setting is not blank, then the server list is defined
 to be `primary_galaxy,galaxy`. The `primary_galaxy` server definition uses the URL
-from those settings, as well as username, password, and/or token if applicable.
+from those settings, as well as username, password, and/or token and auth_url if applicable.
 the `galaxy` server definition uses public Galaxy (`https://galaxy.ansible.com`)
 with no authentication.
 


### PR DESCRIPTION
##### SUMMARY
Allow users to use a custom URL / authentication to a Galaxy server.

This will still set up the public galaxy server as a fallback.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
6.1.0
```


##### ADDITIONAL INFORMATION
Several things have been completed in Ansible core to open the door for this.

https://github.com/ansible/ansible/issues/61247
