### PR TITLE
check if User exists before saving UserSessionMembership

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -20,7 +20,6 @@ from django.db.models.signals import (
 )
 from django.dispatch import receiver
 from django.contrib.auth import SESSION_KEY
-from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 from django.utils import timezone
 
@@ -685,6 +684,7 @@ def save_user_session_membership(sender, **kwargs):
         return
     if UserSessionMembership.objects.filter(user=user_id, session=session).exists():
         return
+    # check if user_id from session has an id match in User before saving
     if User.objects.filter(id=int(user_id)).exists():
         UserSessionMembership(user_id=user_id, session=session, created=timezone.now()).save()
     expired = UserSessionMembership.get_memberships_over_limit(user_id)

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -687,15 +687,15 @@ def save_user_session_membership(sender, **kwargs):
     # check if user_id from session has an id match in User before saving
     if User.objects.filter(id=int(user_id)).exists():
         UserSessionMembership(user_id=user_id, session=session, created=timezone.now()).save()
-    expired = UserSessionMembership.get_memberships_over_limit(user_id)
-    for membership in expired:
-        Session.objects.filter(session_key__in=[membership.session_id]).delete()
-        membership.delete()
-    if len(expired):
-        consumers.emit_channel_notification(
-            'control-limit_reached_{}'.format(user_id),
-            dict(group_name='control', reason='limit_reached')
-        )
+        expired = UserSessionMembership.get_memberships_over_limit(user_id)
+        for membership in expired:
+            Session.objects.filter(session_key__in=[membership.session_id]).delete()
+            membership.delete()
+        if len(expired):
+            consumers.emit_channel_notification(
+                'control-limit_reached_{}'.format(user_id),
+                dict(group_name='control', reason='limit_reached')
+            )
 
 
 @receiver(post_save, sender=OAuth2AccessToken)

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -20,6 +20,7 @@ from django.db.models.signals import (
 )
 from django.dispatch import receiver
 from django.contrib.auth import SESSION_KEY
+from django.contrib.auth.models import User
 from django.contrib.sessions.models import Session
 from django.utils import timezone
 
@@ -684,7 +685,8 @@ def save_user_session_membership(sender, **kwargs):
         return
     if UserSessionMembership.objects.filter(user=user_id, session=session).exists():
         return
-    UserSessionMembership(user_id=user_id, session=session, created=timezone.now()).save()
+    if User.objects.filter(id=int(user_id)).exists():
+        UserSessionMembership(user_id=user_id, session=session, created=timezone.now()).save()
     expired = UserSessionMembership.get_memberships_over_limit(user_id)
     for membership in expired:
         Session.objects.filter(session_key__in=[membership.session_id]).delete()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related to issue #4334 

Change: check that User exists before saving the UserSessionMembership

Significant line addition: `if User.objects.filter(id=int(user_id)).exists():`

An internal database error occurs if
1. User is logged in with active session
2. User is deleted
3. User reloads browser, or makes an HTTP API request

Error stems from signals.py function save_user_session_membership()

UserSessionMembership model will grab the user_id from the session (which now contains stale info) and attempt to save to the database using User as a foreignkey. However, because User was already deleted, it will throw the error.

The solution is to check that a User exists with the same user_id as the session user_id.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```


```
