### PR TITLE
remove inv source update job blocking

### DIFF
--- a/awx/main/scheduler/dependency_graph.py
+++ b/awx/main/scheduler/dependency_graph.py
@@ -96,8 +96,7 @@ class DependencyGraph(object):
             self.data[self.INVENTORY_SOURCE_UPDATES].get(job.inventory_source_id, True)
 
     def can_job_run(self, job):
-        if self.data[self.PROJECT_UPDATES].get(job.project_id, True) is True and \
-                self.data[self.INVENTORY_UPDATES].get(job.inventory_id, True) is True:
+        if self.data[self.PROJECT_UPDATES].get(job.project_id, True) is True:
             if job.allow_simultaneous is False:
                 return self.data[self.JOB_TEMPLATE_JOBS].get(job.job_template_id, True)
             else:


### PR DESCRIPTION
related to https://github.com/ansible/awx/issues/4809

* Before, if an inventory source, that lives in the inventory associated
with a job template, is actively running, any job associated with that
inventory would be blocked.
* Now, that restriciton is lifted. Jobs that have inventory w/ sources
updating are not blocked (they may still be blocked for other reasons).
