### PR TITLE
Only show cred type test button to superusers.

### DIFF
--- a/awx/ui/client/features/credentials/add-edit-credentials.controller.js
+++ b/awx/ui/client/features/credentials/add-edit-credentials.controller.js
@@ -156,7 +156,13 @@ function AddEditCredentialsController (
             if (credential.get('credential_type') === credentialType.get('id')) {
                 vm.inputSources.items = credential.get('related.input_sources.results');
             }
-            vm.isTestable = (isEditable && credentialType.get('kind') === 'external');
+
+            if (mode === 'add') {
+                vm.isTestable = (models.me.get('is_superuser') && credentialType.get('kind') === 'external');
+            } else {
+                vm.isTestable = (isEditable && credentialType.get('kind') === 'external');
+            }
+
             vm.getSubmitData = getSubmitData;
             vm.checkForm = check;
 


### PR DESCRIPTION
##### SUMMARY
ui portion of [#5095](https://github.com/ansible/awx/pull/5095/files)

Adding a _new_ external credential is a special case. In this scenario, clicking the test button goes through the credential _type_ api (not the credential, since it doesn't exist yet). Only superusers may use this api. This PR hides the button for non-superusers (they'll need to save first)

