### PR TITLE
Get rid of warning in collections install

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -152,6 +152,7 @@
         changed_when: "'Installing ' in galaxy_collection_result.stdout"
         environment:
           ANSIBLE_FORCE_COLOR: False
+          ANSIBLE_COLLECTIONS_PATHS: "{{ collections_destination }}"
 
       when: collections_enabled|bool
       delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
This gets rid of the pesky warning message

```
[WARNING]: The specified collections path
'/tmp/awx_210_xamcfe8u/requirements_collections' is not part of the configured
Ansible collections paths
'/var/lib/awx/.ansible/collections:/usr/share/ansible/collections'. The
installed collection won't be picked up in an Ansible run.
```

![Screen Shot 2019-10-08 at 2 20 31 PM](https://user-images.githubusercontent.com/1385596/66421979-dd80f500-e9d6-11e9-881c-f8bb1233c2ed.png)

It does this by putting the collection destination in the environment variables for it to be discovered by Ansible. The same env var winds up getting set inside of the job run that uses it. The collection install step doesn't need this one way or the other.

This change is purely aesthetic.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
7.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
