### PR TITLE
Allow preserving schedules with prevent_teardown

### DIFF
--- a/awxkit/awxkit/api/pages/schedules.py
+++ b/awxkit/awxkit/api/pages/schedules.py
@@ -2,13 +2,23 @@ from awxkit.api.pages import UnifiedJob
 from awxkit.api.resources import resources
 import awxkit.exceptions as exc
 from awxkit.utils import suppress
+from awxkit.config import config
 from . import page
 from . import base
 
 
 class Schedule(UnifiedJob):
 
-    pass
+    def silent_delete(self):
+        """If we are told to prevent_teardown of schedules, then keep them
+        but do not leave them activated, or system will be swamped quickly"""
+        try:
+            if not config.prevent_teardown:
+                return self.delete()
+            else:
+                self.patch(enabled=False)
+        except (exc.NoContent, exc.NotFound, exc.Forbidden):
+            pass
 
 
 page.register_page([resources.schedule,


### PR DESCRIPTION
##### SUMMARY
The standard practice of awxkit scripts is to do `jt.add_schedule()`. However, this circumvents the logic that is typically used for collecting the items to delete at the end of an atomic rollback, or deleting a transient set of resources.

This differs from `org.add_user(user)`, because the `user` object already exists, and thus, is already registered. The add_schedule method is just an outlier in this respect.

This matters for the case where I _don't_ want to clean up resources, and run awxkit with `AWXKIT_PREVENT_TEARDOWN=1` set. That puts the client script author in a pickle. If schedules are left lying around _and_ active, they will keep firing off jobs and will swamp the system (I have experienced exactly this). But the schedule can't be registered through the normal cleanup methods! That means that simply overwriting `Schedule.silent_delete` won't work either, ugh.

Thus, this PR. It is an acceptable practice to make "your" own objects in such a method, if you clean up after yourself.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```

