### PR TITLE
Raise specific exception if migration in progress

### DIFF
--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -184,6 +184,8 @@ class Page(object):
            a __class__ instance if the request path is different than the caller's `endpoint`.
         """
         request_path = response.request.path_url
+        if request_path == '/migrations_notran/':
+            raise exc.IsMigrating('You have been redirected to the migration-in-progress page.')
         request_method = response.request.method.lower()
 
         self.last_elapsed = response.elapsed

--- a/awxkit/awxkit/exceptions.py
+++ b/awxkit/awxkit/exceptions.py
@@ -96,3 +96,8 @@ class WaitUntilTimeout(Common):
 class UnexpectedAWXState(Common):
 
     pass
+
+
+class IsMigrating(Common):
+
+    pass


### PR DESCRIPTION
#### before

```
Traceback (most recent call last):
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/api/__init__.py", line 15, in available_versions
    return api.available_versions
  File "/Users/alancoding/.virtualenvs/akit/lib/python3.6/site-packages/awxkit/api/pages/page.py", line 136, in __getattr__
    self.__class__.__name__, name))
AttributeError: 'Base' object has no attribute 'available_versions'
```

#### after

```
Traceback (most recent call last):
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/api/__init__.py", line 10, in api
    return get_registered_page('/api/')(connection).get()
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py", line 279, in get
    page = self.page_identity(r)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py", line 188, in page_identity
    raise exc.IsMigrating('You have been redirected to the migration-in-progress page.')
awxkit.exceptions.IsMigrating
```

Almost certainly because of recent merge that re-ordered migrations.

Really wanted to get this in while I have the context for it. It's a very frustrating debugging situation.