### PR TITLE
Check inventory use permissions to disable workflow inventory lookup

### DIFF
--- a/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
+++ b/awx/ui/client/src/templates/workflows/edit-workflow/workflow-edit.controller.js
@@ -533,9 +533,24 @@ export default [
         }
 
         if(workflowJobTemplateData.inventory) {
-            OrgAdminLookup.checkForRoleLevelAdminAccess(workflowJobTemplateData.inventory, 'workflow_admin_role')
-            .then(function(canEditInventory){
-                $scope.canEditInventory = canEditInventory;
+            let params = {
+              role_level: 'use_role',
+              id: workflowJobTemplateData.inventory
+            };
+            Rest.setUrl(GetBasePath('inventory'));
+            Rest.get({ params: params })
+              .then(({ data }) => {
+                if (data.count && data.count > 0) {
+                  $scope.canEditInventory = true;
+                } else {
+                  $scope.canEditInventory = false;
+                }
+              })
+              .catch(({ data, status }) => {
+                ProcessErrors(null, data, status, null, {
+                  hdr: 'Error!',
+                  msg: 'Failed to get inventory data based on role_level. Return status: ' + status
+              });
             });
         }
         else {


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/5338

This PR disables the inventory lookup field in the workflow edit form if the user does not have inventory use_role permissions. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```
##### ADDITIONAL INFO
_Disabled inventory lookup for user with Org workflow_admin_role and no Inv use_role_
<img width="819" alt="Screen Shot 2019-11-27 at 11 39 18 AM" src="https://user-images.githubusercontent.com/15881645/69742331-9b3c8000-110a-11ea-98e4-d4764f830a73.png">
