### PR TITLE
Handle undefined schedule value in job detail component

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -282,10 +282,12 @@ function getLaunchedByDetails () {
         tooltip = strings.get('tooltips.SCHEDULE');
         link = `/#/templates/job_template/${jobTemplate.id}/schedules/${schedule.id}`;
         value = $filter('sanitize')(schedule.name);
-    } else {
+    } else if (schedule) {
         tooltip = null;
         link = null;
         value = $filter('sanitize')(schedule.name);
+    } else {
+        return null;
     }
 
     return { label, link, tooltip, value };

--- a/awx/ui/client/features/output/details.partial.html
+++ b/awx/ui/client/features/output/details.partial.html
@@ -5,7 +5,7 @@
     <!-- LEFT PANE HEADER ACTIONS -->
     <div class="JobResults-panelHeaderButtonActions">
         <!-- RELAUNCH ACTION -->
-        <at-relaunch job="vm.job"></at-relaunch>
+        <at-relaunch ng-if="vm.job" job="vm.job"></at-relaunch>
 
         <!-- CANCEL ACTION -->
         <button


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/5048

The UI wasn't handling the scenario where a job could have a `launch_type`, but no `schedule` and no `created_by`. In that case, it would always enter `getLaunchedByDetails()` else block and throw an error because there was no `schedule`. This caused every job detail method that followed `vm.getLaunchedByDetails()` to never be called, which is why the Execution Node label was hidden. 

_Below are the detail methods affected by the bug_
```
        vm.jobExplanation = getJobExplanationDetails();
        vm.verbosity = getVerbosityDetails();
        vm.environment = getEnvironmentDetails();
        vm.credentials = getCredentialDetails();
        vm.forks = getForkDetails();
        vm.limit = getLimitDetails();
        vm.executionNode = getExecutionNodeDetails();
        vm.instanceGroup = getInstanceGroupDetails();
        vm.jobTags = getJobTagDetails();
        vm.skipTags = getSkipTagDetails();
        vm.extraVars = getExtraVarsDetails();
        vm.artifacts = getArtifactsDetails();
        vm.labels = getLabelDetails();
        vm.inventorySource = getInventorySourceDetails();
        vm.overwrite = getOverwriteDetails();
        vm.overwriteVars = getOverwriteVarsDetails();
        vm.licenseError = getLicenseErrorDetails();
        vm.hostLimitError = getHostLimitErrorDetails();
```
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 8.0.0
```


##### ADDITIONAL INFORMATION
* I added a guard clause on the Relaunch button to only display if it has a `vm.job` value. 