### PR TITLE
Set default value for create_preload_data in image_build role

### DIFF
--- a/installer/roles/image_build/defaults/main.yml
+++ b/installer/roles/image_build/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+create_preload_data: true


### PR DESCRIPTION
This caused our AWX release workflow to blow up
