### PR TITLE
Apply username ordering to more views

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -575,6 +575,7 @@ class TeamUsersList(BaseUsersList):
     serializer_class = serializers.UserSerializer
     parent_model = models.Team
     relationship = 'member_role.members'
+    ordering = ('username',)
 
 
 class TeamRolesList(SubListAttachDetachAPIView):
@@ -911,6 +912,7 @@ class UserList(ListCreateAPIView):
     model = models.User
     serializer_class = serializers.UserSerializer
     permission_classes = (UserPermission,)
+    ordering = ('username',)
 
 
 class UserMeList(ListAPIView):
@@ -918,6 +920,7 @@ class UserMeList(ListAPIView):
     model = models.User
     serializer_class = serializers.UserSerializer
     name = _('Me')
+    ordering = ('username',)
 
     def get_queryset(self):
         return self.model.objects.filter(pk=self.request.user.pk)
@@ -1261,6 +1264,7 @@ class CredentialOwnerUsersList(SubListAPIView):
     serializer_class = serializers.UserSerializer
     parent_model = models.Credential
     relationship = 'admin_role.members'
+    ordering = ('username',)
 
 
 class CredentialOwnerTeamsList(SubListAPIView):


### PR DESCRIPTION
##### SUMMARY
The _main_ reason for making this change is to clean up test output:

https://ansible.softwarefactory-project.io/logs/40/5140/6b4b85edb3a7964e720892cb83bb696f46a004fb/check/awx-ansible-modules/a92e202/ara-report/

This hits a lot of `UnorderedObjectListWarning` because it hits the `/api/v2/me/` endpoint. There's only 1 entry, no one cares if it's ordered or not in practice.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
We have already applied this in other views:

https://github.com/ansible/awx/blob/505dcf9dd262a718b5b4165cb82fa76aaae5e81f/awx/api/views/organization.py#L119

that is pretty much an identical case to what we have here. The last thing we want is different user ordering for different user views. Yes, it would be nice if this could be done on the model, but it's not our model. So let's content ourselves with this as the exception.
