### PR TITLE
Add pycurl to container images

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -36,6 +36,7 @@ RUN dnf -y update && \
   python3-pip \
   python3-psycopg2 \
   python3-setuptools \
+  python3-pycurl \
   rsync \
   subversion \
   sudo \

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf -y update && \
   python3-pip \
   python3-psycopg2 \
   python3-setuptools \
+  python3-pycurl \
   rsync \
   subversion \
   sudo \


### PR DESCRIPTION
##### SUMMARY
This was added to the "remove" list here:

e06d4d77343b3ec5680d4c664761c4ae0bc18ed5

But I think that the wires were not fully connected for the container images.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


##### ADDITIONAL INFORMATION
```
>>> import ovirtsdk4 as sdk
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/venv/ansible/lib64/python3.6/site-packages/ovirtsdk4/__init__.py", line 22, in <module>
    import pycurl
ModuleNotFoundError: No module named 'pycurl'
```

