### PR TITLE
Add quotes to properly pass command-line parameters

### DIFF
--- a/tools/docker-compose/entrypoint.sh
+++ b/tools/docker-compose/entrypoint.sh
@@ -11,4 +11,4 @@ EOF
   rm /tmp/passwd
 fi
 
-exec $@
+exec "$@"


### PR DESCRIPTION
##### SUMMARY
Add quotes to properly pass command-line parameters to the docker shell.  

Currently, when running a command with `bash -c`, I observe the following:

```
[chadams@rooftopcellist ansible]$     docker run  --user=$(id -u) -e HOME=/awx_devel/ --workdir=/awx_devel       -v /home/chadams/tower-packaging/tower:/awx_devel       gcr.io/ansible-tower-engineering/awx_devel:devel         bash -c '. /venv/awx/bin/activate'
/venv/awx/bin/activate: line 0: .: filename argument required
.: usage: . filename [arguments]
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer
