### PR TITLE
Changes InventoriesLookup to InventoryLookup

### DIFF
--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -11,7 +11,7 @@ import Lookup from '@components/Lookup';
 
 const getInventories = async params => InventoriesAPI.read(params);
 
-class InventoriesLookup extends React.Component {
+class InventoryLookup extends React.Component {
   render() {
     const { value, tooltip, onChange, required, i18n } = this.props;
 
@@ -19,7 +19,7 @@ class InventoriesLookup extends React.Component {
       <FormGroup
         label={
           <Fragment>
-            {i18n._(t`Inventories`)}{' '}
+            {i18n._(t`Inventory`)}{' '}
             {tooltip && (
               <Tooltip position="right" content={tooltip}>
                 <QuestionCircleIcon />
@@ -28,12 +28,12 @@ class InventoriesLookup extends React.Component {
           </Fragment>
         }
         isRequired={required}
-        fieldId="inventories-lookup"
+        fieldId="inventory-lookup"
       >
         <Lookup
-          id="inventories-lookup"
-          lookupHeader={i18n._(t`Inventories`)}
-          name="inventories"
+          id="inventory-lookup"
+          lookupHeader={i18n._(t`Inventory`)}
+          name="inventory"
           value={value}
           onLookupSave={onChange}
           getItems={getInventories}
@@ -61,17 +61,17 @@ class InventoriesLookup extends React.Component {
   }
 }
 
-InventoriesLookup.propTypes = {
+InventoryLookup.propTypes = {
   value: Inventory,
   tooltip: string,
   onChange: func.isRequired,
   required: bool,
 };
 
-InventoriesLookup.defaultProps = {
+InventoryLookup.defaultProps = {
   value: null,
   tooltip: '',
   required: false,
 };
 
-export default withI18n()(InventoriesLookup);
+export default withI18n()(InventoryLookup);

--- a/awx/ui_next/src/components/Lookup/index.js
+++ b/awx/ui_next/src/components/Lookup/index.js
@@ -1,3 +1,3 @@
 export { default } from './Lookup';
 export { default as InstanceGroupsLookup } from './InstanceGroupsLookup';
-export { default as InventoriesLookup } from './InventoriesLookup';
+export { default as InventoryLookup } from './InventoryLookup';

--- a/awx/ui_next/src/screens/Template/JobTemplateAdd/JobTemplateAdd.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateAdd/JobTemplateAdd.test.jsx
@@ -61,7 +61,7 @@ describe('<JobTemplateAdd />', () => {
     expect(wrapper.find('input#template-description').text()).toBe(
       defaultProps.description
     );
-    expect(wrapper.find('InventoriesLookup').prop('value')).toBe(null);
+    expect(wrapper.find('InventoryLookup').prop('value')).toBe(null);
     expect(wrapper.find('AnsibleSelect[name="job_type"]').props().value).toBe(
       defaultProps.job_type
     );

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -25,7 +25,7 @@ import CollapsibleSection from '@components/CollapsibleSection';
 import { required } from '@util/validators';
 import styled from 'styled-components';
 import { JobTemplate } from '@types';
-import { InventoriesLookup, InstanceGroupsLookup } from '@components/Lookup';
+import { InventoryLookup, InstanceGroupsLookup } from '@components/Lookup';
 import ProjectLookup from './ProjectLookup';
 import { JobTemplatesAPI, LabelsAPI, ProjectsAPI } from '@api';
 
@@ -397,7 +397,7 @@ class JobTemplateForm extends Component {
             name="inventory"
             validate={required(null, i18n)}
             render={({ form }) => (
-              <InventoriesLookup
+              <InventoryLookup
                 value={inventory}
                 tooltip={i18n._(t`Select the inventory containing the hosts
                   you want this job to manage.`)}

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
@@ -109,7 +109,7 @@ describe('<JobTemplateForm />', () => {
       target: { value: 'new job type', name: 'job_type' },
     });
     expect(form.state('values').job_type).toEqual('new job type');
-    wrapper.find('InventoriesLookup').prop('onChange')({
+    wrapper.find('InventoryLookup').prop('onChange')({
       id: 3,
       name: 'inventory',
     });

--- a/awx/ui_next/src/screens/Template/shared/ProjectLookup.jsx
+++ b/awx/ui_next/src/screens/Template/shared/ProjectLookup.jsx
@@ -43,7 +43,7 @@ class ProjectLookup extends React.Component {
         )}
         <Lookup
           id="project"
-          lookupHeader={i18n._(t`Projects`)}
+          lookupHeader={i18n._(t`Project`)}
           name="project"
           value={value}
           onBlur={onBlur}


### PR DESCRIPTION
##### SUMMARY

The inventory lookup on the JT form is a single select so I removed references to `Inventories` as there aren't any lookups in the app where you select multiple inventories.

Also removes pluralization of lookup headers for Inventory and Project since only one can be selected.

Here are the visual changes:

<img width="1412" alt="Screen Shot 2019-09-19 at 11 14 24 AM" src="https://user-images.githubusercontent.com/9889020/65257259-f29cef00-dace-11e9-8445-5aaa2480ed17.png">

<img width="980" alt="Screen Shot 2019-09-19 at 11 14 33 AM" src="https://user-images.githubusercontent.com/9889020/65257267-f6c90c80-dace-11e9-9eef-76be707782b9.png">

<img width="991" alt="Screen Shot 2019-09-19 at 11 14 39 AM" src="https://user-images.githubusercontent.com/9889020/65257277-f9c3fd00-dace-11e9-854f-3d054d33c1bf.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI