### PR TITLE
Make tower_project.py Wait for Project Sync

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -18,6 +18,7 @@ The following notes are changes that may require changes to playbooks.
 
  - Specifying `inputs` or `injectors` as strings in the
    `tower_credential_type` module is no longer supported. Provide as dictionaries instead.
+ - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
 
 ## Running
 

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -12,7 +12,8 @@ def test_create_project(run_module, admin_user, organization):
         name='foo',
         organization=organization.name,
         scm_type='git',
-        scm_url='https://foo.invalid'
+        scm_url='https://foo.invalid',
+        wait=False
     ), admin_user)
     assert result.pop('changed', None), result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
When running a make test command (_e.g._, `make test_collection_integration`), the task related to `tower_job_template.py` fails due to the project (the task associated with `tower_project.py`) not being completely synced.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx-collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```


##### ADDITIONAL INFORMATION

Before this change, the following failure would appear:

```
Running demo integration test script
[WARNING]: running playbook inside collection awx.awx

[WARNING]: The `junit_xml` python module is not installed. Disabling the `junit`
callback plugin.


PLAY [localhost] ***********************************************************************

TASK [awx.awx.tower_organization] ******************************************************
ok: [localhost]

TASK [awx.awx.tower_inventory] *********************************************************
ok: [localhost]

TASK [awx.awx.tower_host] **************************************************************
ok: [localhost]

TASK [awx.awx.tower_project] ***********************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (awx.awx.tower_project) module: job_type Supported parameters include: custom_virtualenv, description, job_timeout, local_path, name, organization, scm_branch, scm_clean, scm_credential, scm_delete_on_update, scm_type, scm_update_cache_timeout, scm_update_on_launch, scm_url, state, tower_config_file, tower_host, tower_password, tower_username, validate_certs"}

PLAY RECAP *****************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

NOTICE: To resume at this test target, use the option: --start-at demo
ERROR: Command "./runme.sh" returned exit status 2.
make: *** [test_collection_integration] Error 1
```
 With this change, everything in the playbook passes:

```
Running demo integration test script
[WARNING]: running playbook inside collection awx.awx

[WARNING]: The `junit_xml` python module is not installed. Disabling the `junit`
callback plugin.


PLAY [localhost] ***********************************************************************

TASK [awx.awx.tower_organization] ******************************************************
ok: [localhost]

TASK [awx.awx.tower_inventory] *********************************************************
ok: [localhost]

TASK [awx.awx.tower_host] **************************************************************
ok: [localhost]

TASK [awx.awx.tower_project] ***********************************************************
changed: [localhost]

TASK [awx.awx.tower_job_template] ******************************************************
changed: [localhost]

PLAY RECAP *****************************************************************************
localhost                  : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
🎉