### PR TITLE
k8s installer: fix warning when applying deployment

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -194,8 +194,8 @@
     "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"
   with_items:
     - 'configmap'
-    - 'deployment'
     - 'secret'
+    - 'deployment'
   no_log: true
 
 - name: Apply Deployment
@@ -203,8 +203,8 @@
     echo {{ item | quote }} | {{ kubectl_or_oc }} apply -f -
   with_items:
     - "{{ configmap }}"
-    - "{{ deployment }}"
     - "{{ secret }}"
+    - "{{ deployment }}"
   no_log: true
 
 - name: Delete any existing management pod


### PR DESCRIPTION
##### SUMMARY
Fixes a warning when deploying the Kubernetes config map, secret and deployment templates.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.1.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The warning appears when the deployment template is applied but the secret object doesn't yet exist.
<!--- Paste verbatim command output below, e.g. before and after your change -->

