### PR TITLE
Display search key along with value in tag

### DIFF
--- a/awx/ui_next/src/components/FilterTags/FilterTags.jsx
+++ b/awx/ui_next/src/components/FilterTags/FilterTags.jsx
@@ -52,7 +52,9 @@ const FilterTags = ({
       .join(' ');
 
     if (Array.isArray(queryParams[key])) {
-      queryParams[key].forEach(val => queryParamsArr.push({ key, value: val, label }));
+      queryParams[key].forEach(val =>
+        queryParamsArr.push({ key, value: val, label })
+      );
     } else {
       queryParamsArr.push({ key, value: queryParams[key], label });
     }

--- a/awx/ui_next/src/components/FilterTags/FilterTags.jsx
+++ b/awx/ui_next/src/components/FilterTags/FilterTags.jsx
@@ -45,28 +45,34 @@ const FilterTags = ({
     qsConfig
   );
   nonDefaultParams.forEach(key => {
+    const label = key
+      .replace('__icontains', '')
+      .split('_')
+      .map(word => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+      .join(' ');
+
     if (Array.isArray(queryParams[key])) {
-      queryParams[key].forEach(val => queryParamsArr.push({ key, value: val }));
+      queryParams[key].forEach(val => queryParamsArr.push({ key, value: val, label }));
     } else {
-      queryParamsArr.push({ key, value: queryParams[key] });
+      queryParamsArr.push({ key, value: queryParams[key], label });
     }
   });
 
   return (
     queryParamsArr.length > 0 && (
       <FilterTagsRow>
-        <ResultCount>{`${itemCount} results`}</ResultCount>
+        <ResultCount>{i18n._(t`${itemCount} results`)}</ResultCount>
         <VerticalSeparator />
         <FilterLabel>{i18n._(t`Active Filters:`)}</FilterLabel>
         <ChipGroup>
-          {queryParamsArr.map(({ key, value }) => (
+          {queryParamsArr.map(({ key, label, value }) => (
             <Chip
               className="searchTagChip"
               key={`${key}__${value}`}
               isReadOnly={false}
               onClick={() => onRemove(key, value)}
             >
-              {value}
+              <b>{label}:</b>&nbsp;{value}
             </Chip>
           ))}
           <div className="pf-c-chip pf-m-overflow">

--- a/awx/ui_next/src/components/FilterTags/FilterTags.test.jsx
+++ b/awx/ui_next/src/components/FilterTags/FilterTags.test.jsx
@@ -27,7 +27,7 @@ describe('<ExpandCollapse />', () => {
   test('renders non-default param tags based on location history', () => {
     const history = createMemoryHistory({
       initialEntries: [
-        '/foo?item.page=1&item.page_size=2&item.foo=bar&item.baz=bust',
+        '/foo?item.page=1&item.page_size=2&item.name__icontains=bar&item.job_type__icontains=project',
       ],
     });
     const wrapper = mountWithContexts(
@@ -42,6 +42,10 @@ describe('<ExpandCollapse />', () => {
     );
     const chips = wrapper.find('.pf-c-chip.searchTagChip');
     expect(chips.length).toBe(2);
+    const chipLabels = wrapper.find('.pf-c-chip__text b');
+    expect(chipLabels.length).toBe(2);
+    expect(chipLabels.at(0).text()).toEqual('Name:');
+    expect(chipLabels.at(1).text()).toEqual('Job Type:');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
##### SUMMARY
<img width="465" alt="Screen Shot 2019-09-09 at 3 38 04 PM" src="https://user-images.githubusercontent.com/9889020/64562310-b91ff300-d31a-11e9-94a1-787d1f3e37b9.png">

That way, when we have lists with lots of basic search options the user will know which key corresponds with which value.  For example, I could see a user searching for `name__icontains=ec2` and `description__icontains=ec2`.  The expectation with this PR would be that a tag `Name: ec2` and a tag `Description: ec2` would both be displayed.