### PR TITLE
cli: fix a -f human formatting bug in py2

### DIFF
--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -163,8 +163,8 @@ def format_human(output, fmt):
         try:
             return locale.format("%.*f", (0, int(v)), True)
         except (ValueError, TypeError):
-            if not isinstance(v, six.text_type):
-                return str(v)
+            if isinstance(v, (list, dict)):
+                return json.dumps(v)
             return v
 
     # calculate the max width of each column


### PR DESCRIPTION
if we encounter non-strings in JSON responses, attempt to represent them
as JSON, instead of stringify-ing them (in py2, stringify-ing adds `u`
markers, which is confusing to users)

related: https://github.com/ansible/awx/issues/4567