### PR TITLE
Use project verbosity without color for galaxy commands

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -126,12 +126,14 @@
         register: doesRequirementsExist
 
       - name: fetch galaxy roles from requirements.yml
-        command: ansible-galaxy install -r requirements.yml -p {{roles_destination|quote}}
+        command: ansible-galaxy install -r requirements.yml -p {{roles_destination|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
         args:
           chdir: "{{project_path|quote}}/roles"
         register: galaxy_result
         when: doesRequirementsExist.stat.exists
         changed_when: "'was installed successfully' in galaxy_result.stdout"
+        environment:
+          ANSIBLE_FORCE_COLOR: False
 
       when: roles_enabled|bool
       delegate_to: localhost
@@ -142,12 +144,14 @@
         register: doesCollectionRequirementsExist
 
       - name: fetch galaxy collections from collections/requirements.yml
-        command: ansible-galaxy collection install -r requirements.yml -p {{collections_destination|quote}}
+        command: ansible-galaxy collection install -r requirements.yml -p {{collections_destination|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
         args:
           chdir: "{{project_path|quote}}/collections"
         register: galaxy_collection_result
         when: doesCollectionRequirementsExist.stat.exists
         changed_when: "'Installing ' in galaxy_collection_result.stdout"
+        environment:
+          ANSIBLE_FORCE_COLOR: False
 
       when: collections_enabled|bool
       delegate_to: localhost


### PR DESCRIPTION
Connect https://github.com/ansible/awx/issues/4673

This does two things:

 - Uses the same verbosity used for the project update playbook for the `ansible-galaxy` commands ran inside of the playbook
 - Stops forcing Ansible use of terminal color specifically for those commands

This allows you to get output like this:

![Screen Shot 2019-09-06 at 11 01 27 AM](https://user-images.githubusercontent.com/1385596/64438574-574f5700-d096-11e9-97ad-b2a0f0165d57.png)

...which is otherwise not possible. Along with Ansible 2.10, which will have https://github.com/ansible/ansible/pull/61902, that will give the user a fully clean, coherent, and detailed output for these commands.

This is something I was partially doing in https://github.com/ansible/awx/pull/4589, but it should be done on its own merits and has no dependencies on that.