### PR TITLE
make kombu DNS failures louder in the logs

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1103,6 +1103,10 @@ LOGGING = {
             'handlers': ['console', 'file', 'tower_warnings'],
             'level': 'WARNING',
         },
+        'kombu': {
+            'handlers': ['console', 'file', 'tower_warnings'],
+            'level': 'WARNING',
+        },
         'rest_framework.request': {
             'handlers': ['console', 'file', 'tower_warnings'],
             'level': 'WARNING',


### PR DESCRIPTION
kombu has a behavior in its `Connection.ensure_connection` code where it quietly backs off and retries certain types of connection issues (forever) - DNS resolution `OSError`s are one of those.  This makes these events much more verbose in the AWX logs to aid in debugging