### PR TITLE
Add job event summary toolbar

### DIFF
--- a/awx/ui_next/src/components/DeleteButton/DeleteButton.jsx
+++ b/awx/ui_next/src/components/DeleteButton/DeleteButton.jsx
@@ -5,17 +5,24 @@ import { Button } from '@patternfly/react-core';
 import AlertModal from '@components/AlertModal';
 import { CardActionsRow } from '@components/Card';
 
-function DeleteButton({ onConfirm, modalTitle, name, i18n }) {
+function DeleteButton({
+  onConfirm,
+  modalTitle,
+  name,
+  i18n,
+  variant,
+  children,
+}) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
       <Button
-        variant="danger"
+        variant={variant || 'danger'}
         aria-label={i18n._(t`Delete`)}
         onClick={() => setIsOpen(true)}
       >
-        {i18n._(t`Delete`)}
+        {children || i18n._(t`Delete`)}
       </Button>
       <AlertModal
         isOpen={isOpen}

--- a/awx/ui_next/src/components/VerticalSeparator/VerticalSeparator.jsx
+++ b/awx/ui_next/src/components/VerticalSeparator/VerticalSeparator.jsx
@@ -5,7 +5,7 @@ const Separator = styled.span`
   display: inline-block;
   width: 1px;
   height: 30px;
-  margin-right: 27px;
+  margin-right: 20px;
   margin-left: 20px;
   background-color: #d7d7d7;
   vertical-align: middle;

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -1,4 +1,7 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
 import styled from 'styled-components';
 import {
   AutoSizer,
@@ -8,18 +11,39 @@ import {
   List,
 } from 'react-virtualized';
 
+import AlertModal from '@components/AlertModal';
 import { CardBody } from '@components/Card';
 import ContentError from '@components/ContentError';
 import ContentLoading from '@components/ContentLoading';
+import ErrorDetail from '@components/ErrorDetail';
+import { StatusIcon } from '@components/Sparkline';
+
 import JobEvent from './JobEvent';
 import JobEventSkeleton from './JobEventSkeleton';
 import PageControls from './PageControls';
 import HostEventModal from './HostEventModal';
-import { HostStatusBar } from './shared';
-import { JobsAPI } from '@api';
+import { HostStatusBar, OutputToolbar } from './shared';
+import {
+  JobsAPI,
+  ProjectUpdatesAPI,
+  SystemJobsAPI,
+  WorkflowJobsAPI,
+  InventoriesAPI,
+  AdHocCommandsAPI,
+} from '@api';
+
+const HeaderTitle = styled.div`
+  display: inline-flex;
+  align-items: center;
+  h1 {
+    margin-left: 10px;
+    font-weight: var(--pf-global--FontWeight--bold);
+  }
+`;
 
 const OutputHeader = styled.div`
-  font-weight: var(--pf-global--FontWeight--bold);
+  display: flex;
+  justify-content: space-between;
 `;
 
 const OutputWrapper = styled.div`
@@ -31,6 +55,7 @@ const OutputWrapper = styled.div`
   height: calc(100vh - 350px);
   outline: 1px solid #d7d7d7;
 `;
+
 const OutputFooter = styled.div`
   background-color: #ebebeb;
   border-right: 1px solid #d7d7d7;
@@ -52,6 +77,7 @@ class JobOutput extends Component {
     this.listRef = React.createRef();
     this.state = {
       contentError: null,
+      deletionError: null,
       hasContentLoading: true,
       results: {},
       currentlyLoading: [],
@@ -67,6 +93,7 @@ class JobOutput extends Component {
 
     this._isMounted = false;
     this.loadJobEvents = this.loadJobEvents.bind(this);
+    this.handleDeleteJob = this.handleDeleteJob.bind(this);
     this.rowRenderer = this.rowRenderer.bind(this);
     this.handleHostEventClick = this.handleHostEventClick.bind(this);
     this.handleHostModalClose = this.handleHostModalClose.bind(this);
@@ -140,6 +167,34 @@ class JobOutput extends Component {
             n => !loadRange.includes(n)
           ),
         }));
+    }
+  }
+
+  async handleDeleteJob() {
+    const { job, history } = this.props;
+    try {
+      switch (job.type) {
+        case 'project_update':
+          await ProjectUpdatesAPI.destroy(job.idd);
+          break;
+        case 'system_job':
+          await SystemJobsAPI.destroy(job.id);
+          break;
+        case 'workflow_job':
+          await WorkflowJobsAPI.destroy(job.id);
+          break;
+        case 'ad_hoc_command':
+          await AdHocCommandsAPI.destroy(job.id);
+          break;
+        case 'inventory_update':
+          await InventoriesAPI.destroy(job.id);
+          break;
+        default:
+          await JobsAPI.destroy(job.id);
+      }
+      history.push('/jobs');
+    } catch (err) {
+      this.setState({ deletionError: err });
     }
   }
 
@@ -279,9 +334,11 @@ class JobOutput extends Component {
   }
 
   render() {
-    const { job } = this.props;
+    const { job, i18n } = this.props;
+
     const {
       contentError,
+      deletionError,
       hasContentLoading,
       hostEvent,
       isHostModalOpen,
@@ -305,7 +362,13 @@ class JobOutput extends Component {
             hostEvent={hostEvent}
           />
         )}
-        <OutputHeader>{job.name}</OutputHeader>
+        <OutputHeader>
+          <HeaderTitle>
+            <StatusIcon status={job.status} />
+            <h1>{job.name}</h1>
+          </HeaderTitle>
+          <OutputToolbar job={job} onDelete={this.handleDeleteJob} />
+        </OutputHeader>
         <HostStatusBar counts={job.host_status_counts} />
         <PageControls
           onScrollFirst={this.handleScrollFirst}
@@ -345,9 +408,20 @@ class JobOutput extends Component {
           </InfiniteLoader>
           <OutputFooter />
         </OutputWrapper>
+        {deletionError && (
+          <AlertModal
+            isOpen={deletionError}
+            variant="danger"
+            onClose={() => this.setState({ deletionError: null })}
+            title={i18n._(t`Job Delete Error`)}
+          >
+            <ErrorDetail error={deletionError} />
+          </AlertModal>
+        )}
       </CardBody>
     );
   }
 }
 
-export default JobOutput;
+export { JobOutput as _JobOutput };
+export default withI18n()(withRouter(JobOutput));

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -175,7 +175,7 @@ class JobOutput extends Component {
     try {
       switch (job.type) {
         case 'project_update':
-          await ProjectUpdatesAPI.destroy(job.idd);
+          await ProjectUpdatesAPI.destroy(job.id);
           break;
         case 'system_job':
           await SystemJobsAPI.destroy(job.id);

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import styled from 'styled-components';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import { shape, func } from 'prop-types';
+import {
+  DownloadIcon,
+  RocketIcon,
+  TrashAltIcon,
+} from '@patternfly/react-icons';
+import { Badge as PFBadge, Button, Tooltip } from '@patternfly/react-core';
+import VerticalSeparator from '@components/VerticalSeparator';
+import DeleteButton from '@components/DeleteButton';
+import LaunchButton from '@components/LaunchButton';
+
+const BadgeGroup = styled.div`
+  margin-left: 20px;
+  height: 18px;
+  display: inline-flex;
+`;
+
+const Badge = styled(PFBadge)`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-left: 10px;
+  ${props =>
+    props.color
+      ? `
+  background-color: ${props.color}
+  color: white;
+  `
+      : null}
+`;
+
+const Wrapper = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+  font-size: 14px;
+`;
+
+function toHHMMSS(s) {
+  function pad(n) {
+    return `00${n}`.slice(-2);
+  }
+
+  const secs = s % 60;
+  s = (s - secs) / 60;
+  const mins = s % 60;
+  const hrs = (s - mins) / 60;
+
+  return `${pad(hrs)}:${pad(mins)}:${pad(secs)}`;
+}
+
+const OUTPUT_NO_COUNT_JOB_TYPES = [
+  'ad_hoc_command',
+  'system_job',
+  'inventory_update',
+];
+
+const OutputToolbar = ({ i18n, job, onDelete }) => {
+  const hideCounts = OUTPUT_NO_COUNT_JOB_TYPES.includes(job.type);
+
+  const playCount = job?.playbook_counts?.play_count;
+  const taskCount = job?.playbook_counts?.task_count;
+  const darkCount = job?.host_status_counts?.dark;
+  const failureCount = job?.host_status_counts?.failures;
+  const totalHostCount = Object.keys(job?.host_status_counts).reduce(
+    (sum, key) => sum + job?.host_status_counts[key],
+    0
+  );
+
+  return (
+    <Wrapper>
+      {!hideCounts && (
+        <>
+          {playCount > 0 && (
+            <BadgeGroup aria-label={i18n._(t`Play Count`)}>
+              <div>{i18n._(t`Plays`)}</div>
+              <Badge isRead>{playCount}</Badge>
+            </BadgeGroup>
+          )}
+          {taskCount > 0 && (
+            <BadgeGroup aria-label={i18n._(t`Task Count`)}>
+              <div>{i18n._(t`Tasks`)}</div>
+              <Badge isRead>{taskCount}</Badge>
+            </BadgeGroup>
+          )}
+          {totalHostCount > 0 && (
+            <BadgeGroup aria-label={i18n._(t`Host Count`)}>
+              <div>{i18n._(t`Hosts`)}</div>
+              <Badge isRead>{totalHostCount}</Badge>
+            </BadgeGroup>
+          )}
+          {darkCount > 0 && (
+            <BadgeGroup aria-label={i18n._(t`Unreachable Host Count`)}>
+              <div>{i18n._(t`Unreachable`)}</div>
+              <Tooltip content={i18n._(t`Unreachable Hosts`)}>
+                <Badge color="#470000" isRead>
+                  {darkCount}
+                </Badge>
+              </Tooltip>
+            </BadgeGroup>
+          )}
+          {failureCount > 0 && (
+            <BadgeGroup aria-label={i18n._(t`Failed Host Count`)}>
+              <div>{i18n._(t`Failed`)}</div>
+              <Tooltip content={i18n._(t`Failed Hosts`)}>
+                <Badge color="#C9190B" isRead>
+                  {failureCount}
+                </Badge>
+              </Tooltip>
+            </BadgeGroup>
+          )}
+        </>
+      )}
+
+      <BadgeGroup aria-label={i18n._(t`Elapsed Time`)}>
+        <div>{i18n._(t`Elapsed`)}</div>
+        <Tooltip content={i18n._(t`Elapsed time that the job ran`)}>
+          <Badge isRead>{toHHMMSS(job.elapsed)}</Badge>
+        </Tooltip>
+      </BadgeGroup>
+
+      <VerticalSeparator />
+
+      {job.type !== 'system_job' &&
+        job.summary_fields.user_capabilities?.start && (
+          <Tooltip content={i18n._(t`Relaunch Job`)}>
+            <LaunchButton resource={job} aria-label={i18n._(t`Relaunch`)}>
+              {({ handleRelaunch }) => (
+                <Button variant="plain" onClick={handleRelaunch}>
+                  <RocketIcon />
+                </Button>
+              )}
+            </LaunchButton>
+          </Tooltip>
+        )}
+
+      {job.related?.stdout && (
+        <Tooltip content={i18n._(t`Download Output`)}>
+          <a href={`${job.related.stdout}?format=txt_download`}>
+            <Button variant="plain">
+              <DownloadIcon />
+            </Button>
+          </a>
+        </Tooltip>
+      )}
+
+      {job.summary_fields.user_capabilities.delete && (
+        <Tooltip content={i18n._(t`Delete Job`)}>
+          <DeleteButton
+            name={job.name}
+            modalTitle={i18n._(t`Delete Job`)}
+            onConfirm={onDelete}
+            variant="plain"
+          >
+            <TrashAltIcon />
+          </DeleteButton>
+        </Tooltip>
+      )}
+    </Wrapper>
+  );
+};
+
+OutputToolbar.propTypes = {
+  job: shape({}).isRequired,
+  onDelete: func.isRequired,
+};
+
+export default withI18n()(OutputToolbar);

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
@@ -41,17 +41,16 @@ const Wrapper = styled.div`
 `;
 
 const toHHMMSS = elapsed => {
-  const pad = n => {
-    return `00${n}`.slice(-2);
-  };
+  const sec_num = parseInt(elapsed, 10);
+  const hours = Math.floor(sec_num / 3600);
+  const minutes = Math.floor(sec_num / 60) % 60;
+  const seconds = sec_num % 60;
 
-  const date = new Date();
-  date.setTime(elapsed * 1000);
-  const hrs = date.getUTCHours();
-  const mins = date.getUTCMinutes();
-  const secs = date.getUTCSeconds();
+  const stampHours = hours < 10 ? `0${hours}` : hours;
+  const stampMinutes = minutes < 10 ? `0${minutes}` : minutes;
+  const stampSeconds = seconds < 10 ? `0${seconds}` : seconds;
 
-  return `${pad(hrs)}:${pad(mins)}:${pad(secs)}`;
+  return `${stampHours}:${stampMinutes}:${stampSeconds}`;
 };
 
 const OUTPUT_NO_COUNT_JOB_TYPES = [
@@ -67,7 +66,7 @@ const OutputToolbar = ({ i18n, job, onDelete }) => {
   const taskCount = job?.playbook_counts?.task_count;
   const darkCount = job?.host_status_counts?.dark;
   const failureCount = job?.host_status_counts?.failures;
-  const totalHostCount = Object.keys(job?.host_status_counts).reduce(
+  const totalHostCount = Object.keys(job?.host_status_counts || {}).reduce(
     (sum, key) => sum + job?.host_status_counts[key],
     0
   );

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
@@ -40,18 +40,19 @@ const Wrapper = styled.div`
   font-size: 14px;
 `;
 
-function toHHMMSS(s) {
-  function pad(n) {
+const toHHMMSS = elapsed => {
+  const pad = n => {
     return `00${n}`.slice(-2);
-  }
+  };
 
-  const secs = s % 60;
-  s = (s - secs) / 60;
-  const mins = s % 60;
-  const hrs = (s - mins) / 60;
+  const date = new Date();
+  date.setTime(elapsed * 1000);
+  const hrs = date.getUTCHours();
+  const mins = date.getUTCMinutes();
+  const secs = date.getUTCSeconds();
 
   return `${pad(hrs)}:${pad(mins)}:${pad(secs)}`;
-}
+};
 
 const OUTPUT_NO_COUNT_JOB_TYPES = [
   'ad_hoc_command',

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
@@ -67,6 +67,22 @@ describe('<OutputToolbar />', () => {
     expect(wrapper.find('div[aria-label="Failed Host Count"]').length).toBe(0);
   });
 
+  test('should display elapsed time as HH:MM:SS', () => {
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          elapsed: 274265,
+        }}
+        onDelete={() => {}}
+      />
+    );
+
+    expect(wrapper.find('div[aria-label="Elapsed Time"] Badge').text()).toBe(
+      '76:11:05'
+    );
+  });
+
   test('should hide relaunch button based on user capabilities', () => {
     expect(wrapper.find('LaunchButton').length).toBe(1);
     wrapper = mountWithContexts(

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { mountWithContexts } from '@testUtils/enzymeHelpers';
+import { OutputToolbar } from '.';
+import mockJobData from '../../shared/data.job.json';
+
+describe('<OutputToolbar />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          host_status_counts: {
+            dark: 1,
+            failures: 2,
+          },
+        }}
+        onDelete={() => {}}
+      />
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  test('initially renders without crashing', () => {
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should hide badge counts based on job type', () => {
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{ ...mockJobData, type: 'system_job' }}
+        onDelete={() => {}}
+      />
+    );
+    expect(wrapper.find('div[aria-label="Play Count"]').length).toBe(0);
+    expect(wrapper.find('div[aria-label="Task Count"]').length).toBe(0);
+    expect(wrapper.find('div[aria-label="Host Count"]').length).toBe(0);
+    expect(
+      wrapper.find('div[aria-label="Unreachable Host Count"]').length
+    ).toBe(0);
+    expect(wrapper.find('div[aria-label="Failed Host Count"]').length).toBe(0);
+    expect(wrapper.find('div[aria-label="Elapsed Time"]').length).toBe(1);
+  });
+
+  test('should hide badge if count is equal to zero', () => {
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          host_status_counts: {},
+          playbook_counts: {},
+        }}
+        onDelete={() => {}}
+      />
+    );
+
+    expect(wrapper.find('div[aria-label="Play Count"]').length).toBe(0);
+    expect(wrapper.find('div[aria-label="Task Count"]').length).toBe(0);
+    expect(wrapper.find('div[aria-label="Host Count"]').length).toBe(0);
+    expect(
+      wrapper.find('div[aria-label="Unreachable Host Count"]').length
+    ).toBe(0);
+    expect(wrapper.find('div[aria-label="Failed Host Count"]').length).toBe(0);
+  });
+
+  test('should hide relaunch button based on user capabilities', () => {
+    expect(wrapper.find('LaunchButton').length).toBe(1);
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          summary_fields: {
+            user_capabilities: {
+              start: false,
+            },
+          },
+        }}
+        onDelete={() => {}}
+      />
+    );
+    expect(wrapper.find('LaunchButton').length).toBe(0);
+  });
+
+  test('should hide delete button based on user capabilities', () => {
+    expect(wrapper.find('DeleteButton').length).toBe(1);
+    wrapper = mountWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          summary_fields: {
+            user_capabilities: {
+              delete: false,
+            },
+          },
+        }}
+        onDelete={() => {}}
+      />
+    );
+    expect(wrapper.find('DeleteButton').length).toBe(0);
+  });
+});

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/index.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/index.jsx
@@ -1,5 +1,6 @@
+export { default as HostStatusBar } from './HostStatusBar';
 export { default as JobEventLine } from './JobEventLine';
 export { default as JobEventLineToggle } from './JobEventLineToggle';
 export { default as JobEventLineNumber } from './JobEventLineNumber';
 export { default as JobEventLineText } from './JobEventLineText';
-export { default as HostStatusBar } from './HostStatusBar';
+export { default as OutputToolbar } from './OutputToolbar';


### PR DESCRIPTION
##### SUMMARY
Part of: https://github.com/ansible/awx/issues/4221 and https://github.com/ansible/awx/issues/4222

Job Results Header Additions:
- Display Job Name
- Display Job Status
- Display Plays count
- Display Tasks count
- Display Hosts count
- Display Host failed and unreachable count
- Display Elapsed Time
- Hook-up relaunch button
- Hook-up download button
- Hook-up delete button

- Hide count badge if job type is an ad_hoc_command, system_job, inventory_update, or if count is 0

<img width="1282" alt="Screen Shot 2020-02-07 at 2 00 12 PM" src="https://user-images.githubusercontent.com/15881645/74057565-33c86980-49b2-11ea-815f-1028ffdb220a.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ITEMS NOT ADDRESSED
- Add dropdown to filter output by status
- Add dropdown to filter output by verbosity level 
