### PR TITLE
Adds edit buttons to Templates, Inventories, Organizations, and Projects list items

### DIFF
--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { arrayOf, node, shape, string } from 'prop-types';
+import DataListCell from '@components/DataListCell';
+import styled from 'styled-components';
+
+const ActionButtonCellStyled = styled(DataListCell)`
+  & > ul {
+    display: flex;
+    li:not(:first-child) {
+      margin-left: 20px;
+    }
+  }
+`;
+
+const ActionButtonCell = ({ ...props }) => {
+  const { actions } = props;
+  return (
+    <ActionButtonCellStyled {...props}>
+      <ul key="listActions">
+        {actions.map(action => (
+          <li key={action.key}>{action.content}</li>
+        ))}
+      </ul>
+    </ActionButtonCellStyled>
+  );
+};
+ActionButtonCell.propTypes = {
+  actions: arrayOf(
+    shape({
+      key: string,
+      content: node,
+    })
+  ),
+};
+ActionButtonCell.defaultProps = {
+  actions: [],
+};
+
+export default ActionButtonCell;

--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.test.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ActionButtonCell from './ActionButtonCell';
+
+describe('ActionButtonCell', () => {
+  test('renders the expected content', () => {
+    const wrapper = mount(<ActionButtonCell />);
+    expect(wrapper).toHaveLength(1);
+  });
+});

--- a/awx/ui_next/src/components/ActionButtonCell/index.js
+++ b/awx/ui_next/src/components/ActionButtonCell/index.js
@@ -1,0 +1,1 @@
+export { default } from './ActionButtonCell';

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { string, bool, func } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import {
   DataListItem,
   DataListItemRow,
   DataListItemCells,
+  Tooltip,
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
+import ListActionButton from '@components/ListActionButton';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Inventory } from '@types';
 
@@ -47,6 +51,37 @@ class InventoryListItem extends React.Component {
                   ? i18n._(t`Smart Inventory`)
                   : i18n._(t`Inventory`)}
               </DataListCell>,
+              <ActionButtonCell
+                lastcolumn="true"
+                key="action"
+                actions={[
+                  {
+                    key: 'edit',
+                    content: (
+                      <Fragment>
+                        {inventory.summary_fields.user_capabilities.edit && (
+                          <Tooltip
+                            content={i18n._(t`Edit Inventory`)}
+                            position="top"
+                          >
+                            <ListActionButton
+                              variant="plain"
+                              component={Link}
+                              to={`/inventories/${
+                                inventory.kind === 'smart'
+                                  ? 'smart_inventory'
+                                  : 'inventory'
+                              }/${inventory.id}/edit`}
+                            >
+                              <PencilAltIcon />
+                            </ListActionButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                ]}
+              />,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.test.jsx
@@ -18,6 +18,9 @@ describe('<InventoryListItem />', () => {
                   id: 1,
                   name: 'Default',
                 },
+                user_capabilities: {
+                  edit: true,
+                },
               },
             }}
             detailUrl="/inventories/inventory/1"
@@ -27,5 +30,59 @@ describe('<InventoryListItem />', () => {
         </MemoryRouter>
       </I18nProvider>
     );
+  });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/inventories']} initialIndex={0}>
+          <InventoryListItem
+            inventory={{
+              id: 1,
+              name: 'Inventory',
+              summary_fields: {
+                organization: {
+                  id: 1,
+                  name: 'Default',
+                },
+                user_capabilities: {
+                  edit: true,
+                },
+              },
+            }}
+            detailUrl="/inventories/inventory/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/inventories']} initialIndex={0}>
+          <InventoryListItem
+            inventory={{
+              id: 1,
+              name: 'Inventory',
+              summary_fields: {
+                organization: {
+                  id: 1,
+                  name: 'Default',
+                },
+                user_capabilities: {
+                  edit: false,
+                },
+              },
+            }}
+            detailUrl="/inventories/inventory/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
   });
 });

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { string, bool, func } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
@@ -7,12 +7,16 @@ import {
   DataListItem,
   DataListItemRow,
   DataListItemCells,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
+import ListActionButton from '@components/ListActionButton';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Organization } from '@types';
 
