### PR TITLE
Rename Automation Insights to Automation Analytics.

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -350,8 +350,8 @@ register(
     'INSIGHTS_TRACKING_STATE',
     field_class=fields.BooleanField,
     default=False,
-    label=_('Gather data for Automation Insights'),
-    help_text=_('Enables Tower to gather data on automation and send it to Red Hat Insights.'),
+    label=_('Gather data for Automation Analytics'),
+    help_text=_('Enables Tower to gather data on automation and send it to Red Hat.'),
     category=_('System'),
     category_slug='system',
 )

--- a/awx/ui/client/src/license/license.partial.html
+++ b/awx/ui/client/src/license/license.partial.html
@@ -190,7 +190,7 @@
 						<div class="License-analyticsCheckbox checkbox">
 								<label class="License-details--label">
 									<input id="license-insights" type="checkbox" ng-model="newLicense.insights" ng-disabled="!user_is_superuser">
-									<span class="License-checkboxLabel" translate><b>Automation analytics</b>: This data is used to enhance future releases of the Tower Software and to provide Automation Insights to Tower subscribers.</span>
+									<span class="License-checkboxLabel" translate><b>Automation analytics</b>: This data is used to enhance future releases of the Tower Software and to provide Automation Analytics to Tower subscribers.</span>
 								</label>
 						</div>
 					</div>


### PR DESCRIPTION
Fix user-facing code, don't worry about settings names.
