### PR TITLE
Adjust pagination when deleting final page of items

### DIFF
--- a/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
@@ -14,7 +14,7 @@ import PaginatedDataList, {
 import {
   getQSConfig,
   parseQueryString,
-  removeParams,
+  replaceParams,
   encodeNonDefaultQueryString,
 } from '@util/qs';
 import { CredentialListItem } from '.';
@@ -105,13 +105,11 @@ function CredentialList({ i18n }) {
   const adjustPagination = () => {
     const params = parseQueryString(QS_CONFIG, location.search);
     if (params.page > 1 && selected.length === credentials.length) {
-      const newParams = removeParams(QS_CONFIG, params, { page: params.page });
-      history.push(
-        `${location.pathname}?${encodeNonDefaultQueryString(
-          QS_CONFIG,
-          newParams
-        )}`
+      const newParams = encodeNonDefaultQueryString(
+        QS_CONFIG,
+        replaceParams(params, { page: params.page - 1 })
       );
+      history.push(`${location.pathname}?${newParams}`);
     } else {
       loadCredentials(location);
     }

--- a/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { CredentialsAPI } from '@api';
@@ -11,7 +11,12 @@ import PaginatedDataList, {
   ToolbarAddButton,
   ToolbarDeleteButton,
 } from '@components/PaginatedDataList';
-import { getQSConfig, parseQueryString } from '@util/qs';
+import {
+  getQSConfig,
+  parseQueryString,
+  removeParams,
+  encodeNonDefaultQueryString,
+} from '@util/qs';
 import { CredentialListItem } from '.';
 
 const QS_CONFIG = getQSConfig('credential', {
@@ -30,6 +35,7 @@ function CredentialList({ i18n }) {
   const [selected, setSelected] = useState([]);
 
   const location = useLocation();
+  const history = useHistory();
 
   const loadCredentials = async ({ search }) => {
     const params = parseQueryString(QS_CONFIG, search);
@@ -92,20 +98,23 @@ function CredentialList({ i18n }) {
       setDeletionError(error);
     }
 
+    adjustPagination();
+    setSelected([]);
+  };
+
+  const adjustPagination = () => {
     const params = parseQueryString(QS_CONFIG, location.search);
-    try {
-      const {
-        data: { count, results },
-      } = await CredentialsAPI.read(params);
-
-      setCredentials(results);
-      setCredentialCount(count);
-      setSelected([]);
-    } catch (error) {
-      setContentError(error);
+    if (params.page > 1 && selected.length === credentials.length) {
+      const newParams = removeParams(QS_CONFIG, params, { page: params.page });
+      history.push(
+        `${location.pathname}?${encodeNonDefaultQueryString(
+          QS_CONFIG,
+          newParams
+        )}`
+      );
+    } else {
+      loadCredentials(location);
     }
-
-    setHasContentLoading(false);
   };
 
   const canAdd =

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -16,7 +16,7 @@ import PaginatedDataList, {
 import {
   getQSConfig,
   parseQueryString,
-  removeParams,
+  replaceParams,
   encodeNonDefaultQueryString,
 } from '@util/qs';
 
@@ -87,17 +87,19 @@ function OrganizationsList({ i18n }) {
 
   const handleOrgDelete = async () => {
     await deleteOrganizations();
+    await adjustPagination();
+  };
+
+  const adjustPagination = () => {
     const params = parseQueryString(QS_CONFIG, location.search);
     if (params.page > 1 && selected.length === organizations.length) {
-      const newParams = removeParams(QS_CONFIG, params, { page: params.page });
-      history.push(
-        `${location.pathname}?${encodeNonDefaultQueryString(
-          QS_CONFIG,
-          newParams
-        )}`
+      const newParams = encodeNonDefaultQueryString(
+        QS_CONFIG,
+        replaceParams(params, { page: params.page - 1 })
       );
+      history.push(`${location.pathname}?${newParams}`);
     } else {
-      await fetchOrganizations();
+      fetchOrganizations();
     }
   };
 

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation, useHistory, useRouteMatch } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Card, PageSection } from '@patternfly/react-core';
@@ -13,7 +13,12 @@ import PaginatedDataList, {
   ToolbarAddButton,
   ToolbarDeleteButton,
 } from '@components/PaginatedDataList';
-import { getQSConfig, parseQueryString } from '@util/qs';
+import {
+  getQSConfig,
+  parseQueryString,
+  removeParams,
+  encodeNonDefaultQueryString,
+} from '@util/qs';
 
 import OrganizationListItem from './OrganizationListItem';
 
@@ -25,6 +30,7 @@ const QS_CONFIG = getQSConfig('organization', {
 
 function OrganizationsList({ i18n }) {
   const location = useLocation();
+  const history = useHistory();
   const match = useRouteMatch();
 
   const [selected, setSelected] = useState([]);
@@ -81,6 +87,16 @@ function OrganizationsList({ i18n }) {
 
   const handleOrgDelete = async () => {
     await deleteOrganizations();
+    const params = parseQueryString(QS_CONFIG, location.search);
+    if (params.page > 1 && selected.length === organizations.length) {
+      const newParams = removeParams(QS_CONFIG, params, { page: params.page });
+      history.push(
+        `${location.pathname}?${encodeNonDefaultQueryString(
+          QS_CONFIG,
+          newParams
+        )}`
+      );
+    }
     await fetchOrganizations();
   };
 

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -88,6 +88,7 @@ function OrganizationsList({ i18n }) {
   const handleOrgDelete = async () => {
     await deleteOrganizations();
     await adjustPagination();
+    setSelected([]);
   };
 
   const adjustPagination = () => {

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -96,8 +96,9 @@ function OrganizationsList({ i18n }) {
           newParams
         )}`
       );
+    } else {
+      await fetchOrganizations();
     }
-    await fetchOrganizations();
   };
 
   const hasContentLoading = isDeleteLoading || isOrgsLoading;

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -29,7 +29,7 @@ const QS_CONFIG = getQSConfig('template', {
   type: 'job_template,workflow_job_template',
 });
 
-function TemplatesList({ i18n }) {
+function TemplateList({ i18n }) {
   const { id: projectId } = useParams();
   const { pathname, search } = useLocation();
 
@@ -252,5 +252,5 @@ function TemplatesList({ i18n }) {
   );
 }
 
-export { TemplatesList as _TemplatesList };
-export default withI18n()(TemplatesList);
+export { TemplateList as _TemplatesList };
+export default withI18n()(TemplateList);

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -252,5 +252,4 @@ function TemplateList({ i18n }) {
   );
 }
 
-export { TemplateList as _TemplatesList };
 export default withI18n()(TemplateList);

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.test.jsx
@@ -9,7 +9,7 @@ import {
 } from '@api';
 import { mountWithContexts, waitForElement } from '@testUtils/enzymeHelpers';
 
-import TemplatesList from './TemplateList';
+import TemplateList from './TemplateList';
 
 jest.mock('@api');
 
@@ -94,7 +94,7 @@ describe('<TemplateList />', () => {
   test('initially renders successfully', async () => {
     await act(async () => {
       mountWithContexts(
-        <TemplatesList
+        <TemplateList
           match={{ path: '/templates', url: '/templates' }}
           location={{ search: '', pathname: '/templates' }}
         />
@@ -105,7 +105,7 @@ describe('<TemplateList />', () => {
   test('Templates are retrieved from the api and the components finishes loading', async () => {
     let wrapper;
     await act(async () => {
-      wrapper = mountWithContexts(<TemplatesList />);
+      wrapper = mountWithContexts(<TemplateList />);
     });
     expect(UnifiedJobTemplatesAPI.read).toBeCalled();
     await act(async () => {
@@ -115,7 +115,7 @@ describe('<TemplateList />', () => {
   });
 
   test('handleSelect is called when a template list item is selected', async () => {
-    const wrapper = mountWithContexts(<TemplatesList />);
+    const wrapper = mountWithContexts(<TemplateList />);
     await act(async () => {
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
@@ -143,7 +143,7 @@ describe('<TemplateList />', () => {
   });
 
   test('handleSelectAll is called when a template list item is selected', async () => {
-    const wrapper = mountWithContexts(<TemplatesList />);
+    const wrapper = mountWithContexts(<TemplateList />);
     await act(async () => {
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
@@ -158,7 +158,7 @@ describe('<TemplateList />', () => {
   });
 
   test('delete button is disabled if user does not have delete capabilities on a selected template', async () => {
-    const wrapper = mountWithContexts(<TemplatesList />);
+    const wrapper = mountWithContexts(<TemplateList />);
     await act(async () => {
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
@@ -217,7 +217,7 @@ describe('<TemplateList />', () => {
   });
 
   test('api is called to delete templates for each selected template.', async () => {
-    const wrapper = mountWithContexts(<TemplatesList />);
+    const wrapper = mountWithContexts(<TemplateList />);
     await act(async () => {
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
@@ -277,7 +277,7 @@ describe('<TemplateList />', () => {
         },
       })
     );
-    const wrapper = mountWithContexts(<TemplatesList />);
+    const wrapper = mountWithContexts(<TemplateList />);
     await act(async () => {
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
@@ -315,7 +315,7 @@ describe('<TemplateList />', () => {
     const wrapper = mountWithContexts(
       <Route
         path="/projects/:id/job_templates"
-        component={() => <TemplatesList />}
+        component={() => <TemplateList />}
       />,
       {
         context: {

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.test.jsx
@@ -71,7 +71,7 @@ const mockTemplates = [
   },
 ];
 
-describe('<TemplatesList />', () => {
+describe('<TemplateList />', () => {
   beforeEach(() => {
     UnifiedJobTemplatesAPI.read.mockResolvedValue({
       data: {

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
@@ -4,7 +4,7 @@ import { mountWithContexts } from '@testUtils/enzymeHelpers';
 
 import TemplatesListItem from './TemplateListItem';
 
-describe('<TemplatesListItem />', () => {
+describe('<TemplateListItem />', () => {
   test('launch button shown to users with start capabilities', () => {
     const wrapper = mountWithContexts(
       <TemplatesListItem

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { mountWithContexts } from '@testUtils/enzymeHelpers';
 
-import TemplatesListItem from './TemplateListItem';
+import TemplateListItem from './TemplateListItem';
 
 describe('<TemplateListItem />', () => {
   test('launch button shown to users with start capabilities', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -26,7 +26,7 @@ describe('<TemplateListItem />', () => {
   });
   test('launch button hidden from users without start capabilities', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -45,7 +45,7 @@ describe('<TemplateListItem />', () => {
   });
   test('edit button shown to users with edit capabilities', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -64,7 +64,7 @@ describe('<TemplateListItem />', () => {
   });
   test('edit button hidden from users without edit capabilities', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -83,7 +83,7 @@ describe('<TemplateListItem />', () => {
   });
   test('missing resource icon is shown.', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -102,7 +102,7 @@ describe('<TemplateListItem />', () => {
   });
   test('missing resource icon is not shown when there is a project and an inventory.', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -123,7 +123,7 @@ describe('<TemplateListItem />', () => {
   });
   test('missing resource icon is not shown when inventory is prompt_on_launch, and a project', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,
@@ -144,7 +144,7 @@ describe('<TemplateListItem />', () => {
   });
   test('missing resource icon is not shown type is workflow_job_template', () => {
     const wrapper = mountWithContexts(
-      <TemplatesListItem
+      <TemplateListItem
         isSelected={false}
         template={{
           id: 1,

--- a/awx/ui_next/src/util/qs.js
+++ b/awx/ui_next/src/util/qs.js
@@ -90,7 +90,6 @@ export { addDefaultsToObject as _addDefaultsToObject };
 /**
  * Convert query param object to url query string
  * Used to encode params for interacting with the api
- * @param {object} qs config object for namespacing params, filtering defaults
  * @param {object} query param object
  * @return {string} url query string
  */


### PR DESCRIPTION
##### SUMMARY

When deleting all items on the last page of a list, this navigates back to the previous page to prevent "no items found" errors. Applied to both Credentials List and Organizations List.

Addresses #4239

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION

I'm going to work on refactoring some of these lists to use the `useRequest` hook and then see about centralizing this logic somehow for all lists, but I'll put that up in a separate PR.