### PR TITLE
Change 'rabbitmqctl status' to a wget | grep to save CPU

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -270,17 +270,43 @@ spec:
           livenessProbe:
             exec:
               command:
-              - /bin/sh
+              - /usr/bin/python
               - -c
-              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
+              - |
+                import httplib
+                import sys
+                conn=httplib.HTTPConnection('localhost:15672')
+                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}' })
+                r1 = conn.getresponse()
+                if r1.status != 200:
+                  sys.stderr.write('Received http error %i\n' % (r1.status))
+                  sys.exit(1)
+                body = r1.read()
+                if body != '{"status":"ok"}':
+                  sys.stderr.write('Received body: %s' % body)
+                  sys.exit(2)
+                sys.exit(0)
             initialDelaySeconds: 30
             timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
-              - /bin/sh
+              - /usr/bin/python
               - -c
-              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
+              - |
+                import httplib
+                import sys
+                conn=httplib.HTTPConnection('localhost:15672')
+                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}' })
+                r1 = conn.getresponse()
+                if r1.status != 200:
+                  sys.stderr.write('Received http error %i\n' % (r1.status))
+                  sys.exit(1)
+                body = r1.read()
+                if body != '{"status":"ok"}':
+                  sys.stderr.write('Received body: %s' % body)
+                  sys.exit(2)
+                sys.exit(0)
             initialDelaySeconds: 10
             timeoutSeconds: 10
           env:

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -270,55 +270,13 @@ spec:
           livenessProbe:
             exec:
               command:
-              - /usr/bin/python
-              - -c
-              - |
-                try:
-                  from http.client import HTTPConnection
-                except ImportError:
-                  from httplib import HTTPConnection
-                import sys
-                import os
-                import base64
-                authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
-                conn=HTTPConnection('localhost:15672')
-                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
-                r1 = conn.getresponse()
-                if r1.status != 200:
-                  sys.stderr.write('Received http error %i\n' % (r1.status))
-                  sys.exit(1)
-                body = r1.read()
-                if body != '{"status":"ok"}':
-                  sys.stderr.write('Received body: %s' % body)
-                  sys.exit(2)
-                sys.exit(0)
+              - /usr/local/bin/healthchecks/rabbit_health_node.py
             initialDelaySeconds: 30
             timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
-              - /usr/bin/python
-              - -c
-              - |
-                try:
-                  from http.client import HTTPConnection
-                except ImportError:
-                  from httplib import HTTPConnection
-                import sys
-                import os
-                import base64
-                authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
-                conn=HTTPConnection('localhost:15672')
-                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
-                r1 = conn.getresponse()
-                if r1.status != 200:
-                  sys.stderr.write('Received http error %i\n' % (r1.status))
-                  sys.exit(1)
-                body = r1.read()
-                if body != '{"status":"ok"}':
-                  sys.stderr.write('Received body: %s' % body)
-                  sys.exit(2)
-                sys.exit(0)
+              - /usr/local/bin/healthchecks/rabbit_health_node.py
             initialDelaySeconds: 10
             timeoutSeconds: 10
           env:
@@ -347,6 +305,8 @@ spec:
           volumeMounts:
             - name: rabbitmq-config
               mountPath: /etc/rabbitmq
+            - name: rabbitmq-healthchecks
+              mountPath: /usr/local/bin/healthchecks
           resources:
             requests:
               memory: "{{ rabbitmq_mem_request }}Gi"
@@ -438,6 +398,41 @@ spec:
               path: enabled_plugins
             - key: rabbitmq_definitions.json
               path: rabbitmq_definitions.json
+        - name: rabbitmq-healthchecks
+          configMap:
+            name: {{ kubernetes_deployment_name }}-healthchecks
+            items:
+            - key: rabbit_health_node.py
+              path: rabbit_health_node.py
+            defaultMode: 0755
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kubernetes_deployment_name }}-healthchecks
+  namespace: {{ kubernetes_namespace }}
+data:
+  rabbit_health_node.py: |
+    #!/usr/bin/env python
+    try:
+      from http.client import HTTPConnection
+    except ImportError:
+      from httplib import HTTPConnection
+    import sys
+    import os
+    import base64
+    authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
+    conn=HTTPConnection('localhost:15672')
+    conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
+    r1 = conn.getresponse()
+    if r1.status != 200:
+      sys.stderr.write('Received http error %i\n' % (r1.status))
+      sys.exit(1)
+    body = r1.read()
+    if body != '{"status":"ok"}':
+      sys.stderr.write('Received body: %s' % body)
+      sys.exit(2)
+    sys.exit(0)
 ---
 apiVersion: v1
 kind: Service

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -273,12 +273,15 @@ spec:
               - /usr/bin/python
               - -c
               - |
-                import httplib
+                try:
+                  from http.client import HTTPConnection
+                except ImportError:
+                  from httplib import HTTPConnection
                 import sys
                 import os
                 import base64
                 authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
-                conn=httplib.HTTPConnection('localhost:15672')
+                conn=HTTPConnection('localhost:15672')
                 conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
                 r1 = conn.getresponse()
                 if r1.status != 200:
