### PR TITLE
Reduce event data stored in memory by callback receiver

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -66,6 +66,19 @@ class PoolWorker(object):
     def start(self):
         self.process.start()
 
+    @staticmethod
+    def tracking_data(data):
+        '''
+        Returns a dict with keys and values taken from data
+        but only including the entries that are relevant to task management
+        '''
+        new_data = {}
+        for field in ('task', 'uuid', 'args', 'kwargs'):
+            if field not in data:
+                continue
+            new_data[field] = data[field]
+        return new_data
+
     def put(self, body):
         uuid = '?'
         if isinstance(body, dict):
@@ -75,7 +88,7 @@ class PoolWorker(object):
         logger.debug('delivered {} to worker[{}] qsize {}'.format(
             uuid, self.pid, self.qsize
         ))
-        self.managed_tasks[uuid] = body
+        self.managed_tasks[uuid] = self.tracking_data(body)
         self.queue.put(body, block=True, timeout=5)
         self.messages_sent += 1
         self.calculate_managed_tasks()


### PR DESCRIPTION
##### SUMMARY
This is an attempt to reduce the in-memory storage of data related to task processing.

While it applies to dispatcher / callback receiver, the problem of large data is exclusively a callback receiver thing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```


##### ADDITIONAL INFORMATION


```
MAX_EVENT_RES_DATA = 700000
JOB_EVENT_MAX_QUEUE_SIZE = 10000
```

Then `700000*10000=7000000000`, or 7 billion. At 1 to 6 bytes per unicode character, that puts a maximum of 7-42 GB per worker, or 28-168 GB consumption of RAM for the callback receiver process.

Realistic number for extremely lightweight playbooks are more like `10,000*4*2.98 kb=120 MB`. That's for things like debug tasks, and is absurdly unrealistic. It would be much more on queue saturation in the real world. Somewhere in between 120 MB and 168 GB. This should hopefully take it down from those numbers to kb range again (`10,000*4*123 bytes=5 kb`), without scaling concerns beyond that.

