### PR TITLE
Fix to handle Str and JSON mix-in data correctly with AWX CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ clean-api:
 	rm -rf awx/projects
 
 clean-awxkit:
-	rm -rf awxkit/*.egg-info awxkit/.tox
+	rm -rf awxkit/*.egg-info awxkit/.tox awxkit/build/*
 
 # convenience target to assert environment variables are defined
 guard-%:

--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -1,4 +1,5 @@
 import functools
+import json
 
 from six import with_metaclass
 
@@ -539,5 +540,15 @@ class SettingsModify(CustomAction):
 
     def perform(self, key, value):
         self.page.endpoint = self.page.endpoint + 'all/'
-        resp = self.page.patch(**{key: value})
+        patch_value = value
+        if self.is_json(value):
+            patch_value = json.loads(value)
+        resp = self.page.patch(**{key: patch_value})
         return resp.from_json({'key': key, 'value': resp[key]})
+
+    def is_json(self, data):
+        try:
+            json.loads(data)
+        except json.decoder.JSONDecodeError:
+            return False
+        return True


### PR DESCRIPTION
##### SUMMARY

The payload of `awx settings` subcommand should handle both String and JSON structured data.
With this fix, the AWX CLI can handle the following two data formats correctly:

1. String data
```
$ awx setting modify AUTH_LDAP_SERVER_URI "ldap://ldap.example.com:389"
{
     "key": "AUTH_LDAP_SERVER_URI",
     "value": "ldap://ldap.example.com:389"
}
```

2. JSON structured data
```
$ awx setting modify AUTH_LDAP_USER_SEARCH '["DC=example,DC=com","SCOPE_SUBTREE","(uid=%(user)s)"]'
{
     "key": "AUTH_LDAP_USER_SEARCH",
     "value": [
          "DC=example,DC=com",
          "SCOPE_SUBTREE",
          "(uid=%(user)s)"
     ]
}/
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI (CLI)

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION

- Fixed issue #5528
