### PR TITLE
[awxkit] Raise a more informative error when timeout

### DIFF
--- a/awxkit/awxkit/api/mixins/has_status.py
+++ b/awxkit/awxkit/api/mixins/has_status.py
@@ -4,6 +4,7 @@ import json
 import six
 
 from awxkit.utils import poll_until
+from awxkit.exceptions import WaitUntilTimeout
 
 
 def bytes_to_str(obj):
@@ -28,7 +29,11 @@ class HasStatus(object):
 
     def wait_until_status(self, status, interval=1, timeout=60, **kwargs):
         status = [status] if not isinstance(status, (list, tuple)) else status
-        poll_until(lambda: getattr(self.get(), 'status') in status, interval=interval, timeout=timeout, **kwargs)
+        try:
+            poll_until(lambda: getattr(self.get(), 'status') in status, interval=interval, timeout=timeout, **kwargs)
+        except WaitUntilTimeout:
+            # This will raise a more informative error than just "WaitUntilTimeout" error
+            self.assert_status(status)
         return self
 
     def wait_until_completed(self, interval=5, timeout=60, **kwargs):


### PR DESCRIPTION
Right now we are often left with very little info if we do get a timeout on something that HasStatus.

Take advantage of the assert_status function that is also available on items using the HasStatus mixin to show
more info.