### PR TITLE
Fix permissions on projects directory by pre-creating it

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -126,7 +126,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]
 
 # Pre-create things that we need to write to
-RUN for dir in /var/lib/awx/ /var/log/tower/ /projects /.ansible /var/log/nginx /var/lib/nginx /.local; \
+RUN for dir in /var/lib/awx/ /var/log/tower/ /var/lib/awx/projects /.ansible /var/log/nginx /var/lib/nginx /.local; \
   do mkdir -p $dir; chmod -R g+rwx $dir; chgrp -R root $dir; done
 
 RUN for file in /etc/passwd /etc/supervisord.conf \


### PR DESCRIPTION
This broke after https://github.com/ansible/awx/commit/f78c9f357dc9cce2d446fb2eddfc05d6cc3c0fff but people seem to like this functionality so instead of reverting it we can do this.
