### PR TITLE
[POC] experiment with pageless pagination for job events

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -136,7 +136,7 @@ class FieldLookupBackend(BaseFilterBackend):
     Filter using field lookups provided via query string parameters.
     '''
 
-    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by',
+    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'after',
                       'search', 'type', 'host_filter', 'count_disabled', 'no_truncate')
 
     SUPPORTED_LOOKUPS = ('exact', 'iexact', 'contains', 'icontains',

--- a/awx/api/pagination.py
+++ b/awx/api/pagination.py
@@ -2,8 +2,10 @@
 # All Rights Reserved.
 
 # Django REST Framework
+import collections
 from django.conf import settings
 from django.core.paginator import Paginator as DjangoPaginator
+from django.template import loader
 from rest_framework import pagination
 from rest_framework.response import Response
 from rest_framework.utils.urls import replace_query_param
@@ -18,6 +20,68 @@ class DisabledPaginator(DjangoPaginator):
     @property
     def count(self):
         return 200
+
+
+class LargeScalePagination(pagination.PageNumberPagination):
+
+    page_size_query_param = 'page_size'
+    max_page_size = settings.MAX_PAGE_SIZE
+
+    def paginate_queryset(self, queryset, request, view=None):
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+        self.order_by = request.query_params.get('order_by') or 'id'
+        after = request.query_params.get('after')
+        operation = 'gt'
+        if self.order_by.startswith('-'):
+            self.order_by = self.order_by[1:]
+            operation = 'lt'
+        if after:
+            queryset = queryset.filter(**{f'{self.order_by}__{operation}': after})
+        self.request = request
+        results = list(queryset[:(page_size + 1)])
+        self.more_pages = len(results) > page_size
+        return results[:page_size]
+
+    def get_paginated_response(self, data):
+        return Response(collections.OrderedDict([
+            ('next', self.get_next_link(data)),
+            #('previous', self.get_previous_link(data)),
+            ('results', data)
+        ]))
+
+    def get_next_link(self, data):
+        if not self.more_pages:
+            return None
+        url = self.request and self.request.get_full_path() or ''
+        url = url.encode('utf-8')
+        return replace_query_param(url, 'after', data[-1][self.order_by])
+
+    def get_previous_link(self, data):
+        url = self.request.build_absolute_uri()
+        return url
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            'type': 'object',
+            'properties': {
+                'next': {
+                    'type': 'string',
+                    'nullable': True,
+                },
+                #'previous': {
+                #    'type': 'string',
+                #    'nullable': True,
+                #},
+                'results': schema,
+            },
+        }
+
+    def to_html(self):
+        template = loader.get_template(self.template)
+        context = self.get_html_context()
+        return template.render(context)
 
 
 class Pagination(pagination.PageNumberPagination):

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -71,6 +71,7 @@ from awx.api.generics import (
     SubListCreateAPIView, SubListCreateAttachDetachAPIView,
     SubListDestroyAPIView
 )
+from awx.api.pagination import LargeScalePagination
 from awx.api.versioning import reverse
 from awx.main import models
 from awx.main.utils import (
@@ -3777,6 +3778,7 @@ class JobEventList(NoTruncateMixin, ListAPIView):
     model = models.JobEvent
     serializer_class = serializers.JobEventSerializer
     search_fields = ('stdout',)
+    pagination_class = LargeScalePagination
 
 
 class JobEventDetail(RetrieveAPIView):
@@ -3854,11 +3856,12 @@ class GroupJobEventsList(BaseJobEventsList):
 class JobJobEventsList(BaseJobEventsList):
 
     parent_model = models.Job
+    pagination_class = LargeScalePagination
 
     def get_queryset(self):
         job = self.get_parent_object()
         self.check_parent_access(job)
-        qs = job.job_events.select_related('host').order_by('start_line')
+        qs = job.job_events.select_related('host')
         return qs.all()
 
 


### PR DESCRIPTION
cc @jakemcdermott 

related: https://github.com/ansible/awx/pull/5679
related: https://github.com/ansible/awx/issues/5590

<img width="722" alt="image" src="https://user-images.githubusercontent.com/214912/73116578-a04d5e00-3f06-11ea-9935-98cbbf8fe0d7.png">

```shell
~ curl -ks "https://awx/api/v2/jobs/10/job_events/?order_by=-counter" | jq '.results[] | "\(.counter) \(.start_line) \(.event)"'
"56 154 playbook_on_stats"
"55 154 runner_on_ok"
"54 151 runner_item_on_ok"
"53 148 runner_item_on_ok"
"52 145 runner_item_on_ok"
"51 142 runner_item_on_ok"
"50 139 runner_item_on_ok"
"49 136 runner_item_on_ok"
"48 133 runner_item_on_ok"
"47 130 runner_item_on_ok"
"46 127 runner_item_on_ok"
"45 124 runner_item_on_ok"
"44 121 runner_item_on_ok"
"43 118 runner_item_on_ok"
"42 115 runner_item_on_ok"
"41 112 runner_item_on_ok"
"40 109 runner_item_on_ok"
"39 106 runner_item_on_ok"
"38 103 runner_item_on_ok"
"37 100 runner_item_on_ok"
"36 97 runner_item_on_ok"
"35 94 runner_item_on_ok"
"34 91 runner_item_on_ok"
"33 88 runner_item_on_ok"
"32 85 runner_item_on_ok"
~ curl -ks "https://awx/api/v2/jobs/10/job_events/?order_by=-counter" | jq '.next'
"https://awx/api/v2/jobs/10/job_events/?after=32&order_by=-counter"
~ curl -ks "https://awx/api/v2/jobs/10/job_events/?after=32&order_by=-counter" | jq '.results[] | "\(.counter) \(.start_line) \(.event)"'
"31 82 runner_item_on_ok"
"30 79 runner_item_on_ok"
"29 76 runner_item_on_ok"
"28 73 runner_item_on_ok"
"27 70 runner_item_on_ok"
"26 67 runner_item_on_ok"
"25 64 runner_item_on_ok"
"24 61 runner_item_on_ok"
"23 58 runner_item_on_ok"
"22 55 runner_item_on_ok"
"21 52 runner_item_on_ok"
"20 49 runner_item_on_ok"
"19 46 runner_item_on_ok"
"18 43 runner_item_on_ok"
"17 40 runner_item_on_ok"
"16 37 runner_item_on_ok"
"15 34 runner_item_on_ok"
"14 31 runner_item_on_ok"
"13 28 runner_item_on_ok"
"12 25 runner_item_on_ok"
"11 22 runner_item_on_ok"
"10 19 runner_item_on_ok"
"9 16 runner_item_on_ok"
"8 13 runner_item_on_ok"
"7 10 runner_item_on_ok"
~ curl -ks "https://awx/api/v2/jobs/10/job_events/?after=7&order_by=-counter" | jq '.results[] | "\(.counter) \(.start_line) \(.event)"'
"6 7 runner_item_on_ok"
"5 4 runner_item_on_ok"
"4 4 runner_on_start"
"3 2 playbook_on_task_start"
"2 0 playbook_on_play_start"
"1 0 playbook_on_start"
~ curl -ks "https://awx/api/v2/jobs/10/job_events/?after=7&order_by=-counter" | jq '.next'
null
```