### PR TITLE
Allow deployments on Kubernetes version 1.16

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -186,6 +186,19 @@
   include_tasks: ssl_cert_gen.yml
   when: "rabbitmq_use_ssl|default(False)|bool"
 
+- name: Get Kubernetes API version
+  command: |
+    {{ kubectl_or_oc }} version -o json
+  register: kube_version
+
+- name: Extract server version from command output
+  set_fact:
+    kube_api_version: "{{ (kube_version.stdout | from_json).serverVersion.gitVersion[1:] }}"
+
+- name: Determine StatefulSet api version
+  set_fact:
+    kubernetes_statefulset_api_version: "{{ 'apps/v1' if kube_api_version is version('1.9', '>=') else 'apps/v1beta1' }}"
+
 - name: Render deployment templates
   set_fact:
     "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -131,7 +131,7 @@ userNames:
 {% endif %}
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: {{ kubernetes_statefulset_api_version }}
 kind: StatefulSet
 metadata:
   name: {{ kubernetes_deployment_name }}
@@ -139,6 +139,11 @@ metadata:
 spec:
   serviceName: {{ kubernetes_deployment_name }}
   replicas: 1
+{% if kubernetes_statefulset_api_version == "apps/v1" %}
+  selector:
+    matchLabels:
+      app: {{ kubernetes_deployment_name }}
+{% endif %}
   template:
     metadata:
       labels:


### PR DESCRIPTION
Allow deployments on Kubernetes version 1.16, 
This change will support Kubernetes from version 1.9+

##### SUMMARY
Running the installer to deploy to K8S doesn't work for creating the apps as apps/v1beta1 has been deprecated in 1.16

see #5286 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer
