### PR TITLE
Pin setuptools in requirements_setup_requires.txt

### DIFF
--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -1,5 +1,6 @@
 pbr>=1.8
 setuptools_scm>=3.1.0
+setuptools==41.6.0
 vcversioner>=2.16.0.0
 pytest-runner
 isort


### PR DESCRIPTION
This is a file we use downstream to ensure that things under our dependencies'
`setup_requires` are available when we build offline.
