### PR TITLE
Set a default value for LOGIN_REDIRECT_URL

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -67,6 +67,7 @@ register(
     field_class=fields.CharField,
     allow_blank=True,
     required=False,
+    default='',
     label=_('Login redirect override URL'),
     help_text=_('URL to which unauthorized users will be redirected to log in. '
                 'If blank, users will be sent to the Tower login page.'),


### PR DESCRIPTION
Set a default value for LOGIN_REDIRECT_URL to prevent "this field may not be null"