### PR TITLE
configure oauth2_provider to use django.conf settings

### DIFF
--- a/awx/conf/apps.py
+++ b/awx/conf/apps.py
@@ -9,7 +9,37 @@ class ConfConfig(AppConfig):
     name = 'awx.conf'
     verbose_name = _('Configuration')
 
+    # oauth2_settings grabs values from defaults.py, and does not get updated
+    # with values set from tower (i.e. the UI), that is django.conf settings.
+    # E.g. REFRESH_TOKEN_EXPIRE_SECONDS will retain the value in defaults.py, and
+    # not the value set from the UI.
+    # The following code resets the models and oauth2_validators imports to use
+    # DynamicOAuth2ProviderSettings instead of OAuth2ProviderSettings.
+    # This sub-class will check that the attribute first exists in django.conf.settings
+    # and return that before using the oauth2_settings.
+    
+    def configure_oauth2_provider(self, settings):
+        from django.conf import settings
+        from oauth2_provider import settings as o_settings
+        from oauth2_provider import models, oauth2_validators
+
+        class DynamicOAuth2ProviderSettings(o_settings.OAuth2ProviderSettings):
+
+            def __getattr__(self, attr):
+                if attr in settings.OAUTH2_PROVIDER:
+                    return settings.OAUTH2_PROVIDER[attr]
+                return super(DynamicOAuth2ProviderSettings, self).__getattr__(attr)
+
+        models.oauth2_settings = DynamicOAuth2ProviderSettings(
+            models.oauth2_settings.user_settings, models.oauth2_settings.defaults,
+            models.oauth2_settings.import_strings, models.oauth2_settings.mandatory
+        )
+        oauth2_validators.oauth2_settings = models.oauth2_settings
+
+
     def ready(self):
         self.module.autodiscover()
         from .settings import SettingsWrapper
         SettingsWrapper.initialize()
+        from django.conf import settings
+        self.configure_oauth2_provider(settings)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fix for #2556 and #4710

Defines a `DynamicOAuth2ProviderSettings` subclass to override the `__getattr__` from the parent class, `OAuth2ProviderSettings`

This class will return values set in django.conf settings first before values set in the original
`OAuth2ProviderSettings` from the oauth2 toolkit app

The default behavior was that `oauth2_settings` would pull from a stale django.conf settings, but not the updated values set in tower UI. Thus commands like `awx-manage cleartokens` and calls to `o/` endpoints would not reflect newer django.conf settings.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 7.0.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
