### PR TITLE
ansible playbook: move to modern syntax

### DIFF
--- a/awx/playbooks/clean_isolated.yml
+++ b/awx/playbooks/clean_isolated.yml
@@ -15,7 +15,9 @@
       ignore_errors: true
 
     - name: remove build artifacts
-      file: path="{{item}}" state=absent
+      file:
+        path: '{{item}}'
+        state: absent
       register: result
       with_items: "{{cleanup_dirs}}"
       until: result is succeeded

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -115,7 +115,8 @@
         - update_insights
 
     - name: Repository Version
-      debug: msg="Repository Version {{ scm_version }}"
+      debug:
+        msg: "Repository Version {{ scm_version }}"
       tags:
         - update_git
         - update_hg
@@ -130,7 +131,8 @@
 
     - block:
         - name: detect requirements.yml
-          stat: path={{project_path|quote}}/roles/requirements.yml
+          stat:
+            path: '{{project_path|quote}}/roles/requirements.yml'
           register: doesRequirementsExist
 
         - name: fetch galaxy roles from requirements.yml
@@ -149,7 +151,8 @@
 
     - block:
         - name: detect collections/requirements.yml
-          stat: path={{project_path|quote}}/collections/requirements.yml
+          stat:
+            path: '{{project_path|quote}}/collections/requirements.yml'
           register: doesCollectionRequirementsExist
 
         - name: fetch galaxy collections from collections/requirements.yml


### PR DESCRIPTION
Move old style syntax to full yaml - for easy mistake detection now that `yamllint` has been enabled on this repository.

Signed-off-by: Yanis Guenane <yguenane@redhat.com>