### PR TITLE
Fix settings page rendering when some fields are set manually in file

### DIFF
--- a/awx/ui/client/src/configuration/settings.service.js
+++ b/awx/ui/client/src/configuration/settings.service.js
@@ -34,14 +34,16 @@ export default ['GetBasePath', '$q', 'Rest', 'i18n',
                                 }
                                 delete optsFromAPI[key].child;
                             };
-                            unnestOauth2ProviderKey('ACCESS_TOKEN_EXPIRE_SECONDS',
-                                i18n._('The duration (in seconds) access tokens remain valid since their creation.'),
-                                i18n._('Access Token Expiration'),
-                                'OAUTH2_PROVIDER');
-                            unnestOauth2ProviderKey('AUTHORIZATION_CODE_EXPIRE_SECONDS',
-                                i18n._('The duration (in seconds) authorization codes remain valid since their creation.'),
-                                i18n._('Authorization Code Expiration'),
-                                'OAUTH2_PROVIDER');
+                            if (optsFromAPI.OAUTH2_PROVIDER) {
+                                unnestOauth2ProviderKey('ACCESS_TOKEN_EXPIRE_SECONDS',
+                                    i18n._('The duration (in seconds) access tokens remain valid since their creation.'),
+                                    i18n._('Access Token Expiration'),
+                                    'OAUTH2_PROVIDER');
+                                unnestOauth2ProviderKey('AUTHORIZATION_CODE_EXPIRE_SECONDS',
+                                    i18n._('The duration (in seconds) authorization codes remain valid since their creation.'),
+                                    i18n._('Authorization Code Expiration'),
+                                    'OAUTH2_PROVIDER');
+                            }
                             return optsFromAPI;
                         };
                         var getActions = appendOauth2ProviderKeys(data.actions.GET);


### PR DESCRIPTION
##### SUMMARY
Fixes issue where settings page wouldn't render if ACCESS_TOKEN_EXPIRE_SECONDS or AUTHORIZATION_CODE_EXPIRE_SECONDS were set manually in a file.  Simple fix, we need to check to make sure that the parent (OAUTH2_PROVIDER) key exists in the OPTIONS response before attempting to use it.

<img width="1505" alt="Screen Shot 2019-10-01 at 10 15 32 AM" src="https://user-images.githubusercontent.com/9889020/65970548-c66d6080-e434-11e9-9f4a-25b6df3a4533.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
