### PR TITLE
Pin zipp to avoid setuptools upgrade

### DIFF
--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -12,7 +12,8 @@ backports.functools_lru_cache
 more-itertools==5.0.0
 poetry==0.12.17
 functools32<4.0.0,>=3.2.3; python_version >= "2.7" and python_version < "2.8"
-flit; python_version >= "3.5"
+flit==2.2.0; python_version >= "3.5"
+zipp==0.6.0  # indirect dependency, higher versions will require setuptools>=42
 twine; python_version >= "3.6"
 incremental>=16.10.1; python_version >= "3.6"
 lxml>=3.0; python_version >= "3.6"


### PR DESCRIPTION
##### SUMMARY
In the setup requirements, setuptools goes rogue and installs and updated versions, even though we pinned it. This is because of an indirect requirement. This pins the zipp library so it won't upgrade and then indirectly get that upgraded requirement, which is incompatible with the dependency snapshot otherwise.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```


##### ADDITIONAL INFORMATION
I have made many attempts to do this better

Ultimately, I think _this_ is the direction we should go in:

https://github.com/ansible/awx/compare/devel...AlanCoding:compile_setup?expand=1

That's a lot of work, and it will be a while before it's ready even if someone picks it up.
