### PR TITLE
Add needed scl enables for community container installs

### DIFF
--- a/installer/roles/image_build/files/supervisor.conf
+++ b/installer/roles/image_build/files/supervisor.conf
@@ -13,7 +13,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:uwsgi]
-command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+command = /usr/bin/scl enable rh-postgresql10 '/var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768'
 directory = /var/lib/awx
 autostart = true
 autorestart = true
@@ -25,7 +25,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:daphne]
-command = /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
+command = /usr/bin/scl enable rh-postgresql10 '/var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer'
 directory = /var/lib/awx
 autostart = true
 autorestart = true

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -82,7 +82,7 @@ ADD requirements/requirements_ansible.txt \
     requirements/requirements_tower_uninstall.txt \
     requirements/requirements_git.txt \
     /tmp/requirements/
-RUN cd /tmp && VENV_BASE="/var/lib/awx/venv" make requirements
+RUN scl enable rh-postgresql10 'cd /tmp && VENV_BASE="/var/lib/awx/venv" make requirements'
 
 RUN yum -y remove cyrus-sasl-devel \
   gcc \


### PR DESCRIPTION
##### SUMMARY
We took out the unnecessary "scl enable"'s for the dev container after making it use pgdg postgresql10, but we accidentally removed the ones needed for the AWX Local and AWX Kubernetes installations.  This will fix AWX installations.  

Related: https://github.com/ansible/awx/pull/4752/files#diff-bd6a3525c5bccde7d201808718bb6a62R16

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
7.0.0
```

