### PR TITLE
Do not allow state where no Galaxy servers are enabled

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -903,6 +903,11 @@ def galaxy_validate(serializer, attrs):
             setting_name = '{}{}'.format(prefix, k.upper())
             errors.setdefault(setting_name, [])
             errors[setting_name].append(msg)
+    if not galaxy_data['url']:
+        if _new_value('PUBLIC_GALAXY_ENABLED') is False:
+            errors.setdefault('PUBLIC_GALAXY_ENABLED', [])
+            msg = _('A URL for Primary Galaxy must be defined before disabling public Galaxy.')
+            errors['PUBLIC_GALAXY_ENABLED'].append(msg)
 
     if errors:
         raise serializers.ValidationError(errors)

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1989,8 +1989,9 @@ class RunProjectUpdate(BaseTask):
                     continue
                 env_key = ('ANSIBLE_GALAXY_SERVER_{}_{}'.format(server.get('id', 'unnamed'), key)).upper()
                 env[env_key] = server[key]
-        # now set the precedence of galaxy servers
-        env['ANSIBLE_GALAXY_SERVER_LIST'] = ','.join([server.get('id', 'unnamed') for server in galaxy_servers])
+        if galaxy_servers:
+            # now set the precedence of galaxy servers
+            env['ANSIBLE_GALAXY_SERVER_LIST'] = ','.join([server.get('id', 'unnamed') for server in galaxy_servers])
         return env
 
     def _build_scm_url_extra_vars(self, project_update):


### PR DESCRIPTION
##### SUMMARY
This avoids letting the user configure the server such that there is no place to grab roles from.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.0
```


