### PR TITLE
Fix Notification Template form validation of headers field

### DIFF
--- a/awx/ui/client/src/notifications/add/add.controller.js
+++ b/awx/ui/client/src/notifications/add/add.controller.js
@@ -105,7 +105,7 @@ export default ['Rest', 'Wait', 'NotificationsFormObject',
 
         $scope.$watch('headers', function validate_headers(str) {
             try {
-                let headers = JSON.parse(str);
+                const headers = typeof str === 'string' ? JSON.parse(str) : str;
                 if (_.isObject(headers) && !_.isArray(headers)) {
                     let valid = true;
                     for (let k in headers) {

--- a/awx/ui/client/src/notifications/edit/edit.controller.js
+++ b/awx/ui/client/src/notifications/edit/edit.controller.js
@@ -189,7 +189,7 @@ export default ['Rest', 'Wait',
 
         $scope.$watch('headers', function validate_headers(str) {
             try {
-                let headers = JSON.parse(str);
+                const headers = typeof str === 'string' ? JSON.parse(str) : str;
                 if (_.isObject(headers) && !_.isArray(headers)) {
                     let valid = true;
                     for (let k in headers) {


### PR DESCRIPTION
##### SUMMARY
Allows user to correct form errors and re-submit the Notification template after the API returns an error on the first attempt — save button is no longer disabled

related #4522 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
There was a bug in form validation where the `headers` field was assumed to be a JSON string. After submitting, the value in this field was an object, which failed validation. Improved the validator function to support both strings and objects.