### PR TITLE
Org-Level Notification Fix + Show URL 

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -452,6 +452,12 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
                                                .filter(workflowjobtemplate_notification_templates_for_approvals__in=[self]))
         # Get Organization NotificationTemplates
         if self.organization is not None:
+            error_notification_templates = set(error_notification_templates + list(base_notification_templates.filter(
+                organization_notification_templates_for_errors=self.organization)))
+            started_notification_templates = set(started_notification_templates + list(base_notification_templates.filter(
+                organization_notification_templates_for_started=self.organization)))
+            success_notification_templates = set(success_notification_templates + list(base_notification_templates.filter(
+                organization_notification_templates_for_success=self.organization)))
             approval_notification_templates = set(approval_notification_templates + list(base_notification_templates.filter(
                 organization_notification_templates_for_approvals=self.organization)))
         return dict(error=list(error_notification_templates),
@@ -696,6 +702,9 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
     @property
     def event_class(self):
         return None
+
+    def get_ui_url(self):
+        return urljoin(settings.TOWER_URL_BASE, '/#/workflows/{}'.format(self.workflow_job.id))
 
     def _get_parent_field_name(self):
         return 'workflow_approval_template'


### PR DESCRIPTION
##### SUMMARY
Addressing issue https://github.com/ansible/awx/issues/4712 .

This PR enables **notifications that are set at the Organization level** to send on Start, Success, and/or Error.  

This fix also adds the URL to approval notifications with bodies (vs. just subjects) such as `email` and `webhook` types.  See below for an example of a notification without a URL:

<img width="726" alt="URL_Not_Showing" src="https://user-images.githubusercontent.com/28930622/66343302-6174a780-e919-11e9-912b-b2abe7be360b.png">


This fix will show a URL, like below:

<img width="727" alt="URL_Showing" src="https://user-images.githubusercontent.com/28930622/66343304-646f9800-e919-11e9-8c21-713b73e66422.png">


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0
```
