### PR TITLE
Only create /var/log/tower/external.log when LOG_AGGREGATOR_AUDIT is enabled

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -294,18 +294,19 @@ class AWXProxyHandler(logging.Handler):
         super(AWXProxyHandler, self).__init__(**kwargs)
         self._handler = None
         self._old_kwargs = {}
-        self._auditor = logging.handlers.RotatingFileHandler(
-            filename='/var/log/tower/external.log',
-            maxBytes=1024 * 1024 * 50, # 50 MB
-            backupCount=5,
-        )
+        if settings.LOG_AGGREGATOR_AUDIT:
+          self._auditor = logging.handlers.RotatingFileHandler(
+              filename='/var/log/tower/external.log',
+              maxBytes=1024 * 1024 * 50, # 50 MB
+              backupCount=5,
+          )
 
-        class WritableLogstashFormatter(LogstashFormatter):
-            @classmethod
-            def serialize(cls, message):
-                return json.dumps(message)
+          class WritableLogstashFormatter(LogstashFormatter):
+              @classmethod
+              def serialize(cls, message):
+                  return json.dumps(message)
 
-        self._auditor.setFormatter(WritableLogstashFormatter())
+          self._auditor.setFormatter(WritableLogstashFormatter())
 
     def get_handler_class(self, protocol):
         return HANDLER_MAPPING.get(protocol, AWXNullHandler)

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -295,18 +295,18 @@ class AWXProxyHandler(logging.Handler):
         self._handler = None
         self._old_kwargs = {}
         if settings.LOG_AGGREGATOR_AUDIT:
-          self._auditor = logging.handlers.RotatingFileHandler(
-              filename='/var/log/tower/external.log',
-              maxBytes=1024 * 1024 * 50, # 50 MB
-              backupCount=5,
-          )
+            self._auditor = logging.handlers.RotatingFileHandler(
+                filename='/var/log/tower/external.log',
+                maxBytes=1024 * 1024 * 50, # 50 MB
+                backupCount=5,
+            )
 
-          class WritableLogstashFormatter(LogstashFormatter):
-              @classmethod
-              def serialize(cls, message):
-                  return json.dumps(message)
+            class WritableLogstashFormatter(LogstashFormatter):
+                @classmethod
+                def serialize(cls, message):
+                    return json.dumps(message)
 
-          self._auditor.setFormatter(WritableLogstashFormatter())
+            self._auditor.setFormatter(WritableLogstashFormatter())
 
     def get_handler_class(self, protocol):
         return HANDLER_MAPPING.get(protocol, AWXNullHandler)


### PR DESCRIPTION
##### SUMMARY
The setFormatter tries to create the external.log file.. So we should check if LOG_AGGREGATOR_AUDIT is active here as well

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Utils

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 8.0.0
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
No idea what verbatim is?
```
