### PR TITLE
Add Project Edit form

### DIFF
--- a/awx/ui_next/src/screens/Project/ProjectEdit/ProjectEdit.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectEdit/ProjectEdit.jsx
@@ -1,10 +1,62 @@
-import React, { Component } from 'react';
-import { CardBody } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { withRouter } from 'react-router-dom';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import styled from 'styled-components';
+import {
+  Card as _Card,
+  CardBody,
+  CardHeader,
+  Tooltip,
+} from '@patternfly/react-core';
+import CardCloseButton from '@components/CardCloseButton';
+import ProjectForm from '../shared/ProjectForm';
+import { ProjectsAPI } from '@api';
 
-class ProjectEdit extends Component {
-  render() {
-    return <CardBody>Coming soon :)</CardBody>;
-  }
+const Card = styled(_Card)`
+  --pf-c-card--child--PaddingLeft: 0;
+  --pf-c-card--child--PaddingRight: 0;
+`;
+
+function ProjectEdit({ project, history, i18n }) {
+  const [formSubmitError, setFormSubmitError] = useState(null);
+
+  const handleSubmit = async values => {
+    try {
+      const {
+        data: { id },
+      } = await ProjectsAPI.update(project.id, values);
+      history.push(`/projects/${id}/details`);
+    } catch (error) {
+      setFormSubmitError(error);
+    }
+  };
+
+  const handleCancel = () => {
+    history.push(`/projects/${project.id}/details`);
+  };
+
+  return (
+    <Card>
+      <CardHeader css="text-align: right">
+        <Tooltip content={i18n._(t`Close`)} position="top">
+          <CardCloseButton onClick={handleCancel} />
+        </Tooltip>
+      </CardHeader>
+      <CardBody>
+        <ProjectForm
+          project={project}
+          handleCancel={handleCancel}
+          handleSubmit={handleSubmit}
+        />
+      </CardBody>
+      {formSubmitError ? (
+        <div className="formSubmitError">formSubmitError</div>
+      ) : (
+        ''
+      )}
+    </Card>
+  );
 }
 
-export default ProjectEdit;
+export default withI18n()(withRouter(ProjectEdit));

--- a/awx/ui_next/src/screens/Project/shared/ProjectForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectForm.jsx
@@ -122,16 +122,23 @@ function ProjectForm({ project, ...props }) {
     scm_update_cache_timeout: 0,
   };
 
