### PR TITLE
Use hard-coded server for roles install

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -444,9 +444,10 @@ register(
     label=_('Primary Galaxy Server URL'),
     help_text=_(
         'For organizations that run their own Galaxy service, this gives the option to specify a '
-        'host as the primary galaxy server. Requirements will be downloaded from the primary if the '
-        'specific role or collection is available there. If the content is not avilable in the primary, '
-        'or if this field is left blank, it will default to galaxy.ansible.com.'
+        'host as the primary galaxy server. Collection requirements will be downloaded from the primary if the '
+        'specific collection is available there. If the collection is not avilable in the primary, '
+        'or if this field is left blank, it will default to galaxy.ansible.com. '
+        'Roles will always be downloaded from the public Galaxy server.'
     ),
     category=_('Jobs'),
     category_slug='jobs'

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -122,7 +122,11 @@
           register: doesRequirementsExist
 
         - name: fetch galaxy roles from requirements.yml
-          command: ansible-galaxy role install -r roles/requirements.yml -p {{roles_destination|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
+          command: >
+            ansible-galaxy role install -r roles/requirements.yml
+            --roles-path {{roles_destination|quote}}
+            --server https://galaxy.ansible.com/
+            {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
           args:
             chdir: "{{project_path|quote}}"
           register: galaxy_result
@@ -143,7 +147,10 @@
           register: doesCollectionRequirementsExist
 
         - name: fetch galaxy collections from collections/requirements.yml
-          command: ansible-galaxy collection install -r collections/requirements.yml -p {{collections_destination|quote}}{{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
+          command: >
+            ansible-galaxy collection install -r collections/requirements.yml
+            --collections-path {{collections_destination|quote}}
+            {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
           args:
             chdir: "{{project_path|quote}}"
           register: galaxy_collection_result


### PR DESCRIPTION
##### SUMMARY
Automation Hub does not host roles, only collections, and this command will error if role requirements are present.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```
