### PR TITLE
cli: fix `awx unified_job_templates`

### DIFF
--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -91,7 +91,7 @@ class ResourceOptionsParser(object):
     def get_allowed_options(self):
         self.allowed_options = self.page.connection.options(
             self.page.endpoint + '1'
-        ).headers['Allow'].split(', ')
+        ).headers.get('Allow', '').split(', ')
 
     def build_list_actions(self):
         action_map = {


### PR DESCRIPTION
this endpoint doesn't return an HTTP Allow header at all (because you
can't really do anything other than list templates)

<img width="614" alt="image" src="https://user-images.githubusercontent.com/214912/65884591-1a117880-e367-11e9-8af4-6aa1b8054fe8.png">
