### PR TITLE
Remove forks no longer needed from dependencies

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,5 @@
 ansible-runner==1.4.4
+ansiconv==1.0.0
 appdirs==1.4.2
 asgi-amqp==1.1.3
 azure-keyvault==1.1.0
@@ -16,6 +17,7 @@ django-jsonfield==1.2.0
 django-oauth-toolkit==1.1.3
 django-polymorphic==2.0.2
 django-pglocks==1.0.2
+django-qsstats-magic==1.1.0
 django-radius==1.3.3
 django-solo==1.1.3
 django-split-settings==0.3.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 adal==1.2.1               # via msrestazure
 amqp==2.4.2               # via kombu
 ansible-runner==1.4.4
+ansiconv==1.0.0
 appdirs==1.4.2
 argparse==1.4.0           # via uwsgitop
 asgi-amqp==1.1.3
@@ -33,6 +34,7 @@ django-jsonfield==1.2.0
 django-oauth-toolkit==1.1.3
 django-pglocks==1.0.2
 django-polymorphic==2.0.2
+django-qsstats-magic==1.1.0
 django-radius==1.3.3
 django-solo==1.1.3
 django-split-settings==0.3.0

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,2 +1,0 @@
-git+https://github.com/ansible/ansiconv.git@tower_1.0.0#egg=ansiconv
-git+https://github.com/ansible/django-qsstats-magic.git@py3#egg=django-qsstats-magic


### PR DESCRIPTION
##### SUMMARY
In both of these cases, we have reason to believe that the forks we have maintained are no longer necessary. The case for `ansiconv` is weaker than the other one, and ultimately it would be desirable to swap it out for a new library which can do the same thing. I might look into that, but maybe not.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


##### ADDITIONAL INFORMATION
still needs to be tested
