### PR TITLE
Remove project update blocking

### DIFF
--- a/awx/main/scheduler/dependency_graph.py
+++ b/awx/main/scheduler/dependency_graph.py
@@ -15,7 +15,6 @@ class DependencyGraph(object):
     INVENTORY_UPDATES = 'inventory_updates'
 
     JOB_TEMPLATE_JOBS = 'job_template_jobs'
-    JOB_PROJECT_IDS = 'job_project_ids'
     JOB_INVENTORY_IDS = 'job_inventory_ids'
 
     SYSTEM_JOB = 'system_job'
@@ -41,8 +40,6 @@ class DependencyGraph(object):
         Track runnable job related project and inventory to ensure updates
         don't run while a job needing those resources is running.
         '''
-        # project_id -> True / False
-        self.data[self.JOB_PROJECT_IDS] = {}
         # inventory_id -> True / False
         self.data[self.JOB_INVENTORY_IDS] = {}
 
@@ -66,7 +63,7 @@ class DependencyGraph(object):
 
     def get_now(self):
         return tz_now()
-        
+
     def mark_system_job(self):
         self.data[self.SYSTEM_JOB] = False
 
@@ -81,15 +78,13 @@ class DependencyGraph(object):
 
     def mark_job_template_job(self, job):
         self.data[self.JOB_INVENTORY_IDS][job.inventory_id] = False
-        self.data[self.JOB_PROJECT_IDS][job.project_id] = False
         self.data[self.JOB_TEMPLATE_JOBS][job.job_template_id] = False
 
     def mark_workflow_job(self, job):
         self.data[self.WORKFLOW_JOB_TEMPLATES_JOBS][job.workflow_job_template_id] = False
 
     def can_project_update_run(self, job):
-        return self.data[self.JOB_PROJECT_IDS].get(job.project_id, True) and \
-            self.data[self.PROJECT_UPDATES].get(job.project_id, True)
+        return self.data[self.PROJECT_UPDATES].get(job.project_id, True)
 
     def can_inventory_update_run(self, job):
         return self.data[self.JOB_INVENTORY_IDS].get(job.inventory_source.inventory_id, True) and \

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 
 from awx.main.scheduler import TaskManager
+from awx.main.scheduler.dependency_graph import DependencyGraph
 from awx.main.utils import encrypt_field
 from awx.main.models import WorkflowJobTemplate, JobTemplate
 
@@ -326,3 +327,29 @@ def test_shared_dependencies_launch(default_instance_group, job_template_factory
     iu = [x for x in ii.inventory_updates.all()]
     assert len(pu) == 1
     assert len(iu) == 1
+
+
+@pytest.mark.django_db
+def test_job_not_blocking_project_update(default_instance_group, job_template_factory):
+    objects = job_template_factory('jt', organization='org1', project='proj',
+                                   inventory='inv', credential='cred',
+                                   jobs=["job"])
+    job = objects.jobs["job"]
+    job.instance_group = default_instance_group
+    job.status = "running"
+    job.save()
+
+    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
+        task_manager = TaskManager()
+        task_manager._schedule()
+
+        proj = objects.project
+        project_update = proj.create_project_update()
+        project_update.instance_group = default_instance_group
+        project_update.status = "pending"
+        project_update.save()
+        assert not task_manager.is_job_blocked(project_update)
+
+        dependency_graph = DependencyGraph(None)
+        dependency_graph.add_job(job)
+        assert not dependency_graph.is_job_blocked(project_update)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A running job that has a project update will block that update from running. This fix removes the block.

Adds a functional test that sets up a job in "running" state, and starts a project update that is in "pending" state. Using `TaskManager::is_job_blocked` and `DependenceGraph::is_job_blocked`, assert that the project update is allowed to run.

issue #5153

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
