### PR TITLE
Adds edit buttons to Templates, Inventories, Organizations, and Projects list items

### DIFF
--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
@@ -1,9 +1,10 @@
 import DataListCell from '@components/DataListCell';
 import styled from 'styled-components';
 
-DataListCell.displayName = 'ActionButtonCell';
-export default styled(DataListCell)`
+const ActionButtonCell = styled(DataListCell)`
   & > :not(:first-child) {
     margin-left: 20px;
   }
 `;
+ActionButtonCell.displayName = 'ActionButtonCell';
+export default ActionButtonCell;

--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
@@ -1,6 +1,7 @@
 import DataListCell from '@components/DataListCell';
 import styled from 'styled-components';
 
+DataListCell.displayName = 'ActionButtonCell';
 export default styled(DataListCell)`
   & > :not(:first-child) {
     margin-left: 20px;

--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.jsx
@@ -1,0 +1,8 @@
+import DataListCell from '@components/DataListCell';
+import styled from 'styled-components';
+
+export default styled(DataListCell)`
+  & > :not(:first-child) {
+    margin-left: 20px;
+  }
+`;

--- a/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.test.jsx
+++ b/awx/ui_next/src/components/ActionButtonCell/ActionButtonCell.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ActionButtonCell from './ActionButtonCell';
+
+describe('ActionButtonCell', () => {
+  test('renders the expected content', () => {
+    const wrapper = mount(<ActionButtonCell />);
+    expect(wrapper).toHaveLength(1);
+  });
+});

--- a/awx/ui_next/src/components/ActionButtonCell/index.js
+++ b/awx/ui_next/src/components/ActionButtonCell/index.js
@@ -1,0 +1,1 @@
+export { default } from './ActionButtonCell';

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
@@ -5,12 +5,16 @@ import {
   DataListItem,
   DataListItemRow,
   DataListItemCells,
+  Tooltip,
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
+import ListActionButton from '@components/ListActionButton';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Inventory } from '@types';
 
@@ -47,6 +51,23 @@ class InventoryListItem extends React.Component {
                   ? i18n._(t`Smart Inventory`)
                   : i18n._(t`Inventory`)}
               </DataListCell>,
+              <ActionButtonCell lastcolumn="true" key="action">
+                {inventory.summary_fields.user_capabilities.edit && (
+                  <Tooltip content={i18n._(t`Edit Inventory`)} position="top">
+                    <ListActionButton
+                      variant="plain"
+                      component={Link}
+                      to={`/inventories/${
+                        inventory.kind === 'smart'
+                          ? 'smart_inventory'
+                          : 'inventory'
+                      }/${inventory.id}/edit`}
+                    >
+                      <PencilAltIcon />
+                    </ListActionButton>
+                  </Tooltip>
+                )}
+              </ActionButtonCell>,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.test.jsx
@@ -18,6 +18,9 @@ describe('<InventoryListItem />', () => {
                   id: 1,
                   name: 'Default',
                 },
+                user_capabilities: {
+                  edit: true,
+                },
               },
             }}
             detailUrl="/inventories/inventory/1"
@@ -27,5 +30,59 @@ describe('<InventoryListItem />', () => {
         </MemoryRouter>
       </I18nProvider>
     );
+  });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/inventories']} initialIndex={0}>
+          <InventoryListItem
+            inventory={{
+              id: 1,
+              name: 'Inventory',
+              summary_fields: {
+                organization: {
+                  id: 1,
+                  name: 'Default',
+                },
+                user_capabilities: {
+                  edit: true,
+                },
+              },
+            }}
+            detailUrl="/inventories/inventory/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/inventories']} initialIndex={0}>
+          <InventoryListItem
+            inventory={{
+              id: 1,
+              name: 'Inventory',
+              summary_fields: {
+                organization: {
+                  id: 1,
+                  name: 'Default',
+                },
+                user_capabilities: {
+                  edit: false,
+                },
+              },
+            }}
+            detailUrl="/inventories/inventory/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
   });
 });

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.jsx
@@ -7,12 +7,16 @@ import {
   DataListItem,
   DataListItemRow,
   DataListItemCells,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
+import ListActionButton from '@components/ListActionButton';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Organization } from '@types';
 
