### PR TITLE
Add proxy support in custom venv container fixes #5756

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -154,9 +154,22 @@ spec:
       serviceAccountName: awx
       terminationGracePeriodSeconds: 10
 {% if custom_venvs is defined %}
+{% set trusted_hosts = "" %}
       initContainers:
         - image: 'centos:7'
           name: init-custom-venvs
+{% if http_proxy is defined or https_proxy is defined %}
+{% set trusted_hosts = "--trusted-host pypi.org --trusted-host files.pythonhosted.org --trusted-host pypi.python.org" %}
+          env:
+{% if http_proxy is defined %}
+            - name: http_proxy
+              value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy is defined %}
+            - name: https_proxy
+              value: {{ https_proxy }}
+{% endif %}
+{% endif %}
           command:
             - sh
             - '-c'
@@ -169,10 +182,10 @@ spec:
               virtualenv -p {{ custom_venv.python | default(custom_venvs_python) }} \
                 {{ custom_venvs_path }}/{{ custom_venv.name }} &&
               source {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/activate &&
-              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install -U psutil \
+              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install {{ trusted_hosts }} -U psutil \
                 "ansible=={{ custom_venv.python_ansible_version }}" &&
 {% if custom_venv.python_modules is defined %}
-              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install -U \
+              {{ custom_venvs_path }}/{{ custom_venv.name }}/bin/pip install {{ trusted_hosts }} -U \
                 {% for module in custom_venv.python_modules %}{{ module }} {% endfor %} &&
 {% endif %}
               deactivate &&

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -169,6 +169,10 @@ spec:
             - name: https_proxy
               value: {{ https_proxy }}
 {% endif %}
+{% if no_proxy is defined %}
+            - name: no_proxy
+              value: {{ no_proxy }}
+{% endif %}
 {% endif %}
           command:
             - sh


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes #5756. It supports the http_proxy, https_proxy, and no_proxy environment variables in the init container that generates custom virtual environments. Pip and yum will pick up on these environment variables automatically and send their traffic through the proxies.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

