### PR TITLE
Don't reload template panel on tab change

### DIFF
--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -120,7 +120,7 @@ class Template extends Component {
       tab.id = n;
     });
 
-    let cardHeader = hasContentLoading ? null : (
+    let cardHeader = (
       <CardHeader style={{ padding: 0 }}>
         <RoutedTabs history={history} tabsArray={tabsArray} />
         <CardCloseButton linkTo="/templates" />


### PR DESCRIPTION
##### SUMMARY
Currently, the template panel appears to reload entirely when the user changes tabs. This PR fixes that.