### PR TITLE
find lookup plugins which are installed as roles

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1602,7 +1602,8 @@ class RunJob(BaseTask):
 
         path_vars = (
             ('ANSIBLE_COLLECTIONS_PATHS', 'collections_paths', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
-            ('ANSIBLE_ROLES_PATH', 'roles_path', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles'))
+            ('ANSIBLE_ROLES_PATH', 'roles_path', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles'),
+            ('ANSIBLE_LOOKUP_PLUGINS', 'lookup_plugins', 'requirements_roles', '~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup'))
 
         config_values = read_ansible_config(job.project.get_project_path(), list(map(lambda x: x[1], path_vars)))
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -128,7 +128,7 @@
         register: doesRequirementsExist
 
       - name: fetch galaxy roles from requirements.yml
-        command: ansible-galaxy install -r requirements.yml -p {{roles_destination|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
+        command: ansible-galaxy install -r requirements.yml -p {{roles_destination|default('.')|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
         args:
           chdir: "{{project_path|quote}}/roles"
         register: galaxy_result


### PR DESCRIPTION
##### SUMMARY
We install additional custom lookup plugins as roles. In `ansible.cfg` we set `lookup_plugins = roles` in order for the runner to find the lookup plugins which were previously installed via `ansible-galaxy install`. We can then set _ANSIBLE_LOOKUP_PLUGINS_ to include the roles path to find additional plugins.

To make it work, we also had to include the fix proposed in #1632.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- `project_update.yml` to install the roles/plugins into _roles_
- `tasks.py` to set _ANSIBLE_LOOKUP_PLUGINS_

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
8.0.0/develop
```


##### ADDITIONAL INFORMATION

In the future, additional plugins could probably be installed as collections.
