### PR TITLE
drastically speed up /api/v2/jobs/N/job_events/ with large counts

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3858,8 +3858,7 @@ class JobJobEventsList(BaseJobEventsList):
     def get_queryset(self):
         job = self.get_parent_object()
         self.check_parent_access(job)
-        qs = job.job_events
-        qs = qs.select_related('host')
+        qs = job.job_events.select_related('host').order_by('start_line')
         return qs.all()
 
 


### PR DESCRIPTION
```
awx-dev=> SELECT COUNT(*) FROM main_jobevent;
  count
----------
 37500083
(1 row)
```

(the more total events in the system, the slower this gets)

before:

<img width="366" alt="image" src="https://user-images.githubusercontent.com/214912/72749798-fcbc2080-3b88-11ea-8749-306464b2fc1f.png">

after:

<img width="419" alt="image" src="https://user-images.githubusercontent.com/214912/72749727-d4ccbd00-3b88-11ea-9606-53e5ceb2e761.png">
