### PR TITLE
'install' was misspelled as 'isntall'

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -146,7 +146,7 @@ secret_key=awxsecret
 # it manages from the docker host, you can set this to turn it into a volume for the container.
 #project_data_dir=/var/lib/awx/projects
 
-# AWX custom virtual environment folder. Only usable for local isntall.
+# AWX custom virtual environment folder. Only usable for local install.
 #custom_venv_dir=/opt/my-envs/
 
 # CA Trust directory. If you need to provide custom CA certificates, supplying


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Within file `installer/inventory` at line 149, `install` was misspelled as `isntall`.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - installer/inventory

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
branch/devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