@@ -297,12 +300,15 @@ spec:
               - /usr/bin/python
               - -c
               - |
-                import httplib
+                try:
+                  from http.client import HTTPConnection
+                except ImportError:
+                  from httplib import HTTPConnection
                 import sys
                 import os
                 import base64
                 authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
-                conn=httplib.HTTPConnection('localhost:15672')
+                conn=HTTPConnection('localhost:15672')
                 conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
                 r1 = conn.getresponse()
                 if r1.status != 200:

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -275,8 +275,11 @@ spec:
               - |
                 import httplib
                 import sys
+                import os
+                import base64
+                authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
                 conn=httplib.HTTPConnection('localhost:15672')
-                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}' })
+                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
                 r1 = conn.getresponse()
                 if r1.status != 200:
                   sys.stderr.write('Received http error %i\n' % (r1.status))
@@ -296,8 +299,11 @@ spec:
               - |
                 import httplib
                 import sys
+                import os
+                import base64
+                authsecret = base64.b64encode(os.getenv('RABBITMQ_USER') + ':' + os.getenv('RABBITMQ_PASSWORD'))
                 conn=httplib.HTTPConnection('localhost:15672')
-                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}' })
+                conn.request('GET', '/api/healthchecks/node', headers={'Authorization': 'Basic %s' % authsecret})
                 r1 = conn.getresponse()
                 if r1.status != 200:
                   sys.stderr.write('Received http error %i\n' % (r1.status))
@@ -325,6 +331,13 @@ spec:
                   key: rabbitmq_erlang_cookie
             - name: K8S_SERVICE_NAME
               value: "rabbitmq"
+            - name: RABBITMQ_USER
+              value: {{ rabbitmq_user }}
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ kubernetes_deployment_name }}-secrets"
+                  key: rabbitmq_password
           volumeMounts:
             - name: rabbitmq-config
               mountPath: /etc/rabbitmq

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -270,7 +270,7 @@ spec:
           livenessProbe:
             exec:
               command:
-              - /bin/ash
+              - /bin/sh
               - -c
               - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
             initialDelaySeconds: 30
@@ -278,7 +278,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              - /bin/ash
+              - /bin/sh
               - -c
               - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
             initialDelaySeconds: 10

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -39,7 +39,7 @@ data:
       [rabbitmq_management,rabbitmq_peer_discovery_k8s].
   rabbitmq_definitions.json: |
       {
-        "users":[{"name": "{{ rabbitmq_user }}", "password": "{{ rabbitmq_password }}", "tags": ""}],
+        "users":[{"name": "{{ rabbitmq_user }}", "password": "{{ rabbitmq_password }}", "tags": "administrator"}],
         "permissions":[
           {"user":"{{ rabbitmq_user }}","vhost":"awx","configure":".*","write":".*","read":".*"}
         ],
@@ -269,12 +269,18 @@ spec:
               containerPort: 5672
           livenessProbe:
             exec:
-              command: ["rabbitmqctl", "status"]
+              command:
+              - /bin/ash
+              - -c
+              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\"status\":\"ok\"}\""
             initialDelaySeconds: 30
             timeoutSeconds: 10
           readinessProbe:
             exec:
-              command: ["rabbitmqctl", "status"]
+              command:
+              - /bin/ash
+              - -c
+              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\"status\":\"ok\"}\""
             initialDelaySeconds: 10
             timeoutSeconds: 10
           env:

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -272,7 +272,7 @@ spec:
               command:
               - /bin/ash
               - -c
-              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\"status\":\"ok\"}\""
+              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
             initialDelaySeconds: 30
             timeoutSeconds: 10
           readinessProbe:
@@ -280,7 +280,7 @@ spec:
               command:
               - /bin/ash
               - -c
-              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\"status\":\"ok\"}\""
+              - "wget -O - --header \"Authorization: Basic {{ ( rabbitmq_user + ':' + rabbitmq_password ) | b64encode }}\"  http://localhost:15672/api/healthchecks/node | grep -qF \"{\\\"status\\\":\\\"ok\\\"}\""
             initialDelaySeconds: 10
             timeoutSeconds: 10
           env:


### PR DESCRIPTION
- This reduces CPU usage from 250 millis on idle to 25 millis on idle
- Default rabbitmq user needs administrator privileges

##### SUMMARY
In the default configuration for the awx-rabbit container, the healthchekcs (livenessProbe and readinessProbe) use the comand 'rabbitmqctl status'. This causes high CPU usage, even on idle (250 millis). By changing the healthchecks to an authenticated request to http://localhost:15672/api/healthchecks/node, and grepping for the desired result in the output, this can be reduced to less than 25 millis, a factor ten saving.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 7.0.0
```


##### ADDITIONAL INFORMATION
There are other projects suffering the same from the CPU hungry behavior of `rabbitmqctl status`, see:
- [GCP Issue](https://github.com/GoogleCloudPlatform/click-to-deploy/issues/522)
- [Helm Issue](https://github.com/helm/charts/issues/3855)