### PR TITLE
do not apply distinct for series of only static fields

### DIFF
--- a/awx/main/tests/unit/api/test_filters.py
+++ b/awx/main/tests/unit/api/test_filters.py
@@ -57,7 +57,7 @@ def test_empty_in(empty_value):
 @pytest.mark.parametrize(u"valid_value", [u'foo', u'foo,'])
 def test_valid_in(valid_value):
     field_lookup = FieldLookupBackend()
-    value, new_lookup = field_lookup.value_to_python(JobTemplate, 'project__name__in', valid_value)
+    value, new_lookup, _ = field_lookup.value_to_python(JobTemplate, 'project__name__in', valid_value)
     assert 'foo' in value
 
 

--- a/awx/main/tests/unit/utils/test_filters.py
+++ b/awx/main/tests/unit/utils/test_filters.py
@@ -79,8 +79,8 @@ class mockHost:
 @mock.patch('awx.main.utils.filters.get_model', return_value=mockHost())
 class TestSmartFilterQueryFromString():
     @mock.patch(
-        'awx.api.filters.get_field_from_path',
-        lambda model, path: (model, path)  # disable field filtering, because a__b isn't a real Host field
+        'awx.api.filters.get_fields_from_path',
+        lambda model, path: ([model], path)  # disable field filtering, because a__b isn't a real Host field
     )
     @pytest.mark.parametrize("filter_string,q_expected", [
         ('facts__facts__blank=""', Q(**{u"facts__facts__blank": u""})),


### PR DESCRIPTION
credit where it's due; this is mostly just @AlanCoding's old PR rebased, with a few minor changes based on review feedback there (https://github.com/ansible/awx/pull/4717) and to fix failing tests

this change drastically speeds up the job list view in the UI when there are hundreds of thousands of jobs

before:

![image](https://user-images.githubusercontent.com/214912/72553838-7e4d3f00-3867-11ea-9a29-03c3f284e14f.png)

after:

![image](https://user-images.githubusercontent.com/214912/72553808-71305000-3867-11ea-9d40-439c8f981d57.png)


