### PR TITLE
Delay inputs comparision to after field validation

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2456,12 +2456,18 @@ class CredentialTypeSerializer(BaseSerializer):
             raise PermissionDenied(
                 detail=_("Modifications not allowed for managed credential types")
             )
+
+        old_inputs = {}
+        if self.instance:
+            old_inputs = copy.deepcopy(self.instance.inputs)
+
+        ret = super(CredentialTypeSerializer, self).validate(attrs)
+
         if self.instance and self.instance.credentials.exists():
-            if 'inputs' in attrs and attrs['inputs'] != self.instance.inputs:
+            if 'inputs' in attrs and old_inputs != self.instance.inputs:
                 raise PermissionDenied(
                     detail= _("Modifications to inputs are not allowed for credential types that are in use")
                 )
-        ret = super(CredentialTypeSerializer, self).validate(attrs)
 
         if 'kind' in attrs and attrs['kind'] not in ('cloud', 'net'):
             raise serializers.ValidationError({

--- a/awx/main/tests/functional/api/test_credential_type.py
+++ b/awx/main/tests/functional/api/test_credential_type.py
@@ -85,14 +85,35 @@ def test_update_credential_type_in_use_xfail(patch, delete, admin):
     Credential(credential_type=_type, name='My Custom Cred').save()
 
     url = reverse('api:credential_type_detail', kwargs={'pk': _type.pk})
-    response = patch(url, {'name': 'Some Other Name'}, admin)
-    assert response.status_code == 200
+    patch(url, {'name': 'Some Other Name'}, admin, expect=200)
 
     url = reverse('api:credential_type_detail', kwargs={'pk': _type.pk})
-    response = patch(url, {'inputs': {}}, admin)
-    assert response.status_code == 403
+    response = patch(url, {'inputs': {}}, admin, expect=403)
+    assert response.data['detail'] == 'Modifications to inputs are not allowed for credential types that are in use'
 
-    assert delete(url, admin).status_code == 403
+    response = delete(url, admin, expect=403)
+    assert response.data['detail'] == 'Credential types that are in use cannot be deleted'
+
+
+@pytest.mark.django_db
+def test_update_credential_type_unvalidated_inputs(post, patch, admin):
+    simple_inputs = {'fields': [
+        {'id': 'api_token', 'label': 'fooo'}
+    ]}
+    response = post(
+        url=reverse('api:credential_type_list'),
+        data={'name': 'foo', 'kind': 'cloud', 'inputs': simple_inputs},
+        user=admin,
+        expect=201
+    )
+    # validation adds the type field to the input
+    _type = CredentialType.objects.get(pk=response.data['id'])
+    Credential(credential_type=_type, name='My Custom Cred').save()
+
+    # should not raise an error because we should only compare
+    # post-validation values to other post-validation values
+    url = reverse('api:credential_type_detail', kwargs={'pk': _type.id})
+    patch(url, {'inputs': simple_inputs}, admin, expect=200)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
This is to unmark https://github.com/ansible/awx/issues/5321 with the API label

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


##### ADDITIONAL INFORMATION

The field validation does in-place modification to the value provided by the user

https://github.com/ansible/awx/blob/9bb9bc682f901b9ef3c57b3e87d3e8c3b711df70/awx/main/fields.py#L787-L789

So, it's kind of obvious that `attrs['inputs'] != self.instance.inputs` is not okay, because the value is modified before save. You are comparing pre-validated values to post-validated values.

Solution is to compare post-validated values to post-validated values.

That way, the blob:

```yaml
      inputs:
        fields:
          - id: env_value
            label: Value to set this environment variable to
            default: foo
```

can be re-applied without being recognized as a changed value, throwing 400 errors.

Makes the collection integration tests run multiple times (for this point at least).