### PR TITLE
Sanitize newlines out of survey option inputs

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -253,7 +253,7 @@ class SurveyJobTemplateMixin(models.Model):
                 else:
                     choice_list = copy(survey_element['choices'])
                     if isinstance(choice_list, str):
-                        choice_list = choice_list.split('\n')
+                        choice_list = [choice for choice in choice_list.splitlines() if choice.strip() != '']
                     for val in data[survey_element['variable']]:
                         if val not in choice_list:
                             errors.append("Value %s for '%s' expected to be one of %s." % (val, survey_element['variable'],
@@ -261,7 +261,7 @@ class SurveyJobTemplateMixin(models.Model):
         elif survey_element['type'] == 'multiplechoice':
             choice_list = copy(survey_element['choices'])
             if isinstance(choice_list, str):
-                choice_list = choice_list.split('\n')
+                choice_list = [choice for choice in choice_list.splitlines() if choice.strip() != '']
             if survey_element['variable'] in data:
                 if data[survey_element['variable']] not in choice_list:
                     errors.append("Value %s for '%s' expected to be one of %s." % (data[survey_element['variable']],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
pertains to #4452 
The main issue here was the playbook itself, which was fixed, however it did expose the ability for a blank newline to be added to a survey, which will break it. 
My changes have added in multiple choice options parsing, which takes the string, splits it up, and then eliminates any extra newlines (which had lead to the blank lines mentioned above). 
Additionally wrote a small validation to prevent the API pushing a default value for a survey that is not in the list of available options.
Additionally edited mixins.py to cover the same scenario in the UI not just the API, however the issue #4866 persists.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```
