### PR TITLE
Reduce API response times by 30% by using memcache migration flag

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -1,8 +1,17 @@
 from django.apps import AppConfig
+from django.db.models.signals import pre_migrate
 from django.utils.translation import ugettext_lazy as _
+
+
+def raise_migration_flag(**kwargs):
+    from awx.main.tasks import set_migration_flag
+    set_migration_flag.delay()
 
 
 class MainConfig(AppConfig):
 
     name = 'awx.main'
     verbose_name = _('Main')
+
+    def ready(self):
+        pre_migrate.connect(raise_migration_flag, sender=self)

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -13,18 +13,17 @@ import urllib.parse
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
-from django.db.migrations.executor import MigrationExecutor
-from django.db import IntegrityError, connection
+from django.db import IntegrityError
 from django.utils.functional import curry
 from django.shortcuts import get_object_or_404, redirect
 from django.apps import apps
-from django.core.cache import cache
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse, resolve
 
 from awx.main.models import ActivityStream
 from awx.main.utils.named_url_graph import generate_graph, GraphNode
+from awx.main.utils.db import migration_in_progress_check_or_relase
 from awx.conf import fields, register
 
 
@@ -214,11 +213,7 @@ class URLModificationMiddleware(MiddlewareMixin):
 class MigrationRanCheckMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
-        if cache.get('migration_in_progress', False):
-            executor = MigrationExecutor(connection)
-            plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-            if not bool(plan):
-                logger.info('Detected that migration finished, migration page taken down.')
-                cache.delete('migration_in_progress')
-            elif getattr(resolve(request.path), 'url_name', '') != 'migrations_notran':
-                return redirect(reverse("ui:migrations_notran"))
+        if migration_in_progress_check_or_relase():
+            if getattr(resolve(request.path), 'url_name', '') == 'migrations_notran':
+                return
+            return redirect(reverse("ui:migrations_notran"))

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -18,6 +18,7 @@ from django.db import IntegrityError, connection
 from django.utils.functional import curry
 from django.shortcuts import get_object_or_404, redirect
 from django.apps import apps
+from django.core.cache import cache
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse, resolve
@@ -213,8 +214,11 @@ class URLModificationMiddleware(MiddlewareMixin):
 class MigrationRanCheckMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
-        executor = MigrationExecutor(connection)
-        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-        if bool(plan) and \
-                getattr(resolve(request.path), 'url_name', '') != 'migrations_notran':
-            return redirect(reverse("ui:migrations_notran"))
+        if cache.get('migration_in_progress', False):
+            executor = MigrationExecutor(connection)
+            plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+            if not bool(plan):
+                logger.info('Detected that migration finished, migration page taken down.')
+                cache.delete('migration_in_progress')
+            elif getattr(resolve(request.path), 'url_name', '') != 'migrations_notran':
+                return redirect(reverse("ui:migrations_notran"))

--- a/awx/main/scheduler/tasks.py
+++ b/awx/main/scheduler/tasks.py
@@ -5,11 +5,15 @@ import logging
 # AWX
 from awx.main.scheduler import TaskManager
 from awx.main.dispatch.publish import task
+from awx.main.utils.db import migration_in_progress_check_or_relase
 
 logger = logging.getLogger('awx.main.scheduler')
 
 
 @task()
 def run_task_manager():
+    if migration_in_progress_check_or_relase():
+        logger.debug("Not running task manager because migration is in progress.")
+        return
     logger.debug("Running Tower task manager.")
     TaskManager().schedule()

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -264,6 +264,12 @@ def apply_cluster_membership_policies():
 
 
 @task(queue='tower_broadcast_all', exchange_type='fanout')
+def set_migration_flag():
+    logger.debug('Received migration-in-progress signal, will serve redirect.')
+    cache.set('migration_in_progress', True)
+
+
+@task(queue='tower_broadcast_all', exchange_type='fanout')
 def handle_setting_changes(setting_keys):
     orig_len = len(setting_keys)
     for i in range(orig_len):

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -1,7 +1,15 @@
 # Copyright (c) 2017 Ansible by Red Hat
 # All Rights Reserved.
 
+import logging
 from itertools import chain
+
+from django.core.cache import cache
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connection
+
+
+logger = logging.getLogger('awx.main.utils.db')
 
 
 def get_all_field_names(model):
@@ -14,3 +22,21 @@ def get_all_field_names(model):
         # GenericForeignKey from the results.
         if not (field.many_to_one and field.related_model is None)
     )))
+
+
+def migration_in_progress_check_or_relase():
+    '''A memcache flag is raised (set to True) to inform cluster
+    that a migration is ongoing see main.apps.MainConfig.ready
+    if the flag is True then the flag is removed on this instance if
+        models-db consistency is observed
+    effective value of migration flag is returned
+    '''
+    migration_in_progress = cache.get('migration_in_progress', False)
+    if migration_in_progress:
+        executor = MigrationExecutor(connection)
+        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+        if not bool(plan):
+            logger.info('Detected that migration finished, migration flag taken down.')
+            cache.delete('migration_in_progress')
+            migration_in_progress = False
+    return migration_in_progress


### PR DESCRIPTION
##### SUMMARY
When profiling times taken in requests (or just ever looking at the debug toolbar output), the migration middleware came up as a big resource consumer. It was tricky to pin down, because it wasn't _much_ if tested with isolated requests.

I did timings with the debug settings off and just logged middleware times and did some typical UI use. I found general numbers of ~40% of the time was spent in middleware and ~30% was spent in the migration middleware alone.

This is not _hard_ to reduce, but this PR still needs some more testing via those prior means and verification of continued functionality.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
