### PR TITLE
Prevent text overlap on workflow nodes when an approval node is deleted

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -830,15 +830,19 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
                         });
 
                     baseSvg.selectAll(".WorkflowChart-deletedText")
+                        .attr("y", (d) => { return scope.mode === 'details' && d.job && d.job.type === "workflow_approval" && (d.job.timed_out || d.job.status === "failed" || d.job.status === "successful") ? 29 : 22; })
                         .style("display", (d) => { return d.unifiedJobTemplate || d.id === scope.graphState.nodeBeingAdded ? "none" : null; });
 
                     baseSvg.selectAll(".WorkflowChart-timedOutText")
+                        .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                         .style("display", (d) => { return d.job && d.job.timed_out ? null : "none"; });
 
                     baseSvg.selectAll(".WorkflowChart-deniedText")
+                        .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                         .style("display", (d) => { return d.job && d.job.type === "workflow_approval" && d.job.status === "failed" && !d.job.timed_out ? null : "none"; });
 
                     baseSvg.selectAll(".WorkflowChart-approvedText")
+                        .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                         .style("display", (d) => { return d.job && d.job.type === "workflow_approval" && d.job.status === "successful" && !d.job.timed_out ? null : "none"; });
 
                     baseSvg.selectAll(".WorkflowChart-activeNode")
@@ -942,7 +946,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
 
                             thisNode.append("foreignObject")
                                 .attr("x", 0)
-                                .attr("y", 22)
+                                .attr("y", (d) => { return scope.mode === 'details' && d.job && d.job.type === "workflow_approval" && (d.job.timed_out || d.job.status === "failed" || d.job.status === "successful") ? 29 : 22; })
                                 .attr("dy", ".35em")
                                 .attr("text-anchor", "middle")
                                 .attr("class", "WorkflowChart-defaultText WorkflowChart-deletedText")
@@ -951,7 +955,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
 
                             thisNode.append("foreignObject")
                                 .attr("x", 0)
-                                .attr("y", 22)
+                                .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                                 .attr("dy", ".35em")
                                 .attr("text-anchor", "middle")
                                 .attr("class", "WorkflowChart-defaultText WorkflowChart-timedOutText")
@@ -960,7 +964,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
 
                             thisNode.append("foreignObject")
                                 .attr("x", 0)
-                                .attr("y", 22)
+                                .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                                 .attr("dy", ".35em")
                                 .attr("text-anchor", "middle")
                                 .attr("class", "WorkflowChart-defaultText WorkflowChart-deniedText")
@@ -969,7 +973,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
 
                             thisNode.append("foreignObject")
                                 .attr("x", 0)
-                                .attr("y", 22)
+                                .attr("y", (d) => { return scope.mode === 'details' && !d.unifiedJobTemplate ? 15 : 22; })
                                 .attr("dy", ".35em")
                                 .attr("text-anchor", "middle")
                                 .attr("class", "WorkflowChart-defaultText WorkflowChart-approvedText")


### PR DESCRIPTION
##### SUMMARY
link #4778 

This change determines when/if an approval node has been acted on _and_ deleted and adjusts the position of the text to accommodate both strings:

<img width="894" alt="Screen Shot 2019-09-30 at 1 36 44 PM" src="https://user-images.githubusercontent.com/9889020/65902260-fb6fa980-e387-11e9-9520-a490d3a18796.png">

Single strings will still appear in the middle of the node:

<img width="905" alt="Screen Shot 2019-09-30 at 1 42 55 PM" src="https://user-images.githubusercontent.com/9889020/65902353-3a9dfa80-e388-11e9-8751-3407050ffa68.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
