### PR TITLE
cli: add an alias for `awx inventories`

### DIFF
--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -19,6 +19,7 @@ DEPRECATED_RESOURCES = {
     'hosts': 'host',
     'instances': 'instance',
     'instance_groups': 'instance_group',
+    'inventory': 'inventories',
     'inventory_scripts': 'inventory_script',
     'inventory_sources': 'inventory_source',
     'inventory_updates': 'inventory_update',


### PR DESCRIPTION
It's weird that the others are plural, but it's just how the API works 🤷‍♂ 