### PR TITLE
Warn Louder When ask_extra_vars Should be Set to True But is Not

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -21,6 +21,7 @@ The following notes are changes that may require changes to playbooks.
  - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
  - Creating a "scan" type job template is no longer supported.
  - `extra_vars` in the `tower_job_launch` module worked with a list previously, but is now configured to work solely in a `dict` format.
+ - When the `extra_vars` parameter is used with the `tower_job_launch` module, the Job Template launch will fail unless `add_extra_vars` or `survey_enabled` is explicitly set to `True` on the Job Template.
 
 ## Running
 

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -126,14 +126,15 @@ def update_fields(module, p):
     extra_vars = params.get('extra_vars')
     try:
         ask_extra_vars = tower_cli.get_resource('job_template').get(name=job_template)['ask_variables_on_launch']
+        survey_enabled = tower_cli.get_resource('job_template').get(name=job_template)['survey_enabled']
     except (exc.ConnectionError, exc.BadRequest, exc.AuthError) as excinfo:
         module.fail_json(msg='Failed to get ask_extra_vars parameter, job template not found: {0}'.format(excinfo), changed=False)
 
-    if extra_vars and ask_extra_vars is not True:
-        module.fail_json(msg="extra_vars is set on launch but the Job Template does not have ask_extra_vars set to True.")
+    if extra_vars and (ask_extra_vars or survey_enabled):
+        params_update['extra_vars'] = [json.dumps(extra_vars)]
 
     elif extra_vars:
-        params_update['extra_vars'] = [json.dumps(extra_vars)]
+        module.fail_json(msg="extra_vars is set on launch but the Job Template does not have ask_extra_vars or survey_enabled set to True.")
 
     params.update(params_update)
     return params


### PR DESCRIPTION
##### SUMMARY
Related to issue https://github.com/ansible/awx/issues/5614

Previously, if `extra_vars` was set on a Job Template at launch (via a playbook task) but the JT's `ask_extra_vars` parameter was absent or not set to True, the task would complete and the `extra_vars` on launch would just silently not show up.  

With this change, the following error prints out and the Job Template with `extra_vars` on launch specified does not run:

![Screen Shot 2020-01-14 at 4 33 55 PM](https://user-images.githubusercontent.com/28930622/72384552-b2035a00-36eb-11ea-9873-9065368e61c7.png)
