### PR TITLE
Make Integration Tests Pass w/ Manual SCM Type

### DIFF
--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -225,7 +225,7 @@ def main():
                                         custom_virtualenv=custom_virtualenv,
                                         create_on_missing=True)
                 json_output['id'] = result['id']
-                if wait:
+                if wait and scm_type != '':
                     project.wait(pk=None, parent_pk=result['id'])
             elif state == 'absent':
                 result = project.delete(name=name)


### PR DESCRIPTION
##### SUMMARY

An integration test checking the current version of AWX is throwing this error: `tower_cli.exceptions.NotFound: No related jobs or updates exist.`  

When running a test playbook locally that invoked a project using the manual SCM type, this error would come up:

```
TASK [awx.awx.tower_project] *****************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: tower_cli.exceptions.NotFound: No related jobs or updates exist.
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call 
last):\n  File \"/Users/bhenderson/.ansible/tmp/ansible-tmp-1574709158.3489-
197592906727421/AnsiballZ_tower_project.py\", line 116, in <module>\n    _ansiballz_main()\n  File 
\"/Users/bhenderson/.ansible/tmp/ansible-tmp-1574709158.3489-
197592906727421/AnsiballZ_tower_project.py\", line 108, in _ansiballz_main\n    
invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File 
\"/Users/bhenderson/.ansible/tmp/ansible-tmp-1574709158.3489-
197592906727421/AnsiballZ_tower_project.py\", line 54, in invoke_module\n    
runpy.run_module(mod_name='ansible_collections.awx.awx.plugins.modules.tower_project', 
init_globals=None, run_name='__main__', alter_sys=True)\n  File 
\"/Users/bhenderson/.pyenv/versions/3.6.0/lib/python3.6/runpy.py\", line 205, in run_module\n    
return _run_module_code(code, init_globals, run_name, mod_spec)\n  File 
\"/Users/bhenderson/.pyenv/versions/3.6.0/lib/python3.6/runpy.py\", line 96, in _run_module_code\n 
   mod_name, mod_spec, pkg_name, script_name)\n  File 
\"/Users/bhenderson/.pyenv/versions/3.6.0/lib/python3.6/runpy.py\", line 85, in _run_code\n    
exec(code, run_globals)\n  File 
\"/tmp/ansible_awx.awx.tower_project_payload_1u8j2a7f/ansible_awx.awx.tower_project_payload.zip
/ansible_collections/awx/awx/plugins/modules/tower_project.py\", line 240, in <module>\n  File 
\"/tmp/ansible_awx.awx.tower_project_payload_1u8j2a7f/ansible_awx.awx.tower_project_payload.zip
/ansible_collections/awx/awx/plugins/modules/tower_project.py\", line 229, in main\n  File
 \"/Users/bhenderson/Desktop/VirtualEnv/collections_work/lib/python3.6/site-
packages/tower_cli/models/base.py\", line 959, in wait\n    pk = self.last_job_data(parent_pk,
 **kwargs)['id']\n  File \"/Users/bhenderson/Desktop/VirtualEnv/collections_work/lib/python3.6/site
-packages/tower_cli/models/base.py\", line 756, in last_job_data\n    raise exc.NotFound('No related
 jobs or updates exist.')\ntower_cli.exceptions.NotFound: No related jobs or updates exist.\n",
 "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

This fix enables tests that check manual SCM-type projects to pass.


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```
