### PR TITLE
expose schedule name for scheduled workflow node job

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1391,8 +1391,8 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                 r['{}_workflow_job_id'.format(name)] = wj.pk
                 r['{}_workflow_job_name'.format(name)] = wj.name
                 if schedule:
-                    r['{}_parent_job_schedule_id'.format(name)] = wj.schedule.pk
-                    r['{}_parent_job_schedule_name'.format(name)] = wj.schedule.name
+                    r['{}_parent_job_schedule_id'.format(name)] = schedule.pk
+                    r['{}_parent_job_schedule_name'.format(name)] = schedule.name
 
         if not created_by:
             schedule = getattr_dne(self, 'schedule')

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -42,9 +42,9 @@ from awx.main.utils import (
     camelcase_to_underscore, get_model_for_type,
     encrypt_dict, decrypt_field, _inventory_updates,
     copy_model_by_class, copy_m2m_relationships,
-    get_type_for_model, parse_yaml_or_json, getattr_dne
+    get_type_for_model, parse_yaml_or_json, getattr_dne,
+    polymorphic, schedule_task_manager
 )
-from awx.main.utils import polymorphic, schedule_task_manager
 from awx.main.constants import ACTIVE_STATES, CAN_CANCEL
 from awx.main.redact import UriCleaner, REPLACE_STR
 from awx.main.consumers import emit_channel_notification
@@ -1386,9 +1386,13 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
 
         wj = self.get_workflow_job()
         if wj:
+            schedule = getattr_dne(wj, 'schedule')
             for name in ('awx', 'tower'):
                 r['{}_workflow_job_id'.format(name)] = wj.pk
                 r['{}_workflow_job_name'.format(name)] = wj.name
+                if schedule:
+                    r['{}_parent_job_schedule_id'.format(name)] = wj.schedule.pk
+                    r['{}_parent_job_schedule_name'.format(name)] = wj.schedule.name
 
         if not created_by:
             schedule = getattr_dne(self, 'schedule')

--- a/awx/main/tests/functional/models/test_unified_job.py
+++ b/awx/main/tests/functional/models/test_unified_job.py
@@ -147,6 +147,39 @@ class TestMetaVars:
         assert data['awx_schedule_id'] == schedule.pk
         assert 'awx_user_name' not in data
 
+    def test_scheduled_workflow_job_node_metavars(self, workflow_job_template):
+        schedule = Schedule.objects.create(
+            name='job-schedule',
+            rrule='DTSTART:20171129T155939z\nFREQ=MONTHLY',
+            unified_job_template=workflow_job_template
+        )
+
+        workflow_job = WorkflowJob.objects.create(
+            name='workflow-job',
+            workflow_job_template=workflow_job_template,
+            schedule=schedule
+        )
+
+        job = Job.objects.create(
+            launch_type='workflow'
+        )
+        workflow_job.workflow_nodes.create(job=job)
+        assert job.awx_meta_vars() == {
+            'awx_job_id': job.id,
+            'tower_job_id': job.id,
+            'awx_job_launch_type': 'workflow',
+            'tower_job_launch_type': 'workflow',
+            'awx_workflow_job_name': 'workflow-job',
+            'tower_workflow_job_name': 'workflow-job',
+            'awx_workflow_job_id': workflow_job.id,
+            'tower_workflow_job_id': workflow_job.id,
+            'awx_parent_job_schedule_id': schedule.id,
+            'tower_parent_job_schedule_id': schedule.id,
+            'awx_parent_job_schedule_name': 'job-schedule',
+            'tower_parent_job_schedule_name': 'job-schedule',
+            
+        }
+
 
 @pytest.mark.django_db
 def test_event_processing_not_finished():


### PR DESCRIPTION
##### SUMMARY
This enhancement exposes the parent schedule name for a job that was kicked off by a scheduled workflow.
If the parent of the job is a _scheduled_ workflow the JSON output for the job's result will now include the parent workflow's schedule name and ID number.

This change is pertinent because the launch type is 'workflow' as the parent is a workflow. However the workflow is scheduled and this change allows for greater tracing or blame.

Pertains to #3124

A small additional change to consolidate import statements was also added, but does not impact functionality in any way.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```

##### ADDITIONAL INFORMATION
To further clarify the issue, the added code will only exist if the current job is derived from a workflow and then only then if that workflow was scheduled.
#3124 <- more details on reproducing expected behavior before and after change may be found there.