### PR TITLE
move the oauth2 last_used update to the bottom of the request

### DIFF
--- a/awx/main/models/oauth.py
+++ b/awx/main/models/oauth.py
@@ -3,7 +3,7 @@ import re
 
 # Django
 from django.core.validators import RegexValidator
-from django.db import models
+from django.db import models, connection
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
@@ -121,7 +121,7 @@ class OAuth2AccessToken(AbstractAccessToken):
         valid = super(OAuth2AccessToken, self).is_valid(scopes)
         if valid:
             self.last_used = now()
-            self.save(update_fields=['last_used'])
+            connection.on_commit(lambda: self.save(update_fields=['last_used']))
         return valid
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
this avoids acquiring a row lock and holding it for the duration of
transactions (which might include a very slow query)

see: https://github.com/ansible/awx/issues/4694