### PR TITLE
Use more modern version of OpenShift client

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -100,7 +100,7 @@ RUN chmod +rx /usr/bin/launch_awx.sh && \
 
 # Install OpenShift CLI
 RUN cd /usr/local/bin && \
-    curl -L https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz | \
+    curl -L https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz | \
     tar -xz --strip-components=1 --wildcards --no-anchored 'oc'
 
 ADD google-cloud-sdk.repo /etc/yum.repos.d/


### PR DESCRIPTION
##### SUMMARY
3.9 is pretty old by now. 3.11 is the current stable version.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer