### PR TITLE
Requirements.txt: Upgrade bundled pyvmomi to 6.7.3

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -56,7 +56,7 @@ psutil==5.4.3    # same as AWX requirement
 setuptools==36.0.1
 pip==9.0.1
 # VMware
-pyvmomi==6.5
+pyvmomi==6.7.3
 # WinRM
 backports.ssl-match-hostname==3.5.0.1
 pywinrm[kerberos]==0.3.0

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -95,7 +95,7 @@ pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0         # via azure-cli-core, pyvmomi, requests-credssp
 pyparsing==2.4.0          # via packaging
 python-dateutil==2.6.1    # via adal, azure-storage, botocore
-pyvmomi==6.5
+pyvmomi==6.7.3
 pywinrm[kerberos]==0.3.0
 pyyaml==5.1               # via azure-cli-core, knack, openstacksdk
 requests-credssp==1.0.2


### PR DESCRIPTION
Fixes issues with vmware_guest_facts expecting version 6.7.1 or greater (JSON support)

##### SUMMARY
Currently the awx ansible task worker ships [pyvmomi 6.5](https://pypi.org/project/pyvmomi/6.5/#history), this version is relatively old (2016), and does not support gathering information from VM Properties using the [vmware_guest_facts](https://docs.ansible.com/ansible/latest/modules/vmware_guest_facts_module.html) module, as it does not support JSON output.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Ansible task worker

##### AWX VERSION
7.0.0


##### CURRENT Output when using vmware_guest_facts
`"The installed version of pyvmomi lacks JSON output support; need pyvmomi>6.7.1"`

