### PR TITLE
Add RefreshToken Expiration setting in UI

### DIFF
--- a/awx/ui/client/src/configuration/forms/settings-form.controller.js
+++ b/awx/ui/client/src/configuration/forms/settings-form.controller.js
@@ -96,6 +96,8 @@ export default [
                     // OAUTH2_PROVIDER key
                     data.ACCESS_TOKEN_EXPIRE_SECONDS = data
                         .OAUTH2_PROVIDER.ACCESS_TOKEN_EXPIRE_SECONDS;
+                    data.REFRESH_TOKEN_EXPIRE_SECONDS = data
+                        .OAUTH2_PROVIDER.REFRESH_TOKEN_EXPIRE_SECONDS;
                     data.AUTHORIZATION_CODE_EXPIRE_SECONDS = data
                         .OAUTH2_PROVIDER.AUTHORIZATION_CODE_EXPIRE_SECONDS;
                     var currentKeys = _.keys(data);
@@ -225,11 +227,12 @@ export default [
         $scope.resetValue = function(key) {
             Wait('start');
             var payload = {};
-            if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
+            if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS'  || key === 'REFRESH_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
                 // the reset for these two keys needs to be nested under OAUTH2_PROVIDER
                 if (payload.OAUTH2_PROVIDER === undefined) {
                     payload.OAUTH2_PROVIDER = {
                         ACCESS_TOKEN_EXPIRE_SECONDS: $scope.ACCESS_TOKEN_EXPIRE_SECONDS,
+                        REFRESH_TOKEN_EXPIRE_SECONDS: $scope.REFRESH_TOKEN_EXPIRE_SECONDS,
                         AUTHORIZATION_CODE_EXPIRE_SECONDS: $scope.AUTHORIZATION_CODE_EXPIRE_SECONDS
                     };
                 }
@@ -314,11 +317,12 @@ export default [
             var keys = _.keys(formDefs[formTracker.getCurrent()].fields);
             var payload = {};
             _.each(keys, function(key) {
-                if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
+                if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS'  || key === 'REFRESH_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
                     // These two values need to be POSTed nested under the OAUTH2_PROVIDER key
                     if (payload.OAUTH2_PROVIDER === undefined) {
                         payload.OAUTH2_PROVIDER = {
                             ACCESS_TOKEN_EXPIRE_SECONDS: $scope.ACCESS_TOKEN_EXPIRE_SECONDS,
+                            REFRESH_TOKEN_EXPIRE_SECONDS: $scope.REFRESH_TOKEN_EXPIRE_SECONDS,
                             AUTHORIZATION_CODE_EXPIRE_SECONDS: $scope.AUTHORIZATION_CODE_EXPIRE_SECONDS
                         };
                     }
@@ -539,11 +543,12 @@ export default [
             var payload = {};
             clearApiErrors();
             _.each(keys, function(key) {
-                if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
+                if (key === 'ACCESS_TOKEN_EXPIRE_SECONDS'  || key === 'REFRESH_TOKEN_EXPIRE_SECONDS' || key === 'AUTHORIZATION_CODE_EXPIRE_SECONDS') {
                     // the reset for these two keys needs to be nested under OAUTH2_PROVIDER
                     if (payload.OAUTH2_PROVIDER === undefined) {
                         payload.OAUTH2_PROVIDER = {
                             ACCESS_TOKEN_EXPIRE_SECONDS: $scope.ACCESS_TOKEN_EXPIRE_SECONDS,
+                            REFRESH_TOKEN_EXPIRE_SECONDS: $scope.REFRESH_TOKEN_EXPIRE_SECONDS,
                             AUTHORIZATION_CODE_EXPIRE_SECONDS: $scope.AUTHORIZATION_CODE_EXPIRE_SECONDS
                         };
                     }

--- a/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
+++ b/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
@@ -47,6 +47,10 @@ export default ['i18n', function(i18n) {
                 type: 'text',
                 reset: 'ACCESS_TOKEN_EXPIRE_SECONDS'
             },
+            REFRESH_TOKEN_EXPIRE_SECONDS: {
+                type: 'text',
+                reset: 'REFRESH_TOKEN_EXPIRE_SECONDS'
+            },
             AUTHORIZATION_CODE_EXPIRE_SECONDS: {
                 type: 'text',
                 reset: 'AUTHORIZATION_CODE_EXPIRE_SECONDS'

--- a/awx/ui/client/src/configuration/settings.service.js
+++ b/awx/ui/client/src/configuration/settings.service.js
@@ -39,6 +39,10 @@ export default ['GetBasePath', '$q', 'Rest', 'i18n',
                                     i18n._('The duration (in seconds) access tokens remain valid since their creation.'),
                                     i18n._('Access Token Expiration'),
                                     'OAUTH2_PROVIDER');
+                                unnestOauth2ProviderKey('REFRESH_TOKEN_EXPIRE_SECONDS',
+                                    i18n._('The duration (in seconds) refresh tokens remain valid after the expiration of their associated access token.'),
+                                    i18n._('Refresh Token Expiration'),
+                                    'OAUTH2_PROVIDER');
                                 unnestOauth2ProviderKey('AUTHORIZATION_CODE_EXPIRE_SECONDS',
                                     i18n._('The duration (in seconds) authorization codes remain valid since their creation.'),
                                     i18n._('Authorization Code Expiration'),


### PR DESCRIPTION
##### SUMMARY

Adds setting to the UI as per https://github.com/ansible/awx/issues/4710

Should land _after_ these 2 related PR's:
* Fix rendering - https://github.com/ansible/awx/pull/4865
* Add `REFRESH_TOKEN_EXPIRE_SECONDS` setting in API - https://github.com/ansible/awx/pull/4886

The REFRESH_TOKEN_EXPIRE_SECONDS value needs to be set for certain cleanup management jobs to work properly.  This allows users to configure that value in case the default we set is not acceptable for them.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - UI

