### PR TITLE
cli: add ability to specify a name instead of primary key

### DIFF
--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -201,7 +201,7 @@ class Page(object):
                 text = response.text
                 if len(text) > 1024:
                     text = text[:1024] + '... <<< Truncated >>> ...'
-                log.warning(
+                log.debug(
                     "Unable to parse JSON response ({0.status_code}): {1} - '{2}'".format(response, e, text))
 
         exc_str = "%s (%s) received" % (

--- a/awxkit/awxkit/cli/__init__.py
+++ b/awxkit/awxkit/cli/__init__.py
@@ -62,6 +62,9 @@ def run(stdout=sys.stdout, stderr=sys.stderr, argv=[]):
                     allow_unicode=True
                 )
             ))
+        elif cli.get_config('format') == 'human':
+            sys.stdout.write(e.__class__.__name__)
+            print('')
         sys.exit(1)
     except Exception as e:
         if cli.verbose:

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -199,7 +199,7 @@ class CLI(object):
         subparsers.required = True
 
         # parse the action from OPTIONS
-        parser = ResourceOptionsParser(page, self.resource, subparsers)
+        parser = ResourceOptionsParser(self.v2, page, self.resource, subparsers)
         if from_sphinx:
             # Our Sphinx plugin runs `parse_action` for *every* available
             # resource + action in the API so that it can generate usage

--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -1,3 +1,5 @@
+import functools
+
 from six import with_metaclass
 
 from .stdout import monitor, monitor_workflow
@@ -44,8 +46,15 @@ class CustomAction(with_metaclass(CustomActionRegistryMeta)):
 class Launchable(object):
 
     def add_arguments(self, parser, with_pk=True):
+        from .options import pk_or_name
         if with_pk:
-            parser.choices[self.action].add_argument('id', type=int, help='')
+            parser.choices[self.action].add_argument(
+                'id',
+                type=functools.partial(
+                    pk_or_name, None, self.resource, page=self.page
+                ),
+                help=''
+            )
         parser.choices[self.action].add_argument(
             '--monitor', action='store_true',
             help='If set, prints stdout of the launched job until it finishes.'
@@ -154,7 +163,14 @@ class HasStdout(object):
     action = 'stdout'
 
     def add_arguments(self, parser):
-        parser.choices['stdout'].add_argument('id', type=int, help='')
+        from .options import pk_or_name
+        parser.choices['stdout'].add_argument(
+            'id',
+            type=functools.partial(
+                pk_or_name, None, self.resource, page=self.page
+            ),
+            help=''
+        )
 
     def perform(self):
         fmt = 'txt_download'

--- a/awxkit/awxkit/cli/docs/source/examples.rst
+++ b/awxkit/awxkit/cli/docs/source/examples.rst
@@ -32,17 +32,15 @@ the output of) a playbook from that repository:
 
 .. code:: bash
 
-    export TOWER_COLOR=f
-    INVENTORY_ID=$(awx inventory list --name 'Demo Inventory' -f jq --filter '.results[0].id')
-    PROJECT_ID=$(awx projects create --wait \
+    awx projects create --wait \
         --organization 1 --name='Example Project' \
         --scm_type git --scm_url 'https://github.com/ansible/ansible-tower-samples' \
-        -f jq --filter '.id')
-    TEMPLATE_ID=$(awx job_templates create \
-        --name='Example Job Template' --project $PROJECT_ID \
-        --playbook hello_world.yml --inventory $INVENTORY_ID \
-        -f jq --filter '.id')
-    awx job_templates launch $TEMPLATE_ID --monitor
+        -f human
+    awx job_templates create \
+        --name='Example Job Template' --project 'Example Project' \
+        --playbook hello_world.yml --inventory 'Demo Inventory' \
+        -f human
+    awx job_templates launch 'Example Job Template' --monitor -f human
 
 Updating a Job Template with Extra Vars
 ---------------------------------------
@@ -51,3 +49,13 @@ Updating a Job Template with Extra Vars
 
     awx job_templates modify 1 --extra_vars "@vars.yml"
     awx job_templates modify 1 --extra_vars "@vars.json"
+
+Importing an SSH Key
+--------------------
+
+.. code:: bash
+
+    awx credentials create --credential_type 'Machine' \
+        --name 'My SSH Key' --user 'alice' \
+        --inputs "{'username': 'server-login', 'ssh_key_data': '@~/.ssh/id_rsa`}"
+

--- a/awxkit/test/cli/test_options.py
+++ b/awxkit/test/cli/test_options.py
@@ -42,7 +42,7 @@ class TestOptions(unittest.TestCase):
                 'POST': {},
             }
         })
-        ResourceOptionsParser(page, 'users', self.parser)
+        ResourceOptionsParser(None, page, 'users', self.parser)
         assert 'list' in self.parser.choices
 
     def test_list_filtering(self):
@@ -54,7 +54,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('list', 'POST')
         assert 'list' in self.parser.choices
 
@@ -71,7 +71,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('list', 'POST')
         assert 'list' in self.parser.choices
 
@@ -90,7 +90,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('create', 'POST')
         assert 'create' in self.parser.choices
 
@@ -110,7 +110,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('create', 'POST')
         assert 'create' in self.parser.choices
 
@@ -126,7 +126,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'job_templates', self.parser)
+        options = ResourceOptionsParser(None, page, 'job_templates', self.parser)
         options.build_query_arguments('create', 'POST')
         assert 'create' in self.parser.choices
 
@@ -142,7 +142,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('create', 'POST')
         assert 'create' in self.parser.choices
 
@@ -168,7 +168,7 @@ class TestOptions(unittest.TestCase):
                 },
             }
         })
-        options = ResourceOptionsParser(page, 'users', self.parser)
+        options = ResourceOptionsParser(None, page, 'users', self.parser)
         options.build_query_arguments('create', 'POST')
         assert 'create' in self.parser.choices
 
@@ -181,12 +181,13 @@ class TestOptions(unittest.TestCase):
             page = OptionsPage.from_json({
                 'actions': {'GET': {}, 'POST': {}}
             })
-            ResourceOptionsParser(page, 'users', self.parser)
+            ResourceOptionsParser(None, page, 'users', self.parser)
             assert method in self.parser.choices
 
             out = StringIO()
             self.parser.choices[method].print_help(out)
             assert 'positional arguments:\n  id' in out.getvalue()
+
 
 class TestSettingsOptions(unittest.TestCase):
 
@@ -203,7 +204,7 @@ class TestSettingsOptions(unittest.TestCase):
             }
         })
         page.endpoint = '/settings/all/'
-        ResourceOptionsParser(page, 'settings', self.parser)
+        ResourceOptionsParser(None, page, 'settings', self.parser)
         assert 'list' in self.parser.choices
         assert 'modify' in self.parser.choices
 


### PR DESCRIPTION
I'm of the opinion that - while not perfect in its handling of uniqueness rules - this is a behavior we should _carry over_ from tower-cli, because it makes life **much** easier on the user.