### PR TITLE
Allow some non-superusers to test credential plugins

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1385,6 +1385,7 @@ class CredentialExternalTest(SubDetailAPIView):
 
     model = models.Credential
     serializer_class = serializers.EmptySerializer
+    obj_permission_type = 'use'
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -1439,3 +1439,15 @@ def test_create_credential_with_invalid_url_xfail(post, organization, admin, url
     assert response.status_code == status
     if status != 201:
         assert response.data['inputs']['server_url'] == [msg]
+
+
+@pytest.mark.django_db
+def test_external_credential_rbac_test_endpoint(post, alice, external_credential):
+    url = reverse('api:credential_external_test', kwargs={'pk': external_credential.pk})
+    data = {'metadata': {'key': 'some_key'}}
+
+    external_credential.read_role.members.add(alice)
+    assert post(url, data, alice).status_code == 403
+
+    external_credential.use_role.members.add(alice)
+    assert post(url, data, alice).status_code == 202

--- a/awx/main/tests/functional/api/test_credential_type.py
+++ b/awx/main/tests/functional/api/test_credential_type.py
@@ -481,3 +481,12 @@ def test_create_with_undefined_template_variable_xfail(post, admin):
     }, admin)
     assert response.status_code == 400
     assert "'api_tolkien' is undefined" in json.dumps(response.data)
+
+
+@pytest.mark.django_db
+def test_credential_type_rbac_external_test(post, alice, admin, credentialtype_external):
+    # only admins may use the credential type test endpoint
+    url = reverse('api:credential_type_external_test', kwargs={'pk': credentialtype_external.pk})
+    data = {'inputs': {}, 'metadata': {}}
+    assert post(url, data, admin).status_code == 202
+    assert post(url, data, alice).status_code == 403

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -280,14 +280,21 @@ def credentialtype_external():
         }],
         'required': ['url', 'token', 'key'],
     }
-    external_type = CredentialType(
-        kind='external',
-        managed_by_tower=True,
-        name='External Service',
-        inputs=external_type_inputs
-    )
-    external_type.save()
-    return external_type
+
+    class MockPlugin(object):
+        def backend(self, **kwargs):
+            return 'secret'
+
+    with mock.patch('awx.main.models.credential.CredentialType.plugin', new_callable=PropertyMock) as mock_plugin:
+        mock_plugin.return_value = MockPlugin()
+        external_type = CredentialType(
+            kind='external',
+            managed_by_tower=True,
+            name='External Service',
+            inputs=external_type_inputs
+        )
+        external_type.save()
+        yield external_type
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
Currently, only admins can use the test endpoint of an external credential.

A user with `use` access or better on an external credential can _already_ do the following:
- create a dummy machine credential or vault credential
- link the external credential to it using any metadata they'd like
- create a job template that uses the linked credential and launch it to test (indirectly) if the metadata and external credential are working correctly.

This ultimately accomplishes the same thing as using the test endpoint, just with more steps. The goal of this PR is to allow users to use the test endpoint / test button for external credentials if they have `use` access.

