### PR TITLE
Upgrade to a pre-19 pip version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,8 @@ virtualenv_ansible:
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
 			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==36.0.1 && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==9.0.1; \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==40.6.3 && \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
 		fi; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ virtualenv_ansible:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
-			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
-			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed setuptools==40.6.3 && \
-			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==40.6.3 && \
+			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
 		fi; \
 	fi
 
@@ -165,23 +165,23 @@ virtualenv_awx:
 
 requirements_ansible: virtualenv_ansible
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
 	else \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/ansible/bin/python -m pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
+	$(VENV_BASE)/ansible/bin/pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 
 requirements_ansible_py3: virtualenv_ansible_py3
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/pip3 install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
 	else \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/pip3 install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/ansible/bin/python -m pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
+	$(VENV_BASE)/ansible/bin/pip3 uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 
 requirements_ansible_dev:
 	if [ "$(VENV_BASE)" ]; then \
-		$(VENV_BASE)/ansible/bin/python -m pip install pytest mock; \
+		$(VENV_BASE)/ansible/bin/pip install pytest mock; \
 	fi
 
 # Install third-party requirements needed for AWX's environment.

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ virtualenv_ansible:
 		fi; \
 		if [ ! -d "$(VENV_BASE)/ansible" ]; then \
 			virtualenv -p python --system-site-packages $(VENV_BASE)/ansible && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed setuptools==40.6.3 && \
