### PR TITLE
Fix bug: WFJT-type node YAML vars broke task manager

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -900,6 +900,9 @@ class LaunchTimeConfigBase(BaseModel):
                         data[prompt_name] = self.display_extra_vars()
                     else:
                         data[prompt_name] = self.extra_vars
+                    # Depending on model, field type may save and return as string
+                    if isinstance(data[prompt_name], str):
+                        data[prompt_name] = parse_yaml_or_json(data[prompt_name])
                 if self.survey_passwords and not display:
                     data['survey_passwords'] = self.survey_passwords
             else:

--- a/awx/main/tests/unit/models/test_workflow_unit.py
+++ b/awx/main/tests/unit/models/test_workflow_unit.py
@@ -234,6 +234,14 @@ class TestWorkflowJobNodeJobKWARGS:
         job_node_no_prompts.unified_job_template = project_unit
         assert job_node_no_prompts.get_job_kwargs() == self.kwargs_base
 
+    def test_extra_vars_node_prompts(self, wfjt_node_no_prompts):
+        wfjt_node_no_prompts.extra_vars = {'foo': 'bar'}
+        assert wfjt_node_no_prompts.prompts_dict() == {'extra_vars': {'foo': 'bar'}}
+
+    def test_string_extra_vars_node_prompts(self, wfjt_node_no_prompts):
+        wfjt_node_no_prompts.extra_vars = '{"foo": "bar"}'
+        assert wfjt_node_no_prompts.prompts_dict() == {'extra_vars': {'foo': 'bar'}}
+
 
 def test_get_ask_mapping_integrity():
     assert list(WorkflowJobTemplate.get_ask_mapping().keys()) == ['extra_vars', 'inventory', 'limit', 'scm_branch']


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/5046

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
The saved prompts data should never ever ever return string vars. This is for internal use, and should always come back as dictionary. It was the fact that the field properties allowed it to be a string that surprised me (and maybe related to some recent field type changes), and that this was possible to use via the API.
