### PR TITLE
Configurable image registry and service account for Postgres deployment.

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -22,6 +22,9 @@ dockerhub_base=ansible
 # kubernetes_namespace=awx
 # tiller_namespace=kube-system
 # Optional Kubernetes Variables
+# pg_image_registry=docker.io
+# pg_serviceaccount=awx
+# pg_volume_capacity=5
 # pg_persistence_storageClass=StorageClassName
 # pg_cpu_limit=1000
 # pg_mem_limit=2

--- a/installer/roles/kubernetes/templates/postgresql-values.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-values.yml.j2
@@ -31,3 +31,18 @@ master:
 {{ affinity | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
 {% endif %}
 {% endif %}
+{% if pg_image_registry is defined %}
+image:
+  registry: {{ pg_image_registry }}
+volumePermissions:
+  image:
+    registry: {{ pg_image_registry }}
+metrics:
+  image:
+    registry: {{ pg_image_registry }}
+{% endif %}
+{% if pg_serviceaccount is defined %}
+serviceAccount:
+  enabled: true
+  name: {{ pg_serviceaccount }}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Extra variables are added to the inventory to allow to overrule the default image registry (docker.io) and service account (none) settings for the Postgres deployment. In our setup we only allow use of a local image registry which can be already specified for the AWX images (kubernetes_*_image) but not for Postgres. And we need to set a service account for RBAC purposes.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
