### PR TITLE
attempt to properly map more foreign keys to named lookups

### DIFF
--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -40,6 +40,11 @@ def pk_or_name(v2, model_name, value, page=None):
     if model_name in UNIQUENESS_RULES:
         identity = UNIQUENESS_RULES[model_name][-1]
 
+    # certain related fields follow a pattern of <foo>_<model> e.g.,
+    # insights_credential, target_credential etc...
+    if not page and '_' in model_name:
+        return pk_or_name(v2, model_name.split('_')[-1], value, page)
+
     if page:
         results = page.get(**{identity: value})
         if results.count == 1:


### PR DESCRIPTION
this is imperfect, but it's at least an improvement until we can come up
with a better solution

in order to really do this right, the API itself probably needs to grow
some more metadata that allows us to specify meaningful a `type` that
relates to API resources (i.e., not "this requires a primary key", but "it's a primary key to a credential").

see: https://github.com/ansible/awx/issues/4874
