### PR TITLE
Use pod uid as instance uuid

### DIFF
--- a/installer/roles/kubernetes/templates/configmap.yml.j2
+++ b/installer/roles/kubernetes/templates/configmap.yml.j2
@@ -144,7 +144,7 @@ data:
 
     #Autoprovisioning should replace this
     CLUSTER_HOST_ID = socket.gethostname()
-    SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
+    SYSTEM_UUID = os.environ.get('MY_POD_UID', '00000000-0000-0000-0000-000000000000')
 
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -285,6 +285,10 @@ spec:
           env:
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
+            - name: MY_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           resources:
             requests:
               memory: "{{ task_mem_request }}Gi"


### PR DESCRIPTION
##### SUMMARY
Inject the pod uid as an environment variable and use it for the
SYSTEM_UUID in the settings file defined by the configmap. This works as a better
alternative to the `0000-...` instance uuid being used for k8s installs.


##### ISSUE TYPE
 - Bugfix Pull Request


![Screenshot from 2020-02-12 13-56-07](https://user-images.githubusercontent.com/9753817/74367213-7cf82f00-4d9f-11ea-8611-f9649e5a0a52.png)
