### PR TITLE
[WIP] Improve task manager performance for task dependencies

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -37,6 +37,7 @@ from awx.main.utils import decrypt_field
 
 logger = logging.getLogger('awx.main.scheduler')
 
+
 class TaskManager():
 
     def __init__(self):
@@ -463,7 +464,6 @@ class TaskManager():
             if self.is_job_blocked(task):
                 logger.debug("{} is blocked from running".format(task.log_format))
                 continue
-
             preferred_instance_groups = task.preferred_instance_groups
             found_acceptable_queue = False
             idle_instance_that_fits = None

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -553,8 +553,7 @@ class TaskManager():
         self.calculate_capacity_consumed(running_tasks)
 
         self.process_running_tasks(running_tasks)
-        # import sdb
-        # sdb.set_trace()
+
         pending_tasks = [t for t in all_sorted_tasks if t.status == 'pending']
         dependencies = self.generate_dependencies(pending_tasks)
         self.process_pending_tasks(dependencies)

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -421,8 +421,9 @@ class TaskManager():
         return False
 
     def generate_dependencies(self, pending_tasks):
-        dependencies = []
+        all_task_dependencies = []
         for task in pending_tasks:
+            dependencies = []
             if type(task) is Job and not task.dependent_jobs.exists():
                 # TODO: Can remove task.project None check after scan-job-default-playbook is removed
                 if task.project is not None and task.project.scm_update_on_launch is True:
@@ -454,7 +455,8 @@ class TaskManager():
 
                 if len(dependencies) > 0:
                     self.capture_chain_failure_dependencies(task, dependencies)
-        return dependencies
+                    all_task_dependencies.append(dependencies)
+        return all_task_dependencies
 
     def process_pending_tasks(self, pending_tasks):
         running_workflow_templates = set([wf.unified_job_template_id for wf in self.get_running_workflow_jobs()])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Task dependencies include project updates or inventory source updates. The task manager looks through each Job in "pending" state and determines if it needs to launch an associated project update or inventory source update. This part of the task manager is quite slow.

The task manager is not persistent. A new Task Manager object is launched each time (once per 30 seconds, and on external signals). Therefore, it must rediscover the state of running/pending tasks each time.

These changes help alleviate the redundant work the task manager performs each time it is called.

**1.** Remove the method `.process_dependencies()`
This method is nearly a copy and paste of `.process_pending_tasks()`, so we can just call that directly instead 

**2.** Only generate dependencies once for each task
The current task manager will generate/spawn dependencies for pending tasks each time it runs. We only need to do this once. We can check that `task.dependent_jobs.exists()` is None before running `generate_dependencies()`.

Performance:
Calling `TaskManager().schedule()` on 5,000 "pending" state Jobs takes around 8 seconds (vs 200 seconds with the previous TaskManager)

Note, this is the elapsed time after the dependencies have been already generated. Generating dependencies for 5,000 tasks the first time takes a few minutes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.1.1
```
##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
