### PR TITLE
cli: fix an awx CLI alias typo

### DIFF
--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -16,7 +16,7 @@ DEPRECATED_RESOURCES = {
     'credentials': 'credential',
     'credential_types': 'credential_type',
     'groups': 'group',
-    'hosts': 'hosts',
+    'hosts': 'host',
     'instances': 'instance',
     'instance_groups': 'instance_group',
     'inventory_scripts': 'inventory_script',


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/4603