### PR TITLE
Use job details status to test status

### DIFF
--- a/awx/ui/client/features/output/details.component.js
+++ b/awx/ui/client/features/output/details.component.js
@@ -39,7 +39,7 @@ function getStatusDetails (jobStatus) {
         value = choices[unmapped];
     }
 
-    return { label, icon, value };
+    return { unmapped, label, icon, value };
 }
 
 function getStartDetails (started) {

--- a/awx/ui/client/features/output/details.partial.html
+++ b/awx/ui/client/features/output/details.partial.html
@@ -12,9 +12,9 @@
             class="List-actionButton List-actionButton--delete"
             data-placement="top"
             ng-click="vm.cancelJob()"
-            ng-show="vm.status.value === 'Pending' ||
-                     vm.status.value === 'Waiting' ||
-                     vm.status.value === 'Running'"
+            ng-show="vm.status.unmapped === 'pending' ||
+                     vm.status.unmapped === 'waiting' ||
+                     vm.status.unmapped === 'running'"
             aw-tool-tip="{{:: vm.strings.get('tooltips.CANCEL') }}"
             data-original-title=""
             title="">
@@ -27,11 +27,11 @@
             data-placement="top"
             ng-click="vm.deleteJob()"
             ng-show="vm.canDelete && (
-                   vm.status.value === 'New' ||
-                   vm.status.value === 'Successful' ||
-                   vm.status.value === 'Failed' ||
-                   vm.status.value === 'Error' ||
-                   vm.status.value === 'Canceled')"
+                   vm.status.unmapped === 'new' ||
+                   vm.status.unmapped === 'successful' ||
+                   vm.status.unmapped === 'failed' ||
+                   vm.status.unmapped === 'error' ||
+                   vm.status.unmapped === 'canceled')"
             aw-tool-tip="{{:: vm.strings.get('tooltips.DELETE') }}"
             data-original-title=""
             title="">


### PR DESCRIPTION
##### SUMMARY
#5485 

The status `value`s we store on the job details vm have been mapped through the status `choices` from the OPTIONS data. These values are translated, which we don't want to use for testing when to show the cancel button.
