### PR TITLE
Bugfix - Slack notification with name and avatar

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -50,6 +50,7 @@ class SlackBackend(AWXBaseEmailBackend):
                     else:
                         ret = connection.api_call("chat.postMessage",
                                                   channel=r,
+                                                  as_user=True,
                                                   text=m.subject)
                     logger.debug(ret)
                     if ret['ok']:


### PR DESCRIPTION
##### SUMMARY
Currently, if color field isn't defined, the Slack integration will send notifications to Slack as the user "bot" with a generic avatar icon.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

main/notifications/slack_backend.py

##### AWX VERSION
This bug is currently present on devel branch ans affect all version.