@@ -66,11 +70,7 @@ class OrganizationListItem extends React.Component {
                   </Link>
                 </span>
               </DataListCell>,
-              <DataListCell
-                key="related-field-counts"
-                righthalf="true"
-                width={2}
-              >
+              <DataListCell key="related-field-counts">
                 <ListGroup>
                   {i18n._(t`Members`)}
                   <Badge isRead>
@@ -84,6 +84,22 @@ class OrganizationListItem extends React.Component {
                   </Badge>
                 </ListGroup>
               </DataListCell>,
+              <ActionButtonCell lastcolumn="true" key="action">
+                {organization.summary_fields.user_capabilities.edit && (
+                  <Tooltip
+                    content={i18n._(t`Edit Organization`)}
+                    position="top"
+                  >
+                    <ListActionButton
+                      variant="plain"
+                      component={Link}
+                      to={`/organizations/${organization.id}/edit`}
+                    >
+                      <PencilAltIcon />
+                    </ListActionButton>
+                  </Tooltip>
+                )}
+              </ActionButtonCell>,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.test.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationListItem.test.jsx
@@ -20,6 +20,9 @@ describe('<OrganizationListItem />', () => {
                   users: 1,
                   teams: 1,
                 },
+                user_capabilities: {
+                  edit: true,
+                },
               },
             }}
             detailUrl="/organization/1"
@@ -29,5 +32,59 @@ describe('<OrganizationListItem />', () => {
         </MemoryRouter>
       </I18nProvider>
     );
+  });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/organizations']} initialIndex={0}>
+          <OrganizationListItem
+            organization={{
+              id: 1,
+              name: 'Org',
+              summary_fields: {
+                related_field_counts: {
+                  users: 1,
+                  teams: 1,
+                },
+                user_capabilities: {
+                  edit: true,
+                },
+              },
+            }}
+            detailUrl="/organization/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <I18nProvider>
+        <MemoryRouter initialEntries={['/organizations']} initialIndex={0}>
+          <OrganizationListItem
+            organization={{
+              id: 1,
+              name: 'Org',
+              summary_fields: {
+                related_field_counts: {
+                  users: 1,
+                  teams: 1,
+                },
+                user_capabilities: {
+                  edit: false,
+                },
+              },
+            }}
+            detailUrl="/organization/1"
+            isSelected
+            onSelect={() => {}}
+          />
+        </MemoryRouter>
+      </I18nProvider>
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
   });
 });

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -8,10 +8,14 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
+import { Link } from 'react-router-dom';
+import { PencilAltIcon, SyncIcon } from '@patternfly/react-icons';
+
 import { Link as _Link } from 'react-router-dom';
 import { SyncIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import ClipboardCopyButton from '@components/ClipboardCopyButton';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
@@ -20,12 +24,6 @@ import ProjectSyncButton from '../shared/ProjectSyncButton';
 import { StatusIcon } from '@components/Sparkline';
 import VerticalSeparator from '@components/VerticalSeparator';
 import { Project } from '@types';
-
-/* eslint-disable react/jsx-pascal-case */
-const Link = styled(props => <_Link {...props} />)`
-  margin-right: 10px;
-`;
-/* eslint-enable react/jsx-pascal-case */
 
 class ProjectListItem extends React.Component {
   static propTypes = {
@@ -61,6 +59,11 @@ class ProjectListItem extends React.Component {
     );
   };
 
+  handleEditClick = project => {
+    const { history } = this.props;
+    history.push(`/projects/${project.id}/edit`);
+  };
+
   render() {
     const { project, isSelected, onSelect, detailUrl, i18n } = this.props;
     const labelId = `check-action-${project.id}`;
@@ -94,11 +97,13 @@ class ProjectListItem extends React.Component {
                     </Link>
                   </Tooltip>
                 )}
-                <span id={labelId}>
-                  <Link to={`${detailUrl}`}>
-                    <b>{project.name}</b>
-                  </Link>
-                </span>
+                <Link
+                  id={labelId}
+                  to={`${detailUrl}`}
+                  style={{ marginLeft: '10px' }}
+                >
+                  <b>{project.name}</b>
+                </Link>
               </DataListCell>,
               <DataListCell key="type">
                 {project.scm_type.toUpperCase()}
@@ -113,7 +118,7 @@ class ProjectListItem extends React.Component {
                   />
                 ) : null}
               </DataListCell>,
-              <DataListCell lastcolumn="true" key="action">
+              <ActionButtonCell lastcolumn="true" key="action">
                 {project.summary_fields.user_capabilities.start && (
                   <Tooltip content={i18n._(t`Sync Project`)} position="top">
                     <ProjectSyncButton projectId={project.id}>
@@ -125,7 +130,18 @@ class ProjectListItem extends React.Component {
                     </ProjectSyncButton>
                   </Tooltip>
                 )}
-              </DataListCell>,
+                {project.summary_fields.user_capabilities.edit && (
+                  <Tooltip content={i18n._(t`Edit Project`)} position="top">
+                    <ListActionButton
+                      variant="plain"
+                      component={Link}
+                      to={`/projects/${project.id}/edit`}
+                    >
+                      <PencilAltIcon />
+                    </ListActionButton>
+                  </Tooltip>
+                )}
+              </ActionButtonCell>,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -11,10 +11,6 @@ import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
 import { PencilAltIcon, SyncIcon } from '@patternfly/react-icons';
 
-import { Link as _Link } from 'react-router-dom';
-import { SyncIcon } from '@patternfly/react-icons';
-import styled from 'styled-components';
-
 import ActionButtonCell from '@components/ActionButtonCell';
 import ClipboardCopyButton from '@components/ClipboardCopyButton';
 import DataListCell from '@components/DataListCell';
@@ -57,11 +53,6 @@ class ProjectListItem extends React.Component {
         )}
       </Fragment>
     );
