### PR TITLE
Enable Approval-Related Email Notifications to Send Properly

### DIFF
--- a/awx/main/notifications/custom_notification_base.py
+++ b/awx/main/notifications/custom_notification_base.py
@@ -3,8 +3,8 @@
 
 
 class CustomNotificationBase(object):
-    DEFAULT_MSG = '{{ job_friendly_name }} #{{ job.id }} "{{ job.name }}" {{ job.status }}: {{ url }}'
-    DEFAULT_BODY = '{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_metadata }}'
+    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
+    DEFAULT_BODY = "{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_metadata }}"
 
     DEFAULT_APPROVAL_RUNNING_MSG = 'The approval node "{{ approval_node_name }}" needs review. This node can be viewed at: {{ workflow_url }}'
     DEFAULT_APPROVAL_RUNNING_BODY = ('The approval node "{{ approval_node_name }}" needs review. '

--- a/awx/main/notifications/custom_notification_base.py
+++ b/awx/main/notifications/custom_notification_base.py
@@ -3,20 +3,21 @@
 
 
 class CustomNotificationBase(object):
-    DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
-    DEFAULT_BODY = "{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_metadata }}"
+    DEFAULT_MSG = '{{ job_friendly_name }} #{{ job.id }} "{{ job.name }}" {{ job.status }}: {{ url }}'
+    DEFAULT_BODY = '{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_metadata }}'
 
-    DEFAULT_APPROVAL_RUNNING_MSG = "The approval node '{{ approval_node_name }}' needs review. This node can be viewed at: {{ workflow_url }}"
-    DEFAULT_APPROVAL_RUNNING_BODY = "'{{ approval_node_name }}' needs review. This approval node can be viewed at: {{ workflow_url }}\n\n{{ job_metadata }}"
+    DEFAULT_APPROVAL_RUNNING_MSG = 'The approval node "{{ approval_node_name }}" needs review. This node can be viewed at: {{ workflow_url }}'
+    DEFAULT_APPROVAL_RUNNING_BODY = ('The approval node "{{ approval_node_name }}" needs review. '
+                                     'This approval node can be viewed at: {{ workflow_url }}\n\n{{ job_metadata }}')
 
-    DEFAULT_APPROVAL_APPROVED_MSG = "The approval node '{{ approval_node_name }}' was approved. {{ workflow_url }}"
-    DEFAULT_APPROVAL_APPROVED_BODY = "The approval node '{{ approval_node_name }}' was approved. {{ workflow_url }}\n\n{{ job_metadata }}"
+    DEFAULT_APPROVAL_APPROVED_MSG = 'The approval node "{{ approval_node_name }}" was approved. {{ workflow_url }}'
+    DEFAULT_APPROVAL_APPROVED_BODY = 'The approval node "{{ approval_node_name }}" was approved. {{ workflow_url }}\n\n{{ job_metadata }}'
 
-    DEFAULT_APPROVAL_TIMEOUT_MSG = "The approval node '{{ approval_node_name }}' has timed out. {{ workflow_url }}"
-    DEFAULT_APPROVAL_TIMEOUT_BODY = "The approval node '{{ approval_node_name }}' has timed out. {{ workflow_url }}\n\n{{ job_metadata }}"
+    DEFAULT_APPROVAL_TIMEOUT_MSG = 'The approval node "{{ approval_node_name }}" has timed out. {{ workflow_url }}'
+    DEFAULT_APPROVAL_TIMEOUT_BODY = 'The approval node "{{ approval_node_name }}" has timed out. {{ workflow_url }}\n\n{{ job_metadata }}'
 
-    DEFAULT_APPROVAL_DENIED_MSG = "The approval node '{{ approval_node_name }}' was denied. {{ workflow_url }}"
-    DEFAULT_APPROVAL_DENIED_BODY = "The approval node '{{ approval_node_name }}' was denied. {{ workflow_url }}\n\n{{ job_metadata }}"
+    DEFAULT_APPROVAL_DENIED_MSG = 'The approval node "{{ approval_node_name }}" was denied. {{ workflow_url }}'
+    DEFAULT_APPROVAL_DENIED_BODY = 'The approval node "{{ approval_node_name }}" was denied. {{ workflow_url }}\n\n{{ job_metadata }}'
 
 
     default_messages = {"started": {"message": DEFAULT_MSG, "body": None},

--- a/awx/main/notifications/custom_notification_base.py
+++ b/awx/main/notifications/custom_notification_base.py
@@ -6,15 +6,23 @@ class CustomNotificationBase(object):
     DEFAULT_MSG = "{{ job_friendly_name }} #{{ job.id }} '{{ job.name }}' {{ job.status }}: {{ url }}"
     DEFAULT_BODY = "{{ job_friendly_name }} #{{ job.id }} had status {{ job.status }}, view details at {{ url }}\n\n{{ job_metadata }}"
 
+    DEFAULT_APPROVAL_RUNNING_MSG = "The approval node '{{ approval_node_name }}' needs review. This node can be viewed at: {{ workflow_url }}"
+    DEFAULT_APPROVAL_RUNNING_BODY = "'{{ approval_node_name }}' needs review. This approval node can be viewed at: {{ workflow_url }}\n\n{{ job_metadata }}"
+
+    DEFAULT_APPROVAL_APPROVED_MSG = "The approval node '{{ approval_node_name }}' was approved. {{ workflow_url }}"
+    DEFAULT_APPROVAL_APPROVED_BODY = "The approval node '{{ approval_node_name }}' was approved. {{ workflow_url }}\n\n{{ job_metadata }}"
+
+    DEFAULT_APPROVAL_TIMEOUT_MSG = "The approval node '{{ approval_node_name }}' has timed out. {{ workflow_url }}"
+    DEFAULT_APPROVAL_TIMEOUT_BODY = "The approval node '{{ approval_node_name }}' has timed out. {{ workflow_url }}\n\n{{ job_metadata }}"
+
+    DEFAULT_APPROVAL_DENIED_MSG = "The approval node '{{ approval_node_name }}' was denied. {{ workflow_url }}"
+    DEFAULT_APPROVAL_DENIED_BODY = "The approval node '{{ approval_node_name }}' was denied. {{ workflow_url }}\n\n{{ job_metadata }}"
+
+
     default_messages = {"started": {"message": DEFAULT_MSG, "body": None},
                         "success": {"message": DEFAULT_MSG, "body": None},
                         "error": {"message": DEFAULT_MSG, "body": None},
-                        "workflow_approval": {"running": {"message": 'The approval node "{{ approval_node_name }}" needs review. '
-                                                                     'This node can be viewed at: {{ workflow_url }}',
-                                                                     "body": None},
-                                              "approved": {"message": 'The approval node "{{ approval_node_name }}" was approved. {{ workflow_url }}',
-                                                           "body": None},
-                                              "timed_out": {"message": 'The approval node "{{ approval_node_name }}" has timed out. {{ workflow_url }}',
-                                                            "body": None},
-                                              "denied": {"message": 'The approval node "{{ approval_node_name }}" was denied. {{ workflow_url }}',
-                                                         "body": None}}}
+                        "workflow_approval": {"running": {"message": DEFAULT_APPROVAL_RUNNING_MSG, "body": None},
+                                              "approved": {"message": DEFAULT_APPROVAL_APPROVED_MSG, "body": None},
+                                              "timed_out": {"message": DEFAULT_APPROVAL_TIMEOUT_MSG, "body": None},
+                                              "denied": {"message": DEFAULT_APPROVAL_DENIED_MSG, "body": None}}}

--- a/awx/main/notifications/email_backend.py
+++ b/awx/main/notifications/email_backend.py
@@ -8,6 +8,18 @@ from awx.main.notifications.custom_notification_base import CustomNotificationBa
 DEFAULT_MSG = CustomNotificationBase.DEFAULT_MSG
 DEFAULT_BODY = CustomNotificationBase.DEFAULT_BODY
 
+DEFAULT_APPROVAL_RUNNING_MSG = CustomNotificationBase.DEFAULT_APPROVAL_RUNNING_MSG
+DEFAULT_APPROVAL_RUNNING_BODY = CustomNotificationBase.DEFAULT_APPROVAL_RUNNING_BODY
+
+DEFAULT_APPROVAL_APPROVED_MSG = CustomNotificationBase.DEFAULT_APPROVAL_APPROVED_MSG
+DEFAULT_APPROVAL_APPROVED_BODY = CustomNotificationBase.DEFAULT_APPROVAL_APPROVED_BODY
+
+DEFAULT_APPROVAL_TIMEOUT_MSG = CustomNotificationBase.DEFAULT_APPROVAL_TIMEOUT_MSG
+DEFAULT_APPROVAL_TIMEOUT_BODY = CustomNotificationBase.DEFAULT_APPROVAL_TIMEOUT_BODY
+
+DEFAULT_APPROVAL_DENIED_MSG = CustomNotificationBase.DEFAULT_APPROVAL_DENIED_MSG
+DEFAULT_APPROVAL_DENIED_BODY = CustomNotificationBase.DEFAULT_APPROVAL_DENIED_BODY
+
 
 class CustomEmailBackend(EmailBackend, CustomNotificationBase):
 
@@ -26,10 +38,10 @@ class CustomEmailBackend(EmailBackend, CustomNotificationBase):
     default_messages = {"started": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
                         "success": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
                         "error": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
-                        "workflow_approval": {"running": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
-                                              "approved": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
-                                              "timed_out": {"message": DEFAULT_MSG, "body": DEFAULT_BODY},
-                                              "denied": {"message": DEFAULT_MSG, "body": DEFAULT_BODY}}}
+                        "workflow_approval": {"running": {"message": DEFAULT_APPROVAL_RUNNING_MSG, "body": DEFAULT_APPROVAL_RUNNING_BODY},
+                                              "approved": {"message": DEFAULT_APPROVAL_APPROVED_MSG, "body": DEFAULT_APPROVAL_APPROVED_BODY},
+                                              "timed_out": {"message": DEFAULT_APPROVAL_TIMEOUT_MSG, "body": DEFAULT_APPROVAL_TIMEOUT_BODY},
+                                              "denied": {"message": DEFAULT_APPROVAL_DENIED_MSG, "body": DEFAULT_APPROVAL_DENIED_BODY}}}
 
     def format_body(self, body):
         # leave body unchanged (expect a string)


