### PR TITLE
Use summary `object_roles` to lookup admin role id

### DIFF
--- a/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
+++ b/awx/ui/client/src/organizations/linkout/addUsers/addUsers.controller.js
@@ -26,11 +26,9 @@ function($scope, $rootScope, ProcessErrors, GetBasePath, generateList,
         let notAdminAlreadyParams = {};
 
         if ($scope.addType === 'Administrators') {
-            Rest.setUrl(GetBasePath('organizations') + `${$state.params.organization_id}/object_roles`);
+            Rest.setUrl(GetBasePath('organizations') + `${$state.params.organization_id}`);
             Rest.get().then(({data}) => {
-                notAdminAlreadyParams.not__roles = data.results
-                    .filter(({name}) => name === i18n._('Admin'))
-                    .map(({id}) => id)[0];            
+                notAdminAlreadyParams.not__roles = data.summary_fields.object_roles.admin_role.id;
                 init();
             });
         } else {


### PR DESCRIPTION
##### SUMMARY
Issue: #5586 

To find the `id` of an org's admin role, use the `object_role` names in the organization's `summary_fields` instead of filtering on potentially translated role names.

![Screenshot from 2020-01-10 11-22-24](https://user-images.githubusercontent.com/9753817/72169855-e0a4cc00-339d-11ea-917a-a89a41f47878.png)


##### COMPONENT NAME
 - UI
