### PR TITLE
Remove incorrect activity stream entries related to managed types

### DIFF
--- a/awx/main/tests/functional/models/test_activity_stream.py
+++ b/awx/main/tests/functional/models/test_activity_stream.py
@@ -296,3 +296,15 @@ def test_cluster_node_long_node_name(inventory, project):
     # node name is very long, we just want to make sure it does not error
     entry = ActivityStream.objects.filter(job=job).first()
     assert entry.action_node.startswith('ffffff')
+
+
+@pytest.mark.django_db
+def test_credential_defaults_idempotency():
+    CredentialType.setup_tower_managed_defaults()
+    old_inputs = CredentialType.objects.get(name='Ansible Tower', kind='cloud').inputs
+    prior_count = ActivityStream.objects.count()
+    # this is commonly re-ran in migrations, and no changes should be shown
+    # because inputs and injectors are not actually tracked in the database
+    CredentialType.setup_tower_managed_defaults()
+    assert CredentialType.objects.get(name='Ansible Tower', kind='cloud').inputs == old_inputs
+    assert ActivityStream.objects.count() == prior_count

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -379,7 +379,12 @@ def get_allowed_fields(obj, serializer_mapping):
         'oauth2accesstoken': ['last_used'],
         'oauth2application': ['client_secret']
     }
-    field_blacklist = ACTIVITY_STREAM_FIELD_EXCLUSIONS.get(obj._meta.model_name, [])
+    model_name = obj._meta.model_name
+    field_blacklist = ACTIVITY_STREAM_FIELD_EXCLUSIONS.get(model_name, [])
+    # see definition of from_db for CredentialType
+    # injection logic of any managed types are incompatible with activity stream
+    if model_name == 'credentialtype' and obj.managed_by_tower and obj.namespace:
+        field_blacklist.extend(['inputs', 'injectors'])
     if field_blacklist:
         allowed_fields = [f for f in allowed_fields if f not in field_blacklist]
     return allowed_fields


### PR DESCRIPTION
##### SUMMARY
(no issue filed)

Description of issue:

Whenever `CredentialType.setup_tower_managed_defaults()` was ran, `inputs` gets set to nothing:

https://github.com/ansible/awx/blob/e9af6af97c990726185187f423d4e6e346a8e7e2/awx/main/models/credential/__init__.py#L422

But whenever activity stream entries are generated, the `new` object's inputs are found to differ from the `old` object's because the `old` object is given a non-database value on object initialization.

https://github.com/ansible/awx/blob/e9af6af97c990726185187f423d4e6e346a8e7e2/awx/main/models/credential/__init__.py#L367

Thus, as you create a new database and migrate it, you get 6 pages of activity stream entries. The majority of these pages are saying that credential types like "Ansible Tower" are having their inputs and injectors reset to empty dictionary.

That is not what is actually happening, because by that point they had already been empty. This process happens a handful of times during the migration, and all the entries are wrong by any definition of the word.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
6.1.0
```


##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/awx/pull/3257
