### PR TITLE
Detect and install pip requirements

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -379,7 +379,7 @@ register(
 register(
     'AWX_PIP_ENABLED',
     field_class=fields.BooleanField,
-    default=True,
+    default=False,
     label=_('Enable Pip Requirements Install'),
     help_text=_('Allows python packages to be dynamically installed from a pip-requirements.txt file for SCM projects.'),
     category=_('Jobs'),

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -377,6 +377,16 @@ register(
 )
 
 register(
+    'AWX_PIP_ENABLED',
+    field_class=fields.BooleanField,
+    default=True,
+    label=_('Enable Pip Requirements Install'),
+    help_text=_('Allows python packages to be dynamically installed from a pip-requirements.txt file for SCM projects.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
     'STDOUT_MAX_BYTES_DISPLAY',
     field_class=fields.IntegerField,
     min_value=0,

--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -18,12 +18,13 @@ logger = logging.getLogger('awx.isolated.manager')
 playbook_logger = logging.getLogger('awx.isolated.manager.playbooks')
 
 
-def set_pythonpath(venv_libdir, env):
+def set_pythonpath(venv_libdir, private_libdir, env):
     env.pop('PYTHONPATH', None)  # default to none if no python_ver matches
     for version in os.listdir(venv_libdir):
         if fnmatch.fnmatch(version, 'python[23].*'):
             if os.path.isdir(os.path.join(venv_libdir, version)):
                 env['PYTHONPATH'] = os.path.join(venv_libdir, version, "site-packages") + ":"
+                env['PYTHONPATH'] += os.path.join(private_libdir, version, "site-packages") + ":"
                 break
 
 

--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -18,13 +18,12 @@ logger = logging.getLogger('awx.isolated.manager')
 playbook_logger = logging.getLogger('awx.isolated.manager.playbooks')
 
 
-def set_pythonpath(venv_libdir, private_libdir, env):
+def set_pythonpath(venv_libdir, env):
     env.pop('PYTHONPATH', None)  # default to none if no python_ver matches
     for version in os.listdir(venv_libdir):
         if fnmatch.fnmatch(version, 'python[23].*'):
             if os.path.isdir(os.path.join(venv_libdir, version)):
                 env['PYTHONPATH'] = os.path.join(venv_libdir, version, "site-packages") + ":"
-                env['PYTHONPATH'] += os.path.join(private_libdir, version, "site-packages") + ":"
                 break
 
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -126,12 +126,12 @@
         register: doesPipRequirementsExist
 
       - name: fetch python packages from pip-requirements.txt
-        command: pip install -I -r pip-requirements.txt --install-option="--prefix={{pip_destination}}"
-        args:
-          chdir: "{{project_path|quote}}"
+        pip:
+          requirements: "{{project_path|quote}}/pip-requirements.txt"
+          extra_args: "-I --install-option='--prefix={{pip_destination|quote}}'"
         register: pip_result
         when: doesPipRequirementsExist.stat.exists
-        changed_when: "'was installed successfully' in pip_result.stdout"
+        changed_when: "'Successfully installed' in pip_result.stdout"
         environment:
           ANSIBLE_FORCE_COLOR: False
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -131,7 +131,6 @@
           extra_args: "-I --install-option='--prefix={{private_venv|quote}}'"
         register: pip_result
         when: doesPipRequirementsExist.stat.exists
-        changed_when: "'Successfully installed' in pip_result.stdout"
         environment:
           ANSIBLE_FORCE_COLOR: False
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -121,6 +121,24 @@
   tasks:
 
     - block:
+      - name: detect pip-requirements.txt
+        stat: path={{project_path|quote}}/pip-requirements.txt
+        register: doesPipRequirementsExist
+
+      - name: fetch python packages from pip-requirements.txt
+        command: pip install -I -r pip-requirements.txt --install-option="--prefix={{pip_destination}}"
+        args:
+          chdir: "{{project_path|quote}}"
+        register: pip_result
+        when: doesPipRequirementsExist.stat.exists
+        changed_when: "'was installed successfully' in pip_result.stdout"
+        environment:
+          ANSIBLE_FORCE_COLOR: False
+
+      when: pip_enabled|bool
+      delegate_to: localhost
+
+    - block:
       - name: detect requirements.yml
         stat: path={{project_path|quote}}/roles/requirements.yml
         register: doesRequirementsExist

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -128,7 +128,7 @@
       - name: fetch python packages from pip-requirements.txt
         pip:
           requirements: "{{project_path|quote}}/pip-requirements.txt"
-          extra_args: "-I --install-option='--prefix={{pip_destination|quote}}'"
+          extra_args: "-I --install-option='--prefix={{private_venv|quote}}'"
         register: pip_result
         when: doesPipRequirementsExist.stat.exists
         changed_when: "'Successfully installed' in pip_result.stdout"

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -61,6 +61,9 @@ export default ['i18n', function(i18n) {
             AWX_ROLES_ENABLED: {
                 type: 'toggleSwitch',
             },
+            AWX_PIP_ENABLED: {
+                type: 'toggleSwitch',
+            },
             AWX_COLLECTIONS_ENABLED: {
                 type: 'toggleSwitch',
             },


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Sometimes it is required to install some python packages in order to use some modules. Now it is possible to list this requirements in a pip-requirements.txt file for SCM projects. In the sync phase this requirements will be downloaded and finally after finishing the job they will be removed.

How it works:
1. If pip-requirements.txt exists, install packages in a temporary private virtualenv (private_data_dir/private_venv).
2. If private_data_dir/private_venv exists, add private_venv's PYTHONPATH to the ansible-runner's PYTHONPATH.

Also, it is possible to enable/disable this feature from settings/jobs. Default is enabled.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```
##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

- It creates private_venv in private_data_dir witch is temporary. Actually it's not a real virtualenv. it works just by setting --prefix=private_venv in pip.
- pip-requirements.txt must be placed in the root dir of the project.