### PR TITLE
keep *-devel package in the dev container

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -102,10 +102,7 @@ RUN cd /usr/local/bin && \
 ADD tools/docker-compose/google-cloud-sdk.repo /etc/yum.repos.d/
 RUN dnf install -y kubectl
 
-RUN dnf -y remove *-devel \
-  gcc \
-  gcc-c++ \
-  nodejs
+RUN dnf -y remove nodejs
 
 RUN dnf -y clean all
 


### PR DESCRIPTION
* requirements/updater.sh does pip magic. In doing this magic, devel
system packages are required to download/install/build. This change
ensures those dev packages are available.