### PR DESCRIPTION
##### SUMMARY

This PR addresses the problem stated in issue https://github.com/ansible/awx/issues/5401

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```


##### ADDITIONAL INFORMATION
Before these changes, the emails attached to approval nodes sent with no information included, like the example below:

![BlankEmail](https://user-images.githubusercontent.com/28930622/69760328-444aa100-1132-11ea-9bc1-9235c205982f.png)

One particular line I kept seeing in the traceback was:
```
jinja2.exceptions.UndefinedError: 'job' is undefined
```
...which indicated that there was an undefined variable, 'job', being called in the approval email notifications.  

Lo and behold, in the `email_backend.py` file, the following was listed as default:

<img width="835" alt="EmailBackendOriginal" src="https://user-images.githubusercontent.com/28930622/69760416-8378f200-1132-11ea-8ac9-0adb16d59c78.png">

The issue with this is that in `awx/main/notifications/custom_notification_base.py`, the `DEFAULT_MSG` and `DEFAULT_BODY` both contain 'job's:

<img width="979" alt="CustomNotificationBaseDefaultsOriginal" src="https://user-images.githubusercontent.com/28930622/69760493-aacfbf00-1132-11ea-88b5-dc02f51794fa.png">

Explicitly stating new default messages and bodies for the email approval notification in the backend file fixed all instances of email approval notifications, whether they are default:

![UntemplatedEmail](https://user-images.githubusercontent.com/28930622/69760564-d94d9a00-1132-11ea-920f-1aa15bc926e0.png)

... or templated:

<img width="662" alt="TemplatedEmailNotificationPage" src="https://user-images.githubusercontent.com/28930622/69760572-de124e00-1132-11ea-80b9-eef10dcde270.png">

![TemplatedEmail](https://user-images.githubusercontent.com/28930622/69760584-e2d70200-1132-11ea-980c-138c7a7f7cc4.png)





