### PR TITLE
Added a longer timeout for spinny specifically

### DIFF
--- a/awx/ui/test/e2e/commands/navigateTo.js
+++ b/awx/ui/test/e2e/commands/navigateTo.js
@@ -6,7 +6,8 @@ exports.command = function navigateTo (url, expectSpinny = true) {
 
     if (expectSpinny) {
         this.waitForElementVisible(spinny, () => {
-            this.waitForElementNotVisible(spinny);
+            // If a process is running, give spinny a little more time before timing out.
+            this.waitForElementNotVisible(spinny, 30000);
         });
     }
 

--- a/awx/ui/test/e2e/commands/waitForSpinny.js
+++ b/awx/ui/test/e2e/commands/waitForSpinny.js
@@ -5,6 +5,9 @@ exports.command = function waitForSpinny (useXpath = false) {
         selector = '//*[contains(@class, "spinny")]';
     }
     this.waitForElementVisible(selector);
-    this.waitForElementNotVisible(selector);
+    // if a process is running for an extended period,
+    // spinny might last longer than five seconds.
+    // this gives it a max of 30 secs before failing.
+    this.waitForElementNotVisible(selector, 30000);
     return this;
 };


### PR DESCRIPTION
##### SUMMARY
A common source of flake is waiting for `.spinny` to _vanish_ (not for it to appear). A process might take longer than 5 seconds to resolve. This allows a more generous 30 seconds. Bear in mind that the 30 is a maximum, not an average.

Please feel free to offer opinions on whether or not we should add this as a sort of backup. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI