### PR TITLE
Quote the playbook passed to runner from the isolated manager

### DIFF
--- a/awx/playbooks/run_isolated.yml
+++ b/awx/playbooks/run_isolated.yml
@@ -26,7 +26,7 @@
       when: key.stat.exists
 
     - name: spawn the playbook
-      command: "ansible-runner start {{src}} -p {{playbook}} -i {{ident}}"
+      command: "ansible-runner start {{src}} -p '{{playbook}}' -i {{ident}}"
       when: playbook is defined
 
     - name: spawn the adhoc command


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If you run a job using a playbook that has spaces in the name on an isolated node, the job will fail.  This PR quotes the filename of the playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 7.0.0
```
