### PR TITLE
Set reasonable default for MAX_FORKS

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -615,14 +615,15 @@ register(
     category=_('Jobs'),
     category_slug='jobs',
 )
+
 register(
     'MAX_FORKS',
     field_class=fields.IntegerField,
     allow_null=False,
-    default=0,
+    default=200,
     label=_('Maximum number of forks per job.'),
     help_text=_('Saving a Job Template with more than this number of forks will result in an error. '
-                'When set to 0 (the default), no limit is applied.'),
+                'When set to 0, no limit is applied.'),
     category=_('Jobs'),
     category_slug='jobs',
 )


### PR DESCRIPTION
##### SUMMARY
Set a reasonably sane default for `MAX_FORKS`.
https://github.com/ansible/awx/issues/5142