### PR TITLE
Fixed deployment for Kubernetes 1.16+

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -89,7 +89,7 @@
         helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
         echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="6.2.1" \
+          --version="8.1.4" \
           --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
           --values - \
           stable/postgresql


### PR DESCRIPTION
Raised postgres chart version.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.1.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
AWX can't be deployed on Kubernetes 1.16 or newer, due to an old Postgres chart dependency.
```
