### PR TITLE
In tower_job_wait intentionally fail module for failure

### DIFF
--- a/awx_collection/plugins/modules/tower_job_wait.py
+++ b/awx_collection/plugins/modules/tower_job_wait.py
@@ -136,6 +136,12 @@ def main():
             json_output['timeout'] = True
         except exc.NotFound as excinfo:
             fail_json = dict(msg='Unable to wait, no job_id {0} found: {1}'.format(job_id, excinfo), changed=False)
+        except exc.JobFailure as excinfo:
+            fail_json = dict(msg='Job with id={} failed, error: {}'.format(job_id, excinfo))
+            fail_json['success'] = False
+            result = job.get(job_id)
+            for k in ('id', 'status', 'elapsed', 'started', 'finished'):
+                fail_json[k] = result.get(k)
         except (exc.ConnectionError, exc.BadRequest, exc.AuthError) as excinfo:
             fail_json = dict(msg='Unable to wait for job: {0}'.format(excinfo), changed=False)
 

--- a/awx_collection/test/awx/test_job.py
+++ b/awx_collection/test/awx/test_job.py
@@ -1,0 +1,53 @@
+import pytest
+from django.utils.timezone import now
+
+from awx.main.models import Job
+
+
+@pytest.mark.django_db
+def test_job_wait_successful(run_module, admin_user):
+    job = Job.objects.create(status='successful', started=now(), finished=now())
+    result = run_module('tower_job_wait', dict(
+        job_id=job.id
+    ), admin_user)
+    result.pop('invocation', None)
+    assert result.pop('finished', '')[:10] == str(job.finished)[:10]
+    assert result.pop('started', '')[:10] == str(job.started)[:10]
+    assert result == {
+        "status": "successful",
+        "success": True,
+        "elapsed": str(job.elapsed),
+        "id": job.id
+    }
+
+
+@pytest.mark.django_db
+def test_job_wait_failed(run_module, admin_user):
+    job = Job.objects.create(status='failed', started=now(), finished=now())
+    result = run_module('tower_job_wait', dict(
+        job_id=job.id
+    ), admin_user)
+    result.pop('invocation', None)
+    assert result.pop('finished', '')[:10] == str(job.finished)[:10]
+    assert result.pop('started', '')[:10] == str(job.started)[:10]
+    assert result == {
+        "status": "failed",
+        "failed": True,
+        "success": False,
+        "elapsed": str(job.elapsed),
+        "id": job.id,
+        "msg": "Job with id=1 failed, error: Job failed."
+    }
+
+
+@pytest.mark.django_db
+def test_job_wait_not_found(run_module, admin_user):
+    result = run_module('tower_job_wait', dict(
+        job_id=42
+    ), admin_user)
+    result.pop('invocation', None)
+    assert result == {
+        "changed": False,
+        "failed": True,
+        "msg": "Unable to wait, no job_id 42 found: The requested object could not be found."
+    }


### PR DESCRIPTION
##### SUMMARY
Addresses https://github.com/ansible/ansible/issues/58736

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
8.0.0
```


##### ADDITIONAL INFORMATION
Replicated bug easily with test

```
(awx_collection) arominge-OSX:tower alancoding$ PYTHONPATH=awx_collection:$PYTHONPATH py.test awx_collection/test/awx/test_job.py 
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
Django settings: awx.settings.development (from ini file)
rootdir: /Users/alancoding/Documents/tower, inifile: pytest.ini
plugins: django-3.6.0, mock-1.11.2, timeout-1.3.3, forked-1.1.3, pythonpath-0.7.3, cov-2.8.1, xdist-1.27.0, celery-4.3.0
collected 1 item                                                                                                                                                                    

awx_collection/test/awx/test_job.py F                                                                                                                                         [100%]

===================================================================================== FAILURES ======================================================================================
_______________________________________________________________________________ test_job_wait_failed ________________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/test_job.py", line 11, in test_job_wait_failed
    ), admin_user)
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/conftest.py", line 79, in rf
    resource_module.main()
  File "/Users/alancoding/Documents/tower/awx_collection/plugins/modules/tower_job_wait.py", line 131, in main
    result = job.monitor(job_id, **params)
  File "/Users/alancoding/Documents/repos/tower-cli/tower_cli/models/base.py", line 868, in monitor
    self.wait(pk, exit_on=['running', 'successful'], outfile=outfile)
  File "/Users/alancoding/Documents/repos/tower-cli/tower_cli/models/base.py", line 980, in wait
    raise exc.JobFailure('Job failed.')
tower_cli.exceptions.JobFailure: Job failed.
================================================================================= 1 failed in 4.54s =================================================================================
```

(for background, we want module _failure_, not an _exception_)

I'll admit my datetime assertions are lazy, but the API formatting is definitely not isoformat, and I don't want to get into it.