-			$(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
+			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed six packaging appdirs && \
+			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed setuptools==40.6.3 && \
+			$(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed pip==18.1; \
 		fi; \
 	fi
 
@@ -165,23 +165,23 @@ virtualenv_awx:
 
 requirements_ansible: virtualenv_ansible
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
 	else \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/ansible/bin/pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
+	$(VENV_BASE)/ansible/bin/python -m pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 
 requirements_ansible_py3: virtualenv_ansible_py3
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/pip3 install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_local.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --ignore-installed -r /dev/stdin ; \
 	else \
-	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/pip3 install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
+	    cat requirements/requirements_ansible.txt requirements/requirements_ansible_git.txt | $(VENV_BASE)/ansible/bin/python -m pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) --ignore-installed -r /dev/stdin ; \
 	fi
-	$(VENV_BASE)/ansible/bin/pip3 uninstall --yes -r requirements/requirements_ansible_uninstall.txt
+	$(VENV_BASE)/ansible/bin/python -m pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 
 requirements_ansible_dev:
 	if [ "$(VENV_BASE)" ]; then \
-		$(VENV_BASE)/ansible/bin/pip install pytest mock; \
+		$(VENV_BASE)/ansible/bin/python -m pip install pytest mock; \
 	fi
 
 # Install third-party requirements needed for AWX's environment.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -49,5 +49,5 @@ tacacs_plus==1.0
 twilio==6.10.4
 uWSGI==2.0.17
 uwsgitop==0.10.0
-pip==9.0.1
-setuptools==36.0.1
+pip==18.1
+setuptools==40.6.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -131,5 +131,5 @@ xmlsec==1.3.3             # via python3-saml
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==9.0.1
-setuptools==36.0.1
+pip==18.1
+setuptools==40.6.3

--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -53,8 +53,8 @@ ovirt-engine-sdk-python==4.3.0    # minimum set inside Ansible facts module requ
 pycurl==7.43.0.1    # higher versions will not install without SSL backend specified
 # AWX usage
 psutil==5.4.3    # same as AWX requirement
-setuptools==36.0.1
-pip==9.0.1
+setuptools==40.6.3
+pip==18.1
 # VMware
 pyvmomi==6.7.3
 # WinRM

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -66,7 +66,7 @@ jsonpatch==1.23           # via openstacksdk
 jsonpointer==2.0          # via jsonpatch
 keystoneauth1==3.14.0     # via openstacksdk
 knack==0.3.3              # via azure-cli-core
-lxml==4.3.3               # via ncclient, pyvmomi
+lxml==4.3.3               # via ncclient
 markupsafe==1.1.1         # via jinja2
 monotonic==1.5; python_version < "3" # via humanfriendly
 msrest==0.6.1
@@ -92,7 +92,7 @@ pygments==2.3.1           # via azure-cli-core, knack
 pyjwt==1.7.1              # via adal, azure-cli-core
 pykerberos==1.2.1         # via requests-kerberos
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.0.0         # via azure-cli-core, pyvmomi, requests-credssp
+pyopenssl==19.0.0         # via azure-cli-core, requests-credssp
 pyparsing==2.4.0          # via packaging
 python-dateutil==2.6.1    # via adal, azure-storage, botocore
 pyvmomi==6.7.3
@@ -116,5 +116,5 @@ wheel==0.30.0             # via azure-cli-core
 xmltodict==0.12.0         # via pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==9.0.1
-setuptools==36.0.1
+pip==18.1
+setuptools==40.6.3


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/3968

There is a lot of history here.

Previously, an upgrade to the latest pip was attempted, that was reverted as of https://github.com/ansible/awx/pull/4114 and https://github.com/ansible/awx/pull/4136, but the labeling there is confusing. Those weren't clean reverts, but eventually we settled back to the very old versions.

I have confirmed an error due to the latest pip & setuptools version which looks like:

```
10:30:37     ERROR: Exception:
10:30:37     Traceback (most recent call last):
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/cli/base_command.py", line 153, in _main
10:30:37         status = self.run(options, args)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 382, in run
10:30:37         resolver.resolve(requirement_set)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/legacy_resolve.py", line 201, in resolve
10:30:37         self._resolve_one(requirement_set, req)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/legacy_resolve.py", line 365, in _resolve_one
10:30:37         abstract_dist = self._get_abstract_dist_for(req_to_install)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/legacy_resolve.py", line 313, in _get_abstract_dist_for
10:30:37         req, self.session, self.finder, self.require_hashes
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 224, in prepare_linked_requirement
10:30:37         req, self.req_tracker, finder, self.build_isolation,
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 49, in _get_prepared_distribution
10:30:37         abstract_dist.prepare_distribution_metadata(finder, build_isolation)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/distributions/source/legacy.py", line 37, in prepare_distribution_metadata
10:30:37         self._setup_isolation(finder)
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_internal/distributions/source/legacy.py", line 90, in _setup_isolation
10:30:37         reqs = backend.get_requires_for_build_wheel()
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_vendor/pep517/wrappers.py", line 152, in get_requires_for_build_wheel
10:30:37         'config_settings': config_settings
10:30:37       File "/builddir/build/BUILD/ansible-tower-3.7.0/venv/ansible/lib/python2.7/site-packages/pip/_vendor/pep517/wrappers.py", line 255, in _call_hook
10:30:37         raise BackendUnavailable(data.get('traceback', ''))
10:30:37     BackendUnavailable
10:30:37     make: *** [requirements_ansible] Error 2
```

This is related to https://github.com/pypa/pip/issues/6164 and https://github.com/pypa/setuptools/issues/1644 which I do not want to go within a mile of.

Pip version 19.0.0 was called out specifically in those issues. As such, dipping down to latest 18.x seems reasonable. Versions selected by inspecting history:

```
pip
19.0    Jan 22, 2019
18.1    Oct 5, 2018

setuptools
40.7.0  Jan 27, 2019
40.6.3  Dec 11, 2018
```

So I'm going to upgrade, pretending that today is Jan 21, 2019.

This is still almost exactly what the partial rollback did in #4114. However, there are several notable differences from there to here:

 - the versions in `Makefile` are set to the same (conservative) versions
 - `setuptools` has a slightly lower version, and there is reason to think it might play better
 - the `pip` version in one of the requirements file was still >19

Importantly, I have not been able to replicate any of the fallout with this PR. It _fixed_ issues I saw with the higher versions, so it would be reasonable to speculate that the issue was caused by the versions in the Makefile.

The hope is that this gets us past the old error:

```
[ec2-user@ip-10-0-14-230 ~]$ sudo /var/lib/awx/venv/awx/bin/pip --help
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/bin/pip", line 7, in <module>
    from pip import main
ImportError: cannot import name 'main'
```

But I still have yet to double and triple check that, and we should hold off merge until that time.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


