### PR TITLE
[WIP] Add SSL capability to our AMQP transport

### DIFF
--- a/awx/main/dispatch/kombu.py
+++ b/awx/main/dispatch/kombu.py
@@ -48,7 +48,7 @@ class Connection(KombuConnection):
                     'ca_certs': settings.AMQPS_CA_BUNDLE,
                 }
 
-        if settings.BROKER_URL[:5].lower() == 'amqps':
+        if settings.BROKER_URL.lower().startswith('amqps'):
             self.transport_cls = _SSLTransport
         else:
             self.transport_cls = _Transport

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -484,6 +484,9 @@ ASGI_AMQP = {
     'MODEL': 'awx.main.models.channels.ChannelGroup',
 }
 
+AMQPS_VERIFY_CERTS = True
+AMQPS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+
 # Django Caching Configuration
 CACHES = {
     'default': {


### PR DESCRIPTION
##### SUMMARY
Add the ability to use SSL when connecting to AMQP (RabbitMQ) via our kombu transport. New settings in settings.py are used to control server certificate verification.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
6.1.0
