### PR TITLE
Render default notifications using Jinja templates

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -92,25 +92,6 @@ class NotificationTemplate(CommonModelNameNotUnique):
     def get_message(self, condition):
         return self.messages.get(condition, {})
 
-    def build_notification_message(self, event_type, context):
-        env = sandbox.ImmutableSandboxedEnvironment()
-        templates = self.get_message(event_type)
-        msg_template = templates.get('message', {})
-
-        try:
-            notification_subject = env.from_string(msg_template).render(**context)
-        except (TemplateSyntaxError, UndefinedError, SecurityError):
-            notification_subject = ''
-
-
-        msg_body = templates.get('body', {})
-        try:
-            notification_body = env.from_string(msg_body).render(**context)
-        except (TemplateSyntaxError, UndefinedError, SecurityError):
-            notification_body = ''
-
-        return (notification_subject, notification_body)
-
     def get_absolute_url(self, request=None):
         return reverse('api:notification_template_detail', kwargs={'pk': self.pk}, request=request)
 

--- a/awx/main/notifications/base.py
+++ b/awx/main/notifications/base.py
@@ -1,21 +1,10 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-import json
-
-from django.utils.encoding import smart_text
 from django.core.mail.backends.base import BaseEmailBackend
-from django.utils.translation import ugettext_lazy as _
 
 
 class AWXBaseEmailBackend(BaseEmailBackend):
 
     def format_body(self, body):
-        if "body" in body:
-            body_actual = body['body']
-        else:
-            body_actual = smart_text(_("{} #{} had status {}, view details at {}\n\n").format(
-                body['friendly_name'], body['id'], body['status'], body['url'])
-            )
-            body_actual += json.dumps(body, indent=4)
-        return body_actual
+        return body

--- a/awx/main/notifications/email_backend.py
+++ b/awx/main/notifications/email_backend.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-import json
-
 from django.utils.encoding import smart_text
 from django.core.mail.backends.smtp import EmailBackend
 from django.utils.translation import ugettext_lazy as _
@@ -20,21 +18,15 @@ class CustomEmailBackend(EmailBackend):
                        "recipients": {"label": "Recipient List", "type": "list"},
                        "timeout": {"label": "Timeout", "type": "int", "default": 30}}
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
     DEFAULT_BODY = smart_text(_("{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_summary_dict }}"))
-    default_messages = {"started": {"message": DEFAULT_SUBJECT, "body": DEFAULT_BODY},
-                        "success": {"message": DEFAULT_SUBJECT, "body": DEFAULT_BODY},
-                        "error": {"message": DEFAULT_SUBJECT, "body": DEFAULT_BODY}}
+    default_messages = {"started": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
+                        "success": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
+                        "error": {"message": DEFAULT_MSG, "body": DEFAULT_BODY}}
     recipient_parameter = "recipients"
     sender_parameter = "sender"
 
 
     def format_body(self, body):
-        if "body" in body:
-            body_actual = body['body']
-        else:
-            body_actual = smart_text(_("{} #{} had status {}, view details at {}\n\n").format(
-                body['friendly_name'], body['id'], body['status'], body['url'])
-            )
-            body_actual += json.dumps(body, indent=4)
-        return body_actual
+        # leave body unchanged (expect a string)
+        return body

--- a/awx/main/notifications/grafana_backend.py
+++ b/awx/main/notifications/grafana_backend.py
@@ -21,10 +21,10 @@ class GrafanaBackend(AWXBaseEmailBackend):
     recipient_parameter = "grafana_url"
     sender_parameter = None
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, grafana_key,dashboardId=None, panelId=None, annotation_tags=None, grafana_no_verify_ssl=False, isRegion=True,
                  fail_silently=False, **kwargs):

--- a/awx/main/notifications/hipchat_backend.py
+++ b/awx/main/notifications/hipchat_backend.py
@@ -23,10 +23,10 @@ class HipChatBackend(AWXBaseEmailBackend):
     recipient_parameter = "rooms"
     sender_parameter = "message_from"
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, token, color, api_url, notify, fail_silently=False, **kwargs):
         super(HipChatBackend, self).__init__(fail_silently=fail_silently)

