### PR TITLE
Mount local projects directory inside of dev container.

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     working_dir: "/awx_devel"
     volumes:
       - "../:/awx_devel"
+      - "../awx/projects/:/var/lib/awx/projects/"
     privileged: true
   # A useful container that simply passes through log messages to the console
   # helpful for testing awx/tower logging


### PR DESCRIPTION
Yesterday I noticed that we have `awx/projects` in our `.gitignore`. I am assuming this pre-dates our containerized development environment. With this commit, any project under `awx/projects/` will be made available in the dev environment for selection when creating a Manual project. This comes in super handy when testing changes to playbooks locally.

I also verified that this does not break if the `awx/projects/` directory does not exist.

