### PR TITLE
Works around bad error message when authentication fails

### DIFF
--- a/awxkit/awxkit/scripts/basic_session.py
+++ b/awxkit/awxkit/scripts/basic_session.py
@@ -90,18 +90,11 @@ def main():
                 exec(open(akit_args.akit_script).read(), globals())
             except Exception as e:
                 exc = e
-                raise exc
+                raise
     except Exception as e:
         exc = e
         rc = 1
-
-    if akit_args.non_interactive:
-        if exc:
-            traceback.print_exc(exc)
-        os._exit(rc)
-
-    if exc:
-        raise exc
+        raise
 
 
 def as_user(username, password=None):


### PR DESCRIPTION
##### SUMMARY
Removes incorrect traceback.print_exc call.  

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awxkit

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```


##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:

TypeError: '>=' not supported between instances of 'Unauthorized' and 'int'

After:
Unauthorized: Unauthorized (401) received - {'detail': 'Authentication credentials were not provided. To establish a login session, visit /api/login/.'}
```
