### PR TITLE
Add openshift label `app`

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -136,6 +136,10 @@ kind: StatefulSet
 metadata:
   name: {{ kubernetes_deployment_name }}
   namespace: {{ kubernetes_namespace }}
+  {% if openshift_host is defined %}
+  labels:
+    app: {{ kubernetes_deployment_name }}
+  {% endif %}
 spec:
   serviceName: {{ kubernetes_deployment_name }}
   replicas: 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add openshift label `app`, so that statefulsets can be displayed by applications (for example in case of staging vs prod) in the web console.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
