### PR TITLE
Ensures Variables Details renders even when no value.

### DIFF
--- a/awx/ui_next/src/components/CodeMirrorInput/VariablesDetail.jsx
+++ b/awx/ui_next/src/components/CodeMirrorInput/VariablesDetail.jsx
@@ -14,10 +14,6 @@ function VariablesDetail({ value, label, rows }) {
   const [currentValue, setCurrentValue] = useState(value);
   const [error, setError] = useState(null);
 
-  if (!value) {
-    return null;
-  }
-
   return (
     <>
       <DetailName
@@ -62,7 +58,7 @@ function VariablesDetail({ value, label, rows }) {
       >
         <CodeMirrorInput
           mode={mode}
-          value={currentValue}
+          value={currentValue || '---'} // When github issue https://github.com/ansible/awx/issues/5502 gets resolved this line of code should be revisited and refactored if possible.
           readOnly
           rows={rows}
           css="margin-top: 10px"

--- a/awx/ui_next/src/components/CodeMirrorInput/VariablesDetail.test.jsx
+++ b/awx/ui_next/src/components/CodeMirrorInput/VariablesDetail.test.jsx
@@ -40,4 +40,9 @@ describe('<VariablesDetail>', () => {
     expect(input2.prop('mode')).toEqual('yaml');
     expect(input2.prop('value')).toEqual('foo: bar\n');
   });
+  test('should render label and value= --- when there are no values', () => {
+    const wrapper = shallow(<VariablesDetail value="" label="Variables" />);
+    expect(wrapper.find('Styled(CodeMirrorInput)').length).toBe(1);
+    expect(wrapper.find('div.pf-c-form__label').text()).toBe('Variables');
+  });
 });


### PR DESCRIPTION


##### SUMMARY
This addresses #5599.  When there is no value VariablesDetails will show ---.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
9.1
```


##### ADDITIONAL INFORMATION
Before this code the Variables field in a detail view would be absent when there were no variables.
