### PR TITLE
Separate TLS Certificate and TLS Private Key (if desired)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -452,6 +452,14 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 > Optionally, provide the path to a file that contains a certificate and its private key.
 
+*ssl_certificate_key*
+
+> Optionally, provide the path to a file that contains the certificate's private key.
+
+> If this variable is defined, nginx will use this path for the certificate key and `ssl_certificate` for the certificate.
+
+> If this variable is **not** defined, nginx will use `ssl_certificate` for **both** the certificate and the key.
+
 *docker_compose_dir*
 
 > When using docker-compose, the `docker-compose.yml` file will be created there (default `/tmp/awxcompose`).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -452,6 +452,8 @@ Before starting the build process, review the [inventory](./installer/inventory)
 
 > Optionally, provide the path to a file that contains a certificate and its private key.
 
+> If also using `ssl_certificate_key` (see below), you can set this to the path to a file that contains only the certificate.
+
 *ssl_certificate_key*
 
 > Optionally, provide the path to a file that contains the certificate's private key.

--- a/installer/inventory
+++ b/installer/inventory
@@ -61,6 +61,7 @@ postgres_data_dir=/tmp/pgdocker
 host_port=80
 host_port_ssl=443
 #ssl_certificate=
+#ssl_certificate_key=
 docker_compose_dir=/tmp/awxcompose
 
 # Required for Openshift when building the image on your own

--- a/installer/roles/image_build/templates/nginx.conf.j2
+++ b/installer/roles/image_build/templates/nginx.conf.j2
@@ -51,7 +51,11 @@ http {
         listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;
+        {% if ssl_certificate_key is defined %}
+        ssl_certificate_key /etc/nginx/awxweb_key.pem;
+        {% else %}
         ssl_certificate_key /etc/nginx/awxweb.pem;
+        {% endif %}
         {% else %}
         listen 8052 default_server;
         {% endif %}

--- a/installer/roles/image_build/templates/nginx.conf.j2
+++ b/installer/roles/image_build/templates/nginx.conf.j2
@@ -52,7 +52,7 @@ http {
 
         ssl_certificate /etc/nginx/awxweb.pem;
         {% if ssl_certificate_key is defined %}
-        ssl_certificate_key /etc/nginx/awxweb_key.pem;
+        ssl_certificate_key /etc/nginx/awxweb.key;
         {% else %}
         ssl_certificate_key /etc/nginx/awxweb.pem;
         {% endif %}

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -32,6 +32,9 @@ services:
     {% if ssl_certificate is defined %}
       - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
     {% endif %}
+    {% if ssl_certificate_key is defined %}
+      - "{{ ssl_certificate_key +':/etc/nginx/awxweb_key.pem:ro' }}"
+    {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}
     dns_search:

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -33,7 +33,7 @@ services:
       - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
     {% endif %}
     {% if ssl_certificate_key is defined %}
-      - "{{ ssl_certificate_key +':/etc/nginx/awxweb_key.pem:ro' }}"
+      - "{{ ssl_certificate_key +':/etc/nginx/awxweb.key:ro' }}"
     {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}
     {% set awx_container_search_domains_list = awx_container_search_domains.split(',') %}


### PR DESCRIPTION
##### SUMMARY
This PR gives the end-user the ability to keep the certificate and private key in two different files if they want, while still maintaining backwards compatibility for those who wish to combine the certificate and the key into one file.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```

##### ADDITIONAL INFORMATION
 Not applicable.