### PR TITLE
Remove venv symlink hack no longer needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,6 @@ test:
 prepare_collection_venv:
 	rm -rf $(COLLECTION_VENV)
 	mkdir $(COLLECTION_VENV)
-	ln -s /usr/lib/python2.7/site-packages/ansible $(COLLECTION_VENV)/ansible
 	$(VENV_BASE)/awx/bin/pip install --target=$(COLLECTION_VENV) git+https://github.com/ansible/tower-cli.git
 
 COLLECTION_TEST_DIRS ?= awx_collection/test/awx


### PR DESCRIPTION
##### SUMMARY
This was one of those desperate hacks just to get the collection tests to _run_.

The problem was that the default python (and the installed Ansible) were py2. But AWX is py3, and we wanted ansible + AWX in the same place. So py2 Ansible was moved into py3 venv sneakily.

Now, with CentOS8, this is no longer needed 🎉 

If tests pass, I say we should do this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.0
```


