### PR TITLE
only restrict OAuth2 tokens for external accounts *at creation time*

### DIFF
--- a/awx/main/models/oauth.py
+++ b/awx/main/models/oauth.py
@@ -124,11 +124,6 @@ class OAuth2AccessToken(AbstractAccessToken):
     def is_valid(self, scopes=None):
         valid = super(OAuth2AccessToken, self).is_valid(scopes)
         if valid:
-            try:
-                self.validate_external_users()
-            except oauth2.AccessDeniedError:
-                logger.exception(f'Failed to authenticate {self.user.username}')
-                return False
             self.last_used = now()
 
             def _update_last_used():
@@ -146,5 +141,6 @@ class OAuth2AccessToken(AbstractAccessToken):
                 ).format(external_account))
 
     def save(self, *args, **kwargs):
-        self.validate_external_users()
+        if not self.pk:
+            self.validate_external_users()
         super(OAuth2AccessToken, self).save(*args, **kwargs)

--- a/awx/main/tests/functional/api/test_oauth.py
+++ b/awx/main/tests/functional/api/test_oauth.py
@@ -69,7 +69,7 @@ def test_token_creation_disabled_for_external_accounts(oauth_application, post, 
 
 
 @pytest.mark.django_db
-def test_existing_token_disabled_for_external_accounts(oauth_application, get, post, admin):
+def test_existing_token_enabled_for_external_accounts(oauth_application, get, post, admin):
     UserEnterpriseAuth(user=admin, provider='radius').save()
     url = drf_reverse('api:oauth_authorization_root_view') + 'token/'
     with override_settings(RADIUS_SERVER='example.org', ALLOW_OAUTH2_FOR_EXTERNAL_USERS=True):
@@ -98,9 +98,9 @@ def test_existing_token_disabled_for_external_accounts(oauth_application, get, p
             resp = get(
                 drf_reverse('api:user_me_list', kwargs={'version': 'v2'}),
                 HTTP_AUTHORIZATION='Bearer ' + token,
-                status=401
+                status=200
             )
-            assert b'To establish a login session' in resp.content
+            assert json.loads(resp.content)['results'][0]['username'] == 'admin'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
related: https://github.com/ansible/awx/pull/5477

cc @gamuniz 