### PR TITLE
Add extra_vars Example to Job Launch Module

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -20,6 +20,7 @@ The following notes are changes that may require changes to playbooks.
    `tower_credential_type` module is no longer supported. Provide as dictionaries instead.
  - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
  - Creating a "scan" type job template is no longer supported.
+ - `extra_vars` in the `tower_job_launch` module worked with a list previously, but is now configured to work solely in a `dict` format.
 
 ## Running
 

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -42,17 +42,23 @@ def test_job_launch_with_prompting(run_module, admin_user, project, inventory, m
         name='foo',
         project=project,
         playbook='helloworld.yml',
+        ask_variables_on_launch=True,
         ask_inventory_on_launch=True,
         ask_credential_on_launch=True
     )
     result = run_module('tower_job_launch', dict(
         job_template='foo',
         inventory=inventory.name,
-        credential=machine_credential.name
+        credential=machine_credential.name,
+        extra_vars={"var1": "My First Variable",
+                    "var2": "My Second Variable",
+                    "var3": "My Third Variable"
+                    }
     ), admin_user)
     assert result.pop('changed', None), result
 
     job = Job.objects.get(id=result['id'])
+    assert job.extra_vars == '{"var1": "My First Variable", "var2": "My Second Variable", "var3": "My Third Variable"}'
     assert job.inventory == inventory
     assert [cred.id for cred in job.credentials.all()] == [machine_credential.id]
 


### PR DESCRIPTION
... as well as update the `extra_vars` type to `dict` (to make it consistent with other modules such as the one for Job Templates).

Addressing issue https://github.com/ansible/awx/issues/5558