### PR TITLE
remove another expensive logging lookup in the parent callback process

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -72,9 +72,6 @@ class PoolWorker(object):
             if not body.get('uuid'):
                 body['uuid'] = str(uuid4())
             uuid = body['uuid']
-        logger.debug('delivered {} to worker[{}] qsize {}'.format(
-            uuid, self.pid, self.qsize
-        ))
         self.managed_tasks[uuid] = body
         self.queue.put(body, block=True, timeout=5)
         self.messages_sent += 1


### PR DESCRIPTION
this line is causing us to hit `memcached` constantly, and even though memcached is fast, it *does* have a cost in throughput when you're talking about hundreds of thousands of calls

also, in production environments, this line doesn't even get written to any log files by default anyways, so it's literally pointless overhead

before:

![image](https://user-images.githubusercontent.com/214912/73094874-7caaf900-3eaf-11ea-9128-e20756f5d775.png)

after:

![image](https://user-images.githubusercontent.com/214912/73094883-82084380-3eaf-11ea-8a92-c4443b40d029.png)

On an `m5.4xl` with reasonable IOPS and `settings.JOB_EVENT_WORKERS = 8`, this drastically improves event write speed:

![image](https://user-images.githubusercontent.com/214912/73095286-36a26500-3eb0-11ea-9863-956c55edfcdd.png)
