### PR TITLE
Fix condition to show prompt button on the schedule add/edit form

### DIFF
--- a/awx/ui/client/src/scheduler/schedulerAdd.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerAdd.controller.js
@@ -20,6 +20,13 @@ export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
         scheduler,
         job_type;
 
+    /*
+     * Normally if "ask_*" checkboxes are checked in a job template settings,
+     * shouldShowPromptButton() returns True to show the "PROMPT" button.
+     * However, extra_vars("ask_variables_on_launch") does not use this and
+     * displays a separate text area within the add/edit page for input.
+     * We exclude "ask_variables_on_launch" from shouldShowPromptButton() here.
+     */
     const shouldShowPromptButton = (launchConf) => launchConf.survey_enabled ||
         launchConf.ask_inventory_on_launch ||
         launchConf.ask_credential_on_launch ||
@@ -30,7 +37,6 @@ export default ['$filter', '$state', '$stateParams', '$http', 'Wait',
         launchConf.ask_skip_tags_on_launch ||
         launchConf.ask_diff_mode_on_launch ||
         launchConf.credential_needed_to_start ||
-        launchConf.ask_variables_on_launch ||
         launchConf.ask_scm_branch_on_launch ||
         launchConf.variables_needed_to_start.length !== 0;
 

--- a/awx/ui/client/src/scheduler/schedulerEdit.controller.js
+++ b/awx/ui/client/src/scheduler/schedulerEdit.controller.js
@@ -10,6 +10,13 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
 
     let schedule, scheduler, scheduleCredentials = [];
 
+    /*
+     * Normally if "ask_*" checkboxes are checked in a job template settings,
+     * shouldShowPromptButton() returns True to show the "PROMPT" button.
+     * However, extra_vars("ask_variables_on_launch") does not use this and
+     * displays a separate text area within the add/edit page for input.
+     * We exclude "ask_variables_on_launch" from shouldShowPromptButton() here.
+     */
     const shouldShowPromptButton = (launchConf) => launchConf.survey_enabled ||
         launchConf.ask_inventory_on_launch ||
         launchConf.ask_credential_on_launch ||
@@ -20,7 +27,6 @@ function($filter, $state, $stateParams, Wait, $scope, moment,
         launchConf.ask_skip_tags_on_launch ||
         launchConf.ask_diff_mode_on_launch ||
         launchConf.credential_needed_to_start ||
-        launchConf.ask_variables_on_launch ||
         launchConf.ask_scm_branch_on_launch ||
         launchConf.passwords_needed_to_start.length !== 0 ||
         launchConf.variables_needed_to_start.length !== 0;


### PR DESCRIPTION
### SUMMARY
Normally if "ask_*" checkboxes are checked in a job template settings, shouldShowPromptButton() returns _True_ to show the __PROMPT__ button.
However, extra_vars("ask_variables_on_launch") does not use this and displays a separate text within the edit page area. So we should exclude "ask_variables_on_launch" from shouldShowPromptButton().

- Fixed issue #4528

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- UI

##### AWX VERSION
- AWX: devel

##### ADDITIONAL INFORMATION
None