### PR TITLE
Set policy variables to defaults when an instance group is containerized

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -294,8 +294,8 @@ def on_instance_group_saved(sender, instance, created=False, raw=False, **kwargs
     if created or instance.has_policy_changes():
         if not instance.is_containerized:
             schedule_policy_task()
-        if created or instance.is_containerized:
-            instance.set_default_policy_fields()
+    elif created or instance.is_containerized:
+        instance.set_default_policy_fields()
 
 
 @receiver(post_save, sender=Instance)

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -270,6 +270,11 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
                                       .filter(capacity__gt=0, enabled=True)
                                       .values_list('hostname', flat=True)))
 
+    def set_default_policy_fields(self):
+        self.policy_instance_list = []
+        self.policy_instance_minimum = 0
+        self.policy_instance_percentage = 0
+
 
 class TowerScheduleState(SingletonModel):
     schedule_last_run = models.DateTimeField(auto_now_add=True)
@@ -289,6 +294,8 @@ def on_instance_group_saved(sender, instance, created=False, raw=False, **kwargs
     if created or instance.has_policy_changes():
         if not instance.is_containerized:
             schedule_policy_task()
+        if created or instance.is_containerized:
+            instance.set_default_policy_fields()
 
 
 @receiver(post_save, sender=Instance)

--- a/awx/main/tests/functional/api/test_instance_group.py
+++ b/awx/main/tests/functional/api/test_instance_group.py
@@ -274,3 +274,21 @@ def test_instance_group_update_fields(patch, instance, instance_group, admin, co
     assert ["Containerized instances may not be managed via the API"] == resp.data['policy_instance_minimum']
     resp = patch(cg_url, {'policy_instance_list':[instance.hostname]}, admin)
     assert ["Containerized instances may not be managed via the API"] == resp.data['policy_instance_list']
+
+
+@pytest.mark.django_db
+def test_containerized_group_default_fields(instance_group, kube_credential):
+    ig = InstanceGroup(name="test_policy_field_defaults")
+    ig.policy_instance_list = [1]
+    ig.policy_instance_minimum = 5
+    ig.policy_instance_percentage = 5
+    ig.save()
+    assert ig.policy_instance_list == [1]
+    assert ig.policy_instance_minimum == 5
+    assert ig.policy_instance_percentage == 5
+    ig.credential = kube_credential
+    ig.save()
+    assert ig.policy_instance_list == []
+    assert ig.policy_instance_minimum == 0
+    assert ig.policy_instance_percentage == 0
+    


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When an instance group is containerized via the API, these changes build onto the when_saved funcitonality to resets policy variables to their default values.
_Doesn't pertain to a current issue._
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request (?)

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.0
```
