### PR TITLE
[WIP, another option] Changes to the AWX collection containerized test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,8 +135,11 @@ use_dev_supervisor.txt
 
 
 # Ansible module tests
-/awx_collection_test_venv/
+/awx_collection/tower_cli/
+/awx_collection/click/
 /awx_collection/*.tar.gz
+/awx_collection/*.egg-info/
+/awx_collection/*.dist-info/
 /awx_collection/galaxy.yml
 /sanity/
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ COMPOSE_TAG ?= $(GIT_BRANCH)
 COMPOSE_HOST ?= $(shell hostname)
 
 VENV_BASE ?= /venv
-COLLECTION_VENV ?= /awx_devel/awx_collection_test_venv
 SCL_PREFIX ?=
 CELERY_SCHEDULE_FILE ?= /var/lib/awx/beat.db
 
@@ -379,10 +378,9 @@ test:
 	awx-manage check_migrations --dry-run --check  -n 'vNNN_missing_migration_file'
 
 prepare_collection_venv:
-	rm -rf $(COLLECTION_VENV)
-	mkdir $(COLLECTION_VENV)
-	ln -s /usr/lib/python2.7/site-packages/ansible $(COLLECTION_VENV)/ansible
-	$(VENV_BASE)/awx/bin/pip install --target=$(COLLECTION_VENV) git+https://github.com/ansible/tower-cli.git
+	rm -rf /awx_devel/awx_collection/tower_cli
+	$(VENV_BASE)/awx/bin/pip install --target=/awx_devel/awx_collection --no-deps click
+	$(VENV_BASE)/awx/bin/pip install --target=/awx_devel/awx_collection --no-deps git+https://github.com/ansible/tower-cli.git
 
 COLLECTION_TEST_DIRS ?= awx_collection/test/awx
 COLLECTION_PACKAGE ?= awx
@@ -392,7 +390,7 @@ test_collection:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	PYTHONPATH=$(COLLECTION_VENV):/awx_devel/awx_collection:$PYTHONPATH py.test $(COLLECTION_TEST_DIRS)
+	PYTHONPATH=/awx_devel/awx_collection:$PYTHONPATH py.test $(COLLECTION_TEST_DIRS)
 
 flake8_collection:
 	flake8 awx_collection/  # Different settings, in main exclude list

--- a/awx_collection/setup.cfg
+++ b/awx_collection/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length=160
 ignore=E402
+exclude=click/,tower_cli/


### PR DESCRIPTION
##### SUMMARY
So this is kind of crazy, but in my defense it was always kind of crazy.

----

Remove venv symlink hack no longer needed

Avoid installing deps already shared with AWX venv done via --no-deps
Supporting this change, the destination changed from new folder to just awx_collection which is already in PYTHONPATH, so remove that

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.0
```


##### ADDITIONAL INFORMATION
So by doing a no-dep install of tower-cli and click, we are hard coding some knowledge of this library... but really, our ultimate goal is to get rid of this thing anyway.
