### PR TITLE
requirements_setup_requires: Top limit wheel to less than 42.0.0

### DIFF
--- a/requirements/requirements_setup_requires.txt
+++ b/requirements/requirements_setup_requires.txt
@@ -7,7 +7,7 @@ isort
 virtualenv
 m2r
 cffi>=1.1
-wheel>=0.33.6
+wheel>=0.33.6,<42.0.0
 backports.functools_lru_cache
 more-itertools==5.0.0
 poetry==0.12.17


### PR DESCRIPTION
Signed-off-by: Yanis Guenane <yguenane@redhat.com>
