### PR TITLE
Use fully qualified inventory plugin name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ flake8_collection:
 test_collection_all: prepare_collection_venv test_collection flake8_collection
 
 build_collection:
-	ansible-playbook -i localhost, awx_collection/template_galaxy.yml -e collection_package=$(COLLECTION_PACKAGE) -e namespace_name=$(COLLECTION_NAMESPACE) -e package_version=$(VERSION)
+	ansible-playbook -i localhost, awx_collection/template_galaxy.yml -e collection_package=$(COLLECTION_PACKAGE) -e collection_namespace=$(COLLECTION_NAMESPACE) -e collection_version=$(VERSION)
 	ansible-galaxy collection build awx_collection --output-path=awx_collection
 
 test_unit:

--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 
 # Example for using tower_inventory.yml file
 
-plugin: tower
+plugin: awx.awx.tower
 host: your_ansible_tower_server_network_address
 username: your_ansible_tower_username
 password: your_ansible_tower_password
@@ -116,7 +116,7 @@ except ImportError:
 
 
 class InventoryModule(BaseInventoryPlugin):
-    NAME = 'tower'
+    NAME = 'awx.awx.tower'  # REPLACE
     # Stays backward compatible with tower inventory script.
     # If the user supplies '@tower_inventory' as path, the plugin will read from environment variables.
     no_config_file_supplied = False

--- a/awx_collection/template_galaxy.yml
+++ b/awx_collection/template_galaxy.yml
@@ -21,6 +21,12 @@
         regexp: '^extends_documentation_fragment: awx.awx.auth$'
         replace: 'extends_documentation_fragment: {{ collection_namespace }}.{{ collection_package }}.auth'
       with_items: "{{ module_files.files }}"
+
+    - name: Change files to support desired namespace and package names
+      replace:
+        path: "{{ playbook_dir }}/plugins/inventory/tower.py"
+        regexp: "^    NAME = 'awx.awx.tower'  # REPLACE$"
+        replace: "    NAME = '{{ collection_namespace }}.{{ collection_package }}.tower'  # REPLACE"
     when:
       - (collection_package != 'awx') or (collection_namespace != 'awx')
 


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/4925

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
7.0.0
```


##### ADDITIONAL INFORMATION
We still need some testing solution for the inventory plugin, but I just had to manually release it as a test.

https://galaxy.ansible.com/alancoding/awx

by

```
make build_collection COLLECTION_NAMESPACE=alancoding VERSION=0.0.12
```

Then upload, and install to user directory and running with an inventory with `plugin: alancoding.awx.tower`.
