### PR TITLE
Handle case of deleted inventory

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1904,7 +1904,8 @@ class RunJob(BaseTask):
         except Inventory.DoesNotExist:
             pass
         else:
-            update_inventory_computed_fields.delay(inventory.id)
+            if inventory is not None:
+                update_inventory_computed_fields.delay(inventory.id)
 
 
 @task()


### PR DESCRIPTION
##### SUMMARY
Remove this log:

```
2020-02-13 08:12:28,890 ERROR    awx.main.tasks job 3431 (error) Final run hook errored.
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1431, in run
    self.final_run_hook(self.instance, status, private_data_dir, fact_modification_times, isolated_manager_instance=isolated_manager_instance)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1907, in final_run_hook
    update_inventory_computed_fields.delay(inventory.id)
AttributeError: 'NoneType' object has no attribute 'id'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
It's a benign error, but it's just frustrating log pollution when other things have gone sideways.
