### PR TITLE
Make AWX compatible with Helm 3.x

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -20,7 +20,6 @@ dockerhub_base=ansible
 # Kubernetes Install
 # kubernetes_context=test-cluster
 # kubernetes_namespace=awx
-# tiller_namespace=kube-system
 # Optional Kubernetes Variables
 # pg_image_registry=docker.io
 # pg_serviceaccount=awx

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -86,11 +86,11 @@
 
     - name: Deploy and Activate Postgres (Kubernetes)
       shell: |
-        helm repo update --tiller-namespace={{ tiller_namespace | default('kube-system') }}
-        echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} --install \
+        helm repo update
+        echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} \
+          --install \
           --namespace {{ kubernetes_namespace }} \
           --version="6.2.1" \
-          --tiller-namespace={{ tiller_namespace | default('kube-system') }} \
           --values - \
           stable/postgresql
       register: kubernetes_pg_activate

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -93,6 +93,7 @@
 
     - name: Deploy and Activate Postgres (Kubernetes)
       shell: |
+        helm repo add stable https://kubernetes-charts.storage.googleapis.com
         helm repo update
         helm upgrade {{ postgresql_service_name }} \
           --install \

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -79,19 +79,26 @@
 
 - name: Deploy PostgreSQL (Kubernetes)
   block:
-    - name: Template PostgreSQL Deployment (Kubernetes)
-      set_fact:
-        pg_values: "{{ lookup('template', 'postgresql-values.yml.j2') }}"
+    - name: Create Temporary Values File (Kubernetes)
+      tempfile:
+        state: file
+        suffix: .yml
+      register: values_file
+
+    - name: Populate Temporary Values File (Kubernetes)
+      template:
+        src: postgresql-values.yml.j2
+        dest: "{{ values_file.path }}"
       no_log: true
 
     - name: Deploy and Activate Postgres (Kubernetes)
       shell: |
         helm repo update
-        echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} \
+        helm upgrade {{ postgresql_service_name }} \
           --install \
           --namespace {{ kubernetes_namespace }} \
           --version="8.1.5" \
-          --values - \
+          --values {{ values_file.path }} \
           stable/postgresql
       register: kubernetes_pg_activate
       no_log: true

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -98,7 +98,7 @@
         helm upgrade {{ postgresql_service_name }} \
           --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="8.1.5" \
+          --version="8.3.0" \
           --values {{ values_file.path }} \
           stable/postgresql
       register: kubernetes_pg_activate

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -103,6 +103,11 @@
           stable/postgresql
       register: kubernetes_pg_activate
       no_log: true
+
+    - name: Remove tempfile
+      file:
+        path: "{{ values_file.path }}"
+        state: absent
   when:
     - pg_hostname is not defined or pg_hostname == ''
     - postgres_svc_details is defined and postgres_svc_details.rc != 0

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -90,7 +90,7 @@
         echo {{ pg_values | quote }} | helm upgrade {{ postgresql_service_name }} \
           --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="6.2.1" \
+          --version="8.1.5" \
           --values - \
           stable/postgresql
       register: kubernetes_pg_activate


### PR DESCRIPTION
##### SUMMARY
In issue #5371, an incompatibility with older Helm 2.x (using tiller)
was found.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 9.1.1
```
##### ADDITIONAL INFORMATION
Future installs will require Helm 3.x.
Tested with Helm 3.0.2.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>