### PR TITLE
Configurable login redirect

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -62,3 +62,14 @@ register(
     category=_('Authentication'),
     category_slug='authentication',
 )
+register(
+    'LOGIN_REDIRECT_OVERRIDE',
+    field_class=fields.CharField,
+    allow_blank=True,
+    required=False,
+    label=_('Login redirect override URL'),
+    help_text=_('URL to which unauthorized users will be redirected to log in. '
+                'If blank, users will be sent to the Tower login page.'),
+    category=_('Authentication'),
+    category_slug='authentication',
+)

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -60,6 +60,7 @@ class ApiRootView(APIView):
         data['oauth2'] = drf_reverse('api:oauth_authorization_root_view')
         data['custom_logo'] = settings.CUSTOM_LOGO
         data['custom_login_info'] = settings.CUSTOM_LOGIN_INFO
+        data['login_redirect_override'] = settings.LOGIN_REDIRECT_OVERRIDE
         return Response(data)
 
 

--- a/awx/main/views.py
+++ b/awx/main/views.py
@@ -4,7 +4,7 @@
 import json
 
 # Django
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
@@ -97,3 +97,6 @@ def handle_csp_violation(request):
     logger = logging.getLogger('awx')
     logger.error(json.loads(request.body))
     return HttpResponse(content=None)
+
+def handle_login_redirect(request):
+    return HttpResponseRedirect("/#/login")

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -373,6 +373,10 @@ TACACSPLUS_AUTH_PROTOCOL = 'ascii'
 # Note: This setting may be overridden by database settings.
 AUTH_BASIC_ENABLED = True
 
+# If set, specifies a URL that unauthenticated users will be redirected to
+# when trying to access a UI page that requries authentication.
+LOGIN_REDIRECT_OVERRIDE = None
+
 # If set, serve only minified JS for UI.
 USE_MINIFIED_JS = False
 

--- a/awx/ui/client/src/app.js
+++ b/awx/ui/client/src/app.js
@@ -375,7 +375,13 @@ angular
                     if (!/^\/(login|logout)/.test($location.path())) {
                         $rootScope.preAuthUrl = $location.path();
                     }
-                    $location.path('/login');
+                    if ($location.path() !== '/login') {
+                        if (global.$AnsibleConfig.login_redirect_override) {
+                            window.location.replace(global.$AnsibleConfig.login_redirect_override);
+                        } else {
+                            $location.path('/login');
+                        }
+                    }
                 } else {
                     var lastUser = $cookies.getObject('current_user'),
                         timestammp = Store('sessionTime');
@@ -383,7 +389,11 @@ angular
                         var stime = timestammp[lastUser.id].time,
                             now = new Date().getTime();
                         if ((stime - now) <= 0) {
-                            $location.path('/login');
+                            if (global.$AnsibleConfig.login_redirect_override) {
+                                window.location.replace(global.$AnsibleConfig.login_redirect_override);
+                            } else {
+                                $location.path('/login');
+                            }
                         }
                     }
                     // If browser refresh, set the user_is_superuser value

--- a/awx/ui/client/src/app.js
+++ b/awx/ui/client/src/app.js
@@ -375,13 +375,7 @@ angular
                     if (!/^\/(login|logout)/.test($location.path())) {
                         $rootScope.preAuthUrl = $location.path();
                     }
