### PR TITLE
allow external pg connections

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -50,6 +50,8 @@ services:
     container_name: tools_postgres_1
     ports:
       - "5432:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
   memcached:
     image: memcached:alpine
     container_name: tools_memcached_1


### PR DESCRIPTION
* Postgres containers now, by default, do not allow passwordless users
to connect remotely. This change explicitly allows that case.

This fixes the below observed problem.

`docker logs -f tools_postgres_1`

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".
       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```