### PR TITLE
Use summary_fields.controller_id to tell if job is isolated

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -563,7 +563,7 @@ function getInstanceGroupDetails () {
     }
 
     let isolated = null;
-    if (instanceGroup.is_isolated) {
+    if (instanceGroup.controller_id) {
         isolated = strings.get('details.ISOLATED');
     }
 


### PR DESCRIPTION
##### SUMMARY
context: we used to use `controller_id` to decide when to show the isolated badge. We updated it to use `is_isolated` when we added `is_isolated` to _instance groups_ (not jobs) so this is just changing it back so it works.
