### PR TITLE
use existing version of Instance

### DIFF
--- a/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
+++ b/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
@@ -3,15 +3,14 @@ from uuid import uuid4
 
 from django.db import migrations
 
-from awx.main.models import Instance
-
 
 def _generate_new_uuid_for_iso_nodes(apps, schema_editor):
+    Instance = apps.get_model('main', 'Instance')
     for instance in Instance.objects.all():
         if instance.is_isolated():
             instance.uuid = str(uuid4())
             instance.save()
-    
+
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
* Without this change, future modifications to the Instance object may
result in migration fails (i.e. adding a field to the Instance model)
