### PR TITLE
Add organization parameter to tower_inventory_source (and add test logging)

### DIFF
--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -38,7 +38,7 @@ options:
       required: True
       type: str
     organization:
-      descripton:
+      description:
         - Organization the inventory belongs to.
       reguired: True
     source:
@@ -306,7 +306,7 @@ def main():
 
             try:
                 inventory_res = tower_cli.get_resource('inventory')
-                params['inventory'] = inventory_res.get(name=inventory,organization=org['id'])['id']
+                params['inventory'] = inventory_res.get(name=inventory, organization=org['id'])['id']
             except (exc.NotFound) as excinfo:
                 module.fail_json(
                     msg='Failed to update inventory source, '

--- a/awx_collection/test/awx/test_inventory_source.py
+++ b/awx_collection/test/awx/test_inventory_source.py
@@ -1,0 +1,56 @@
+import pytest
+
+from awx.main.models import Organization, Inventory, InventorySource
+
+
+@pytest.mark.django_db
+def test_create_inventory_source_implied_org(run_module, admin_user):
+    org = Organization.objects.create(name='test-org')
+    inv = Inventory.objects.create(name='test-inv', organization=org)
+
+    result = run_module('tower_inventory_source', dict(
+        name='Test Inventory Source',
+        inventory='test-inv',
+        source='ec2',
+        state='present'
+    ), admin_user)
+    assert result.pop('changed', None), result
+
+    inv_src = InventorySource.objects.get(name='Test Inventory Source')
+    assert inv_src.inventory == inv
+
+    result.pop('invocation')
+    assert result == {
+        "inventory_source": "Test Inventory Source",
+        "state": "present",
+        "id": inv_src.id,
+    }
+
+
+@pytest.mark.django_db
+def test_create_inventory_source_multiple_orgs(run_module, admin_user):
+    org = Organization.objects.create(name='test-org')
+    inv = Inventory.objects.create(name='test-inv', organization=org)
+
+    # make another inventory by same name in another org
+    org2 = Organization.objects.create(name='test-org-number-two')
+    Inventory.objects.create(name='test-inv', organization=org2)
+
+    result = run_module('tower_inventory_source', dict(
+        name='Test Inventory Source',
+        inventory='test-inv',
+        source='ec2',
+        organization='test-org',
+        state='present'
+    ), admin_user)
+    assert result.pop('changed', None), result
+
+    inv_src = InventorySource.objects.get(name='Test Inventory Source')
+    assert inv_src.inventory == inv
+
+    result.pop('invocation')
+    assert result == {
+        "inventory_source": "Test Inventory Source",
+        "state": "present",
+        "id": inv_src.id,
+    }


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/5193

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
Discovered some shortcomings in the request mocking while doing this. It seems there is some magic going on somewhere in the stack between python requests and Django request processing. This arbitrarily named `params` was being populated by tower-cli as part of the request. It seems that `requests` knew what to do with that, but I did not. Anyway, dumbly gluing it onto the data seemed to fix it up just fine.

I also added a request logger, we could consider moving this to the inherited fixture if people like it. It's particularly helpful for send/receive since its operation might take 100 requests to finish, and you somehow gotta fixture out where you are when it blows up.
