### PR TITLE
Use proper headers to auth with Vault

### DIFF
--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -102,7 +102,7 @@ def kv_backend(**kwargs):
         request_kwargs['verify'] = create_temporary_fifo(cacert.encode())
 
     sess = requests.Session()
-    sess.headers['Authorization'] = 'Bearer {}'.format(token)
+    sess.headers['X-Vault-Token'] = token
 
     if api_version == 'v2':
         if kwargs.get('secret_version'):
@@ -157,7 +157,7 @@ def ssh_backend(**kwargs):
         request_kwargs['json']['valid_principals'] = kwargs['valid_principals']
 
     sess = requests.Session()
-    sess.headers['Authorization'] = 'Bearer {}'.format(token)
+    sess.headers['X-Vault-Token'] = token
     # https://www.vaultproject.io/api/secret/ssh/index.html#sign-ssh-key
     request_url = '/'.join([url, secret_path, 'sign', role]).rstrip('/')
     resp = sess.post(request_url, **request_kwargs)

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -102,6 +102,8 @@ def kv_backend(**kwargs):
         request_kwargs['verify'] = create_temporary_fifo(cacert.encode())
 
     sess = requests.Session()
+    sess.headers['Authorization'] = 'Bearer {}'.format(token)
+    # Compatability header for older installs of Hashicorp Vault
     sess.headers['X-Vault-Token'] = token
 
     if api_version == 'v2':
@@ -157,6 +159,8 @@ def ssh_backend(**kwargs):
         request_kwargs['json']['valid_principals'] = kwargs['valid_principals']
 
     sess = requests.Session()
+    sess.headers['Authorization'] = 'Bearer {}'.format(token)
+    # Compatability header for older installs of Hashicorp Vault
     sess.headers['X-Vault-Token'] = token
     # https://www.vaultproject.io/api/secret/ssh/index.html#sign-ssh-key
     request_url = '/'.join([url, secret_path, 'sign', role]).rstrip('/')


### PR DESCRIPTION
##### SUMMARY
Reading examples at
https://learn.hashicorp.com/vault/getting-started/apis show needing to
use `X-Vault-Token` header, instead of `Authorization`. Without this
header, the vault server would return a 400 status with an error message
of "missing client token". With this change AWX is now able to interface
with the Hashicorp backend.

Edited with more context.

It appears that recent versions of HashiCorp Vault support the `Authorization` header in addition to the `X-Vault-Token` header. However older versions (like the one we're using) do not support `Authorization` and only support `X-Vault-Token`. I believe that AWX should default to the header that's most widely supported, until such time as Vault no longer accepts that header.

https://www.vaultproject.io/docs/auth/token.html#via-the-api

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->