### PR TITLE
Added cryptography to awxkit deps

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -71,6 +71,7 @@ setup(
     extras_require={
         'formatting': ['jq'],
         'websockets': ['websocket-client>0.54.0'],
+        'crypto': ['cryptography']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
##### SUMMARY
Some commands require `cryptography` to actually run. For example:

```create_or_replace --resource="job_templates" --name="jt" "https://localhost:3001"') failed because the command exited with a non-zero code.```

The source error is cryptography being missing thanks to the way it generates SSH keys for credentials.

This dependency exists in the top-level awx requirements, but anyone running awxkit alone will need this explicitly.