### PR TITLE
fix instance migration is_isolated() issue

### DIFF
--- a/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
+++ b/awx/main/migrations/0101_v370_generate_new_uuids_for_iso_nodes.py
@@ -7,7 +7,10 @@ from django.db import migrations
 def _generate_new_uuid_for_iso_nodes(apps, schema_editor):
     Instance = apps.get_model('main', 'Instance')
     for instance in Instance.objects.all():
-        if instance.is_isolated():
+        # The below code is a copy paste of instance.is_isolated()
+        # We can't call is_isolated because we are using the "old" version
+        # of the Instance definition.
+        if instance.rampart_groups.filter(controller__isnull=False).exists():
             instance.uuid = str(uuid4())
             instance.save()
 


### PR DESCRIPTION
* Older versions of Instance model code may not contain the
is_isolated() method. This change accounts for that fact.
