### PR TITLE
Open collection config 'r' for py3 compatibility

### DIFF
--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -91,7 +91,7 @@ def tower_auth_config(module):
         if os.path.isdir(config_file):
             module.fail_json(msg='directory can not be used as config file: %s' % config_file)
 
-        with open(config_file, 'rb') as f:
+        with open(config_file, 'r') as f:
             return parser.string_to_dict(f.read())
     else:
         auth_config = {}


### PR DESCRIPTION
##### SUMMARY
This fixes using the k=v file format for the `tower_config_file` with python 3 and the AWX collection, which currently on works in python 2

##### COMPONENT NAME
- AWX Collection

##### AWX VERSION
awx: 9.1.1