### PR TITLE
Make possible to not start containers on compose

### DIFF
--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -18,3 +18,5 @@ memcached_image: "memcached"
 memcached_version: "alpine"
 memcached_hostname: "memcached"
 memcached_port: "11211"
+
+compose_start_containers: true

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -23,16 +23,18 @@
     mode: 0600
   register: awx_secret_key
 
-- name: Start the containers
-  docker_compose:
-    project_src: "{{ docker_compose_dir }}"
-    restarted: "{{ awx_compose_config is changed or awx_secret_key is changed }}"
-  register: awx_compose_start
+- block:
+    - name: Start the containers
+      docker_compose:
+        project_src: "{{ docker_compose_dir }}"
+        restarted: "{{ awx_compose_config is changed or awx_secret_key is changed }}"
+      register: awx_compose_start
 
-- name: Update CA trust in awx_web container
-  command: docker exec awx_web '/usr/bin/update-ca-trust'
-  when: awx_compose_config.changed or awx_compose_start.changed
+    - name: Update CA trust in awx_web container
+      command: docker exec awx_web '/usr/bin/update-ca-trust'
+      when: awx_compose_config.changed or awx_compose_start.changed
 
-- name: Update CA trust in awx_task container
-  command: docker exec awx_task '/usr/bin/update-ca-trust'
-  when: awx_compose_config.changed or awx_compose_start.changed
+    - name: Update CA trust in awx_task container
+      command: docker exec awx_task '/usr/bin/update-ca-trust'
+      when: awx_compose_config.changed or awx_compose_start.changed
+  when: compose_start_containers|bool

--- a/installer/roles/local_docker/tasks/main.yml
+++ b/installer/roles/local_docker/tasks/main.yml
@@ -47,6 +47,7 @@
   file:
     path: "{{ postgres_data_dir + '/pgdata' }}"
     state: absent
+  when: compose_start_containers|bool
 
 - import_tasks: set_image.yml
 - import_tasks: compose.yml


### PR DESCRIPTION
##### SUMMARY
When upgrading from releases it could happen that you need to do some
manual steps (i.e. upgrading from postgres 9.6 to 10). In these cases
you'd want to check the docker-compose.yml and then launch it by
yourself.
Today we don't have any method to get just the files that will be used
while installing via compose, without starting the containers. This
commit adds a variable named "compose_start_containers" (true by
default) that, if false, will make the playbook just generate the files
in the compose directory and not start the containers.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.1.1
```


##### ADDITIONAL INFORMATION
