### PR TITLE
Removes restriction on scrolling for output fewer than 50 lines

### DIFF
--- a/awx/ui/client/features/output/index.controller.js
+++ b/awx/ui/client/features/output/index.controller.js
@@ -230,8 +230,7 @@ function canStartFollowing () {
     }
 
     if (followOnce && // one-time activation from top of first page
-        scroll.isBeyondUpperThreshold() &&
-        slide.getTailCounter() - slide.getHeadCounter() >= OUTPUT_PAGE_SIZE) {
+        scroll.isBeyondUpperThreshold()) {
         followOnce = false;
 
         return true;


### PR DESCRIPTION
##### SUMMARY
For jobs with fewer than 50 lines of output we weren't scrolling to the bottom of the output.  This PR removes that restriction so output will be followed right from the very beginning:

![scroll_output](https://user-images.githubusercontent.com/9889020/66425018-b9c0ad80-e9dc-11e9-9566-4ec80339b3f5.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI