### PR TITLE
Make spelling of canceled consistent

### DIFF
--- a/awx/api/templates/api/inventory_source_cancel.md
+++ b/awx/api/templates/api/inventory_source_cancel.md
@@ -1,7 +1,7 @@
 # Cancel Inventory Update
 
 Make a GET request to this resource to determine if the inventory update can be
-cancelled.  The response will include the following field:
+canceled.  The response will include the following field:
 
 * `can_cancel`: Indicates whether this update can be canceled (boolean,
   read-only)

--- a/awx/api/templates/api/job_cancel.md
+++ b/awx/api/templates/api/job_cancel.md
@@ -1,7 +1,7 @@
 {% ifmeth GET %}
-# Determine if a Job can be cancelled
+# Determine if a Job can be canceled
 
-Make a GET request to this resource to determine if the job can be cancelled.
+Make a GET request to this resource to determine if the job can be canceled.
 The response will include the following field:
 
 * `can_cancel`: Indicates whether this job can be canceled (boolean, read-only)

--- a/awx/api/templates/api/project_update_cancel.md
+++ b/awx/api/templates/api/project_update_cancel.md
@@ -1,7 +1,7 @@
 # Cancel Project Update
 
 Make a GET request to this resource to determine if the project update can be
-cancelled.  The response will include the following field:
+canceled.  The response will include the following field:
 
 * `can_cancel`: Indicates whether this update can be canceled (boolean,
   read-only)

--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -32,13 +32,13 @@ def set_pythonpath(venv_libdir, env):
 
 class IsolatedManager(object):
 
-    def __init__(self, cancelled_callback=None, check_callback=None, pod_manager=None):
+    def __init__(self, canceled_callback=None, check_callback=None, pod_manager=None):
         """
-        :param cancelled_callback:  a callable - which returns `True` or `False`
+        :param canceled_callback:  a callable - which returns `True` or `False`
                                     - signifying if the job has been prematurely
-                                      cancelled
+                                      canceled
         """
-        self.cancelled_callback = cancelled_callback
+        self.canceled_callback = canceled_callback
         self.check_callback = check_callback
         self.started_at = None
         self.captured_command_artifact = False
@@ -105,7 +105,7 @@ class IsolatedManager(object):
             'envvars': env,
             'finished_callback': finished_callback,
             'verbosity': verbosity,
-            'cancel_callback': self.cancelled_callback,
+            'cancel_callback': self.canceled_callback,
             'settings': {
                 'job_timeout': settings.AWX_ISOLATED_LAUNCH_TIMEOUT,
                 'pexpect_timeout': getattr(settings, 'PEXPECT_TIMEOUT', 5),
@@ -209,14 +209,14 @@ class IsolatedManager(object):
         dispatcher = CallbackQueueDispatcher()
 
         while status == 'failed':
-            canceled = self.cancelled_callback() if self.cancelled_callback else False
+            canceled = self.canceled_callback() if self.canceled_callback else False
             if not canceled and time.time() - last_check < interval:
-                # If the job isn't cancelled, but we haven't waited `interval` seconds, wait longer
+                # If the job isn't canceled, but we haven't waited `interval` seconds, wait longer
                 time.sleep(1)
                 continue
 
             if canceled:
-                logger.warning('Isolated job {} was manually cancelled.'.format(self.instance.id))
+                logger.warning('Isolated job {} was manually canceled.'.format(self.instance.id))
 
             logger.debug('Checking on isolated job {} with `check_isolated.yml`.'.format(self.instance.id))
             runner_obj = self.run_management_playbook('check_isolated.yml',

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1336,7 +1336,7 @@ class BaseTask(object):
 
                 ansible_runner.utils.dump_artifacts(params)
                 isolated_manager_instance = isolated_manager.IsolatedManager(
-                    cancelled_callback=lambda: self.update_model(self.instance.pk).cancel_flag,
+                    canceled_callback=lambda: self.update_model(self.instance.pk).cancel_flag,
                     check_callback=self.check_handler,
                     pod_manager=pod_manager
                 )
@@ -2154,7 +2154,7 @@ class RunProjectUpdate(BaseTask):
             try:
                 instance.refresh_from_db(fields=['cancel_flag'])
                 if instance.cancel_flag:
-                    logger.debug("ProjectUpdate({0}) was cancelled".format(instance.pk))
+                    logger.debug("ProjectUpdate({0}) was canceled".format(instance.pk))
                     return
                 fcntl.lockf(self.lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 break

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/factories/cancel-source-update.factory.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/factories/cancel-source-update.factory.js
@@ -29,7 +29,7 @@ export default
                             Rest.post()
                             .then(() => {
                                 Wait('stop');
-                                //Alert('Inventory Sync Cancelled', 'Request to cancel the sync process was submitted to the task manger. ' +
+                                //Alert('Inventory Sync Canceled', 'Request to cancel the sync process was submitted to the task manger. ' +
                                 //    'Click the <i class="fa fa-refresh fa-lg"></i> button to monitor the status.', 'alert-info');
                             })
                             .catch(({data, status}) => {

--- a/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
+++ b/awx/ui/client/src/templates/workflows/workflow-chart/workflow-chart.directive.js
@@ -646,7 +646,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
                                 if(d.job.status === "successful"){
                                     return "#5cb85c";
                                 }
-                                else if (d.job.status === "failed" || d.job.status === "error" || d.job.status === "cancelled") {
+                                else if (d.job.status === "failed" || d.job.status === "error" || d.job.status === "canceled") {
                                     return "#d9534f";
                                 }
                                 else {
@@ -913,7 +913,7 @@ export default ['moment', '$timeout', '$window', '$filter', 'TemplatesStrings',
                                         if(d.job.status === "successful"){
                                             return "#5cb85c";
                                         }
-                                        else if (d.job.status === "failed" || d.job.status === "error" || d.job.status === "cancelled") {
+                                        else if (d.job.status === "failed" || d.job.status === "error" || d.job.status === "canceled") {
                                             return "#d9534f";
                                         }
                                         else {

--- a/awx/ui_next/CONTRIBUTING.md
+++ b/awx/ui_next/CONTRIBUTING.md
@@ -283,11 +283,11 @@ mountWithContexts(<Organization />< {
 
 ## Internationalization
 
-Internationalization leans on the [lingui](https://github.com/lingui/js-lingui) project.  [Official documentation here](https://lingui.js.org/).  We use this libary to mark our strings for translation.  If you want to see this in action you'll need to take the following steps:
+Internationalization leans on the [lingui](https://github.com/lingui/js-lingui) project.  [Official documentation here](https://lingui.js.org/).  We use this library to mark our strings for translation.  If you want to see this in action you'll need to take the following steps:
 
 ### Marking strings for translation and replacement in the UI
 
-The lingui library provides various React helpers for dealing with both marking strings for translation, and replacing strings that have been traslated.  For consistency and ease of use, we have consolidated on one pattern for the codebase.  To set strings to be translated in the UI:
+The lingui library provides various React helpers for dealing with both marking strings for translation, and replacing strings that have been translated.  For consistency and ease of use, we have consolidated on one pattern for the codebase.  To set strings to be translated in the UI:
 
 - import the withI18n function and wrap the export of your component in it (i.e. `export default withI18n()(Foo)`)
 - doing the above gives you access to the i18n object on props.  Make sure to put it in the scope of the function that contains strings needed to be translated (i.e. `const { i18n } = this.props;`)

--- a/awxkit/awxkit/cli/utils.py
+++ b/awxkit/awxkit/cli/utils.py
@@ -22,7 +22,7 @@ STATUS_COLORS = {
     'successful': 'green',
     'failed': 'red',
     'error': 'red',
-    'cancelled': 'grey',
+    'canceled': 'grey',
 }
 
 


### PR DESCRIPTION
##### SUMMARY

Different sections of the codebase spell the word cancel(l)ed differently.  There were fewer "cancelled"'s and they were in less nasty places for a string change, so I changed them all to "canceled".  

Translation considerations:
* No model names/fields were changed
* No endpoints were changed
* None of the UI strings changed were marked with `i18n`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Nitpick Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
