### PR TITLE
add the ability to enable profiling for the callback receiver workers

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1222,6 +1222,9 @@ AWX_REQUEST_PROFILE = False
 #
 AWX_REQUEST_PROFILE_WITH_DOT = False
 
+# Allow profiling callback workers via SIGUSR1
+AWX_CALLBACK_PROFILE = False
+
 # Delete temporary directories created to store playbook run-time
 AWX_CLEANUP_PATHS = True
 


### PR DESCRIPTION
this is what I've been using to profile the callback receiver and draw graphs like this:

![image](https://user-images.githubusercontent.com/214912/73190099-72793c80-40f3-11ea-8e7e-978ab1061ec6.png)
