### PR TITLE
Add a uwsgi param to prevent SAML error

### DIFF
--- a/installer/roles/kubernetes/templates/configmap.yml.j2
+++ b/installer/roles/kubernetes/templates/configmap.yml.j2
@@ -120,6 +120,7 @@ data:
                 include {{ extra_nginx_include }};
                 {%- endif %}
                 proxy_set_header X-Forwarded-Port 443;
+                uwsgi_param HTTP_X_FORWARDED_PORT 443;
             }
         }
     }

--- a/installer/roles/local_docker/templates/nginx.conf.j2
+++ b/installer/roles/local_docker/templates/nginx.conf.j2
@@ -113,6 +113,7 @@ http {
             include {{ extra_nginx_include }};
             {%- endif %}
             proxy_set_header X-Forwarded-Port 443;
+            uwsgi_param HTTP_X_FORWARDED_PORT 443;
         }
     }
 }


### PR DESCRIPTION
Add the uwsgi_param 'HTTP_X_FORWARDED_PORT' to nginx configuration,
This prevents the python-saml "invalid_response" error

related issue : #5570 and #1016

Signed-off-by: loitho

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Hi there, I added the line uwsgi_param HTTP_X_FORWARDED_PORT 443 into the nginx configuration to prevent the following error that happens with the SAML module when running AWX with docker-compose :
> SAML login failed: ['invalid_response'] (The response was received at https://test-awx.com:8053/sso/complete/saml/ instead of https://test-awx.com/sso/complete/saml/


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.1.0
```


##### ADDITIONAL INFORMATION

When the Identity Provider execute the callback back to AWX after a successfully authentication (let's say to "https://test-awx.com/sso/complete/saml/" the call is received by the Nginx server listening on the 8053 port which then "wsgi_pass" the request to the Django server.

The problem is that the Django server then see the request arriving at the 8053 port and throw the error : 
> SAML login failed: ['invalid_response'] (The response was received at https://test-awx.com:8053/sso/complete/saml/ instead of https://test-awx.com/sso/complete/saml/

Because Django determines the port it's running at by checking "HTTP_X_FORWARDED_PORT" and then the "SERVER_PORT"
https://docs.djangoproject.com/fr/3.0/ref/request-response/#django.http.HttpRequest.get_port
And because there wasn't any HTTP_X_FORWARDED_PORT header set for wsgi, it was using the default server port (8053)

Adding the uwsgi_param "HTTP_X_FORWARDED_PORT" prevent Django from throwing the invalid request error and allow for SAML to work

