### PR TITLE
scl enable db where needed to make local test targets work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ test:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto $(TEST_DIRS)
+	scl enable rh-postgresql10 "PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto $(TEST_DIRS)"
 	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py2,py3
 	awx-manage check_migrations --dry-run --check  -n 'vNNN_missing_migration_file'
 

--- a/tools/docker-compose/start_tests.sh
+++ b/tools/docker-compose/start_tests.sh
@@ -8,4 +8,4 @@ sed -i "s/placeholder/$(cat /awx_devel/VERSION)/" /awx_devel/awx.egg-info/PKG-IN
 cp /tmp/awx.egg-link /venv/awx/lib/python3.6/site-packages/awx.egg-link
 
 cp awx/settings/local_settings.py.docker_compose awx/settings/local_settings.py
-make "${1:-test}"
+scl enable rh-postgresql10 'make "${1:-test}"'


### PR DESCRIPTION
##### SUMMARY
Currently, if you try to run tests in the local dev environment using the `start_tests.sh` script or the `make test` target, both fail.  This will fix it.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

