### PR TITLE
Update required Ansible version to 2.8+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,7 @@ To install the assets, clone the `awx-logos` repo so that it is next to your `aw
 
 Before you can run a deployment, you'll need the following installed in your local environment:
 
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.4+
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) Requires Version 2.8+
 - [Docker](https://docs.docker.com/engine/installation/)
     + A recent version
 - [docker](https://pypi.org/project/docker/) Python module


### PR DESCRIPTION
##### SUMMARY
Update the required Ansible version from 2.4+ to 2.8+ in INSTALL.md

Attempting to build the docker image with Ansible 2.5.1 (current version on Ubuntu Server 18.04LTS) results in the following error:
```
TASK [image_build : Build sdist builder image] *******************************************************************************************
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (docker_image) module: build, force_source, source Supported parameters include: api_version, archive_path, buildargs, cacert_path, cert_path, container_limits, debug, docker_host, dockerfile, filter_logger, force, http_timeout, key_path, load_path, name, nocache, path, pull, push, repository, rm, ssl_version, state, tag, timeout, tls, tls_hostname, tls_verify, use_tls"}                                                                                 
```
Installing Ansible 2.9 from the Ubuntu PPA allows the install to continue without error. The `force_source` parameter was added to docker_image in Ansible 2.8 ([source](https://docs.ansible.com/ansible/latest/modules/docker_image_module.html#parameters)). Therefore 2.8 should be the minimum required version.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.0.0
```