### PR TITLE
Kubernetes Ingress TLS support

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -26,12 +26,14 @@ dockerhub_base=ansible
 # pg_cpu_limit=1000
 # pg_mem_limit=2
 
-# Kubernetes Ingress Annotations
-# You can use the variables below to pass annotations to Kubernetes Ingress
-# The example below shows an annotation to be used with Traefik but other Ingress controllers are also supported.
-#kubernetes_ingress_hostname=awx.example.org
-#kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
-#kubernetes_ingress_tls_secret=awx-cert
+# Kubernetes Ingress Configuration
+# You can use the variables below to configure Kubernetes Ingress
+# Set hostname
+# kubernetes_ingress_hostname=awx.example.org
+# Add annotations. The example below shows an annotation to be used with Traefik but other Ingress controllers are also supported
+# kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
+# Specify a secret for TLS termination
+# kubernetes_ingress_tls_secret=awx-cert
 
 # Kubernetes and Openshift Install Resource Requests
 # These are the request and limit values for a pod's container for task/web/rabbitmq/memcached/management.

--- a/installer/inventory
+++ b/installer/inventory
@@ -31,6 +31,7 @@ dockerhub_base=ansible
 # The example below shows an annotation to be used with Traefik but other Ingress controllers are also supported.
 #kubernetes_ingress_hostname=awx.example.org
 #kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
+#kubernetes_ingress_tls_secret=awx-cert
 
 # Kubernetes and Openshift Install Resource Requests
 # These are the request and limit values for a pod's container for task/web/rabbitmq/memcached/management.

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -433,6 +433,12 @@ metadata:
 {% endfor %}
 
 spec:
+{% if kubernetes_ingress_tls_secret is defined %}
+  tls:
+  - hosts:
+    - {{ kubernetes_ingress_hostname }}
+    secretName: {{ kubernetes_ingress_tls_secret }}
+{% endif %}
   rules:
   - host: {{ kubernetes_ingress_hostname }}
     http:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change allows the user to optionally specify a TLS secret for the Kubernetes Ingress resource which allows for TLS termination (or even automatic certificate generation when used in conjunction with a tool like cert-manager).


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
7.0.0
```