### PR TITLE
Added 'rescued' and 'ignored' fields into all_hosts dictionary update

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -666,6 +666,14 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
     def processed_hosts(self):
         return self._get_hosts(job_host_summaries__processed__gt=0)
 
+    @property
+    def ignored_hosts(self):
+        return self._get_hosts(job_host_summaries__ignored__gt=0)
+
+    @property
+    def rescued_hosts(self):
+        return self._get_hosts(job_host_summaries__rescued__gt=0)
+
     def notification_data(self, block=5):
         data = super(Job, self).notification_data()
         all_hosts = {}
@@ -684,7 +692,9 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
                                           failures=h.failures,
                                           ok=h.ok,
                                           processed=h.processed,
-                                          skipped=h.skipped)  # TODO: update with rescued, ignored (see https://github.com/ansible/awx/issues/4394)
+                                          skipped=h.skipped,
+                                          rescued=h.rescued,
+                                          ignored=h.ignored)
         data.update(dict(inventory=self.inventory.name if self.inventory else None,
                          project=self.project.name if self.project else None,
                          playbook=self.playbook,

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import mock
 import json
 
-from awx.main.models import Job, Instance
+from awx.main.models import Job, Instance, JobHostSummary
 from awx.main.tasks import cluster_node_heartbeat
 from django.test.utils import override_settings
 
@@ -45,6 +45,24 @@ def test_job_notification_data(inventory, machine_credential, project):
     job.credentials.set([machine_credential])
     notification_data = job.notification_data(block=0)
     assert json.loads(notification_data['extra_vars'])['SSN'] == encrypted_str
+
+
+@pytest.mark.django_db
+def test_job_notification_host_data(inventory, machine_credential, project, job_template, host):
+    job = Job.objects.create(
+        job_template=job_template, inventory=inventory, name='hi world', project=project
+    )
+    JobHostSummary.objects.create(job=job, host=host, changed=1, dark=2, failures=3, ok=4, processed=3, skipped=2, rescued=1, ignored=0)
+    assert job.notification_data()['hosts'] == {'single-host': 
+                                                {'failed': True,
+                                                    'changed': 1, 
+                                                    'dark': 2, 
+                                                    'failures': 3, 
+                                                    'ok': 4, 
+                                                    'processed': 3, 
+                                                    'skipped': 2, 
+                                                    'rescued': 1, 
+                                                    'ignored': 0}}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
- Adds 'Rescued' and 'Ignored' into the dictionary update for for all_hosts. This should expose it in the JSON return for all notification types. 
- Pertains to #4394 
- Additionally exposes them as properties a few lines above the dictionary update in keeping with the standards for the other pre-existing fields.
- Test case added to create these fields and then verify their existence in the return.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 6.1.0
```


##### ADDITIONAL INFORMATION
- Recreation for this issue can be found in the original issue, #4394 

- Additionally, it may be easier (depending on your current AWX setup) to mock the email setup instead using @beeankha's nifty trick 
```
docker run --network="tools_default" -p 25:25 -e maildomain=mail.example.com -e smtp_user=user:pwd --name postfix -d catatnight/postfix
```

- Alternatively, you could use ncat: 
```yum install -y nmap-ncat```
Then listen on your chosen localhost port number:
```nc -kl <portnumber>```
