### PR TITLE
Add volume and mount for CA trust to management pod

### DIFF
--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -10,6 +10,11 @@ spec:
       image: "{{ kubernetes_task_image }}:{{ kubernetes_task_version }}"
       command: ["sleep", "infinity"]
       volumeMounts:
+{% if ca_trust_dir is defined %}
+        - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+          mountPath: "/etc/pki/ca-trust/source/anchors/"
+          readOnly: true
+{% endif %}
         - name: {{ kubernetes_deployment_name }}-application-config
           mountPath: "/etc/tower/settings.py"
           subPath: settings.py
@@ -46,6 +51,12 @@ spec:
 {{ affinity | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
 {% endif %}
   volumes:
+{% if ca_trust_dir is defined %}
+    - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+      hostPath:
+        path: "{{ ca_trust_dir }}"
+        type: Directory
+{% endif %}
     - name: {{ kubernetes_deployment_name }}-application-config
       configMap:
         name: {{ kubernetes_deployment_name }}-config


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I was having issues running the initial database migrations on an empty database. `awx-manage migrate --noinput` from the installer on the `ansible-tower-management` pod was failing with `psycopg2.OperationalError: root certificate file [redacted] does not exist`. Providing the directory when the variable is set resolves this. This is the exact syntax that the CA path gets passed into the web/task containers in deployment.yml.j2.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.1.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->



<!--- Paste verbatim command output below, e.g. before and after your change -->

