### PR TITLE
resolving issue #3551 - alternative installation path

### DIFF
--- a/installer/installpathsalternatives.yml
+++ b/installer/installpathsalternatives.yml
@@ -1,0 +1,3 @@
+---
+docker_compose_dir: "~/awxcompose"
+postgres_data_dir: "~/awxpgdocker"

--- a/installer/inventory
+++ b/installer/inventory
@@ -57,11 +57,13 @@ dockerhub_base=ansible
 # Common Docker parameters
 awx_task_hostname=awx
 awx_web_hostname=awxweb
-postgres_data_dir=/tmp/pgdocker
+# Fallback directory defined in installpathsalternatives.yml (e.g. due to missing write permissions)
+postgres_data_dir=/opt/awxpgdocker
 host_port=80
 host_port_ssl=443
 #ssl_certificate=
-docker_compose_dir=/tmp/awxcompose
+# Fallback directory defined in installpathsalternatives.yml (e.g. due to missing write permissions)
+docker_compose_dir=/opt/awxcompose
 
 # Required for Openshift when building the image on your own
 # Optional for Openshift if using Dockerhub or another prebuilt registry

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -1,8 +1,16 @@
 ---
-- name: Create {{ docker_compose_dir }} directory
-  file:
-    path: "{{ docker_compose_dir }}"
-    state: directory
+- name: Create {{ docker_compose_dir }} directory 
+  block: 
+    - file: 
+        path: "{{ docker_compose_dir }}"
+        state: directory
+  rescue:
+    - include_vars:
+        file: installpathsalternatives.yml
+    - file: 
+        path: "{{ docker_compose_dir }}"
+        state: directory
+    - debug: "msg='could not write to directory given in inventory - moving to home directory instead'"
 
 - name: Create Docker Compose Configuration
   template:


### PR DESCRIPTION
##### SUMMARY
resolving the topic covered in/related #3551
issue summary: up to now /tmp is used in inventory as storage default, which leads to issues in case it has not been changed (reboot drops all data) - the requested changes move the data to /opt and in case this is not writeable to the /home/user of the executing user

note; this PR is a replacement for the old one #4088

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### DETAILS

the solutions brings up an error during the installation and therefore will be noticed by the user for sure:

![image](https://user-images.githubusercontent.com/2744285/66052627-352fe400-e531-11e9-97df-0bec59cddc99.png)
