### PR TITLE
Remove docker_remove_local_images from documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -506,10 +506,6 @@ If you wish to tag and push built images to a Docker registry, set the following
 
 > Username of the user that will push images to the registry. Defaults to *developer*.
 
-*docker_remove_local_images*
-
-> Due to the way that the docker_image module behaves, images will not be pushed to a remote repository if they are present locally.  Set this to delete local versions of the images that will be pushed to the remote.  This will fail if containers are currently running from those images.
-
 **Note**
 
 > These settings are ignored if using official images

--- a/installer/inventory
+++ b/installer/inventory
@@ -78,10 +78,6 @@ docker_compose_dir="~/.awx/awxcompose"
 # docker_registry_username=developer
 
 
-# Docker_image will not attempt to push to remote if the image already exists locally
-# Set this to true to delete images from docker on the build host so that they are pushed to the remote repository
-# docker_remove_local_images=False
-
 # Set pg_hostname if you have an external postgres server, otherwise
 # a new postgres service will be created
 # pg_hostname=postgresql


### PR DESCRIPTION
docker_remove_local_images was removed with commit https://github.com/ansible/awx/commit/28994d4b0bde200b623354c2365735fe3555739f#diff-c12c21a2e99296acf472dc226bc19da8
(version 9.0.0). This PR removes it from INSTALL and inventory documentation.

Signed-off-by: Stefan Jakobs <sjakobs@anexia-it.com>

##### SUMMARY

This removes a documentation leftover from a change in 9.0.0.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```

