### PR TITLE
Fix filtering azure inventory based on user-specified tags

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -2036,9 +2036,25 @@ class azure_rm(PluginFileInjector):
         for key, loc in old_filterables:
             value = source_vars.get(key, None)
             if value and isinstance(value, str):
-                user_filters.append('{} not in {}'.format(
-                    loc, value.split(',')
-                ))
+                # tags can be list of key:value pairs
+                #  e.g. 'Creator:jmarshall, peanutbutter:jelly'
+                # or tags can be a list of keys
+                #  e.g. 'Creator, peanutbutter'
+                if key == "tags":
+                    # grab each key value pair
+                    for kvpair in value.split(','):
+                        # split into key and value
+                        kv = kvpair.split(':')
+                        # filter out any host that does not have key
+                        # in their tags.keys() variable
+                        user_filters.append('"{}" not in tags.keys()'.format(kv[0].strip()))
+                        # if a value is provided, check that the key:value pair matches
+                        if len(kv) > 1:
+                            user_filters.append('tags["{}"] != "{}"'.format(kv[0].strip(), kv[1].strip()))
+                else:
+                    user_filters.append('{} not in {}'.format(
+                        loc, value.split(',')
+                    ))
         if user_filters:
             ret.setdefault('exclude_host_filters', [])
             ret['exclude_host_filters'].extend(user_filters)

--- a/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
@@ -3,6 +3,10 @@ conditional_groups:
 default_host_filters: []
 exclude_host_filters:
 - resource_group not in ['foo_resources', 'bar_resources']
+- '"Creator" not in tags.keys()'
+- tags["Creator"] != "jmarshall"
+- '"peanutbutter" not in tags.keys()'
+- tags["peanutbutter"] != "jelly"
 - location not in ['southcentralus', 'westus']
 fail_on_template_errors: false
 hostvar_expressions:

--- a/awx/main/tests/data/inventory/scripts/azure_rm/files/file_reference
+++ b/awx/main/tests/data/inventory/scripts/azure_rm/files/file_reference
@@ -7,4 +7,5 @@ locations = southcentralus,westus
 base_source_var = value_of_var
 use_private_ip = True
 resource_groups = foo_resources,bar_resources
+tags = Creator:jmarshall, peanutbutter:jelly
 

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -54,7 +54,8 @@ INI_TEST_VARS = {
     },
     'azure_rm': {
         'use_private_ip': True,
-        'resource_groups': 'foo_resources,bar_resources'
+        'resource_groups': 'foo_resources,bar_resources',
+        'tags': 'Creator:jmarshall, peanutbutter:jelly'
     },
     'satellite6': {
         'satellite6_group_patterns': 'foo_group_patterns',


### PR DESCRIPTION
Fix filtering azure inventory based on user-specified tags

fix for issue #5044 

Users can specify a list of keys, or a list of key:value pairs under source variables. e.g. `tags: Creator, peanutbutter` or `tags: Creator:jmarshall, peanutbutter:jelly`. If provided, only hosts that have all keys or key:value pairs in the list will be returned.

inventory.py sets up the azure_rm.yml that includes the `exclude_host_filters` field. This code adds a line for each key in the list, as well as an additional line in the case of a key:value pair.

e.g. 

```
exclude_host_filters:
- "'Creator' not in tags.keys()"
- tags['Creator'] not in ['jmarshall']
```

Each line is a conditional, and if any conditionals are true, then the host is filtered out.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
