### PR TITLE
fix an nuanced bug which can cause OAuth2 migrations to fail

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -86,7 +86,14 @@ def oauth2_getattribute(self, attr):
     # Custom method to override
     # oauth2_provider.settings.OAuth2ProviderSettings.__getattribute__
     from django.conf import settings
-    val = settings.OAUTH2_PROVIDER.get(attr)
+    val = None
+    if 'migrate' not in sys.argv:
+        # certain Django OAuth Toolkit migrations actually reference
+        # setting lookups for references to model classes (e.g.,
+        # oauth2_settings.REFRESH_TOKEN_MODEL)
+        # If we're doing an OAuth2 setting lookup *while running* a migration,
+        # don't do our usual "Configure Tower in Tower" database setting lookup
+        val = settings.OAUTH2_PROVIDER.get(attr)
     if val is None:
         val = object.__getattribute__(self, attr)
     return val


### PR DESCRIPTION
```python
  File "/venv/awx/lib64/python3.6/site-packages/oauth2_provider/migrations/0006_auto_20171214_2232.py", line 11, in <module>
    class Migration(migrations.Migration):
  File "/venv/awx/lib64/python3.6/site-packages/oauth2_provider/migrations/0006_auto_20171214_2232.py", line 21, in Migration
    field=models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=oauth2_settings.REFRESH_TOKEN_MODEL, related_name='refreshed_access_token'),
  File "/awx_devel/awx/__init__.py", line 91, in oauth2_getattribute
    val = object.__getattribute__(self, attr)
  File "/awx_devel/awx/__init__.py", line 91, in oauth2_getattribute
    val = object.__getattribute__(self, attr)
  File "/usr/lib64/python3.6/bdb.py", line 51, in trace_dispatch
    return self.dispatch_line(frame)
  File "/usr/lib64/python3.6/bdb.py", line 70, in dispatch_line
    if self.quitting: raise BdbQuit
```

see this Django OAuth Toolkit migration:

```python
[stable/1.1:] ~/venvs/tmp-a9f726005e62f47/django-oauth-toolkit/oauth2_provider/migrations ack oauth2_settings\.
0005_auto_20170514_1141.py
21:            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=oauth2_settings.APPLICATION_MODEL),
0001_initial.py
42:                ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE)),
58:                ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE)),
71:                ('access_token', models.OneToOneField(related_name='refresh_token', to=oauth2_settings.ACCESS_TOKEN_MODEL, on_delete=models.CASCADE)),
72:                ('application', models.ForeignKey(to=oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE)),
0006_auto_20171214_2232.py
21:            field=models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=oauth2_settings.REFRESH_TOKEN_MODEL, related_name='refreshed_access_token'),
38:            field=models.OneToOneField(blank=True, null=True, related_name='refresh_token', to=oauth2_settings.ACCESS_TOKEN_MODEL, on_delete=models.SET_NULL),
```