### PR TITLE
Fixed missing user-id in URL links when adding users to Team and Org …

### DIFF
--- a/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
+++ b/awx/ui/client/src/access/rbac-multiselect/rbac-multiselect-list.directive.js
@@ -106,7 +106,7 @@ export default ['addPermissionsTeamsList', 'addPermissionsUsersList', 'TemplateL
                         last_name: list.fields.last_name
                     };
                     delete list.fields.username.ngClick;
-                    list.fields.username.ngHref = "#/users/{{user.id}}";
+                    list.fields.username.ngHref = "#/users/{{" + list.iterator + ".id}}";
                     list.fields.username.columnClass = 'col-sm-4 col-xs-11';
                     list.fields.first_name.columnClass = 'd-none d-sm-flex col-sm-4';
                     list.fields.last_name.columnClass = 'd-none d-sm-flex col-sm-4';


### PR DESCRIPTION
##### SUMMARY
Fixed missing user-id in URL links when adding users to Team and Org in modal window:
    
- Fixed issue #4749 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
- devel
```


##### ADDITIONAL INFORMATION
None