### PR TITLE
project_update: Make subversion module honor locale

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -75,6 +75,8 @@
           force: "{{scm_clean}}"
           username: "{{scm_username|default(omit)}}"
           password: "{{scm_password|default(omit)}}"
+        environment:
+          LC_ALL: 'en_US.UTF-8'
         register: svn_result
 
       - name: Set the svn repository version


### PR DESCRIPTION
Currently the subversion module does not honor system configured locale
as the module itself overrides them to `C`.

This commit enforces the module to honor the `LANG` locale for
deployment. Allowing project update with repo that contains UTF-8
characters.

Closes: https://github.com/ansible/awx/issues/4936
Signed-off-by: Yanis Guenane <yguenane@redhat.com>