@@ -66,11 +70,7 @@ class OrganizationListItem extends React.Component {
                   </Link>
                 </span>
               </DataListCell>,
-              <DataListCell
-                key="related-field-counts"
-                righthalf="true"
-                width={2}
-              >
+              <DataListCell key="related-field-counts">
                 <ListGroup>
                   {i18n._(t`Members`)}
                   <Badge isRead>
@@ -84,6 +84,33 @@ class OrganizationListItem extends React.Component {
                   </Badge>
                 </ListGroup>
               </DataListCell>,
+              <ActionButtonCell
+                lastcolumn="true"
+                key="action"
+                actions={[
+                  {
+                    key: 'edit',
+                    content: (
+                      <Fragment>
+                        {organization.summary_fields.user_capabilities.edit && (
+                          <Tooltip
+                            content={i18n._(t`Edit Organization`)}
+                            position="top"
+                          >
+                            <ListActionButton
+                              variant="plain"
+                              component={Link}
+                              to={`/organizations/${organization.id}/edit`}
+                            >
+                              <PencilAltIcon />
+                            </ListActionButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                ]}
+              />,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.test.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.test.jsx
@@ -20,6 +20,9 @@ describe('<OrganizationListItem />', () => {
                   users: 1,
                   teams: 1,
                 },
+                user_capabilities: {
+                  edit: true,
+                },
               },
             }}
             detailUrl="/organization/1"
@@ -29,5 +32,59 @@ describe('<OrganizationListItem />', () => {
         </MemoryRouter>
       </I18nProvider>
     );
+  });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/organizations']} initialIndex={0}>
+          <OrganizationListItem
+            organization={{
+              id: 1,
+              name: 'Org',
+              summary_fields: {
+                related_field_counts: {
+                  users: 1,
+                  teams: 1,
+                },
+                user_capabilities: {
+                  edit: true,
+                },
+              },
+            }}
+            detailUrl="/organization/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/organizations']} initialIndex={0}>
+          <OrganizationListItem
+            organization={{
+              id: 1,
+              name: 'Org',
+              summary_fields: {
+                related_field_counts: {
+                  users: 1,
+                  teams: 1,
+                },
+                user_capabilities: {
+                  edit: false,
+                },
+              },
+            }}
+            detailUrl="/organization/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
   });
 });

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -8,10 +8,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
-import { Link as _Link } from 'react-router-dom';
-import { SyncIcon } from '@patternfly/react-icons';
-import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { PencilAltIcon, SyncIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
 import ListActionButton from '@components/ListActionButton';
@@ -19,12 +19,6 @@ import ProjectSyncButton from '../shared/ProjectSyncButton';
 import { StatusIcon } from '@components/Sparkline';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Project } from '@types';
