### PR TITLE
Style job output pagination control bar

### DIFF
--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -15,25 +15,21 @@ import ContentError from '@components/ContentError';
 import ContentLoading from '@components/ContentLoading';
 import JobEvent from './JobEvent';
 import JobEventSkeleton from './JobEventSkeleton';
-import MenuControls from './MenuControls';
+import PageControls from './PageControls';
 import HostEventModal from './HostEventModal';
 
 const OutputHeader = styled.div`
   font-weight: var(--pf-global--FontWeight--bold);
 `;
-const OutputToolbar = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`;
+
 const OutputWrapper = styled.div`
-  height: calc(100vh - 350px);
   background-color: #fafafa;
-  margin-top: 24px;
-  font-family: monospace;
-  font-size: 15px;
-  outline: 1px solid #d7d7d7;
   display: flex;
   flex-direction: column;
+  font-family: monospace;
+  font-size: 15px;
+  height: calc(100vh - 350px);
+  outline: 1px solid #d7d7d7;
 `;
 const OutputFooter = styled.div`
   background-color: #ebebeb;
@@ -310,14 +306,12 @@ class JobOutput extends Component {
           />
         )}
         <OutputHeader>{job.name}</OutputHeader>
-        <OutputToolbar>
-          <MenuControls
-            onScrollFirst={this.handleScrollFirst}
-            onScrollLast={this.handleScrollLast}
-            onScrollNext={this.handleScrollNext}
-            onScrollPrevious={this.handleScrollPrevious}
-          />
-        </OutputToolbar>
+        <PageControls
+          onScrollFirst={this.handleScrollFirst}
+          onScrollLast={this.handleScrollLast}
+          onScrollNext={this.handleScrollNext}
+          onScrollPrevious={this.handleScrollPrevious}
+        />
         <OutputWrapper>
           <InfiniteLoader
             isRowLoaded={this.isRowLoaded}

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.test.jsx
@@ -21,14 +21,14 @@ async function checkOutput(wrapper, expectedLines) {
 }
 
 async function findScrollButtons(wrapper) {
-  const menuControls = await waitForElement(wrapper, 'MenuControls');
-  const scrollFirstButton = menuControls.find(
+  const pageControls = await waitForElement(wrapper, 'PageControls');
+  const scrollFirstButton = pageControls.find(
     'button[aria-label="scroll first"]'
   );
-  const scrollLastButton = menuControls.find(
+  const scrollLastButton = pageControls.find(
     'button[aria-label="scroll last"]'
   );
-  const scrollPreviousButton = menuControls.find(
+  const scrollPreviousButton = pageControls.find(
     'button[aria-label="scroll previous"]'
   );
   return {

--- a/awx/ui_next/src/screens/Job/JobOutput/PageControls.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/PageControls.jsx
@@ -10,26 +10,25 @@ import {
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-  display: grid;
-  grid-gap: 20px;
-  grid-template-columns: repeat(5, 1fr);
+  display: flex;
+  height: 35px;
+  outline: 1px solid #d7d7d7;
+  width: 100%;
 `;
 
 const Button = styled(PFButton)`
-  &:hover {
-    background-color: #0066cc;
-    color: white;
-  }
+  position: relative;
+  z-index: 1;
 `;
 
-const MenuControls = ({
+const PageControls = ({
   onScrollFirst,
   onScrollLast,
   onScrollNext,
   onScrollPrevious,
 }) => (
   <Wrapper>
-    <Button variant="plain">
+    <Button variant="plain" css="margin-right: auto">
       <PlusIcon />
     </Button>
     <Button
@@ -51,4 +50,4 @@ const MenuControls = ({
   </Wrapper>
 );
 
-export default MenuControls;
+export default PageControls;

--- a/awx/ui_next/src/screens/Job/JobOutput/PageControls.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/PageControls.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import MenuControls from './MenuControls';
+import PageControls from './PageControls';
 
 let wrapper;
 let PlusIcon;
@@ -17,14 +17,14 @@ const findChildren = () => {
   AngleDownIcon = wrapper.find('AngleDownIcon');
 };
 
-describe('MenuControls', () => {
+describe('PageControls', () => {
   test('should render successfully', () => {
-    wrapper = mount(<MenuControls />);
+    wrapper = mount(<PageControls />);
     expect(wrapper).toHaveLength(1);
   });
 
   test('should render menu control icons', () => {
-    wrapper = mount(<MenuControls />);
+    wrapper = mount(<PageControls />);
     findChildren();
     expect(PlusIcon.length).toBe(1);
     expect(AngleDoubleUpIcon.length).toBe(1);


### PR DESCRIPTION
##### SUMMARY
* Rename MenuControls component to PageControls
* Position job output page control buttons on top of standard out 
* Add an outline border around page control button container

<img width="924" alt="Screen Shot 2020-02-05 at 11 32 34 AM" src="https://user-images.githubusercontent.com/15881645/73867105-11004e80-4814-11ea-8e85-f7d00895124e.png">

![hovstyle](https://user-images.githubusercontent.com/15881645/73879000-a4904a00-4829-11ea-8a4a-7251f4ba92af.gif)

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

