### PR TITLE
Fail Gracefully on tower_job_launch Module When JT is Not Found

### DIFF
--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -127,8 +127,8 @@ def update_fields(module, p):
     try:
         ask_extra_vars = tower_cli.get_resource('job_template').get(name=job_template)['ask_variables_on_launch']
         survey_enabled = tower_cli.get_resource('job_template').get(name=job_template)['survey_enabled']
-    except (exc.ConnectionError, exc.BadRequest, exc.AuthError) as excinfo:
-        module.fail_json(msg='Failed to get ask_extra_vars parameter, job template not found: {0}'.format(excinfo), changed=False)
+    except (exc.NotFound) as excinfo:
+        module.fail_json(msg='Unable to launch job, job_template/{0} was not found: {1}'.format(job_template, excinfo), changed=False)
 
     if extra_vars and (ask_extra_vars or survey_enabled):
         params_update['extra_vars'] = [json.dumps(extra_vars)]

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -125,10 +125,12 @@ def update_fields(module, p):
     job_template = params.get('job_template')
     extra_vars = params.get('extra_vars')
     try:
-        ask_extra_vars = tower_cli.get_resource('job_template').get(name=job_template)['ask_variables_on_launch']
-        survey_enabled = tower_cli.get_resource('job_template').get(name=job_template)['survey_enabled']
+        job_template_to_launch = tower_cli.get_resource('job_template').get(name=job_template)
     except (exc.NotFound) as excinfo:
         module.fail_json(msg='Unable to launch job, job_template/{0} was not found: {1}'.format(job_template, excinfo), changed=False)
+
+    ask_extra_vars = job_template_to_launch['ask_variables_on_launch']
+    survey_enabled = job_template_to_launch['survey_enabled']
 
     if extra_vars and (ask_extra_vars or survey_enabled):
         params_update['extra_vars'] = [json.dumps(extra_vars)]


### PR DESCRIPTION
##### SUMMARY
Currently we get a traceback when the Job Template is not found before a job launch is attempted; with this change, there will be a more helpful and consistent error displayed showing the user that the Job Template does not exist/was unable to be found.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