-
-/* eslint-disable react/jsx-pascal-case */
-const Link = styled(props => <_Link {...props} />)`
-  margin-right: 10px;
-`;
-/* eslint-enable react/jsx-pascal-case */
 
 class ProjectListItem extends React.Component {
   static propTypes = {
@@ -60,6 +54,11 @@ class ProjectListItem extends React.Component {
     );
   };
 
+  handleEditClick = project => {
+    const { history } = this.props;
+    history.push(`/projects/${project.id}/edit`);
+  };
+
   render() {
     const { project, isSelected, onSelect, detailUrl, i18n } = this.props;
     const labelId = `check-action-${project.id}`;
@@ -93,28 +92,68 @@ class ProjectListItem extends React.Component {
                     </Link>
                   </Tooltip>
                 )}
-                <span id={labelId}>
-                  <Link to={`${detailUrl}`}>
-                    <b>{project.name}</b>
-                  </Link>
-                </span>
+                <Link
+                  id={labelId}
+                  to={`${detailUrl}`}
+                  style={{ marginLeft: '10px' }}
+                >
+                  <b>{project.name}</b>
+                </Link>
               </DataListCell>,
               <DataListCell key="type">
                 {project.scm_type.toUpperCase()}
               </DataListCell>,
-              <DataListCell lastcolumn="true" key="action">
-                {project.summary_fields.user_capabilities.start && (
-                  <Tooltip content={i18n._(t`Sync Project`)} position="top">
-                    <ProjectSyncButton projectId={project.id}>
-                      {handleSync => (
-                        <ListActionButton variant="plain" onClick={handleSync}>
-                          <SyncIcon />
-                        </ListActionButton>
-                      )}
-                    </ProjectSyncButton>
-                  </Tooltip>
-                )}
-              </DataListCell>,
+              <ActionButtonCell
+                lastcolumn="true"
+                key="action"
+                actions={[
+                  {
+                    key: 'sync',
+                    content: (
+                      <Fragment>
+                        {project.summary_fields.user_capabilities.start && (
+                          <Tooltip
+                            content={i18n._(t`Sync Project`)}
+                            position="top"
+                          >
+                            <ProjectSyncButton projectId={project.id}>
+                              {handleSync => (
+                                <ListActionButton
+                                  variant="plain"
+                                  onClick={handleSync}
+                                >
+                                  <SyncIcon />
+                                </ListActionButton>
+                              )}
+                            </ProjectSyncButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                  {
+                    key: 'edit',
+                    content: (
+                      <Fragment>
+                        {project.summary_fields.user_capabilities.edit && (
+                          <Tooltip
+                            content={i18n._(t`Edit Project`)}
+                            position="top"
+                          >
+                            <ListActionButton
+                              variant="plain"
+                              component={Link}
+                              to={`/projects/${project.id}/edit`}
+                            >
+                              <PencilAltIcon />
+                            </ListActionButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                ]}
+              />,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
@@ -57,4 +57,56 @@ describe('<ProjectsListItem />', () => {
     );
     expect(wrapper.find('ProjectSyncButton').exists()).toBeFalsy();
   });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <ProjectsListItem
+        isSelected={false}
+        detailUrl="/project/1"
+        onSelect={() => {}}
+        project={{
+          id: 1,
+          name: 'Project 1',
+          url: '/api/v2/projects/1',
+          type: 'project',
+          scm_type: 'git',
+          summary_fields: {
+            last_job: {
+              id: 9000,
+              status: 'successful',
+            },
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <ProjectsListItem
+        isSelected={false}
+        detailUrl="/project/1"
+        onSelect={() => {}}
+        project={{
+          id: 1,
+          name: 'Project 1',
+          url: '/api/v2/projects/1',
+          type: 'project',
+          scm_type: 'git',
+          summary_fields: {
+            last_job: {
+              id: 9000,
+              status: 'successful',
+            },
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  });
 });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import {
   DataListItem,
@@ -8,8 +8,9 @@ import {
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
 import { withI18n } from '@lingui/react';
-import { RocketIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, RocketIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
 import LaunchButton from '@components/LaunchButton';
@@ -19,6 +20,16 @@ import { Sparkline } from '@components/Sparkline';
 import { toTitleCase } from '@util/strings';
 
 import styled from 'styled-components';
+
+const rightStyle = `
+@media screen and (max-width: 768px) {
+  && {
+    padding-top: 0px;
+    flex: 0 0 33%;
+    padding-right: 20px;
+  }
+}
+`;
 
 const DataListItemCells = styled(PFDataListItemCells)`
   display: flex;
@@ -37,13 +48,10 @@ const LeftDataListCell = styled(DataListCell)`
   }
 `;
 const RightDataListCell = styled(DataListCell)`
-  @media screen and (max-width: 768px) {
-    && {
-      padding-top: 0px;
-      flex: 0 0 33%;
-      padding-right: 20px;
-    }
-  }
+  ${rightStyle}
+`;
+const RightActionButtonCell = styled(ActionButtonCell)`
+  ${rightStyle}
 `;
 
 class TemplateListItem extends Component {
@@ -87,27 +95,59 @@ class TemplateListItem extends Component {
               >
                 <Sparkline jobs={template.summary_fields.recent_jobs} />
               </RightDataListCell>,
-              <RightDataListCell
-                css="max-width: 40px;"
+              <RightActionButtonCell
+                css="max-width: 80px;"
                 righthalf="true"
                 lastcolumn="true"
                 key="launch"
-              >
-                {canLaunch && template.type === 'job_template' && (
-                  <Tooltip content={i18n._(t`Launch Template`)} position="top">
-                    <LaunchButton resource={template}>
-                      {({ handleLaunch }) => (
-                        <ListActionButton
-                          variant="plain"
-                          onClick={handleLaunch}
-                        >
-                          <RocketIcon />
-                        </ListActionButton>
-                      )}
-                    </LaunchButton>
-                  </Tooltip>
-                )}
-              </RightDataListCell>,
+                actions={[
+                  {
+                    key: 'launch',
+                    content: (
+                      <Fragment>
+                        {canLaunch && template.type === 'job_template' && (
+                          <Tooltip
+                            content={i18n._(t`Launch Template`)}
+                            position="top"
+                          >
+                            <LaunchButton resource={template}>
+                              {({ handleLaunch }) => (
+                                <ListActionButton
+                                  variant="plain"
+                                  onClick={handleLaunch}
+                                >
+                                  <RocketIcon />
+                                </ListActionButton>
+                              )}
+                            </LaunchButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                  {
+                    key: 'edit',
+                    content: (
+                      <Fragment>
+                        {template.summary_fields.user_capabilities.edit && (
+                          <Tooltip
+                            content={i18n._(t`Edit Template`)}
+                            position="top"
+                          >
+                            <ListActionButton
+                              variant="plain"
+                              component={Link}
+                              to={`/templates/${template.type}/${template.id}/edit`}
+                            >
+                              <PencilAltIcon />
+                            </ListActionButton>
+                          </Tooltip>
+                        )}
+                      </Fragment>
+                    ),
+                  },
+                ]}
+              />,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplatesListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplatesListItem.test.jsx
@@ -43,4 +43,42 @@ describe('<TemplatesListItem />', () => {
     );
     expect(wrapper.find('LaunchButton').exists()).toBeFalsy();
   });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <TemplatesListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <TemplatesListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
##### SUMMARY
link #5066 #5067 #5068 #5069 

This PR adds an edit button to these four lists.  Edit button is hidden when user does not have `edit` user_capabilities.  Action buttons should be spaced 20px apart.  For accessibility and reusability purposes I decided to nest the action buttons in a `ul`/`li` structure.  I felt like having a component where action items could be passed as an array seemed cleaner than repeatedly defining this structure in every list.  AFAIK we don't have a pattern where anything other than buttons will go in that action cell.

<img width="1452" alt="Screen Shot 2019-10-24 at 3 00 13 PM" src="https://user-images.githubusercontent.com/9889020/67516944-8aae6b00-f66f-11e9-8d4f-9f0afc0729db.png">
<img width="1525" alt="Screen Shot 2019-10-24 at 3 00 08 PM" src="https://user-images.githubusercontent.com/9889020/67516945-8aae6b00-f66f-11e9-8d11-0bbd5c66ef66.png">
<img width="1531" alt="Screen Shot 2019-10-24 at 3 00 02 PM" src="https://user-images.githubusercontent.com/9889020/67516947-8aae6b00-f66f-11e9-933d-1446b0d42d18.png">
<img width="1579" alt="Screen Shot 2019-10-24 at 2 59 55 PM" src="https://user-images.githubusercontent.com/9889020/67516948-8aae6b00-f66f-11e9-9f29-b8dbab21c4bd.png">
<img width="414" alt="Screen Shot 2019-10-24 at 3 00 20 PM" src="https://user-images.githubusercontent.com/9889020/67516957-8f731f00-f66f-11e9-97fc-a559c8b07252.png">


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
