### PR TITLE
Instance groups links to docs

### DIFF
--- a/awx/ui/client/src/instance-groups/add-edit/add-instance-group.controller.js
+++ b/awx/ui/client/src/instance-groups/add-edit/add-instance-group.controller.js
@@ -7,8 +7,8 @@ function AddController ($state, models, strings) {
     vm.panelTitle = strings.get('state.ADD_BREADCRUMB_LABEL');
 
     vm.docs = {
-        url: 'https://docs.ansible.com/ansible-tower/latest/html/administration/clustering.html',
-        help_text: vm.strings.get('tooltips.DOCS_HELP_TEXT')
+        url: 'https://docs.ansible.com/ansible-tower/latest/html/userguide/instance_groups.html',
+        help_text: vm.strings.get('tooltips.IG_DOCS_HELP_TEXT')
     };
 
     vm.tab = {

--- a/awx/ui/client/src/instance-groups/add-edit/edit-instance-group.controller.js
+++ b/awx/ui/client/src/instance-groups/add-edit/edit-instance-group.controller.js
@@ -17,8 +17,8 @@ function EditController ($rootScope, $state, models, strings) {
     vm.panelTitle = instanceGroup.get('name');
 
     vm.docs = {
-        url: 'https://docs.ansible.com/ansible-tower/latest/html/administration/clustering.html',
-        help_text: vm.strings.get('tooltips.DOCS_HELP_TEXT')
+        url: 'https://docs.ansible.com/ansible-tower/latest/html/userguide/instance_groups.html',
+        help_text: vm.strings.get('tooltips.IG_DOCS_HELP_TEXT')
     };
 
     vm.tab = {

--- a/awx/ui/client/src/instance-groups/container-groups/add-container-group.controller.js
+++ b/awx/ui/client/src/instance-groups/container-groups/add-container-group.controller.js
@@ -10,6 +10,11 @@ function AddContainerGroupController(ToJSON, $scope, $state, models, strings, i1
   vm.panelTitle = strings.get('state.ADD_CONTAINER_GROUP_BREADCRUMB_LABEL');
   vm.lookUpTitle = strings.get('container.LOOK_UP_TITLE');
 
+  vm.docs = {
+    url: 'https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#ag-container-groups',
+    help_text: vm.strings.get('tooltips.CG_DOCS_HELP_TEXT')
+  };
+
   vm.form = instanceGroup.createFormSchema('post');
   vm.form.name.required = true;
   delete vm.form.name.help_text;

--- a/awx/ui/client/src/instance-groups/container-groups/add-container-group.view.html
+++ b/awx/ui/client/src/instance-groups/container-groups/add-container-group.view.html
@@ -6,7 +6,11 @@
   </div>
 </a>
 <at-panel>
-  <at-panel-heading title="{{:: vm.panelTitle }}"></at-panel-heading>
+  <at-panel-heading title="{{:: vm.panelTitle }}">
+    <a class="Panel-docsLink" ng-href="{{ vm.docs.url }}" target="_blank" aw-tool-tip="{{:: vm.docs.help_text }}">
+      <i class="fa fa-book"></i>
+    </a>
+  </at-panel-heading>
   <at-tab-group>
       <at-tab state="vm.tab.details">{{:: vm.strings.get('tab.DETAILS') }}</at-tab>
       <at-tab state="vm.tab.jobs">{{:: vm.strings.get('tab.JOBS') }}</at-tab>

--- a/awx/ui/client/src/instance-groups/container-groups/edit-container-group.controller.js
+++ b/awx/ui/client/src/instance-groups/container-groups/edit-container-group.controller.js
@@ -23,6 +23,11 @@ function EditContainerGroupController($rootScope, $scope, $state, models, string
   vm.panelTitle = EditContainerGroupDataset.data.name;
   vm.lookUpTitle = strings.get('container.LOOK_UP_TITLE');
 
+  vm.docs = {
+    url: 'https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#ag-container-groups',
+    help_text: vm.strings.get('tooltips.CG_DOCS_HELP_TEXT')
+  };
+
   vm.form = instanceGroup.createFormSchema('post');
   vm.switchDisabled = false;
   vm.form.disabled = !instanceGroup.has('options', 'actions.PUT');

--- a/awx/ui/client/src/instance-groups/instance-groups.strings.js
+++ b/awx/ui/client/src/instance-groups/instance-groups.strings.js
@@ -32,7 +32,8 @@ function InstanceGroupsStrings(BaseString) {
     ns.tooltips = {
         ADD_INSTANCE_GROUP: t.s('Create a new Instance Group'),
         ASSOCIATE_INSTANCES: t.s('Associate an existing Instance'),
-        DOCS_HELP_TEXT: t.s('Instance Groups Help')
+        IG_DOCS_HELP_TEXT: t.s('Instance Groups Help'),
+        CG_DOCS_HELP_TEXT: t.s('Container Groups Help')
     };
 
     ns.instance = {


### PR DESCRIPTION
Adds link to docs on container groups add/edit forms to match instance groups.  Updates instance groups link.

link https://github.com/ansible/awx/issues/5367