### PR TITLE
Update Approval Node Count in the Event of a Timeout

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -527,11 +527,14 @@ class TaskManager():
             if task.timeout == 0:
                 continue
             if (now - task.created) >= approval_timeout_seconds:
-                timeout_message = "The approval node {} ({}) has expired after {} seconds.".format(task.name, task.pk, task.timeout)
+                timeout_message = _(
+                    "The approval node {name} ({pk}) has expired after {timeout} seconds."
+                ).format(name=task.name, pk=task.pk, timeout=task.timeout)
                 logger.warn(timeout_message)
                 task.timed_out = True
                 task.status = 'failed'
-                task.job_explanation = _(timeout_message)
+                task.websocket_emit_status(task.status)
+                task.job_explanation = timeout_message
                 task.save(update_fields=['status', 'job_explanation', 'timed_out'])
 
     def calculate_capacity_consumed(self, tasks):


### PR DESCRIPTION
This change makes it so that the "needs approval" counter updates correctly whenever an approval node times out (it would previously not update unless the page was refreshed). 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Addressing Issue https://github.com/ansible/awx/issues/4621
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
