### PR TITLE
assorted style cleanup in UI next

### DIFF
--- a/awx/ui_next/src/components/ContentError/ContentError.jsx
+++ b/awx/ui_next/src/components/ContentError/ContentError.jsx
@@ -16,6 +16,7 @@ import ErrorDetail from '@components/ErrorDetail';
 
 const EmptyState = styled(PFEmptyState)`
   width: var(--pf-c-empty-state--m-lg--MaxWidth);
+  max-width: 100%;
 `;
 
 async function logout() {

--- a/awx/ui_next/src/components/ErrorDetail/ErrorDetail.jsx
+++ b/awx/ui_next/src/components/ErrorDetail/ErrorDetail.jsx
@@ -22,6 +22,13 @@ const CardBody = styled(PFCardBody)`
 
 const Expandable = styled(PFExpandable)`
   text-align: left;
+
+  & .pf-c-expandable__toggle {
+    padding-left: 10px;
+    margin-left: 5px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
 `;
 
 class ErrorDetail extends Component {

--- a/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { QuestionCircleIcon as PFQuestionCircleIcon} from '@patternfly/react-icons';
+import { QuestionCircleIcon as PFQuestionCircleIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 
 import { InstanceGroupsAPI } from '@api';

--- a/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
@@ -1,12 +1,17 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { QuestionCircleIcon as PFQuestionCircleIcon} from '@patternfly/react-icons';
+import styled from 'styled-components';
 
 import { InstanceGroupsAPI } from '@api';
 import Lookup from '@components/Lookup';
+
+const QuestionCircleIcon = styled(PFQuestionCircleIcon)`
+  margin-left: 10px;
+`;
 
 const getInstanceGroups = async params => InstanceGroupsAPI.read(params);
 
@@ -21,18 +26,14 @@ class InstanceGroupsLookup extends React.Component {
     return (
       <div className={className}>
         <FormGroup
-          label={
-            <Fragment>
-              {i18n._(t`Instance Groups`)}{' '}
-              {tooltip && (
-                <Tooltip position="right" content={tooltip}>
-                  <QuestionCircleIcon />
-                </Tooltip>
-              )}
-            </Fragment>
-          }
+          label={i18n._(t`Instance Groups`)}
           fieldId="org-instance-groups"
         >
+          {tooltip && (
+            <Tooltip position="right" content={tooltip}>
+              <QuestionCircleIcon />
+            </Tooltip>
+          )}
           <Lookup
             id="org-instance-groups"
             lookupHeader={i18n._(t`Instance Groups`)}

--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -3,7 +3,7 @@ import { string, func, bool } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { QuestionCircleIcon as PFQuestionCircleIcon} from '@patternfly/react-icons';
+import { QuestionCircleIcon as PFQuestionCircleIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 
 import { InventoriesAPI } from '@api';

--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -1,13 +1,18 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { string, func, bool } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { QuestionCircleIcon as PFQuestionCircleIcon} from '@patternfly/react-icons';
+import styled from 'styled-components';
 
 import { InventoriesAPI } from '@api';
 import { Inventory } from '@types';
 import Lookup from '@components/Lookup';
+
+const QuestionCircleIcon = styled(PFQuestionCircleIcon)`
+  margin-left: 10px;
+`;
 
 const getInventories = async params => InventoriesAPI.read(params);
 
@@ -17,19 +22,15 @@ class InventoryLookup extends React.Component {
 
     return (
       <FormGroup
-        label={
-          <Fragment>
-            {i18n._(t`Inventory`)}{' '}
-            {tooltip && (
-              <Tooltip position="right" content={tooltip}>
-                <QuestionCircleIcon />
-              </Tooltip>
-            )}
-          </Fragment>
-        }
+        label={i18n._(t`Inventory`)}
         isRequired={required}
         fieldId="inventory-lookup"
       >
+        {tooltip && (
+          <Tooltip position="right" content={tooltip}>
+            <QuestionCircleIcon />
+          </Tooltip>
+        )}
         <Lookup
           id="inventory-lookup"
           lookupHeader={i18n._(t`Inventory`)}

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -46,6 +46,8 @@ const InputGroup = styled(PFInputGroup)`
 const ChipHolder = styled.div`
   --pf-c-form-control--BorderTopColor: var(--pf-global--BorderColor--200);
   --pf-c-form-control--BorderRightColor: var(--pf-global--BorderColor--200);
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px
 `;
 
 class Lookup extends React.Component {

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -47,7 +47,7 @@ const ChipHolder = styled.div`
   --pf-c-form-control--BorderTopColor: var(--pf-global--BorderColor--200);
   --pf-c-form-control--BorderRightColor: var(--pf-global--BorderColor--200);
   border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px
+  border-bottom-right-radius: 3px;
 `;
 
 class Lookup extends React.Component {

--- a/awx/ui_next/src/components/Search/Search.jsx
+++ b/awx/ui_next/src/components/Search/Search.jsx
@@ -44,6 +44,8 @@ const Dropdown = styled(PFDropdown)`
 
       ::before {
         border-color: var(--pf-global--BorderColor--200);
+        border-top-left-radius: 3px;
+        border-bottom-left-radius: 3px;
       }
 
       > span {
@@ -64,6 +66,8 @@ const Dropdown = styled(PFDropdown)`
 const NoOptionDropdown = styled.div`
   align-self: stretch;
   border: 1px solid var(--pf-global--BorderColor--200);
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
   padding: 3px 7px;
   white-space: nowrap;
 `;

--- a/awx/ui_next/src/screens/Organization/OrganizationNotifications/__snapshots__/OrganizationNotifications.test.jsx.snap
+++ b/awx/ui_next/src/screens/Organization/OrganizationNotifications/__snapshots__/OrganizationNotifications.test.jsx.snap
@@ -643,9 +643,9 @@ exports[`<OrganizationNotifications /> initially renders succesfully 1`] = `
                                                                                   "componentStyle": ComponentStyle {
                                                                                     "componentId": "Search__NoOptionDropdown-sc-1dwuww3-3",
                                                                                     "isStatic": true,
-                                                                                    "lastClassName": "iMdtNX",
+                                                                                    "lastClassName": "cbKaoS",
                                                                                     "rules": Array [
-                                                                                      "align-self:stretch;border:1px solid var(--pf-global--BorderColor--200);padding:3px 7px;white-space:nowrap;",
+                                                                                      "align-self:stretch;border:1px solid var(--pf-global--BorderColor--200);border-top-left-radius:3px;border-bottom-left-radius:3px;padding:3px 7px;white-space:nowrap;",
                                                                                     ],
                                                                                   },
                                                                                   "displayName": "Search__NoOptionDropdown",
@@ -661,7 +661,7 @@ exports[`<OrganizationNotifications /> initially renders succesfully 1`] = `
                                                                               forwardedRef={null}
                                                                             >
                                                                               <div
-                                                                                className="Search__NoOptionDropdown-sc-1dwuww3-3 iMdtNX"
+                                                                                className="Search__NoOptionDropdown-sc-1dwuww3-3 cbKaoS"
                                                                               >
                                                                                 Name
                                                                               </div>


### PR DESCRIPTION
Some assorted ui_next style clean up things:

- fix spacing of detail toggle for http error

<img width="530" alt="Screen Shot 2019-09-16 at 11 25 27 AM" src="https://user-images.githubusercontent.com/1342624/65173309-8497ef80-da1c-11e9-88d4-8b0ff6c3e8c4.png">
<img width="529" alt="Screen Shot 2019-09-16 at 11 25 36 AM" src="https://user-images.githubusercontent.com/1342624/65173310-8497ef80-da1c-11e9-8fd3-1bda40f6f0d2.png">
<img width="491" alt="Screen Shot 2019-09-16 at 11 31 39 AM" src="https://user-images.githubusercontent.com/1342624/65173311-8497ef80-da1c-11e9-8e85-15c10e8915c1.png">
<img width="490" alt="Screen Shot 2019-09-16 at 11 31 46 AM" src="https://user-images.githubusercontent.com/1342624/65173312-8497ef80-da1c-11e9-95ca-af1c2723607a.png">
<img width="489" alt="Screen Shot 2019-09-16 at 11 31 53 AM" src="https://user-images.githubusercontent.com/1342624/65173313-8497ef80-da1c-11e9-8fba-8c8e9b7498e3.png">

- round all corners of combo fields

<img width="865" alt="Screen Shot 2019-09-16 at 3 14 16 PM" src="https://user-images.githubusercontent.com/1342624/65173222-5fa37c80-da1c-11e9-9306-ee4c10025e11.png">
<img width="654" alt="Screen Shot 2019-09-16 at 3 14 29 PM" src="https://user-images.githubusercontent.com/1342624/65173223-5fa37c80-da1c-11e9-894d-42451e152fe4.png">
<img width="655" alt="Screen Shot 2019-09-16 at 3 14 38 PM" src="https://user-images.githubusercontent.com/1342624/65173224-5fa37c80-da1c-11e9-9360-f75d1477554d.png">
<img width="1360" alt="Screen Shot 2019-09-16 at 3 25 16 PM" src="https://user-images.githubusercontent.com/1342624/65173225-5fa37c80-da1c-11e9-9fbc-553b81b02d04.png">

- make sure required asterisk is always before help popover ?

<img width="1355" alt="Screen Shot 2019-09-16 at 3 36 53 PM" src="https://user-images.githubusercontent.com/1342624/65173252-6e8a2f00-da1c-11e9-8184-7498e5a64d77.png">

- bug: fix ? popover from opening lookups (this use to be the case for the instance groups lookup)

---

- (This one will be fixed once pattern fly’s change to fix the css vars is released by them) No spacing between full width fields in advanced suction of JT form.  Here's a screenshot of the issue below:

<img width="1372" alt="Screen Shot 2019-09-16 at 4 02 00 PM" src="https://user-images.githubusercontent.com/1342624/65173800-9928b780-da1d-11e9-9bdc-0f6cd80aa292.png">

A couple of things that came up in @trahman73 and I's audit that this PR does not handle:

- (Looks like the pulsing running for both ui ui_next are the green, will probably need to change in both) Running job in sparkling should be grey moving box not green
- (Couldn’t figure this one out, uses same ToolbarAddButton component as add on org list…not sure why tooltip is not showing up) Org > access add button does not have tooltip
- (PF thing…no tooltip prop available for Dropdown component) Add button on template list needs tooltip
- (Might be a weird PF thing) Tiny icon on about modal
- (Might be a weird PF thing) BUG: Pagination buttons seem disabled when they should be

LONGER TERM
- Revision for job detail not truncated/no copy. Button
- Lower Priority: Grey background for subfields (provisioning callbacks checkbox on JT form opens fields that should have grey background) (TBD add label for these sections)