### PR TITLE
CHANGED: docker_service to docker_compose

### DIFF
--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -24,7 +24,7 @@
   register: awx_secret_key
 
 - name: Start the containers
-  docker_service:
+  docker_compose:
     project_src: "{{ docker_compose_dir }}"
     restarted: "{{ awx_compose_config is changed or awx_secret_key is changed }}"
   register: awx_compose_start


### PR DESCRIPTION
Signed-off-by: Joe <11597133+m33k@users.noreply.github.com>

##### SUMMARY

- Changed the docker_service module which has been renamed to docker_compose in Ansible.
This will keep the following message below from appearing when running the playbook.


##### ISSUE TYPE

 - Improvement Pull Request (Issue type does not exist yet)


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - role: local_docker
 - task: Start the containers
 - module: docker_compose


##### AWX VERSION

```
awx]# make VERSION
awx: 9.0.1

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

 - If you run the playbook, there is a deprecation warning that appears. This commit fixes this small issue.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [local_docker : Start the containers] ********************************************************************************************************************************************************
[DEPRECATION WARNING]: The 'docker_service' module has been renamed to 'docker_compose'.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

```
