### PR TITLE
Unbind keydown listeners when Alert modals are closed.

### DIFF
--- a/awx/ui/client/src/shared/Utilities.js
+++ b/awx/ui/client/src/shared/Utilities.js
@@ -89,9 +89,11 @@ angular.module('Utilities', ['RestServices', 'Utilities'])
             scope.disableButtons2 = (disableButtons) ? true : false;
 
             $('#alert-modal2').on('hidden.bs.modal', function() {
+                $(document).unbind('keydown');
                 if (action) {
                     action();
                 }
+                $('#alert-modal2').off();
             });
             $('#alert-modal2').on('shown.bs.modal', function() {
                 $('#alert2_ok_btn').focus();
@@ -117,10 +119,12 @@ angular.module('Utilities', ['RestServices', 'Utilities'])
             });
 
             $('#alert-modal').on('hidden.bs.modal', function() {
+                $(document).unbind('keydown');
                 if (action) {
                     action();
                 }
                 $('.modal-backdrop').remove();
+                $('#alert-modal').off();
             });
             $('#alert-modal').on('shown.bs.modal', function() {
                 $('#alert_ok_btn').focus();


### PR DESCRIPTION
##### SUMMARY
This fixes a bug where attempting to hit enter in any sort of textarea would be ignored if the user had previously encountered an Alert modal while navigating throughout the application.

There are two other places where listeners are set up for the enter key.  One is on the login modal and the other is a directive that we use on inputs.  Both of those listeners are scoped to _specific_ elements and shouldn't impact the enter key throughout the app.  The code changed here binds a listener to the entire _document_ so when you hit an Alert the enter key would previously be foobar until you manually refresh the page.  I'm pretty confident this is what's been happening when folks report that they're unable to hit the enter key on certain textareas.

One of the easier ways to reproduce this bug (before the fix) was to create a new personal access token.  When you create the token, an Alert modal is shown with a key in it.  If you then went to any textarea in the application and attempted to hit enter it would not take you to a new line.

link #4192 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
