### PR TITLE
Generate new uuid for newly registered iso nodes

### DIFF
--- a/awx/main/management/commands/provision_instance.py
+++ b/awx/main/management/commands/provision_instance.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved
 
+from uuid import uuid4
+
 from awx.main.models import Instance
 from django.conf import settings
 
@@ -22,6 +24,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--hostname', dest='hostname', type=str,
                             help='Hostname used during provisioning')
+        parser.add_argument('--is-isolated', dest='is_isolated', action='store_true',
+                            help='Specify whether the instance is isolated')
 
     def _register_hostname(self, hostname):
         if not hostname:
@@ -37,7 +41,10 @@ class Command(BaseCommand):
     def handle(self, **options):
         if not options.get('hostname'):
             raise CommandError("Specify `--hostname` to use this command.")
-        self.uuid = settings.SYSTEM_UUID
+        if options['is_isolated']:
+            self.uuid = str(uuid4())
+        else:
+            self.uuid = settings.SYSTEM_UUID
         self.changed = False
         self._register_hostname(options.get('hostname'))
         if self.changed:

--- a/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
+++ b/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from uuid import uuid4
+
+from django.db import migrations
+
+from awx.main.models import Instance
+
+
+def _generate_new_uuid_for_iso_nodes(apps, schema_editor):
+    for instance in Instance.objects.all():
+        if instance.is_isolated():
+            instance.uuid = str(uuid4())
+            instance.save()
+    
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0100_v370_projectupdate_job_tags'),
+    ]
+
+    operations = [
+        migrations.RunPython(_generate_new_uuid_for_iso_nodes)
+    ]


### PR DESCRIPTION
##### SUMMARY
When provisioning a new isolated node, generate a new uuid instead of
reusing the `SYSTEM_UUID` of the controller node.

