### PR TITLE
Don't complain if LOGIN_REDIRECT_URL is null

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -375,7 +375,7 @@ AUTH_BASIC_ENABLED = True
 
 # If set, specifies a URL that unauthenticated users will be redirected to
 # when trying to access a UI page that requries authentication.
-LOGIN_REDIRECT_OVERRIDE = None
+LOGIN_REDIRECT_OVERRIDE = ''
 
 # If set, serve only minified JS for UI.
 USE_MINIFIED_JS = False


### PR DESCRIPTION
Unlike https://github.com/ansible/awx/pull/5531, this actually fixes the issue where you get `'LOGIN_REDIRECT_OVERRIDE': ['This field may not be null.']` when issuing a PUT to `/api/v2/settings/all` with default values.