### PR TITLE
Add extra_vars Parameter to tower_job_template.py Module

### DIFF
--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -85,8 +85,14 @@ options:
       choices: [0, 1, 2, 3, 4]
       default: 0
       type: int
+    extra_vars:
+      description:
+        - Specify C(extra_vars) for the template.
+      type: dict
+      version_added: 3.7
     extra_vars_path:
       description:
+        - This parameter has been deprecated, please use 'extra_vars' instead.
         - Path to the C(extra_vars) YAML file.
       type: path
     job_tags:
@@ -238,6 +244,8 @@ EXAMPLES = '''
 '''
 
 from ..module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
+import json
+
 
 try:
     import tower_cli
@@ -248,7 +256,7 @@ except ImportError:
     pass
 
 
-def update_fields(p):
+def update_fields(module, p):
     '''This updates the module field names
     to match the field names tower-cli expects to make
     calling of the modify/delete methods easier.
@@ -275,9 +283,18 @@ def update_fields(p):
         v = params.pop(old_k)
         params_update[new_k] = v
 
-    extra_vars = params.get('extra_vars_path')
-    if extra_vars is not None:
-        params_update['extra_vars'] = ['@' + extra_vars]
+    extra_vars = params.get('extra_vars')
+    extra_vars_path = params.get('extra_vars_path')
+
+    if extra_vars:
+        params_update['extra_vars'] = [json.dumps(extra_vars)]
+
+    elif extra_vars_path is not None:
+        params_update['extra_vars'] = ['@' + extra_vars_path]
+        module.deprecate(
+            msg='extra_vars_path should not be used anymore. Use \'extra_vars: "{{ lookup(\'file\', \'/path/to/file\') | from_yaml }}"\' instead',
+            version="3.8"
+        )
 
     params.update(params_update)
     return params
@@ -320,6 +337,7 @@ def main():
         forks=dict(type='int'),
         limit=dict(default=''),
         verbosity=dict(type='int', choices=[0, 1, 2, 3, 4], default=0),
+        extra_vars=dict(type='dict', required=False),
         extra_vars_path=dict(type='path', required=False),
         job_tags=dict(default=''),
         force_handlers_enabled=dict(type='bool', default=False),
@@ -350,7 +368,8 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[
             ('credential', 'credentials'),
-            ('vault_credential', 'credentials')
+            ('vault_credential', 'credentials'),
+            ('extra_vars_path', 'extra_vars'),
         ]
     )
 
@@ -364,7 +383,7 @@ def main():
         jt = tower_cli.get_resource('job_template')
 
         params = update_resources(module, module.params)
-        params = update_fields(params)
+        params = update_fields(module, params)
         params['create_on_missing'] = True
 
         try:

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -12,6 +12,7 @@ def test_create_job_template(run_module, admin_user, project, inventory):
     module_args = {
         'name': 'foo', 'playbook': 'helloworld.yml',
         'project': project.name, 'inventory': inventory.name,
+        'extra_vars': {'foo': 'bar'},
         'job_type': 'run',
         'state': 'present'
     }
@@ -19,6 +20,7 @@ def test_create_job_template(run_module, admin_user, project, inventory):
     result = run_module('tower_job_template', module_args, admin_user)
 
     jt = JobTemplate.objects.get(name='foo')
+    assert jt.extra_vars
 
     assert result == {
         "job_template": "foo",

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -20,7 +20,7 @@ def test_create_job_template(run_module, admin_user, project, inventory):
     result = run_module('tower_job_template', module_args, admin_user)
 
     jt = JobTemplate.objects.get(name='foo')
-    assert jt.extra_vars
+    assert jt.extra_vars == '{"foo": "bar"}'
 
     assert result == {
         "job_template": "foo",


### PR DESCRIPTION
##### SUMMARY
Addressing Issue https://github.com/ansible/awx/issues/5167

Previously, the `tower_job_template` module only had `extra_vars_path` as an option.  Now you can directly input vars into a playbook like so:

```
  - awx.awx.tower_job_template:
      name: TEST
      project: demo
      inventory: demo
      playbook: debug.yml
      extra_vars:
        foo: Weeee
```

...with the result:

<img width="1067" alt="Screen Shot 2019-12-04 at 4 17 39 PM" src="https://user-images.githubusercontent.com/28930622/70182754-78820c80-16b2-11ea-9fd0-2e261288b3b8.png">



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```

