### PR TITLE
By default, give status code in exception representation

### DIFF
--- a/awxkit/awxkit/exceptions.py
+++ b/awxkit/awxkit/exceptions.py
@@ -15,7 +15,7 @@ class Common(Exception):
         return self.__str__()
 
     def __str__(self):
-        return str(self.msg)
+        return '{} - {}'.format(self.status_string, self.msg)
 
 
 class BadRequest(Common):


### PR DESCRIPTION
##### SUMMARY
This change is so that we don't have errors like this anymore:

```
Error Message
awxkit.exceptions.Unknown: {}
Stacktrace
Traceback (most recent call last):
  File "/home/ec2-user/tower-qa/tests/api/test_alan.py", line 116, in test_schedule_teardown
    jt = factories.job_template()
  File "/home/ec2-user/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 166, in __call__
    return self._has_create_factory(request=self.request, **kwargs)
  File "/home/ec2-user/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 39, in __call__
    has_create = cls.model(connection).create(**kwargs)
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/job_templates.py", line 176, in create
    project=project, **kwargs)
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/job_templates.py", line 147, in create_payload
    Project)))
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/mixins/has_create.py", line 360, in create_and_update_dependencies
    created = to_create(self.connection).create(**scoped_args)
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/projects.py", line 112, in create
    self.update_identity(Projects(self.connection).post(payload))
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/page.py", line 307, in post
    return self.page_identity(r, request_json=json)
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/page.py", line 262, in page_identity
    raise exc.Unknown(exc_str, data)
awxkit.exceptions.Unknown: {}
```

We have the status code, but we don't show it in the event that the code _really_ doesn't know what happened.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.1.1
```