-                    if ($location.path() !== '/login') {
-                        if (global.$AnsibleConfig.login_redirect_override) {
-                            window.location.replace(global.$AnsibleConfig.login_redirect_override);
-                        } else {
-                            $location.path('/login');
-                        }
-                    }
+                    $location.path('/login');
                 } else {
                     var lastUser = $cookies.getObject('current_user'),
                         timestammp = Store('sessionTime');

--- a/awx/ui/client/src/app.js
+++ b/awx/ui/client/src/app.js
@@ -3,6 +3,8 @@ global.$AnsibleConfig = null;
 // Provided via Webpack DefinePlugin in webpack.config.js
 global.$ENV = {};
 
+global.$ConfigResponse = {};
+
 var urlPrefix;
 
 if ($basePath) {

--- a/awx/ui/client/src/app.start.js
+++ b/awx/ui/client/src/app.start.js
@@ -52,7 +52,7 @@ function fetchLocaleStrings (callback) {
 }
 
 function fetchConfig (callback) {
-    const request = $.ajax(`/api`);
+    const request = $.ajax('/api/');
 
     request.done(res => {
         angular.module('awApp').constant('ConfigSettings', res);

--- a/awx/ui/client/src/app.start.js
+++ b/awx/ui/client/src/app.start.js
@@ -15,7 +15,7 @@ function bootstrap (callback) {
             angular.module('I18N').constant('LOCALE', locale);
         }
 
-        fetchConfig((config) => {
+        fetchConfig(() => {
             angular.element(document).ready(() => callback());
         });
     });

--- a/awx/ui/client/src/app.start.js
+++ b/awx/ui/client/src/app.start.js
@@ -55,7 +55,7 @@ function fetchConfig (callback) {
     const request = $.ajax('/api/');
 
     request.done(res => {
-        angular.module('awApp').constant('ConfigSettings', res);
+        global.$ConfigResponse = res;
         if (res.login_redirect_override) {
             if (!document.cookie.split(';').filter((item) => item.includes('userLoggedIn=true')).length && !window.location.href.includes('/#/login')) {
                 window.location.replace(res.login_redirect_override);

--- a/awx/ui/client/src/app.start.js
+++ b/awx/ui/client/src/app.start.js
@@ -15,7 +15,9 @@ function bootstrap (callback) {
             angular.module('I18N').constant('LOCALE', locale);
         }
 
-        angular.element(document).ready(() => callback());
+        fetchConfig((config) => {
+            angular.element(document).ready(() => callback());
+        });
     });
 }
 
@@ -47,6 +49,25 @@ function fetchLocaleStrings (callback) {
     });
 
     request.fail(() => callback({ code: DEFAULT_LOCALE }));
+}
+
+function fetchConfig (callback) {
+    const request = $.ajax(`/api`);
+
+    request.done(res => {
+        angular.module('awApp').constant('ConfigSettings', res);
+        if (res.login_redirect_override) {
+            if (!document.cookie.split(';').filter((item) => item.includes('userLoggedIn=true')).length && !window.location.href.includes('/#/login')) {
+                window.location.replace(res.login_redirect_override);
+            } else {
+                callback();
+            }
+        } else {
+            callback();
+        }
+    });
+
+    request.fail(() => callback());
 }
 
 /**

--- a/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
+++ b/awx/ui/client/src/configuration/forms/system-form/sub-forms/system-misc.form.js
@@ -40,6 +40,10 @@ export default ['i18n', function(i18n) {
             ALLOW_OAUTH2_FOR_EXTERNAL_USERS: {
                 type: 'toggleSwitch',
             },
+            LOGIN_REDIRECT_OVERRIDE: {
+                type: 'text',
+                reset: 'LOGIN_REDIRECT_OVERRIDE'
+            },
             ACCESS_TOKEN_EXPIRE_SECONDS: {
                 type: 'text',
                 reset: 'ACCESS_TOKEN_EXPIRE_SECONDS'

--- a/awx/ui/client/src/login/logout.route.js
+++ b/awx/ui/client/src/login/logout.route.js
@@ -11,11 +11,7 @@ export default {
     route: '/logout',
     controller: ['Authorization', '$state', function(Authorization, $state) {
         Authorization.logout().then( () =>{
-            if (global.$AnsibleConfig.login_redirect_override) {
-                window.location.replace(global.$AnsibleConfig.login_redirect_override);
-            } else {
-                $state.go('signIn');
-            }
+            $state.go('signIn');
         });
 
     }],

--- a/awx/ui/client/src/login/logout.route.js
+++ b/awx/ui/client/src/login/logout.route.js
@@ -11,7 +11,11 @@ export default {
     route: '/logout',
     controller: ['Authorization', '$state', function(Authorization, $state) {
         Authorization.logout().then( () =>{
-            $state.go('signIn');
+            if (global.$AnsibleConfig.login_redirect_override) {
+                window.location.replace(global.$AnsibleConfig.login_redirect_override);
+            } else {
+                $state.go('signIn');
+            }
         });
 
     }],

--- a/awx/ui/client/src/shared/load-config/load-config.factory.js
+++ b/awx/ui/client/src/shared/load-config/load-config.factory.js
@@ -2,7 +2,6 @@ export default
     function LoadConfig($log, $rootScope, $http, Store) {
         return function() {
 
-
             var configSettings = {};
 
             var configInit = function() {
@@ -10,12 +9,11 @@ export default
                 if ($rootScope.loginConfig) {
                     $rootScope.loginConfig.resolve('config loaded');
                 }
+                global.$AnsibleConfig = configSettings;
+                Store('AnsibleConfig', global.$AnsibleConfig);
                 $rootScope.$emit('ConfigReady');
 
                 // Load new hardcoded settings from above
-
-                global.$AnsibleConfig = configSettings;
-                Store('AnsibleConfig', global.$AnsibleConfig);
                 $rootScope.$emit('LoadConfig');
             };
 
@@ -37,6 +35,10 @@ export default
                         $rootScope.custom_login_info = data.custom_login_info;
                     } else {
                         configSettings.custom_login_info = false;
+                    }
+
+                    if (data.login_redirect_override) {
+                        configSettings.login_redirect_override = data.login_redirect_override;
                     }
 
                     configInit();

--- a/awx/ui/client/src/shared/load-config/load-config.factory.js
+++ b/awx/ui/client/src/shared/load-config/load-config.factory.js
@@ -1,57 +1,40 @@
 export default
-    function LoadConfig($log, $rootScope, $http, Store) {
+    function LoadConfig($rootScope, Store, ConfigSettings) {
         return function() {
 
             var configSettings = {};
 
-            var configInit = function() {
-                // Auto-resolving what used to be found when attempting to load local_setting.json
-                if ($rootScope.loginConfig) {
-                    $rootScope.loginConfig.resolve('config loaded');
-                }
-                global.$AnsibleConfig = configSettings;
-                Store('AnsibleConfig', global.$AnsibleConfig);
-                $rootScope.$emit('ConfigReady');
+            if(ConfigSettings.custom_logo) {
+                configSettings.custom_logo = true;
+                $rootScope.custom_logo = ConfigSettings.custom_logo;
+            } else {
+                configSettings.custom_logo = false;
+            }
 
-                // Load new hardcoded settings from above
-                $rootScope.$emit('LoadConfig');
-            };
+            if(ConfigSettings.custom_login_info) {
+                configSettings.custom_login_info = ConfigSettings.custom_login_info;
+                $rootScope.custom_login_info = ConfigSettings.custom_login_info;
+            } else {
+                configSettings.custom_login_info = false;
+            }
 
-            // Retrieve the custom logo information - update configSettings from above
-            $http({
-                method: 'GET',
-                url: '/api/',
-            })
-                .then(function({data}) {
-                    if(data.custom_logo) {
-                        configSettings.custom_logo = true;
-                        $rootScope.custom_logo = data.custom_logo;
-                    } else {
-                        configSettings.custom_logo = false;
-                    }
+            if (ConfigSettings.login_redirect_override) {
+                configSettings.login_redirect_override = ConfigSettings.login_redirect_override;
+            }
 
-                    if(data.custom_login_info) {
-                        configSettings.custom_login_info = data.custom_login_info;
-                        $rootScope.custom_login_info = data.custom_login_info;
-                    } else {
-                        configSettings.custom_login_info = false;
-                    }
+            // Auto-resolving what used to be found when attempting to load local_setting.json
+            if ($rootScope.loginConfig) {
+                $rootScope.loginConfig.resolve('config loaded');
+            }
+            global.$AnsibleConfig = configSettings;
+            Store('AnsibleConfig', global.$AnsibleConfig);
+            $rootScope.$emit('ConfigReady');
 
-                    if (data.login_redirect_override) {
-                        configSettings.login_redirect_override = data.login_redirect_override;
-                    }
-
-                    configInit();
-
-                }).catch(({error}) => {
-                    $log.debug(error);
-                    configInit();
-                });
+            // Load new hardcoded settings from above
+            $rootScope.$emit('LoadConfig');
 
         };
     }
 
 LoadConfig.$inject =
-    [   '$log', '$rootScope', '$http',
-        'Store'
-    ];
+    [ '$rootScope', 'Store', 'ConfigSettings' ];

--- a/awx/ui/client/src/shared/load-config/load-config.factory.js
+++ b/awx/ui/client/src/shared/load-config/load-config.factory.js
@@ -1,25 +1,25 @@
 export default
-    function LoadConfig($rootScope, Store, ConfigSettings) {
+    function LoadConfig($rootScope, Store) {
         return function() {
 
             var configSettings = {};
 
-            if(ConfigSettings.custom_logo) {
+            if(global.$ConfigResponse.custom_logo) {
                 configSettings.custom_logo = true;
-                $rootScope.custom_logo = ConfigSettings.custom_logo;
+                $rootScope.custom_logo = global.$ConfigResponse.custom_logo;
             } else {
                 configSettings.custom_logo = false;
             }
 
-            if(ConfigSettings.custom_login_info) {
-                configSettings.custom_login_info = ConfigSettings.custom_login_info;
-                $rootScope.custom_login_info = ConfigSettings.custom_login_info;
+            if(global.$ConfigResponse.custom_login_info) {
+                configSettings.custom_login_info = global.$ConfigResponse.custom_login_info;
+                $rootScope.custom_login_info = global.$ConfigResponse.custom_login_info;
             } else {
                 configSettings.custom_login_info = false;
             }
 
-            if (ConfigSettings.login_redirect_override) {
-                configSettings.login_redirect_override = ConfigSettings.login_redirect_override;
+            if (global.$ConfigResponse.login_redirect_override) {
+                configSettings.login_redirect_override = global.$ConfigResponse.login_redirect_override;
             }
 
             // Auto-resolving what used to be found when attempting to load local_setting.json
@@ -37,4 +37,4 @@ export default
     }
 
 LoadConfig.$inject =
-    [ '$rootScope', 'Store', 'ConfigSettings' ];
+    [ '$rootScope', 'Store' ];

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -9,6 +9,7 @@ from awx.main.views import (
     handle_404,
     handle_500,
     handle_csp_violation,
+    handle_login_redirect,
 )
 
 
@@ -22,6 +23,7 @@ urlpatterns = [
     url(r'^(?:api/)?404.html$', handle_404),
     url(r'^(?:api/)?500.html$', handle_500),
     url(r'^csp-violation/', handle_csp_violation),
+    url(r'^login/', handle_login_redirect),
 ]
 
 if settings.SETTINGS_MODULE == 'awx.settings.development':


### PR DESCRIPTION
##### SUMMARY

Allow users to specify an internal or external URL to which unauthorized users should be redirected.  This will allow SAML and other social auth users to provide a more seamless login experience.  See https://github.com/ansible/awx/issues/1886.