### PR TITLE
fixed insights api 204 errors

### DIFF
--- a/awx/playbooks/action_plugins/insights.py
+++ b/awx/playbooks/action_plugins/insights.py
@@ -89,7 +89,9 @@ class ActionModule(ActionBase):
                 playbook_url = '{}/api/remediations/v1/remediations/{}/playbook'.format(
                     insights_url, item['id'])
                 res = session.get(playbook_url, timeout=120)
-                if res.status_code != 200:
+                if res.status_code == 204:
+                    continue
+                elif res.status_code != 200:
                     result['failed'] = True
                     result['msg'] = (
                         'Expected {} to return a status code of 200 but returned status '


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In some cases if an insights playbook has been deleted it will throw a 204 rather than 404 since the playbook exists but is empty.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 7.0.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
