### PR TITLE
FIX docker image builds failing for awx/devel branch #4759

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -71,6 +71,7 @@ RUN chmod +x /tini
 RUN python3 -m ensurepip && pip3 install virtualenv
 RUN pip install supervisor
 
+RUN ln -sf /opt/rh/rh-postgresql10/root/usr/lib64/libpq.so.rh-postgresql10-5 /usr/lib64
 RUN find / -name pg_config
 
 ADD Makefile /tmp/Makefile


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related to issue #4759

The build succeeds.
However, this alone will cause an error when starting awx_web log.
```
raise ImproperlyConfigured (" Error loading psycopg2 module:% s "% e)
django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module: libpq.so.rh-postgresql10-5: cannot open shared object file: No such file or directory
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx 7.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
