### PR TITLE
Allow CTiT log level to log bulk_create lines

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1142,8 +1142,7 @@ LOGGING = {
             'handlers': ['null']
         },
         'awx.main.commands.run_callback_receiver': {
-            'handlers': ['callback_receiver'],
-            'level': 'INFO'  # in debug mode, includes full callback data
+            'handlers': ['callback_receiver'],  # level handled by dynamic_level_filter
         },
         'awx.main.dispatch': {
             'handlers': ['dispatcher'],


### PR DESCRIPTION
##### SUMMARY
Problem this addresses:

In a production deployment, provide a way to find the rate of batching of event saves. Example of such log lines:

```
awx_1        | 2020-01-20 17:38:24,370 DEBUG    awx.main.commands.run_callback_receiver JobEvent.objects.bulk_create(653)
awx_1        | 2020-01-20 17:38:24,429 DEBUG    awx.main.models.inventory Going to update inventory computed fields, pk=46
awx_1        | 2020-01-20 17:38:24,461 DEBUG    awx.main.models.inventory Finished updating inventory computed fields, pk=46, in 0.028 seconds
awx_1        | 2020-01-20 17:38:24,512 DEBUG    awx.main.commands.run_callback_receiver task f302561a-7b9b-4764-9e7c-5df9267ca0be is finished
awx_1        | 2020-01-20 17:38:24,617 DEBUG    awx.main.commands.run_callback_receiver JobEvent.objects.bulk_create(485)
```

These will show up in the file for the callback receiver logs (not the tower.log file).

Drawback:

This enables logs related to the callback receiver from the root dispatcher code, which is extremely high volume and looks like this:

```
awx_1        | 2020-01-20 17:38:24,233 DEBUG    awx.main.commands.run_callback_receiver delivered 9ed6f3af-4d70-4b37-9469-21d5ecd41149 to worker[2022] qsize 31
awx_1        | 2020-01-20 17:38:24,235 DEBUG    awx.main.commands.run_callback_receiver delivered c1e639d5-378f-4153-bfa4-d147668a8d2f to worker[2024] qsize 0
awx_1        | 2020-01-20 17:38:24,237 DEBUG    awx.main.commands.run_callback_receiver task a5018914-33f2-4b8b-af17-9700e6973d7f is finished
awx_1        | 2020-01-20 17:38:24,237 DEBUG    awx.main.commands.run_callback_receiver delivered 92c49340-5aab-4dfb-9b9c-8b5acbbd18c2 to worker[2023] qsize 0
awx_1        | 2020-01-20 17:38:24,239 DEBUG    awx.main.commands.run_callback_receiver delivered 80add3d4-ccee-4fad-9e85-2b03fe9cc162 to worker[2023] qsize 0
awx_1        | 2020-01-20 17:38:24,240 DEBUG    awx.main.commands.run_callback_receiver task 92c49340-5aab-4dfb-9b9c-8b5acbbd18c2 is finished
```

For large jobs, these are dramatically higher frequency than the bulk_create lines, and there's no way to get one without the other. No attempt is made to solve that problem.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```

