### PR TITLE
fix for LDAPServerURIField error if number present in top-level-domain

### DIFF
--- a/awx/conf/fields.py
+++ b/awx/conf/fields.py
@@ -121,11 +121,14 @@ class URLField(CharField):
 
     def __init__(self, **kwargs):
         schemes = kwargs.pop('schemes', None)
+        regex = kwargs.pop('regex', None)
         self.allow_plain_hostname = kwargs.pop('allow_plain_hostname', False)
         super(URLField, self).__init__(**kwargs)
         validator_kwargs = dict(message=_('Enter a valid URL'))
         if schemes is not None:
             validator_kwargs['schemes'] = schemes
+        if regex is not None:
+            validator_kwargs['regex'] = regex
         self.validators.append(URLValidator(**validator_kwargs))
 
     def to_representation(self, value):

--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -11,6 +11,7 @@ import awx
 # Django
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
+from django.core.validators import URLValidator, _lazy_re_compile
 
 # Django Auth LDAP
 import django_auth_ldap.config
@@ -233,12 +234,34 @@ class AuthenticationBackendsField(fields.StringListField):
 
 class LDAPServerURIField(fields.URLField):
 
+    tld_re = (
+        r'\.'                                              # dot
+        r'(?!-)'                                           # can't start with a dash
+        r'(?:[a-z' + URLValidator.ul + r'0-9' + '-]{2,63}' # domain label, this line was changed from the original URLValidator
+        r'|xn--[a-z0-9]{1,59})'                            # or punycode label
+        r'(?<!-)'                                          # can't end with a dash
+        r'\.?'                                             # may have a trailing dot
+    )
+
+    host_re = '(' + URLValidator.hostname_re + URLValidator.domain_re + tld_re + '|localhost)'
+
+    regex = _lazy_re_compile(
+        r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
+        r'(?:[^\s:@/]+(?::[^\s:@/]*)?@)?'  # user:pass authentication
+        r'(?:' + URLValidator.ipv4_re + '|' + URLValidator.ipv6_re + '|' + host_re + ')'
+        r'(?::\d{2,5})?'  # port
+        r'(?:[/?#][^\s]*)?'  # resource path
+        r'\Z', re.IGNORECASE)
+
     def __init__(self, **kwargs):
+
         kwargs.setdefault('schemes', ('ldap', 'ldaps'))
         kwargs.setdefault('allow_plain_hostname', True)
+        kwargs.setdefault('regex', LDAPServerURIField.regex)
         super(LDAPServerURIField, self).__init__(**kwargs)
 
     def run_validators(self, value):
+
         for url in filter(None, re.split(r'[, ]', (value or ''))):
             super(LDAPServerURIField, self).run_validators(url)
         return value

--- a/awx/sso/tests/unit/test_fields.py
+++ b/awx/sso/tests/unit/test_fields.py
@@ -8,6 +8,7 @@ from awx.sso.fields import (
     SAMLOrgAttrField,
     SAMLTeamAttrField,
     LDAPGroupTypeParamsField,
+    LDAPServerURIField
 )
 
 
@@ -114,3 +115,20 @@ class TestLDAPGroupTypeParamsField():
         with pytest.raises(ValidationError) as e:
             field.to_internal_value(data)
         assert e.value.detail == expected
+
+
+class TestLDAPServerURIField():
+
+    @pytest.mark.parametrize("ldap_uri, exception, expected", [
+        (r'ldap://servername.com:444', None, r'ldap://servername.com:444'),
+        (r'ldap://servername.so3:444', None, r'ldap://servername.so3:444'),
+        (r'ldaps://servername3.s300:344', None, r'ldaps://servername3.s300:344'),
+        (r'ldap://servername.-so3:444', ValidationError, None),
+    ])
+    def test_run_validators_valid(self, ldap_uri, exception, expected):
+        field = LDAPServerURIField()
+        if exception is None:
+            assert field.run_validators(ldap_uri) == expected
+        else:
+            with pytest.raises(exception):
+                field.run_validators(ldap_uri)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related to issue #3646
continuation of this closed PR https://github.com/ansible/awx/pull/4774

LDAP server URI field does not validate if top-level-domain contains a number, throwing a generic 400 error to the user.

The URI field is passed to a built-in django validator that does a regex match to check for validity.

This URI validator can take in a custom regex. My solution sets up a custom regex in the LDAPServerURIField class and passes it to the URLValidator that is appended in the parent class init.

For the custom regex, I simply grabbed the default URLValidator regex defined here,
https://github.com/django/django/blob/55b68de643b5c2d5f0a8ea7587ab3b2966021ccc/django/core/validators.py#L89

and added number capabilities,

`r'(?:[a-z' + URLValidator.ul + r'0-9' + '-]{2,63}' # domain label`

Added a unit test to make sure valid URIs pass, and invalid URIs catch the correct exception.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
