### PR TITLE
add link to awxkit docs

### DIFF
--- a/awxkit/README.md
+++ b/awxkit/README.md
@@ -2,3 +2,5 @@ awxkit
 ======
 
 Python library that backs the provided `awx` command line client.
+
+For more information on installing the CLI and building the docs on how to use it, look [here](./awxkit/cli/docs).


### PR DESCRIPTION
##### SUMMARY

Adds a link from the base of the awxkit code to the cli installation docs.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX: 7.0.0
```

