### PR TITLE
ToolBar checkbox checks, JT Add Button closes and Test Clean up

### DIFF
--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -109,7 +109,7 @@ class DataListToolbar extends React.Component {
               <Fragment>
                 <ToolbarItem>
                   <Checkbox
-                    checked={isAllSelected}
+                    isChecked={isAllSelected}
                     onChange={onSelectAll}
                     aria-label={i18n._(t`Select all`)}
                     id="select-all"

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -12,6 +12,10 @@ describe('<DataListToolbar />', () => {
     }
   });
 
+  const onSearch = jest.fn();
+  const onSort = jest.fn();
+  const onSelectAll = jest.fn();
+
   test('it triggers the expected callbacks', () => {
     const columns = [
       { name: 'Name', key: 'name', isSortable: true, isSearchable: true },
@@ -21,10 +25,6 @@ describe('<DataListToolbar />', () => {
     const searchTextInput = 'input[aria-label="Search text input"]';
     const selectAll = 'input[aria-label="Select all"]';
     const sort = 'button[aria-label="Sort"]';
-
-    const onSearch = jest.fn();
-    const onSort = jest.fn();
-    const onSelectAll = jest.fn();
 
     toolbar = mountWithContexts(
       <DataListToolbar
@@ -72,8 +72,6 @@ describe('<DataListToolbar />', () => {
       { name: 'Bakery', key: 'bakery', isSortable: true },
       { name: 'Baz', key: 'baz' },
     ];
-
-    const onSort = jest.fn();
 
     toolbar = mountWithContexts(
       <DataListToolbar
@@ -198,9 +196,6 @@ describe('<DataListToolbar />', () => {
     const columns = [
       { name: 'Name', key: 'name', isSortable: true, isSearchable: true },
     ];
-    const onSearch = jest.fn();
-    const onSort = jest.fn();
-    const onSelectAll = jest.fn();
 
     toolbar = mountWithContexts(
       <DataListToolbar
@@ -219,5 +214,27 @@ describe('<DataListToolbar />', () => {
     const button = toolbar.find('#test');
     expect(button).toHaveLength(1);
     expect(button.text()).toEqual('click');
+  });
+
+  test('it triggers the expected callbacks', () => {
+    const columns = [
+      { name: 'Name', key: 'name', isSortable: true, isSearchable: true },
+    ];
+
+    toolbar = mountWithContexts(
+      <DataListToolbar
+        isAllSelected
+        showExpandCollapse
+        sortedColumnKey="name"
+        sortOrder="ascending"
+        columns={columns}
+        onSearch={onSearch}
+        onSort={onSort}
+        onSelectAll={onSelectAll}
+        showSelectAll
+      />
+    );
+    const checkbox = toolbar.find('Checkbox');
+    expect(checkbox.prop('isChecked')).toBe(true);
   });
 });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -56,6 +56,7 @@ class TemplatesList extends Component {
 
   componentDidMount() {
     this.loadTemplates();
+    document.addEventListener('click', this.handleAddToggle, false);
   }
 
   componentDidUpdate(prevProps) {
@@ -63,6 +64,10 @@ class TemplatesList extends Component {
     if (location !== prevProps.location) {
       this.loadTemplates();
     }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleAddToggle, false);
   }
 
   handleDeleteErrorClose() {
@@ -84,9 +89,15 @@ class TemplatesList extends Component {
     }
   }
 
-  handleAddToggle() {
+  handleAddToggle(e) {
     const { isAddOpen } = this.state;
-    this.setState({ isAddOpen: !isAddOpen });
+    if (this.node && this.node.contains(e.target) && isAddOpen) {
+      this.setState({ isAddOpen: false });
+    } else if (this.node && this.node.contains(e.target) && !isAddOpen) {
+      this.setState({ isAddOpen: true });
+    } else {
+      this.setState({ isAddOpen: false });
+    }
   }
 
   async handleTemplateDelete() {
@@ -215,28 +226,32 @@ class TemplatesList extends Component {
                     itemName={i18n._(t`Template`)}
                   />,
                   canAdd && (
-                    <Dropdown
+                    <div
+                      ref={node => {
+                        this.node = node;
+                      }}
                       key="add"
-                      isPlain
-                      isOpen={isAddOpen}
-                      position={DropdownPosition.right}
-                      onSelect={this.handleAddSelect}
-                      toggle={
-                        <ToolbarAddButton onClick={this.handleAddToggle} />
-                      }
-                      dropdownItems={[
-                        <DropdownItem key="job">
-                          <Link to={`${match.url}/job_template/add/`}>
-                            {i18n._(t`Job Template`)}
-                          </Link>
-                        </DropdownItem>,
-                        <DropdownItem key="workflow">
-                          <Link to={`${match.url}_workflow/add/`}>
-                            {i18n._(t`Workflow Template`)}
-                          </Link>
-                        </DropdownItem>,
-                      ]}
-                    />
+                    >
+                      <Dropdown
+                        isPlain
+                        isOpen={isAddOpen}
+                        position={DropdownPosition.right}
+                        onSelect={this.handleAddSelect}
+                        toggle={<ToolbarAddButton onClick={() => {}} />}
+                        dropdownItems={[
+                          <DropdownItem key="job" isPlain>
+                            <Link to={`${match.url}/job_template/add/`}>
+                              {i18n._(t`Job Template`)}
+                            </Link>
+                          </DropdownItem>,
+                          <DropdownItem key="workflow" isPlain>
+                            <Link to={`${match.url}_workflow/add/`}>
+                              {i18n._(t`Workflow Template`)}
+                            </Link>
+                          </DropdownItem>,
+                        ]}
+                      />
+                    </div>
                   ),
                 ]}
               />

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -239,12 +239,12 @@ class TemplatesList extends Component {
                         onSelect={this.handleAddSelect}
                         toggle={<ToolbarAddButton onClick={() => {}} />}
                         dropdownItems={[
-                          <DropdownItem key="job" isPlain>
+                          <DropdownItem isHovered={false} key="job">
                             <Link to={`${match.url}/job_template/add/`}>
                               {i18n._(t`Job Template`)}
                             </Link>
                           </DropdownItem>,
-                          <DropdownItem key="workflow" isPlain>
+                          <DropdownItem key="workflow">
                             <Link to={`${match.url}_workflow/add/`}>
                               {i18n._(t`Workflow Template`)}
                             </Link>

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -56,11 +56,11 @@ class TemplatesList extends Component {
 
   componentDidMount() {
     this.loadTemplates();
-    document.addEventListener('click', this.handleAddToggle, false);
   }
 
   componentDidUpdate(prevProps) {
     const { location } = this.props;
+
     if (location !== prevProps.location) {
       this.loadTemplates();
     }
@@ -91,12 +91,19 @@ class TemplatesList extends Component {
 
   handleAddToggle(e) {
     const { isAddOpen } = this.state;
+    document.addEventListener('click', this.handleAddToggle, false);
+
     if (this.node && this.node.contains(e.target) && isAddOpen) {
+
+      document.removeEventListener('click', this.handleAddToggle, false);
       this.setState({ isAddOpen: false });
+
     } else if (this.node && this.node.contains(e.target) && !isAddOpen) {
       this.setState({ isAddOpen: true });
+
     } else {
       this.setState({ isAddOpen: false });
+      document.removeEventListener('click', this.handleAddToggle, false);
     }
   }
 
@@ -236,10 +243,9 @@ class TemplatesList extends Component {
                         isPlain
                         isOpen={isAddOpen}
                         position={DropdownPosition.right}
-                        onSelect={this.handleAddSelect}
-                        toggle={<ToolbarAddButton onClick={() => {}} />}
+                        toggle={<ToolbarAddButton onClick={this.handleAddToggle}/>}
                         dropdownItems={[
-                          <DropdownItem isHovered={false} key="job">
+                          <DropdownItem key="job">
                             <Link to={`${match.url}/job_template/add/`}>
                               {i18n._(t`Job Template`)}
                             </Link>
@@ -268,13 +274,17 @@ class TemplatesList extends Component {
             )}
             emptyStateControls={
               canAdd && (
-                <Dropdown
+                <div
+                  ref={node => {
+                    this.node = node;
+                  }}
                   key="add"
+                >
+                <Dropdown
                   isPlain
                   isOpen={isAddOpen}
                   position={DropdownPosition.right}
-                  onSelect={this.handleAddSelect}
-                  toggle={<ToolbarAddButton onClick={this.handleAddToggle} />}
+                  toggle={<ToolbarAddButton onClick={this.handleAddToggle}/> }
                   dropdownItems={[
                     <DropdownItem key="job">
                       <Link to={`${match.url}/job_template/add/`}>
@@ -288,6 +298,7 @@ class TemplatesList extends Component {
                     </DropdownItem>,
                   ]}
                 />
+              </div>
               )
             }
           />

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -94,13 +94,10 @@ class TemplatesList extends Component {
     document.addEventListener('click', this.handleAddToggle, false);
 
     if (this.node && this.node.contains(e.target) && isAddOpen) {
-
       document.removeEventListener('click', this.handleAddToggle, false);
       this.setState({ isAddOpen: false });
-
     } else if (this.node && this.node.contains(e.target) && !isAddOpen) {
       this.setState({ isAddOpen: true });
-
     } else {
       this.setState({ isAddOpen: false });
       document.removeEventListener('click', this.handleAddToggle, false);
@@ -243,7 +240,9 @@ class TemplatesList extends Component {
                         isPlain
                         isOpen={isAddOpen}
                         position={DropdownPosition.right}
-                        toggle={<ToolbarAddButton onClick={this.handleAddToggle}/>}
+                        toggle={
+                          <ToolbarAddButton onClick={this.handleAddToggle} />
+                        }
                         dropdownItems={[
                           <DropdownItem key="job">
                             <Link to={`${match.url}/job_template/add/`}>
@@ -280,25 +279,25 @@ class TemplatesList extends Component {
                   }}
                   key="add"
                 >
-                <Dropdown
-                  isPlain
-                  isOpen={isAddOpen}
-                  position={DropdownPosition.right}
-                  toggle={<ToolbarAddButton onClick={this.handleAddToggle}/> }
-                  dropdownItems={[
-                    <DropdownItem key="job">
-                      <Link to={`${match.url}/job_template/add/`}>
-                        {i18n._(t`Job Template`)}
-                      </Link>
-                    </DropdownItem>,
-                    <DropdownItem key="workflow">
-                      <Link to={`${match.url}_workflow/add/`}>
-                        {i18n._(t`Workflow Template`)}
-                      </Link>
-                    </DropdownItem>,
-                  ]}
-                />
-              </div>
+                  <Dropdown
+                    isPlain
+                    isOpen={isAddOpen}
+                    position={DropdownPosition.right}
+                    toggle={<ToolbarAddButton onClick={this.handleAddToggle} />}
+                    dropdownItems={[
+                      <DropdownItem key="job">
+                        <Link to={`${match.url}/job_template/add/`}>
+                          {i18n._(t`Job Template`)}
+                        </Link>
+                      </DropdownItem>,
+                      <DropdownItem key="workflow">
+                        <Link to={`${match.url}_workflow/add/`}>
+                          {i18n._(t`Workflow Template`)}
+                        </Link>
+                      </DropdownItem>,
+                    ]}
+                  />
+                </div>
               )
             }
           />


### PR DESCRIPTION


##### SUMMARY
This addresses #4616  and #4766 .
The Select-All check box in the DataList Toolbar will be checked when the
user clicks on it. Also, the JT Add button closes when the user clicks
elsewhere on the page as well as when the user clicks on the button a second time.
I also added a test and cleaned up some tests in the DataListToolBar file.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
7.0.0
```


##### ADDITIONAL INFORMATION
![JobTemplate](https://user-images.githubusercontent.com/39280967/65432061-8e3ca100-dde8-11e9-8c9a-ee76ab0c0b66.gif)


