### PR TITLE
fix scary error message on initial (install time) awx-manage migrate

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -87,7 +87,7 @@ def _ctit_db_wrapper(trans_safe=False):
         yield
     except DBError:
         if trans_safe:
-            if 'check_migrations' not in sys.argv:
+            if 'migrate' not in sys.argv and 'check_migrations' not in sys.argv:
                 logger.exception('Database settings are not available, using defaults.')
         else:
             logger.exception('Error modifying something related to database settings.')


### PR DESCRIPTION
cc @AlanCoding I've noticed this every time I install awx, and it's kind of noisy; looks potentially related to: https://github.com/ansible/awx/commit/3dd8e490c660aee5090eae507760963333979dbd

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/214912/73933758-28d6e180-48ab-11ea-8d81-dff6e5044f23.png">