### PR TITLE
Show error body when license application fails

### DIFF
--- a/awx/ui/client/src/license/license.controller.js
+++ b/awx/ui/client/src/license/license.controller.js
@@ -229,9 +229,8 @@ export default
                                 }, 4000);
                             }
                         });
-                }).catch(({data, status}) => {
-                    Wait('stop');
-                    ProcessErrors($scope, data, status, null, {
+                }).catch((err) => {
+                    ProcessErrors($scope, err, null, null, {
                         hdr: i18n._('Error Applying License')
                     });
                 });


### PR DESCRIPTION
##### SUMMARY
Errors that come back from when POSTing to `/api/v2/config` don't have a `data` attribute.  Response looks like:

```
{
    "error": "invalid license"
}
```

<img width="600" alt="Screen Shot 2019-09-30 at 12 07 56 PM" src="https://user-images.githubusercontent.com/9889020/65896566-6f578500-e37b-11e9-9bf1-b4e61516596b.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
