### PR TITLE
Add credential_type summarizable fk field

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -141,6 +141,7 @@ SUMMARIZABLE_FK_FIELDS = {
     'target_credential': DEFAULT_SUMMARY_FIELDS + ('kind', 'cloud', 'credential_type_id'),
     'webhook_credential': DEFAULT_SUMMARY_FIELDS,
     'approved_or_denied_by': ('id', 'username', 'first_name', 'last_name'),
+    'credential_type': DEFAULT_SUMMARY_FIELDS,
 }
 
 


### PR DESCRIPTION
##### SUMMARY
This would be most helpful for _several_ ui features. UI needs to display the name of the credential type when listing credentials. There's also quite a few cases where it needs to _categorize_ and _group_ credentials based off of each credential's credential_type info. Adding this information to the summary fields helps avoid many additional api requests and complicated access patterns across the product.

I don't see any reason _not_ to include this in the credential summary fields. I'm curious what others think about this.

#### Additional Information
![Screenshot from 2019-12-18 18-46-30](https://user-images.githubusercontent.com/9753817/71132893-cfb1d200-21c6-11ea-8941-0c862a3ef2aa.png)
