### PR TITLE
Move development PROJECTS_ROOT

### DIFF
--- a/awx/settings/local_settings.py.docker_compose
+++ b/awx/settings/local_settings.py.docker_compose
@@ -69,7 +69,7 @@ CHANNEL_LAYERS = {
 
 # Absolute filesystem path to the directory to host projects (with playbooks).
 # This directory should NOT be web-accessible.
-PROJECTS_ROOT = '/projects/'
+PROJECTS_ROOT = '/var/lib/awx/projects/'
 
 # Absolute filesystem path to the directory for job status stdout
 # This directory should not be web-accessible


### PR DESCRIPTION
##### SUMMARY
I suspect the reasons for this have become less relevant over time. Now we are saving a file `/var/lib/awx/beat.db`.

Moving forward, we need to introduce a collections folder. So we will have both of these folders:

1. `/projects` and `/collections`
2. `/var/lib/awx/projects` and `/var/lib/awx/collections`

The 2nd option seems more appealing to me, but I want to raise the issue now whatever the outcome.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
Tested updating projects, and no problems encountered.