+  /* Save current scm subform field values to state */
   const saveSubFormState = form => {
-    const updatedScmFormFields = { ...scmFormFields };
+    const currentScmFormFields = { ...scmFormFields };
 
-    Object.keys(updatedScmFormFields).forEach(label => {
-      updatedScmFormFields[label] = form.values[label];
+    Object.keys(currentScmFormFields).forEach(label => {
+      currentScmFormFields[label] = form.values[label];
     });
 
-    setScmSubFormState(updatedScmFormFields);
+    setScmSubFormState(currentScmFormFields);
   };
 
+  /**
+   * If scm type is !== the initial scm type value,
+   * reset scm subform field values to defaults.
+   * If scm type is === the initial scm type value,
+   * reset scm subform field values to scmSubFormState.
+   */
   const resetScmTypeFields = (value, form) => {
     if (form.values.scm_type === form.initialValues.scm_type) {
       saveSubFormState(form);

--- a/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
@@ -21,6 +21,13 @@ describe('<ProjectAdd />', () => {
     scm_update_cache_timeout: 3,
     allow_override: false,
     custom_virtualenv: '/venv/custom-env',
+    summary_fields: {
+      credential: {
+        id: 100,
+        credential_type_id: 4,
+        kind: 'scm',
+      },
+    },
   };
 
   const projectOptionsResolve = {

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/GitSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/GitSubForm.jsx
@@ -11,8 +11,8 @@ import {
 
 const GitSubForm = ({
   i18n,
-  scmCredential,
-  setScmCredential,
+  credential,
+  onCredentialSelection,
   scmUpdateOnLaunch,
 }) => (
   <>
@@ -74,8 +74,8 @@ const GitSubForm = ({
       }
     />
     <ScmCredentialFormField
-      setScmCredential={setScmCredential}
-      scmCredential={scmCredential}
+      credential={credential}
+      onCredentialSelection={onCredentialSelection}
     />
     <ScmTypeOptions scmUpdateOnLaunch={scmUpdateOnLaunch} />
   </>

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/HgSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/HgSubForm.jsx
@@ -10,8 +10,8 @@ import {
 
 const HgSubForm = ({
   i18n,
-  scmCredential,
-  setScmCredential,
+  credential,
+  onCredentialSelection,
   scmUpdateOnLaunch,
 }) => (
   <>
@@ -34,8 +34,8 @@ const HgSubForm = ({
     />
     <BranchFormField i18n={i18n} label={i18n._(t`SCM Branch/Tag/Revision`)} />
     <ScmCredentialFormField
-      setScmCredential={setScmCredential}
-      scmCredential={scmCredential}
+      credential={credential}
+      onCredentialSelection={onCredentialSelection}
     />
     <ScmTypeOptions scmUpdateOnLaunch={scmUpdateOnLaunch} />
   </>

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx
@@ -8,8 +8,8 @@ import { ScmTypeOptions } from './SharedFields';
 
 const InsightsSubForm = ({
   i18n,
-  setInsightsCredential,
-  insightsCredential,
+  credential,
+  onCredentialSelection,
   scmUpdateOnLaunch,
 }) => (
   <>
@@ -18,19 +18,16 @@ const InsightsSubForm = ({
       validate={required(i18n._(t`Select a value for this field`), i18n)}
       render={({ form }) => (
         <CredentialLookup
-          credentialTypeId={insightsCredential.typeId}
+          credentialTypeId={credential.typeId}
           label={i18n._(t`Insights Credential`)}
           helperTextInvalid={form.errors.credential}
           isValid={!form.touched.credential || !form.errors.credential}
           onBlur={() => form.setFieldTouched('credential')}
-          onChange={credential => {
-            form.setFieldValue('credential', credential.id);
-            setInsightsCredential({
-              ...insightsCredential,
-              value: credential,
-            });
+          onChange={value => {
+            onCredentialSelection('insights', value);
+            form.setFieldValue('credential', value.id);
           }}
-          value={insightsCredential.value}
+          value={credential.value}
           required
         />
       )}

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SharedFields.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SharedFields.jsx
@@ -41,20 +41,17 @@ export const BranchFormField = withI18n()(({ i18n, label }) => (
 ));
 
 export const ScmCredentialFormField = withI18n()(
-  ({ i18n, setScmCredential, scmCredential }) => (
+  ({ i18n, credential, onCredentialSelection }) => (
     <Field
       name="credential"
       render={({ form }) => (
         <CredentialLookup
-          credentialTypeId={scmCredential.typeId}
+          credentialTypeId={credential.typeId}
           label={i18n._(t`SCM Credential`)}
-          value={scmCredential.value}
-          onChange={credential => {
-            form.setFieldValue('credential', credential.id);
-            setScmCredential({
-              ...scmCredential,
-              value: credential,
-            });
+          value={credential.value}
+          onChange={value => {
+            onCredentialSelection('scm', value);
+            form.setFieldValue('credential', value.id);
           }}
         />
       )}

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SvnSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SvnSubForm.jsx
@@ -10,8 +10,8 @@ import {
 
 const SvnSubForm = ({
   i18n,
-  scmCredential,
-  setScmCredential,
+  credential,
+  onCredentialSelection,
   scmUpdateOnLaunch,
 }) => (
   <>
@@ -30,8 +30,8 @@ const SvnSubForm = ({
     />
     <BranchFormField i18n={i18n} label={i18n._(t`Revision #`)} />
     <ScmCredentialFormField
-      setScmCredential={setScmCredential}
-      scmCredential={scmCredential}
+      credential={credential}
+      onCredentialSelection={onCredentialSelection}
     />
     <ScmTypeOptions scmUpdateOnLaunch={scmUpdateOnLaunch} />
   </>


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/4987

In this PR: 
* Add Project Edit form and related unit tests
* Refactor Project Form credential useState hooks
* If a user selects a new `scm_type`, save the current form state in case they return to the initial `scm_type`. This keeps their current form progress. 

![edit proj](https://user-images.githubusercontent.com/15881645/68127813-92c6a000-fee4-11e9-8293-e36cdfb09f5f.gif)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.0
```

##### ADDITIONAL INFORMATION
* Manual scm type subform will be added in a following PR. 
