### PR TITLE
Update the "Credential" label on JT forms to say "Credentials"

### DIFF
--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -137,7 +137,7 @@ function(NotificationsList, i18n) {
                     includePlaybookNotFoundError: true
                 },
                 credential: {
-                    label: i18n._('Credential'),
+                    label: i18n._('Credentials'),
                     type: 'custom',
                     control: `
                         <multi-credential


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/4831

Before: 

<img width="391" alt="image" src="https://user-images.githubusercontent.com/214912/65769993-1382c700-e103-11e9-9b25-ed3381d41d1b.png">

After:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/214912/65770179-85f3a700-e103-11e9-9507-5660babf026b.png">

