### PR TITLE
Fix and test for warning when creating project

### DIFF
--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -145,7 +145,7 @@ def main():
         scm_clean=dict(type='bool', default=False),
         scm_delete_on_update=dict(type='bool', default=False),
         scm_update_on_launch=dict(type='bool', default=False),
-        scm_update_cache_timeout=dict(type='int', default=0),
+        scm_update_cache_timeout=dict(type='int'),
         job_timeout=dict(type='int', default=0),
         custom_virtualenv=dict(),
         local_path=dict(),

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -1,0 +1,25 @@
+import pytest
+
+from awx.main.models import Project
+
+
+@pytest.mark.django_db
+def test_create_project(run_module, admin_user, organization):
+    result = run_module('tower_project', dict(
+        name='foo',
+        organization=organization.name,
+        scm_type='git',
+        scm_url='https://foo.invalid'
+    ), admin_user)
+    assert result.pop('changed', None), result
+
+    proj = Project.objects.get(name='foo')
+    assert proj.scm_url == 'https://foo.invalid'
+    assert proj.organization == organization
+
+    result.pop('invocation')
+    assert result == {
+        'id': proj.id,
+        'project': 'foo',
+        'state': 'present'
+    }


### PR DESCRIPTION
##### SUMMARY
Address the issue https://github.com/ansible/ansible/issues/60327

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
Without fix

```
PYTHONPATH=awx_collection:$PYTHONPATH py.test awx_collection/test/awx/test_project.py 
========================================================================= test session starts =========================================================================
platform darwin -- Python 3.6.5, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
Django settings: awx.settings.development (from ini file)
rootdir: /Users/alancoding/Documents/tower, inifile: pytest.ini
plugins: django-3.6.0, mock-1.11.2, timeout-1.3.3, forked-1.1.3, pythonpath-0.7.3, cov-2.8.1, xdist-1.27.0, celery-4.3.0
collected 1 item                                                                                                                                                      

awx_collection/test/awx/test_project.py F                                                                                                                       [100%]

============================================================================== FAILURES ===============================================================================
_________________________________________________________________________ test_create_project _________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/test_project.py", line 21, in test_create_project
    assert result == {
AssertionError: assert {'id': 1, 'pr...set to true']} == {'id': 1, 'pr...e': 'present'}
  Omitting 3 identical items, use -vv to show
  Left contains 1 more item:
  {'warnings': ['scm_update_cache_timeout will be ignored since '
                'scm_update_on_launch was not set to true']}
  Use -v to get the full diff
========================================================================== warnings summary ===========================================================================
awx_collection/test/awx/test_project.py::test_create_project
  /Users/alancoding/.virtualenvs/awx_collection/lib/python3.6/site-packages/django/db/models/query.py:113: RemovedInDjango31Warning: Organization QuerySet won't use Meta.ordering in Django 3.1. Add .order_by('name') to retain the current query.
    for row in compiler.results_iter(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================================================== 1 failed, 1 warnings in 1.58s ====================================================================
```
