### PR TITLE
Fix inconsistent warning icon sizes

### DIFF
--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -88,14 +88,16 @@ class TemplateListItem extends Component {
                   </Link>
                 </span>
                 {missingResourceIcon && (
-                  <Tooltip
-                    content={i18n._(
-                      t`Resources are missing from this template.`
-                    )}
-                    position="right"
-                  >
-                    <ExclamationTriangleIcon css="color: #c9190b; margin-left: 20px;" />
-                  </Tooltip>
+                  <span>
+                    <Tooltip
+                      content={i18n._(
+                        t`Resources are missing from this template.`
+                      )}
+                      position="right"
+                    >
+                      <ExclamationTriangleIcon css="color: #c9190b; margin-left: 20px;" />
+                    </Tooltip>
+                  </span>
                 )}
               </LeftDataListCell>,
               <RightDataListCell


### PR DESCRIPTION
##### SUMMARY
**before**
![Screenshot from 2019-12-17 16-16-11](https://user-images.githubusercontent.com/9753817/71034995-9440d600-20e8-11ea-9f6b-d0e0e0289f09.png)




**after**
![Screenshot from 2019-12-17 16-08-29](https://user-images.githubusercontent.com/9753817/71035013-9c991100-20e8-11ea-9508-27757cc07482.png)
