### PR TITLE
Fix bug where SCM inventory did not have a collections destination

### DIFF
--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -264,6 +264,7 @@ def test_inventory_update_injected_content(this_kind, script_or_plugin, inventor
         assert envvars.pop('ANSIBLE_INVENTORY_ENABLED') == ('auto' if use_plugin else 'script')
         set_files = bool(os.getenv("MAKE_INVENTORY_REFERENCE_FILES", 'false').lower()[0] not in ['f', '0'])
         env, content = read_content(private_data_dir, envvars, inventory_update)
+        env.pop('ANSIBLE_COLLECTIONS_PATHS', None)  # collection paths not relevant to this test
         base_dir = os.path.join(DATA, script_or_plugin)
         if not os.path.exists(base_dir):
             os.mkdir(base_dir)

--- a/awx/ui/client/features/output/status.service.js
+++ b/awx/ui/client/features/output/status.service.js
@@ -49,7 +49,7 @@ function JobStatusService (moment, message) {
             scmRefspec: model.get('scm_refspec'),
             inventoryScm: {
                 id: model.get('source_project_update'),
-                status: model.get('summary_fields.inventory_source.status')
+                status: model.get('summary_fields.source_project.status')
             }
         };
 


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/4750

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
7.0.0
```


##### ADDITIONAL INFORMATION
We made a big change to how _jobs_ operate where they will use a temporary copy of the project folder.

This just pulls in a minor amount of those new styles into how SCM inventory works (which also runs a project sync before-hand).


