### PR TITLE
Fail early processing project factory

### DIFF
--- a/awxkit/awxkit/api/pages/projects.py
+++ b/awxkit/awxkit/api/pages/projects.py
@@ -112,7 +112,8 @@ class Project(HasCopy, HasCreate, HasNotifications, UnifiedJobTemplate):
         self.update_identity(Projects(self.connection).post(payload))
 
         if kwargs.get('wait', True):
-            self.related.current_update.get().wait_until_completed()
+            update = self.related.current_update.get()
+            update.wait_until_completed().assert_successful()
             return self.get()
 
         return self


### PR DESCRIPTION
##### SUMMARY
In data generators, don't let JT processing continue with failed projects

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION

error before:

```
tests/api/test_alan.py::TestAlan::test_project FAILED                                                                                                                [100%]

================================================================================= FAILURES =================================================================================
__________________________________________________________________________ TestAlan.test_project ___________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/repos/tower-qa/tests/api/test_alan.py", line 184, in test_project
    factories.job_template()
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 199, in __call__
    return self._has_create_factory(request=self.request, **kwargs)
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 59, in __call__
    has_create = cls.model(connection).create(**kwargs)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/job_templates.py", line 179, in create
    self.connection).post(payload))
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py", line 307, in post
    return self.page_identity(r, request_json=json)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/page.py", line 260, in page_identity
    raise exc.BadRequest(exc_str, data)
awxkit.exceptions.BadRequest: {'playbook': ['Playbook not found for project.']}
```

error after:

```
tests/api/test_alan.py::TestAlan::test_project FAILED                                                                                                                [100%]

================================================================================= FAILURES =================================================================================
__________________________________________________________________________ TestAlan.test_project ___________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/repos/tower-qa/tests/api/test_alan.py", line 184, in test_project
    factories.job_template()
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 199, in __call__
    return self._has_create_factory(request=self.request, **kwargs)
  File "/Users/alancoding/Documents/repos/tower-qa/tests/lib/fixtures/factory_fixtures.py", line 59, in __call__
    has_create = cls.model(connection).create(**kwargs)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/job_templates.py", line 176, in create
    project=project, **kwargs)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/job_templates.py", line 147, in create_payload
    Project)))
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/mixins/has_create.py", line 360, in create_and_update_dependencies
    created = to_create(self.connection).create(**scoped_args)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/pages/projects.py", line 116, in create
    update.wait_until_completed().assert_successful()
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/mixins/has_status.py", line 92, in assert_successful
    return self.assert_status('successful', msg=msg)
  File "/Users/alancoding/Documents/tower/awxkit/awxkit/api/mixins/has_status.py", line 89, in assert_status
    raise AssertionError(msg)
AssertionError: Project_Update-384 has status of error, which is not in ['successful'].
result_traceback:
Traceback (most recent call last):
  File "/awx_devel/awx/main/tasks.py", line 1275, in run
    self.pre_run_hook(self.instance, private_data_dir)
  File "/awx_devel/awx/main/tasks.py", line 2231, in pre_run_hook
    os.mkdir(settings.PROJECTS_ROOT)
FileExistsError: [Errno 17] File exists: '/var/lib/awx/projects/'

TIME WHEN STATUS WAS FOUND: 2020-02-12 14:30:24.729099 (UTC)
```

Under nominal conditions, this isn't expected to ever fail, unless github isn't working or the configured default project URL is bad. But that's actually a pretty good point about github, there are some things we can't control.

...but in this particular example I'm showing there, I just messed up my environment (remember those file permission errors we've had other times?). I suspect there are several cases where this will be a frustrating-reducing change.
