### PR TITLE
Fix right side <body> spacing bug

### DIFF
--- a/awx/ui/client/legacy/styles/ansible-ui.less
+++ b/awx/ui/client/legacy/styles/ansible-ui.less
@@ -21,12 +21,6 @@
     src: url(/static/assets/OpenSans-Bold.ttf);
 }
 
-/* Bootstrap fix that's causing a right margin to appear
-   whenver a modal is opened */
-body.modal-open {
-  margin-right: 0;
-}
-
 /* Helper Classes */
 .pad-right-sm { padding-right: 10px; }
 .pad-left-md { padding-left: 30px; }

--- a/awx/ui/client/legacy/styles/bootstrap-custom-overrides.less
+++ b/awx/ui/client/legacy/styles/bootstrap-custom-overrides.less
@@ -4,6 +4,13 @@ body {
     color: @default-data-txt;
     background-color: @default-secondary-bg;
     font-size: 0.88rem;
+    /*
+    * Bootstrap fix that's causing a right margin and padding
+    * to appear whenever a modal is opened
+    * https://github.com/twbs/bootstrap/issues/27071
+    */
+    margin-right: 0px !important;
+    padding-right: 0px !important;
 }
 
 .dropdown-toggle::after {


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/4299
Bootstrap modal adds 15px of spacing to < body /> to accommodate the scrollbar, but it doesn't clean the spacing up

This PR hardcodes margin-right and padding-right to 0px

![padding](https://user-images.githubusercontent.com/15881645/68242245-2e880700-ffde-11e9-8d65-7e3b88c23ea2.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ADDITIONAL INFORMATION
Possibly related: https://github.com/twbs/bootstrap/issues/27071
