### PR TITLE
Consistent naming scheme; memcached_host -> memcached_hostname

### DIFF
--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -16,6 +16,6 @@ postgresql_image: "postgres:{{postgresql_version}}"
 
 memcached_image: "memcached"
 memcached_version: "alpine"
-memcached_host: "memcached"
+memcached_hostname: "memcached"
 memcached_port: "11211"
 

--- a/installer/roles/local_docker/templates/credentials.py.j2
+++ b/installer/roles/local_docker/templates/credentials.py.j2
@@ -26,7 +26,7 @@ CHANNEL_LAYERS = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '{}:{}'.format("{{ memcached_host }}", "{{ memcached_port }}")
+        'LOCATION': '{}:{}'.format("{{ memcached_hostname }}", "{{ memcached_port }}")
     },
     'ephemeral': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
environment.sh uses hostname for everything, and both environment and
credentials provide a default of 'memcached', so this should also be one less
variable to care about.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```
