### PR TITLE
Add delete button to User and Team details

### DIFF
--- a/awx/ui_next/src/screens/Host/HostAdd/HostAdd.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostAdd/HostAdd.test.jsx
@@ -30,7 +30,7 @@ describe('<HostAdd />', () => {
   });
 
   test('handleSubmit should post to api', async () => {
-    act(() => {
+    await act(async () => {
       wrapper.find('HostForm').prop('handleSubmit')(hostData);
     });
     expect(HostsAPI.create).toHaveBeenCalledWith(hostData);
@@ -44,12 +44,14 @@ describe('<HostAdd />', () => {
   test('successful form submission should trigger redirect', async () => {
     HostsAPI.create.mockResolvedValueOnce({
       data: {
-        id: 5,
         ...hostData,
+        id: 5,
       },
     });
     await waitForElement(wrapper, 'button[aria-label="Save"]');
-    await wrapper.find('HostForm').invoke('handleSubmit')(hostData);
+    await act(async () => {
+      wrapper.find('HostForm').invoke('handleSubmit')(hostData);
+    });
     expect(history.location.pathname).toEqual('/hosts/5/details');
   });
 });

--- a/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.test.jsx
+++ b/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.test.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
-
+import { act } from 'react-dom/test-utils';
 import { mountWithContexts, waitForElement } from '@testUtils/enzymeHelpers';
-
 import TeamDetail from './TeamDetail';
+import { TeamsAPI } from '@api';
 
 jest.mock('@api');
 
 describe('<TeamDetail />', () => {
+  let wrapper;
   const mockTeam = {
     name: 'Foo',
     description: 'Bar',
@@ -19,15 +20,25 @@ describe('<TeamDetail />', () => {
       },
       user_capabilities: {
         edit: true,
+        delete: true,
       },
     },
   };
-  test('initially renders succesfully', () => {
-    mountWithContexts(<TeamDetail team={mockTeam} />);
+
+  beforeEach(async () => {
+    wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
   });
 
-  test('should render Details', async done => {
-    const wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  test('initially renders succesfully', async () => {
+    await waitForElement(wrapper, 'TeamDetail');
+  });
+
+  test('should render Details', async () => {
     const testParams = [
       { label: 'Name', value: 'Foo' },
       { label: 'Description', value: 'Bar' },
@@ -42,23 +53,52 @@ describe('<TeamDetail />', () => {
       expect(detail.find('dt').text()).toBe(label);
       expect(detail.find('dd').text()).toBe(value);
     }
-    done();
   });
 
-  test('should show edit button for users with edit permission', async done => {
-    const wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
-    const editButton = await waitForElement(wrapper, 'TeamDetail Button');
+  test('should show edit button for users with edit permission', async () => {
+    const editButton = await waitForElement(
+      wrapper,
+      'TeamDetail Button[aria-label="Edit"]'
+    );
     expect(editButton.text()).toEqual('Edit');
     expect(editButton.prop('to')).toBe('/teams/undefined/edit');
-    done();
   });
 
-  test('should hide edit button for users without edit permission', async done => {
+  test('should hide edit button for users without edit permission', async () => {
     const readOnlyTeam = { ...mockTeam };
     readOnlyTeam.summary_fields.user_capabilities.edit = false;
-    const wrapper = mountWithContexts(<TeamDetail team={readOnlyTeam} />);
+    wrapper = mountWithContexts(<TeamDetail team={readOnlyTeam} />);
     await waitForElement(wrapper, 'TeamDetail');
-    expect(wrapper.find('TeamDetail Button').length).toBe(0);
-    done();
+    expect(wrapper.find('TeamDetail Button[aria-label="Edit"]').length).toBe(0);
+  });
+
+  test('expected api call is made for delete', async () => {
+    await waitForElement(wrapper, 'TeamDetail Button[aria-label="Delete"]');
+    await act(async () => {
+      wrapper.find('DeleteButton').invoke('onConfirm')();
+    });
+    expect(TeamsAPI.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('Error dialog shown for failed deletion', async () => {
+    TeamsAPI.destroy.mockImplementationOnce(() => Promise.reject(new Error()));
+    wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
+    await waitForElement(wrapper, 'TeamDetail Button[aria-label="Delete"]');
+    await act(async () => {
+      wrapper.find('DeleteButton').invoke('onConfirm')();
+    });
+    await waitForElement(
+      wrapper,
+      'Modal[title="Error!"]',
+      el => el.length === 1
+    );
+    await act(async () => {
+      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
+    });
+    await waitForElement(
+      wrapper,
+      'Modal[title="Error!"]',
+      el => el.length === 0
+    );
   });
 });

--- a/awx/ui_next/src/screens/User/UserDetail/UserDetail.test.jsx
+++ b/awx/ui_next/src/screens/User/UserDetail/UserDetail.test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
 import { mountWithContexts, waitForElement } from '@testUtils/enzymeHelpers';
+import { UsersAPI } from '@api';
 import UserDetail from './UserDetail';
 import mockDetails from '../data.user.json';
+
+jest.mock('@api');
 
 describe('<UserDetail />', () => {
   test('initially renders succesfully', () => {
@@ -39,7 +43,36 @@ describe('<UserDetail />', () => {
     assertDetail('Created', `10/28/2019, 3:01:07 PM`);
   });
 
-  test('should show edit button for users with edit permission', async done => {
+  test('User Type Detail should render expected strings', async () => {
+    let wrapper;
+    wrapper = mountWithContexts(
+      <UserDetail
+        user={{
+          ...mockDetails,
+          is_superuser: false,
+          is_system_auditor: true,
+        }}
+      />
+    );
+    expect(wrapper.find(`Detail[label="User Type"] dd`).text()).toBe(
+      'System Auditor'
+    );
+
+    wrapper = mountWithContexts(
+      <UserDetail
+        user={{
+          ...mockDetails,
+          is_superuser: false,
+          is_system_auditor: false,
+        }}
+      />
+    );
+    expect(wrapper.find(`Detail[label="User Type"] dd`).text()).toBe(
+      'Normal User'
+    );
+  });
+
+  test('should show edit button for users with edit permission', async () => {
     const wrapper = mountWithContexts(<UserDetail user={mockDetails} />);
     const editButton = await waitForElement(
       wrapper,
@@ -47,10 +80,9 @@ describe('<UserDetail />', () => {
     );
     expect(editButton.text()).toEqual('Edit');
     expect(editButton.prop('to')).toBe(`/users/${mockDetails.id}/edit`);
-    done();
   });
 
-  test('should hide edit button for users without edit permission', async done => {
+  test('should hide edit button for users without edit permission', async () => {
     const wrapper = mountWithContexts(
       <UserDetail
         user={{
@@ -65,7 +97,6 @@ describe('<UserDetail />', () => {
     );
     await waitForElement(wrapper, 'UserDetail');
     expect(wrapper.find('UserDetail Button[aria-label="edit"]').length).toBe(0);
-    done();
   });
 
   test('edit button should navigate to user edit', () => {
@@ -78,5 +109,36 @@ describe('<UserDetail />', () => {
       .find('Button[aria-label="edit"] Link')
       .simulate('click', { button: 0 });
     expect(history.location.pathname).toEqual('/users/1/edit');
+  });
+
+  test('expected api call is made for delete', async () => {
+    const wrapper = mountWithContexts(<UserDetail user={mockDetails} />);
+    await waitForElement(wrapper, 'UserDetail Button[aria-label="Delete"]');
+    await act(async () => {
+      wrapper.find('DeleteButton').invoke('onConfirm')();
+    });
+    expect(UsersAPI.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('Error dialog shown for failed deletion', async () => {
+    UsersAPI.destroy.mockImplementationOnce(() => Promise.reject(new Error()));
+    const wrapper = mountWithContexts(<UserDetail user={mockDetails} />);
+    await waitForElement(wrapper, 'UserDetail Button[aria-label="Delete"]');
+    await act(async () => {
+      wrapper.find('DeleteButton').invoke('onConfirm')();
+    });
+    await waitForElement(
+      wrapper,
+      'Modal[title="Error!"]',
+      el => el.length === 1
+    );
+    await act(async () => {
+      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
+    });
+    await waitForElement(
+      wrapper,
+      'Modal[title="Error!"]',
+      el => el.length === 0
+    );
   });
 });

--- a/awx/ui_next/src/screens/User/data.user.json
+++ b/awx/ui_next/src/screens/User/data.user.json
@@ -18,7 +18,7 @@
   "summary_fields": {
       "user_capabilities": {
           "edit": true,
-          "delete": false
+          "delete": true
       }
   },
   "created": "2019-10-28T15:01:07.218634Z",


### PR DESCRIPTION
##### SUMMARY
As part of: https://github.com/ansible/awx/issues/4984

* Add delete button to User and Team details
* Update unit tests
* Fix HostAdd unit test error 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ADDITIONAL INFORMATION
<img width="529" alt="Screen Shot 2020-01-23 at 5 55 12 PM" src="https://user-images.githubusercontent.com/15881645/73031268-a4e01c80-3e09-11ea-8df1-971352da1dca.png">
<img width="532" alt="Screen Shot 2020-01-23 at 5 54 46 PM" src="https://user-images.githubusercontent.com/15881645/73031269-a578b300-3e09-11ea-9ee9-cafae5ea57bd.png">

