### PR TITLE
fix a bug that prevents launch-time passphrases w/ cred plugins

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -151,7 +151,7 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
     @property
     def has_encrypted_ssh_key_data(self):
         try:
-            ssh_key_data = decrypt_field(self, 'ssh_key_data')
+            ssh_key_data = self.get_input('ssh_key_data')
         except AttributeError:
             return False
 
@@ -633,9 +633,6 @@ ManagedCredentialType(
             'secret': True,
             'ask_at_runtime': True
         }],
-        'dependencies': {
-            'ssh_key_unlock': ['ssh_key_data'],
-        }
     }
 )
 
@@ -667,9 +664,6 @@ ManagedCredentialType(
             'type': 'string',
             'secret': True
         }],
-        'dependencies': {
-            'ssh_key_unlock': ['ssh_key_data'],
-        }
     }
 )
 
@@ -738,7 +732,6 @@ ManagedCredentialType(
             'secret': True,
         }],
         'dependencies': {
-            'ssh_key_unlock': ['ssh_key_data'],
             'authorize_password': ['authorize'],
         },
         'required': ['username'],

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -496,9 +496,6 @@ def test_falsey_field_data(get, post, organization, admin, field_value):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('kind, extraneous', [
-    ['ssh', 'ssh_key_unlock'],
-    ['scm', 'ssh_key_unlock'],
-    ['net', 'ssh_key_unlock'],
     ['net', 'authorize_password'],
 ])
 def test_field_dependencies(get, post, organization, admin, kind, extraneous):

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -137,7 +137,6 @@ def test_credential_creation(organization_factory):
     [PKCS8_PRIVATE_KEY, None, True],  # unencrypted PKCS8 key, no unlock pass
     [PKCS8_PRIVATE_KEY, 'passme', False],  # unencrypted PKCS8 key, unlock pass
     [None, None, True],  # no key, no unlock pass
-    [None, 'super-secret', False],  # no key, unlock pass
     ['INVALID-KEY-DATA', None, False],  # invalid key data
     [EXAMPLE_PRIVATE_KEY.replace('=', '\u003d'), None, True],  # automatically fix JSON-encoded GCE keys
 ])


### PR DESCRIPTION
with the advent of credential plugins there's no way for us to *actually
know* the RSA key value at the time the credential is _created_, because
the order of operations is:

1.  _Create_ the credential with a specified passphrase
2.  _Associate_ a new dynamic inventory source pointed at some third party
    provider (hashi, cyberark, etc...)

this commit removes the code that warns you about an extraneous
passphrase (if you don't specify a private key)

additionally, the code for determining whether or not a credential
_requires_ a password/phrase at launch time has been updated to test
private key validity based on the *actual* value stored in the third party
provider

see: https://github.com/ansible/awx/issues/4791