### PR TITLE
Add pexpect to awx images

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -51,6 +51,7 @@ RUN yum -y install acl \
   python-setuptools \
   python36-devel \
   python36-setuptools \
+  pexpect \
   rsync \
   setools-libs \
   subversion \


### PR DESCRIPTION
##### SUMMARY
This Pull Requests add the "pexpect" package to the AWX container images, as it is needed for roles using the expect module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Installer

##### AWX VERSION
7.0.0
