### PR TITLE
INSTALL - make sure postgres pod is running with label app set

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -509,7 +509,7 @@ If you wish to tag and push built images to a Docker registry, set the following
 
 AWX requires access to a PostgreSQL database, and by default, one will be created and deployed in a container, and data will be persisted to a host volume. In this scenario, you must set the value of `postgres_data_dir` to a path that can be mounted to the container. When the container is stopped, the database files will still exist in the specified path.
 
-If you wish to use an external database, in the inventory file, set the value of `pg_hostname`, and update `pg_username`, `pg_password`, `pg_admin_password`, `pg_database`, and `pg_port` with the connection information. Additionally, if the service is running through pod, make sure the label name is set to postgres, otherwise the ansible-playbook install will fail.
+If you wish to use an external database, in the inventory file, set the value of `pg_hostname`, and update `pg_username`, `pg_password`, `pg_admin_password`, `pg_database`, and `pg_port` with the connection information. Additionally, if the service is running through pod, make sure the label app is set to postgres, otherwise the ansible-playbook install will fail.
 
 ### Start the build
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -509,7 +509,7 @@ If you wish to tag and push built images to a Docker registry, set the following
 
 AWX requires access to a PostgreSQL database, and by default, one will be created and deployed in a container, and data will be persisted to a host volume. In this scenario, you must set the value of `postgres_data_dir` to a path that can be mounted to the container. When the container is stopped, the database files will still exist in the specified path.
 
-If you wish to use an external database, in the inventory file, set the value of `pg_hostname`, and update `pg_username`, `pg_password`, `pg_admin_password`, `pg_database`, and `pg_port` with the connection information.
+If you wish to use an external database, in the inventory file, set the value of `pg_hostname`, and update `pg_username`, `pg_password`, `pg_admin_password`, `pg_database`, and `pg_port` with the connection information. Additionally, if the service is running through pod, make sure the label name is set to postgres, otherwise the ansible-playbook install will fail.
 
 ### Start the build
 

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -116,7 +116,7 @@
 - name: Check if Postgres 9.6 is being used
   shell: |
     POD=$({{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
-      get pods -l=name=postgresql --field-selector status.phase=Running -o jsonpath="{.items[0].metadata.name}")
+      get pods -l=app=postgres --field-selector status.phase=Running -o jsonpath="{.items[0].metadata.name}")
     {{ kubectl_or_oc }} exec -ti $POD -n {{ kubernetes_namespace }} -- bash -c "psql -U {{ pg_username }} -tAc 'select version()'"
   register: pg_version
 
@@ -150,7 +150,7 @@
     - name: Wait for Postgres to finish upgrading
       shell: |
         POD=$({{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
-          get pods -l=name=postgresql -o jsonpath="{.items[0].metadata.name}")
+          get pods -l=app=postgres -o jsonpath="{.items[0].metadata.name}")
         {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} logs $POD | grep 'Upgrade DONE'
       register: pg_upgrade_logs
       retries: 360


### PR DESCRIPTION
ansible-playbook install will fail if postgres service pod is running
without label name set as postgres. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer
 - Docs

##### AWX VERSION
awx: 8.0.0


##### ADDITIONAL INFORMATION
The same command from installer:
```
$ kubectl get pods -l=name=postgres --field-selector status.phase=Running -o jsonpath="{.items[0].metadata.name}"
error: error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[0].metadata.name}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}

```

After adding:
labels:
  name: postgres

```
 kubectl get pods -l=name=postgres --field-selector status.phase=Running -o jsonpath="{.items[0].metadata.name}"
postgres-8549f56f76-jv2fn
```

Related source code: 
installer/roles/kubernetes/tasks/main.yml
Lines: 116 and 150