### PR TITLE
Refactor Inventory Plugin Module to Import from module_utils

### DIFF
--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -161,7 +161,7 @@ class InventoryModule(BaseInventoryPlugin):
         inventory_url = '/api/v2/inventories/{inv_id}/script/?hostvars=1&towervars=1&all=1'.format(inv_id=inventory_id)
         inventory_url = urljoin(tower_host, inventory_url)
 
-        inventory = self.make_request(request_handler, inventory_url)
+        inventory = make_request(request_handler, inventory_url)
         # To start with, create all the groups.
         for group_name in inventory:
             if group_name != '_meta':
@@ -191,7 +191,7 @@ class InventoryModule(BaseInventoryPlugin):
         # Fetch extra variables if told to do so
         if self.get_option('include_metadata'):
             config_url = urljoin(tower_host, '/api/v2/config/')
-            config_data = self.make_request(request_handler, config_url)
+            config_data = make_request(request_handler, config_url)
             server_data = {}
             server_data['license_type'] = config_data.get('license_info', {}).get('license_type', 'unknown')
             for key in ('version', 'ansible_version'):

--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -100,12 +100,14 @@ inventory_id: the_ID_of_targeted_ansible_tower_inventory
 
 import os
 import re
+
 from ansible.module_utils import six
 from ansible.module_utils.urls import Request
 from ansible.module_utils._text import to_text, to_native
 from ansible.errors import AnsibleOptionsError
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.config.manager import ensure_type
+
 from ..module_utils.ansible_tower import make_request
 
 # Python 2/3 Compatibility

--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -102,13 +102,12 @@ import os
 import re
 
 from ansible.module_utils import six
-from ansible.module_utils.urls import Request
 from ansible.module_utils._text import to_text, to_native
 from ansible.errors import AnsibleOptionsError
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.config.manager import ensure_type
 
-from ..module_utils.ansible_tower import make_request
+from ..module_utils.ansible_tower import make_request, Request
 
 # Python 2/3 Compatibility
 try:

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -33,7 +33,7 @@ import json
 import os
 import traceback
 from ansible.module_utils._text import to_native
-from ansible.module_utils.urls import Request, urllib_error, ConnectionError, socket, httplib
+from ansible.module_utils.urls import urllib_error, ConnectionError, socket, httplib
 from ansible.errors import AnsibleParserError
 
 TOWER_CLI_IMP_ERR = None
@@ -50,7 +50,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
-def make_request(self, request_handler, tower_url):
+def make_request(module, request_handler, tower_url):
     '''
     Makes the request to given URL, handles errors, returns JSON
     '''

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -35,6 +35,7 @@ import traceback
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import urllib_error, ConnectionError, socket, httplib
+from ansible.module_utils.urls import Request  # noqa (the sole purpose of this line is to allow for import into other files)
 from ansible.errors import AnsibleParserError
 
 TOWER_CLI_IMP_ERR = None

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -32,6 +32,7 @@ __metaclass__ = type
 import json
 import os
 import traceback
+
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import urllib_error, ConnectionError, socket, httplib
 from ansible.errors import AnsibleParserError
@@ -50,7 +51,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
-def make_request(module, request_handler, tower_url):
+def make_request(request_handler, tower_url):
     '''
     Makes the request to given URL, handles errors, returns JSON
     '''

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -51,6 +51,10 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
+class CollectionsParserError(Exception):
+    pass
+
+
 def make_request(request_handler, tower_url):
     '''
     Makes the request to given URL, handles errors, returns JSON
@@ -141,7 +145,3 @@ class TowerModule(AnsibleModule):
         if not HAS_TOWER_CLI:
             self.fail_json(msg=missing_required_lib('ansible-tower-cli'),
                            exception=TOWER_CLI_IMP_ERR)
-
-
-class CollectionsParserError(Exception):
-    pass

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -35,8 +35,7 @@ import traceback
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import urllib_error, ConnectionError, socket, httplib
-from ansible.module_utils.urls import Request  # noqa (the sole purpose of this line is to allow for import into other files)
-from ansible.errors import AnsibleParserError
+from ansible.module_utils.urls import Request  # noqa
 
 TOWER_CLI_IMP_ERR = None
 try:
@@ -63,14 +62,14 @@ def make_request(request_handler, tower_url):
         # If Tower gives a readable error message, display that message to the user.
         if callable(getattr(e, 'read', None)):
             n_error_msg += ' with message: {err_msg}'.format(err_msg=to_native(e.read()))
-        raise AnsibleParserError(n_error_msg)
+        raise CollectionsParserError(n_error_msg)
 
     # Attempt to parse JSON.
     try:
         return json.loads(response.read())
     except (ValueError, TypeError) as e:
         # If the JSON parse fails, print the ValueError
-        raise AnsibleParserError('Failed to parse json from host: {err}'.format(err=to_native(e)))
+        raise CollectionsParserError('Failed to parse json from host: {err}'.format(err=to_native(e)))
 
 
 def tower_auth_config(module):
@@ -142,3 +141,7 @@ class TowerModule(AnsibleModule):
         if not HAS_TOWER_CLI:
             self.fail_json(msg=missing_required_lib('ansible-tower-cli'),
                            exception=TOWER_CLI_IMP_ERR)
+
+
+class CollectionsParserError(Exception):
+    pass


### PR DESCRIPTION
##### SUMMARY

Taking initial steps towards migrating Collections off of Tower CLI (per issue https://github.com/ansible/awx/issues/5145)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Collections Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
The goal of this refactor is to simplify where changes will need to happen in regards to the Tower CLI removal work (just in `module_utils` 🤞).
