### PR TITLE
Add wording for control message log

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -61,7 +61,7 @@ class AWXConsumer(ConsumerMixin):
         ])
 
     def control(self, body, message):
-        logger.warn(body)
+        logger.warn('Consumer received control message {}'.format(body))
         control = body.get('control')
         if control in ('status', 'running'):
             producer = Producer(


### PR DESCRIPTION
##### SUMMARY
As my server dies, I see logs like this:

```
2020-02-11 13:38:40,248 WARNING  awx.main.dispatch scaling up worker pid:8168
2020-02-11 13:38:40,402 INFO     awx.main.commands.run_callback_receiver Event processing is finished for Job 1392, sending notifications
2020-02-11 13:38:40,579 WARNING  awx.main.dispatch scaling up worker pid:8307
2020-02-11 13:38:40,954 WARNING  awx.main.dispatch checking dispatcher running for localhost
2020-02-11 13:38:40,997 WARNING  awx.main.dispatch {'control': 'running'}
2020-02-11 13:38:41,711 INFO     awx.main.commands.run_callback_receiver Event processing is finished for Job 1396, sending notifications
2020-02-11 13:38:41,723 INFO     awx.main.commands.run_callback_receiver Event processing is finished for Job 1395, sending notifications
```

This just makes it so that the WARNING carries some context with it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```
