### PR TITLE
Fix cases where total_hosts can be wrong

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -11,6 +11,7 @@ import sys
 
 # Django
 from django.conf import settings
+from django.db import connection
 from django.db.models.signals import (
     pre_save,
     post_save,
@@ -140,7 +141,7 @@ def emit_update_inventory_computed_fields(sender, **kwargs):
     except Inventory.DoesNotExist:
         pass
     else:
-        update_inventory_computed_fields.delay(inventory.id, True)
+        connection.on_commit(lambda: update_inventory_computed_fields.delay(inventory.id))
 
 
 def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
@@ -161,7 +162,7 @@ def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
         pass
     else:
         if inventory is not None:
-            update_inventory_computed_fields.delay(inventory.id, True)
+            connection.on_commit(lambda: update_inventory_computed_fields.delay(inventory.id))
 
 
 def rebuild_role_ancestor_list(reverse, model, instance, pk_set, action, **kwargs):


### PR DESCRIPTION
##### SUMMARY
This is a weird history, it is a subset of https://github.com/ansible/awx/pull/2729

This revives specifically the part that addressed the field `total_hosts` having an incorrect count.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
