### PR TITLE
Increase async test timeout

### DIFF
--- a/awx/ui_next/jest.setup.js
+++ b/awx/ui_next/jest.setup.js
@@ -6,4 +6,6 @@ export const asyncFlush = () => new Promise((resolve) => setImmediate(resolve));
 const enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
+jest.setTimeout(5000 * 4);
+
 enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
When our CI system is overloaded, tests start running slower.
