### PR TITLE
Don't render the 404 not found page until the content's finished loading

### DIFF
--- a/awx/ui_next/src/screens/Job/Job.jsx
+++ b/awx/ui_next/src/screens/Job/Job.jsx
@@ -149,15 +149,17 @@ class Job extends Component {
               <Route
                 key="not-found"
                 path="*"
-                render={() => (
-                  <ContentError isNotFound>
-                    <Link
-                      to={`/jobs/${match.params.type}/${match.params.id}/details`}
-                    >
-                      {i18n._(`View Job Details`)}
-                    </Link>
-                  </ContentError>
-                )}
+                render={() =>
+                  !hasContentLoading && (
+                    <ContentError isNotFound>
+                      <Link
+                        to={`/jobs/${match.params.type}/${match.params.id}/details`}
+                      >
+                        {i18n._(`View Job Details`)}
+                      </Link>
+                    </ContentError>
+                  )
+                }
               />,
             ]}
           </Switch>

--- a/awx/ui_next/src/screens/Organization/Organization.jsx
+++ b/awx/ui_next/src/screens/Organization/Organization.jsx
@@ -238,15 +238,17 @@ class Organization extends Component {
             <Route
               key="not-found"
               path="*"
-              render={() => (
-                <ContentError isNotFound>
-                  {match.params.id && (
-                    <Link to={`/organizations/${match.params.id}/details`}>
-                      {i18n._(`View Organization Details`)}
-                    </Link>
-                  )}
-                </ContentError>
-              )}
+              render={() =>
+                !hasContentLoading && (
+                  <ContentError isNotFound>
+                    {match.params.id && (
+                      <Link to={`/organizations/${match.params.id}/details`}>
+                        {i18n._(`View Organization Details`)}
+                      </Link>
+                    )}
+                  </ContentError>
+                )
+              }
             />
             ,
           </Switch>

--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -119,17 +119,19 @@ class Template extends Component {
               <Route
                 key="not-found"
                 path="*"
-                render={() => (
-                  <ContentError isNotFound>
-                    {match.params.id && (
-                      <Link
-                        to={`/templates/${match.params.templateType}/${match.params.id}/details`}
-                      >
-                        {i18n._(`View Template Details`)}
-                      </Link>
-                    )}
-                  </ContentError>
-                )}
+                render={() =>
+                  !hasContentLoading && (
+                    <ContentError isNotFound>
+                      {match.params.id && (
+                        <Link
+                          to={`/templates/${match.params.templateType}/${match.params.id}/details`}
+                        >
+                          {i18n._(`View Template Details`)}
+                        </Link>
+                      )}
+                    </ContentError>
+                  )
+                }
               />,
             ]}
           </Switch>


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/4549

Here's the new behavior:

![org_details](https://user-images.githubusercontent.com/9889020/64623563-297c5200-d3b7-11e9-8db5-48b6a8399bed.gif)

Error page still shown on erroneous routes:

<img width="1386" alt="Screen Shot 2019-09-10 at 10 39 11 AM" src="https://user-images.githubusercontent.com/9889020/64623621-42850300-d3b7-11e9-830f-6553388035c3.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
