### PR TITLE
Revert 9b95cc27c4840140996a036223e2909a30953b95.

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1465,12 +1465,14 @@ class RunJob(BaseTask):
             if authorize:
                 env['ANSIBLE_NET_AUTH_PASS'] = network_cred.get_input('authorize_password', default='')
 
-        for env_key, folder in (
-                ('ANSIBLE_COLLECTIONS_PATHS', 'requirements_collections'),
-                ('ANSIBLE_ROLES_PATH', 'requirements_roles')):
-            paths = []
+        for env_key, folder, default in (
+                ('ANSIBLE_COLLECTIONS_PATHS', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
+                ('ANSIBLE_ROLES_PATH', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles')):
+            paths = default.split(':')
             if env_key in env:
-                paths.append(env[env_key])
+                for path in env[env_key].split(':'):
+                    if path not in paths:
+                        paths.append(env[env_key])
             paths.append(os.path.join(private_data_dir, folder))
             env[env_key] = os.pathsep.join(paths)
 

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -876,10 +876,6 @@ class BaseTask(object):
             show_paths = self.proot_show_paths + local_paths + \
                 settings.AWX_PROOT_SHOW_PATHS
 
-            # Help the user out by including the collections path inside the bubblewrap environment
-            if getattr(settings, 'AWX_ANSIBLE_COLLECTIONS_PATHS', []):
-                show_paths.extend(settings.AWX_ANSIBLE_COLLECTIONS_PATHS)
-
             pi_path = settings.AWX_PROOT_BASE_PATH
             if not self.instance.is_isolated():
                 pi_path = tempfile.mkdtemp(
@@ -966,11 +962,6 @@ class BaseTask(object):
         if self.should_use_proot(instance):
             env['PROOT_TMP_DIR'] = settings.AWX_PROOT_BASE_PATH
         env['AWX_PRIVATE_DATA_DIR'] = private_data_dir
-
-        if 'ANSIBLE_COLLECTIONS_PATHS' in env:
-            env['ANSIBLE_COLLECTIONS_PATHS'] += os.pathsep + os.pathsep.join(settings.AWX_ANSIBLE_COLLECTIONS_PATHS)
-        else:
-            env['ANSIBLE_COLLECTIONS_PATHS'] = os.pathsep.join(settings.AWX_ANSIBLE_COLLECTIONS_PATHS)
         return env
 
     def should_use_proot(self, instance):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1472,8 +1472,8 @@ class RunJob(BaseTask):
             if env_key in env:
                 for path in env[env_key].split(':'):
                     if path not in paths:
-                        paths.append(env[env_key])
-            paths.append(os.path.join(private_data_dir, folder))
+                        paths = [env[env_key]] + paths
+            paths = [os.path.join(private_data_dir, folder)] + paths
             env[env_key] = os.pathsep.join(paths)
 
         return env

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -262,7 +262,6 @@ def test_inventory_update_injected_content(this_kind, script_or_plugin, inventor
         """
         private_data_dir = envvars.pop('AWX_PRIVATE_DATA_DIR')
         assert envvars.pop('ANSIBLE_INVENTORY_ENABLED') == ('auto' if use_plugin else 'script')
-        assert envvars.pop('ANSIBLE_COLLECTIONS_PATHS') == os.pathsep.join(settings.AWX_ANSIBLE_COLLECTIONS_PATHS)
         set_files = bool(os.getenv("MAKE_INVENTORY_REFERENCE_FILES", 'false').lower()[0] not in ['f', '0'])
         env, content = read_content(private_data_dir, envvars, inventory_update)
         base_dir = os.path.join(DATA, script_or_plugin)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -444,7 +444,6 @@ class TestGenericRun():
         settings.AWX_PROOT_HIDE_PATHS = ['/AWX_PROOT_HIDE_PATHS1', '/AWX_PROOT_HIDE_PATHS2']
         settings.ANSIBLE_VENV_PATH = '/ANSIBLE_VENV_PATH'
         settings.AWX_VENV_PATH = '/AWX_VENV_PATH'
-        settings.AWX_ANSIBLE_COLLECTIONS_PATHS = ['/AWX_COLLECTION_PATH1', '/AWX_COLLECTION_PATH2']
 
         process_isolation_params = task.build_params_process_isolation(job, private_data_dir, cwd)
         assert True is process_isolation_params['process_isolation']
@@ -454,10 +453,6 @@ class TestGenericRun():
             "The per-job private data dir should be in the list of directories the user can see."
         assert cwd in process_isolation_params['process_isolation_show_paths'], \
             "The current working directory should be in the list of directories the user can see."
-        assert '/AWX_COLLECTION_PATH1' in process_isolation_params['process_isolation_show_paths'], \
-            "AWX global collection directory 1 of 2 should get added to the list of directories the user can see."
-        assert '/AWX_COLLECTION_PATH2' in process_isolation_params['process_isolation_show_paths'], \
-            "AWX global collection directory 2 of 2 should get added to the list of directories the user can see."
 
         for p in [settings.AWX_PROOT_BASE_PATH,
                   '/etc/tower',
@@ -516,20 +511,6 @@ class TestGenericRun():
         with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'FOO': 'BAR'}):
             env = task.build_env(job, private_data_dir)
         assert env['FOO'] == 'BAR'
-
-    def test_awx_task_env_respects_ansible_collections_paths(self, patch_Job, private_data_dir):
-        job = Job(project=Project(), inventory=Inventory())
-
-        task = tasks.RunJob()
-        task._write_extra_vars_file = mock.Mock()
-
-        with mock.patch('awx.main.tasks.settings.AWX_ANSIBLE_COLLECTIONS_PATHS', ['/AWX_COLLECTION_PATH']):
-            with mock.patch('awx.main.tasks.settings.AWX_TASK_ENV', {'ANSIBLE_COLLECTIONS_PATHS': '/MY_COLLECTION1:/MY_COLLECTION2'}):
-                env = task.build_env(job, private_data_dir)
-        used_paths = env['ANSIBLE_COLLECTIONS_PATHS'].split(':')
-        assert used_paths[-1].endswith('/requirements_collections')
-        used_paths.pop()
-        assert used_paths == ['/MY_COLLECTION1', '/MY_COLLECTION2', '/AWX_COLLECTION_PATH']
 
     def test_valid_custom_virtualenv(self, patch_Job, private_data_dir):
         job = Job(project=Project(), inventory=Inventory())

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1189,9 +1189,6 @@ AWX_REQUEST_PROFILE = False
 # Delete temporary directories created to store playbook run-time
 AWX_CLEANUP_PATHS = True
 
-# Expose collections to Ansible playbooks
-AWX_ANSIBLE_COLLECTIONS_PATHS = ['/var/lib/awx/collections']
-
 MIDDLEWARE = [
     'awx.main.middleware.TimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/awx/settings/local_settings.py.docker_compose
+++ b/awx/settings/local_settings.py.docker_compose
@@ -276,5 +276,3 @@ TEST_OPENSTACK_PROJECT = ''
 # Azure credentials.
 TEST_AZURE_USERNAME = ''
 TEST_AZURE_KEY_DATA = ''
-
-AWX_ANSIBLE_COLLECTIONS_PATHS = ['/tmp/collections']

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -53,10 +53,3 @@ Example of tmp directory where job is running:
 └── tmp_6wod58k
 
 ```
-
-### Global Collections Path
-
-AWX appends the directories specified in `AWX_ANSIBLE_COLLECTIONS_PATHS`
-to the environment variable `ANSIBLE_COLLECTIONS_PATHS`. The default value of `AWX_ANSIBLE_COLLECTIONS_PATHS`
-contains `/var/lib/awx/collections`. It is recommended that place your collections that you wish to call in
-your playbooks into this path.


### PR DESCRIPTION

We do not want to create a new setting for a on-Tower-host global collection path at this time.

Update of   https://github.com/ansible/awx/pull/4645
