### PR TITLE
Add ability to specify docker network subnet CIDR and LDAPTLS_REQCERT option

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -159,3 +159,9 @@ secret_key=awxsecret
 # which makes include "optional" - i.e. not fail
 # if file is absent
 #extra_nginx_include="/etc/nginx/awx_extra[.]conf"
+
+# Define ldaptls_reqcert variable and use it in awx_web container to ignore CA certificate
+#ldaptls_reqcert="never"
+
+# Docker compose explicit subnet. Set subnet CIDR to avoid overlapping on your network
+#docker_compose_subnet="172.17.0.1/16"

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -58,6 +58,9 @@ services:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
+    {% if ldaptls_reqcert is defined %}
+      LDAPTLS_REQCERT: "{{ ldaptls_reqcert }}"
+    {% endif %}
 
   task:
     image: {{ awx_task_docker_actual_image }}
@@ -149,3 +152,13 @@ services:
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
   {% endif %}
+
+{% if docker_compose_subnet is defined %}
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet:  {{ docker_compose_subnet }}
+{% endif %}


### PR DESCRIPTION
    [+] Add docker_compose_subnet option / var into inventory and docker-compose.yml.j2
    template, in order to define docker network subnet.
    [+] Add ldaptls_reqcert option / var into inventory and docker-compose.yml.j2
    template, in order to iqnore ssl certs on ldap starttls / tls
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This pr is made in order to be able to define docker subnet network and to ignore ssl certificate when authenticate against ldap servers.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