-  };
-
-  handleEditClick = project => {
-    const { history } = this.props;
-    history.push(`/projects/${project.id}/edit`);
   };
 
   render() {

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
@@ -71,6 +71,7 @@ describe('<ProjectsListItem />', () => {
           url: '/api/v2/projects/1',
           type: 'project',
           scm_type: 'git',
+          scm_revision: '7788f7erga0jijodfgsjisiodf98sdga9hg9a98gaf',
           summary_fields: {
             last_job: {
               id: 9000,
@@ -97,6 +98,7 @@ describe('<ProjectsListItem />', () => {
           url: '/api/v2/projects/1',
           type: 'project',
           scm_type: 'git',
+          scm_revision: '7788f7erga0jijodfgsjisiodf98sdga9hg9a98gaf',
           summary_fields: {
             last_job: {
               id: 9000,

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
@@ -59,4 +59,56 @@ describe('<ProjectsListItem />', () => {
     );
     expect(wrapper.find('ProjectSyncButton').exists()).toBeFalsy();
   });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <ProjectsListItem
+        isSelected={false}
+        detailUrl="/project/1"
+        onSelect={() => {}}
+        project={{
+          id: 1,
+          name: 'Project 1',
+          url: '/api/v2/projects/1',
+          type: 'project',
+          scm_type: 'git',
+          summary_fields: {
+            last_job: {
+              id: 9000,
+              status: 'successful',
+            },
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <ProjectsListItem
+        isSelected={false}
+        detailUrl="/project/1"
+        onSelect={() => {}}
+        project={{
+          id: 1,
+          name: 'Project 1',
+          url: '/api/v2/projects/1',
+          type: 'project',
+          scm_type: 'git',
+          summary_fields: {
+            last_job: {
+              id: 9000,
+              status: 'successful',
+            },
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  });
 });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -8,8 +8,9 @@ import {
 } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
 import { withI18n } from '@lingui/react';
-import { RocketIcon } from '@patternfly/react-icons';
+import { PencilAltIcon, RocketIcon } from '@patternfly/react-icons';
 
+import ActionButtonCell from '@components/ActionButtonCell';
 import DataListCell from '@components/DataListCell';
 import DataListCheck from '@components/DataListCheck';
 import LaunchButton from '@components/LaunchButton';
@@ -19,6 +20,16 @@ import { Sparkline } from '@components/Sparkline';
 import { toTitleCase } from '@util/strings';
 
 import styled from 'styled-components';
+
+const rightStyle = `
+@media screen and (max-width: 768px) {
+  && {
+    padding-top: 0px;
+    flex: 0 0 33%;
+    padding-right: 20px;
+  }
+}
+`;
 
 const DataListItemCells = styled(PFDataListItemCells)`
   display: flex;
@@ -37,13 +48,10 @@ const LeftDataListCell = styled(DataListCell)`
   }
 `;
 const RightDataListCell = styled(DataListCell)`
-  @media screen and (max-width: 768px) {
-    && {
-      padding-top: 0px;
-      flex: 0 0 33%;
-      padding-right: 20px;
-    }
-  }
+  ${rightStyle}
+`;
+const RightActionButtonCell = styled(ActionButtonCell)`
+  ${rightStyle}
 `;
 
 class TemplateListItem extends Component {
@@ -87,8 +95,8 @@ class TemplateListItem extends Component {
               >
                 <Sparkline jobs={template.summary_fields.recent_jobs} />
               </RightDataListCell>,
-              <RightDataListCell
-                css="max-width: 40px;"
+              <RightActionButtonCell
+                css="max-width: 80px;"
                 righthalf="true"
                 lastcolumn="true"
                 key="launch"
@@ -107,7 +115,18 @@ class TemplateListItem extends Component {
                     </LaunchButton>
                   </Tooltip>
                 )}
-              </RightDataListCell>,
+                {template.summary_fields.user_capabilities.edit && (
+                  <Tooltip content={i18n._(t`Edit Template`)} position="top">
+                    <ListActionButton
+                      variant="plain"
+                      component={Link}
+                      to={`/templates/${template.type}/${template.id}/edit`}
+                    >
+                      <PencilAltIcon />
+                    </ListActionButton>
+                  </Tooltip>
+                )}
+              </RightActionButtonCell>,
             ]}
           />
         </DataListItemRow>

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplatesListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplatesListItem.test.jsx
@@ -43,4 +43,42 @@ describe('<TemplatesListItem />', () => {
     );
     expect(wrapper.find('LaunchButton').exists()).toBeFalsy();
   });
+  test('edit button shown to users with edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <TemplatesListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+  test('edit button hidden from users without edit capabilities', () => {
+    const wrapper = mountWithContexts(
+      <TemplatesListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
##### SUMMARY
link #5066 #5067 #5068 #5069 

This PR adds an edit button to these four lists.  Edit button is hidden when user does not have `edit` user_capabilities.  Action buttons should be spaced 20px apart.  For accessibility and reusability purposes I decided to nest the action buttons in a `ul`/`li` structure.  I felt like having a component where action items could be passed as an array seemed cleaner than repeatedly defining this structure in every list.  AFAIK we don't have a pattern where anything other than buttons will go in that action cell.

<img width="1452" alt="Screen Shot 2019-10-24 at 3 00 13 PM" src="https://user-images.githubusercontent.com/9889020/67516944-8aae6b00-f66f-11e9-8d4f-9f0afc0729db.png">
<img width="1525" alt="Screen Shot 2019-10-24 at 3 00 08 PM" src="https://user-images.githubusercontent.com/9889020/67516945-8aae6b00-f66f-11e9-8d11-0bbd5c66ef66.png">
<img width="1531" alt="Screen Shot 2019-10-24 at 3 00 02 PM" src="https://user-images.githubusercontent.com/9889020/67516947-8aae6b00-f66f-11e9-933d-1446b0d42d18.png">
<img width="1579" alt="Screen Shot 2019-10-24 at 2 59 55 PM" src="https://user-images.githubusercontent.com/9889020/67516948-8aae6b00-f66f-11e9-9f29-b8dbab21c4bd.png">
<img width="414" alt="Screen Shot 2019-10-24 at 3 00 20 PM" src="https://user-images.githubusercontent.com/9889020/67516957-8f731f00-f66f-11e9-97fc-a559c8b07252.png">


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI