### PR TITLE
Make tower_group idempotent

### DIFF
--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -49,7 +49,6 @@ options:
       description:
         - The source to use for this group.
       choices: ["manual", "file", "ec2", "rax", "vmware", "gce", "azure", "azure_rm", "openstack", "satellite6" , "cloudforms", "custom"]
-      default: manual
       type: str
     source_regions:
       description:
@@ -127,15 +126,15 @@ def main():
         credential=dict(),
         source=dict(choices=["manual", "file", "ec2", "rax", "vmware",
                              "gce", "azure", "azure_rm", "openstack",
-                             "satellite6", "cloudforms", "custom"], default="manual"),
+                             "satellite6", "cloudforms", "custom"]),
         source_regions=dict(),
         source_vars=dict(),
         instance_filters=dict(),
         group_by=dict(),
         source_script=dict(),
-        overwrite=dict(type='bool', default=False),
-        overwrite_vars=dict(type='bool', default=False),
-        update_on_launch=dict(type='bool', default=False),
+        overwrite=dict(type='bool'),
+        overwrite_vars=dict(type='bool'),
+        update_on_launch=dict(type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 

--- a/awx_collection/test/awx/test_group.py
+++ b/awx_collection/test/awx/test_group.py
@@ -1,0 +1,56 @@
+import pytest
+
+from awx.main.models import Organization, Inventory, Group
+
+
+@pytest.mark.django_db
+def test_create_group(run_module, admin_user):
+    org = Organization.objects.create(name='test-org')
+    inv = Inventory.objects.create(name='test-inv', organization=org)
+
+    result = run_module('tower_group', dict(
+        name='Test Group',
+        inventory='test-inv',
+        variables='ansible_network_os: iosxr',
+        state='present'
+    ), admin_user)
+    assert result.get('changed'), result
+
+    group = Group.objects.get(name='Test Group')
+    assert group.inventory == inv
+    assert group.variables == 'ansible_network_os: iosxr'
+
+    result.pop('invocation')
+    assert result == {
+        'id': group.id,
+        'group': 'Test Group',
+        'changed': True,
+        'state': 'present'
+    }
+
+
+@pytest.mark.django_db
+def test_tower_group_idempotent(run_module, admin_user):
+    # https://github.com/ansible/ansible/issues/46803
+    org = Organization.objects.create(name='test-org')
+    inv = Inventory.objects.create(name='test-inv', organization=org)
+    group = Group.objects.create(
+        name='Test Group',
+        inventory=inv,
+        variables='ansible_network_os: iosxr'
+    )
+
+    result = run_module('tower_group', dict(
+        name='Test Group',
+        inventory='test-inv',
+        variables='ansible_network_os: iosxr',
+        state='present'
+    ), admin_user)
+
+    result.pop('invocation')
+    assert result == {
+        'id': group.id,
+        'group': 'Test Group',
+        'changed': False,  # idempotency assertion
+        'state': 'present'
+    }


### PR DESCRIPTION
##### SUMMARY
Addresses bug described in https://github.com/ansible/ansible/issues/46803

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
Cause is historical. This modules passes in a _lot_ of parameters which are no longer present in the API. Since these fields don't even exist, obviously the provided parameters don't match with the parameters of an existing object from the API.

The solution, similar to some other issues, is to stop setting a default for everything. These were never specified by the user, so passing `None` works. The value `None` is interpreted as "not provided" by tower-cli. _Actual_ null values have to be specified via a special keyword, which is a separate subject.