--- a/awx/main/notifications/irc_backend.py
+++ b/awx/main/notifications/irc_backend.py
@@ -25,10 +25,10 @@ class IrcBackend(AWXBaseEmailBackend):
     recipient_parameter = "targets"
     sender_parameter = None
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, server, port, nickname, password, use_ssl, fail_silently=False, **kwargs):
         super(IrcBackend, self).__init__(fail_silently=fail_silently)

--- a/awx/main/notifications/mattermost_backend.py
+++ b/awx/main/notifications/mattermost_backend.py
@@ -19,10 +19,10 @@ class MattermostBackend(AWXBaseEmailBackend):
     recipient_parameter = "mattermost_url"
     sender_parameter = None
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, mattermost_no_verify_ssl=False, mattermost_channel=None, mattermost_username=None,
                  mattermost_icon_url=None, fail_silently=False, **kwargs):

--- a/awx/main/notifications/rocketchat_backend.py
+++ b/awx/main/notifications/rocketchat_backend.py
@@ -19,10 +19,10 @@ class RocketChatBackend(AWXBaseEmailBackend):
     recipient_parameter = "rocketchat_url"
     sender_parameter = None
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, rocketchat_no_verify_ssl=False, rocketchat_username=None, rocketchat_icon_url=None, fail_silently=False, **kwargs):
         super(RocketChatBackend, self).__init__(fail_silently=fail_silently)

--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -19,10 +19,10 @@ class SlackBackend(AWXBaseEmailBackend):
     recipient_parameter = "channels"
     sender_parameter = None
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, token, hex_color="", fail_silently=False, **kwargs):
         super(SlackBackend, self).__init__(fail_silently=fail_silently)

--- a/awx/main/notifications/twilio_backend.py
+++ b/awx/main/notifications/twilio_backend.py
@@ -21,10 +21,10 @@ class TwilioBackend(AWXBaseEmailBackend):
     recipient_parameter = "to_numbers"
     sender_parameter = "from_number"
 
-    DEFAULT_SUBJECT = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    default_messages = {"started": {"message": DEFAULT_SUBJECT},
-                        "success": {"message": DEFAULT_SUBJECT},
-                        "error": {"message": DEFAULT_SUBJECT}}
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    default_messages = {"started": {"message": DEFAULT_MSG},
+                        "success": {"message": DEFAULT_MSG},
+                        "error": {"message": DEFAULT_MSG}}
 
     def __init__(self, account_sid, account_token, fail_silently=False, **kwargs):
         super(TwilioBackend, self).__init__(fail_silently=fail_silently)

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -38,15 +38,13 @@ class WebhookBackend(AWXBaseEmailBackend):
         super(WebhookBackend, self).__init__(fail_silently=fail_silently)
 
     def format_body(self, body):
-        # If `body` has body field, attempt to use this as the main body,
-        # otherwise, leave it as a sub-field
-        if isinstance(body, dict) and 'body' in body and isinstance(body['body'], str):
-            try:
-                potential_body = json.loads(body['body'])
-                if isinstance(potential_body, dict):
-                    body = potential_body
-            except json.JSONDecodeError:
-                pass
+        # expect body to be a string representing a dict
+        try:
+            potential_body = json.loads(body)
+            if isinstance(potential_body, dict):
+                body = potential_body
+        except json.JSONDecodeError:
+            body = {}
         return body
 
     def send_messages(self, messages):

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -144,5 +144,3 @@ class TestJobNotificationMixin(object):
 
         context_stub = JobNotificationMixin.context_stub()
         check_structure_and_completeness(TestJobNotificationMixin.CONTEXT_STRUCTURE, context_stub)
-
-


### PR DESCRIPTION
When [templated notifications](https://github.com/ansible/awx/pull/4291) were introduced, we ended up with two different paths for rendering notifications:
* The "old system" in which hard-coded message strings (stored inside the notification-rendering methods themselves) were rendered using `.format()`
* The "new templating system" where custom messages written using Jinja templates were rendered using Jinja

This PR makes it so that _all_ notifications are rendered using the new Jinja-based system. Since default notifications vary depending on notification type, their definitions are stored in the various `<notification_type>_backend.py` classes (see the [email](https://github.com/ansible/awx/blob/devel/awx/main/notifications/email_backend.py#L23-L24) and [slack](https://github.com/ansible/awx/blob/devel/awx/main/notifications/slack_backend.py#L22) backends for example).

This work is mostly done. Want to run these changes through some tests before calling it done, though. Initial ad hoc testing suggests this is in good shape.