### PR TITLE
Bump RabbitMQ version in k8s/openshift installs

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -30,7 +30,7 @@ rabbitmq_cpu_request: 500
 memcached_mem_request: 1
 memcached_cpu_request: 500
 
-kubernetes_rabbitmq_version: "3.7.15"
+kubernetes_rabbitmq_version: "3.7.21"
 kubernetes_rabbitmq_image: "ansible/awx_rabbitmq"
 
 kubernetes_memcached_version: "latest"


### PR DESCRIPTION
See https://github.com/ansible/awx-rabbitmq/pull/13
