### PR TITLE
[WIP] Postgres10 SCL Follow-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ test:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto $(TEST_DIRS)
+	scl enable rh-postgresql10 "PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto $(TEST_DIRS)"
 	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py2,py3
 	awx-manage check_migrations --dry-run --check  -n 'vNNN_missing_migration_file'
 

--- a/installer/roles/image_build/files/launch_awx.sh
+++ b/installer/roles/image_build/files/launch_awx.sh
@@ -10,8 +10,8 @@ source /etc/tower/conf.d/environment.sh
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$MEMCACHED_HOST port=$MEMCACHED_PORT" all
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$RABBITMQ_HOST port=$RABBITMQ_PORT" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_user --become-user postgres -a "name=$DATABASE_NAME password=$DATABASE_PASSWORD encrypted=yes login_user=postgres login_password=$DATABASE_ADMIN_PASSWORD login_host=postgres" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user postgres -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=postgres login_host=$DATABASE_HOST login_password=$DATABASE_ADMIN_PASSWORD port=$DATABASE_PORT" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_user --become-user postgres -a "name=$DATABASE_NAME password=$DATABASE_PASSWORD encrypted=yes login_user=$DATABASE_USER login_password=$DATABASE_PASSWORD login_host=postgres" all
+ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user postgres -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
 
 awx-manage collectstatic --noinput --clear
 

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -10,8 +10,8 @@ ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=${RABBITMQ_HOST} port=5
 # TODO: FIX
 #/etc/init.d/ssh start
 
-ansible -i "127.0.0.1," -c local -v -m postgresql_user --become-user postgres -a "name=awx-dev password=AWXsome1 encrypted=yes login_user=postgres login_password=postgrespass login_host=postgres" all
-ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user postgres -a "name=awx-dev owner=awx-dev login_user=postgres login_password=postgrespass login_host=postgres" all
+ansible -i "127.0.0.1," -c local -v -m postgresql_user --become-user postgres -a "name=awx-dev password=AWXsome1 encrypted=yes login_user=awx login_password=awxpass login_host=postgres" all
+ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user postgres -a "name=awx-dev owner=awx-dev login_user=awx login_password=awxpass login_host=postgres" all
 
 # Move to the source directory so we can bootstrap
 if [ -f "/awx_devel/manage.py" ]; then


### PR DESCRIPTION
##### SUMMARY
Follow-up for https://github.com/ansible/awx/pull/4058

This `scl enable`'s for the `test` make target and also uses the `awx` user instead of the `postgres` user for bootstrapping the database in container installs.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Installer

