### PR TITLE
Update custom_virtualenvs.md

### DIFF
--- a/docs/custom_virtualenvs.md
+++ b/docs/custom_virtualenvs.md
@@ -26,12 +26,12 @@ first if absent:
 Now, we need to tell Tower to look into this directory for custom venvs. For that,
 we can add this directory to the `CUSTOM_VENV_PATHS` setting as:
 
-    $ HTTP PATCH /api/v2/settings/system {'CUSTOM_VENV_PATHS': ["/opt/my-envs/"]}
+    $ HTTP PATCH /api/v2/settings/system/ {'CUSTOM_VENV_PATHS': ["/opt/my-envs/"]}
 
 If we have venvs spanned over multiple directories, we can add all the paths and
 Tower will aggregate venvs from them:
 
-    $ HTTP PATCH /api/v2/settings/system {'CUSTOM_VENV_PATHS': ["/path/1/to/venv/",
+    $ HTTP PATCH /api/v2/settings/system/ {'CUSTOM_VENV_PATHS': ["/path/1/to/venv/",
                                                                 "/path/2/to/venv/",
                                                                 "/path/3/to/venv/"]}
 
@@ -146,7 +146,7 @@ Project, or Job Template level:
 
     Content-Type: application/json
     {
-        'custom_virtualenv': '/opt/my-envs/custom-venv'
+        'custom_virtualenv': '/opt/my-envs/custom-venv/'
     }
 
 An HTTP `GET` request to `/api/v2/config/` will provide a list of
@@ -154,8 +154,8 @@ detected installed virtualenvs:
 
     {
         "custom_virtualenvs": [
-            "/opt/my-envs/custom-venv",
-            "/opt/my-envs/my-other-custom-venv",
+            "/opt/my-envs/custom-venv/",
+            "/opt/my-envs/my-other-custom-venv/",
         ],
         ...
     }


### PR DESCRIPTION
Adding trailing slashes to API calls + directories. This caused me a ton of wasted time as the API call silently returns but does nothing without the trailing slash.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Documentation does not include trailing slash, which causes the API to silently return but does not actually make the change to add the virtualenv (or any other requested changes via PATCH).

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.0.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
