### PR TITLE
Add ingress_hostname to openshift

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -28,10 +28,11 @@ dockerhub_base=ansible
 # pg_cpu_limit=1000
 # pg_mem_limit=2
 
+# Ingress Configuratio
+ingress_hostname=awx.example.org
+
 # Kubernetes Ingress Configuration
 # You can use the variables below to configure Kubernetes Ingress
-# Set hostname
-# kubernetes_ingress_hostname=awx.example.org
 # Add annotations. The example below shows an annotation to be used with Traefik but other Ingress controllers are also supported
 # kubernetes_ingress_annotations={'kubernetes.io/ingress.class': 'traefik', 'traefik.ingress.kubernetes.io/redirect-entry-point': 'https'}
 # Specify a secret for TLS termination

--- a/installer/inventory
+++ b/installer/inventory
@@ -28,8 +28,8 @@ dockerhub_base=ansible
 # pg_cpu_limit=1000
 # pg_mem_limit=2
 
-# Ingress Configuratio
-ingress_hostname=awx.example.org
+# Kubernetes and Openshift Ingress Configuration
+#kubernetes_ingress_hostname=awx.example.org
 
 # Kubernetes Ingress Configuration
 # You can use the variables below to configure Kubernetes Ingress

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -555,11 +555,11 @@ spec:
 {% if kubernetes_ingress_tls_secret is defined %}
   tls:
   - hosts:
-    - {{ kubernetes_ingress_hostname }}
+    - {{ ingress_hostname }}
     secretName: {{ kubernetes_ingress_tls_secret }}
 {% endif %}
   rules:
-  - host: {{ kubernetes_ingress_hostname }}
+  - host: {{ ingress_hostname }}
     http:
       paths:
       - path: /
@@ -581,6 +581,7 @@ metadata:
   name: {{ kubernetes_deployment_name }}-web-svc
   namespace: {{ kubernetes_namespace }}
 spec:
+  host: {{ ingress_hostname }}
   port:
     targetPort: http
   tls:

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -555,11 +555,11 @@ spec:
 {% if kubernetes_ingress_tls_secret is defined %}
   tls:
   - hosts:
-    - {{ ingress_hostname }}
+    - {{ kubernetes_ingress_hostname }}
     secretName: {{ kubernetes_ingress_tls_secret }}
 {% endif %}
   rules:
-  - host: {{ ingress_hostname }}
+  - host: {{ kubernetes_ingress_hostname }}
     http:
       paths:
       - path: /
@@ -581,7 +581,7 @@ metadata:
   name: {{ kubernetes_deployment_name }}-web-svc
   namespace: {{ kubernetes_namespace }}
 spec:
-  host: {{ ingress_hostname }}
+  host: {{ kubernetes_ingress_hostname }}
   port:
     targetPort: http
   tls:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add `ingress_hostname` to Openshift for route configuration.

~~Also renames `kubernetes_ingress_hostname` to `ingress_hostname` for easier configuration.~~

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Maybe the change of `kubernetes_ingress_hostname` to `ingress_hostname` isn't worth the breaking change of variable name ?
