### PR TITLE
Changes ui-side behavior in response to websocket job status updates on several lists

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1222,7 +1222,8 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                 status_data['finished'] = self.finished
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'
-            status_data['unified_job_template_id'] = self.unified_job_template.id
+            if getattr(self, 'unified_job_template_id', None):
+                status_data['unified_job_template_id'] = self.unified_job_template_id
             emit_channel_notification('jobs-status_changed', status_data)
 
             if self.spawned_by_workflow:

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1219,7 +1219,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                     status_data['instance_group_name'] = self.instance_group.name
                 else:
                     status_data['instance_group_name'] = None
-            elif status in ['successful', 'failed', 'canceled']:
+            elif status in ['successful', 'failed', 'canceled'] and self.finished:
                 status_data['finished'] = datetime.datetime.strftime(self.finished, "%Y-%m-%dT%H:%M:%S.%fZ")
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1220,10 +1220,12 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                     status_data['instance_group_name'] = None
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'
+            status_data['unified_job_template_id'] = self.unified_job_template.id
             emit_channel_notification('jobs-status_changed', status_data)
 
             if self.spawned_by_workflow:
                 status_data['group_name'] = "workflow_events"
+                status_data['workflow_job_template_id'] = self.unified_job_template.id
                 emit_channel_notification('workflow_events-' + str(self.workflow_job_id), status_data)
         except IOError:  # includes socket errors
             logger.exception('%s failed to emit channel msg about status change', self.log_format)

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1218,6 +1218,8 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                     status_data['instance_group_name'] = self.instance_group.name
                 else:
                     status_data['instance_group_name'] = None
+            elif status in ['successful', 'failed', 'cancelled', 'failed']:
+                status_data['finished'] = self.finished
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'
             status_data['unified_job_template_id'] = self.unified_job_template.id

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -3,6 +3,7 @@
 
 # Python
 from io import StringIO
+import datetime
 import codecs
 import json
 import logging
@@ -1219,7 +1220,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                 else:
                     status_data['instance_group_name'] = None
             elif status in ['successful', 'failed', 'canceled']:
-                status_data['finished'] = self.finished
+                status_data['finished'] = datetime.datetime.strftime(self.finished, "%Y-%m-%dT%H:%M:%S.%fZ")
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'
             if getattr(self, 'unified_job_template_id', None):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1218,7 +1218,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                     status_data['instance_group_name'] = self.instance_group.name
                 else:
                     status_data['instance_group_name'] = None
-            elif status in ['successful', 'failed', 'cancelled', 'failed']:
+            elif status in ['successful', 'failed', 'canceled']:
                 status_data['finished'] = self.finished
             status_data.update(self.websocket_emit_data())
             status_data['group_name'] = 'jobs'

--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -119,10 +119,19 @@ function ListJobsController (
         for (let i = 0; i < vm.jobs.length; i++) {
             if (vm.jobs[i].id === msg.unified_job_id) {
                 // Update the job status.
-                // If/when we get more info in the message we can
-                // update those fields here as well.
                 vm.jobs[i].status = msg.status;
-                i = vm.jobs.length;
+                if (msg.finished) {
+                    vm.jobs[i].finished = msg.finished;
+                    const orderByValue = _.get($state.params, 'job_search.order_by');
+                    if (orderByValue === '-finished') {
+                        // Attempt to sort the rows in the list by their finish
+                        // timestamp in descending order
+                        vm.jobs.sort((a, b) =>
+                            (!b.finished) - (!a.finished)
+                            || new Date(b.finished) - new Date(a.finished));
+                    }
+                }
+                break;
             }
         }
     };

--- a/awx/ui/client/features/jobs/jobsList.controller.js
+++ b/awx/ui/client/features/jobs/jobsList.controller.js
@@ -25,15 +25,15 @@ function ListJobsController (
 
     vm.strings = strings;
 
+    let newJobs = [];
+
     // smart-search
     const name = 'jobs';
     const iterator = 'job';
     let paginateQuerySet = {};
 
     let launchModalOpen = false;
-    let refreshAfterLaunchClose = false;
-    let pendingRefresh = false;
-    let refreshTimerRunning = false;
+    let newJobsTimerRunning = false;
 
     vm.searchBasePath = SearchBasePath;
 
@@ -104,23 +104,44 @@ function ListJobsController (
         $scope.$emit('updateCount', vm.job_dataset.count, 'jobs');
     });
 
-    $scope.$on('ws-jobs', () => {
-        if (!launchModalOpen) {
-            if (!refreshTimerRunning) {
-                refreshJobs();
-            } else {
-                pendingRefresh = true;
+    const canAddRowsDynamically = () => {
+        const orderByValue = _.get($state.params, 'job_search.order_by');
+        const pageValue = _.get($state.params, 'job_search.page');
+        const idInValue = _.get($state.params, 'job_search.id__in');
+
+        return (!idInValue && (!pageValue || pageValue === '1')
+            && (orderByValue === '-finished' || orderByValue === '-started'));
+    };
+
+    const updateJobRow = (msg) => {
+        // Loop across the jobs currently shown and update the row
+        // if it exists
+        for (let i = 0; i < vm.jobs.length; i++) {
+            if (vm.jobs[i].id === msg.unified_job_id) {
+                // Update the job status.
+                // If/when we get more info in the message we can
+                // update those fields here as well.
+                vm.jobs[i].status = msg.status;
+                i = vm.jobs.length;
             }
-        } else {
-            refreshAfterLaunchClose = true;
+        }
+    };
+
+    $scope.$on('ws-jobs', (e, msg) => {
+        if (msg.status === 'pending' && canAddRowsDynamically()) {
+            newJobs.push(msg.unified_job_id);
+            if (!launchModalOpen && !newJobsTimerRunning) {
+                fetchNewJobs();
+            }
+        } else if (!newJobs.includes(msg.unified_job_id)) {
+            updateJobRow(msg);
         }
     });
 
     $scope.$on('launchModalOpen', (evt, isOpen) => {
         evt.stopPropagation();
-        if (!isOpen && refreshAfterLaunchClose) {
-            refreshAfterLaunchClose = false;
-            refreshJobs();
+        if (!isOpen && newJobs.length > 0) {
+            fetchNewJobs();
         }
         launchModalOpen = isOpen;
     });
@@ -289,22 +310,49 @@ function ListJobsController (
         });
     };
 
-    function refreshJobs () {
-        qs.search(SearchBasePath, $state.params.job_search, { 'X-WS-Session-Quiet': true })
+    const fetchNewJobs = () => {
+        newJobsTimerRunning = true;
+        const newJobIdsFilter = newJobs.join(',');
+        newJobs = [];
+        const newJobsSearchParams = Object.assign({}, $state.params.job_search);
+        newJobsSearchParams.count_disabled = 1;
+        newJobsSearchParams.id__in = newJobIdsFilter;
+        delete newJobsSearchParams.page_size;
+        const stringifiedSearchParams = qs.encodeQueryset(newJobsSearchParams, false);
+        Rest.setUrl(`${vm.searchBasePath}${stringifiedSearchParams}`);
+        Rest.get()
             .then(({ data }) => {
-                vm.jobs = data.results;
-                vm.job_dataset = data;
+                vm.job_dataset.count += data.results.length;
+                const pageSize = parseInt($state.params.job_search.page_size, 10) || 20;
+                const joinedJobs = data.results.concat(vm.jobs);
+                vm.jobs = joinedJobs.length > pageSize
+                    ? joinedJobs.slice(0, pageSize)
+                    : joinedJobs;
+                $timeout(() => {
+                    if (canAddRowsDynamically()) {
+                        if (newJobs.length > 0 && !launchModalOpen) {
+                            fetchNewJobs();
+                        } else {
+                            newJobsTimerRunning = false;
+                        }
+                    } else {
+                        // Bail out - one of [order_by, page, id__in] params has changed since we
+                        // received these new job messages
+                        newJobs = [];
+                        newJobsTimerRunning = false;
+                    }
+                }, 5000);
+            })
+            .catch(({ data, status }) => {
+                ProcessErrors($scope, data, status, null, {
+                    hdr: strings.get('error.HEADER'),
+                    msg: strings.get('error.CALL', {
+                        path: `${vm.searchBasePath}${stringifiedSearchParams}`,
+                        status
+                    })
+                });
             });
-        pendingRefresh = false;
-        refreshTimerRunning = true;
-        $timeout(() => {
-            if (pendingRefresh) {
-                refreshJobs();
-            } else {
-                refreshTimerRunning = false;
-            }
-        }, 5000);
-    }
+    };
 
     vm.isCollapsed = true;
 

--- a/awx/ui/client/features/projects/projectsList.controller.js
+++ b/awx/ui/client/features/projects/projectsList.controller.js
@@ -113,9 +113,7 @@ function projectsListController (
                 // And we found the affected project
                 $log.debug(`Received event for project: ${project.name}`);
                 $log.debug(`Status changed to: ${data.status}`);
-                if (data.status === 'successful' || data.status === 'failed' || data.status === 'canceled') {
-                    reloadList();
-                } else {
+                if (!(data.status === 'successful' || data.status === 'failed' || data.status === 'canceled')) {
                     project.scm_update_tooltip = vm.strings.get('update.UPDATE_RUNNING');
                 }
                 project.status = data.status;

--- a/awx/ui/client/features/projects/projectsList.controller.js
+++ b/awx/ui/client/features/projects/projectsList.controller.js
@@ -113,9 +113,6 @@ function projectsListController (
                 // And we found the affected project
                 $log.debug(`Received event for project: ${project.name}`);
                 $log.debug(`Status changed to: ${data.status}`);
-                if (!(data.status === 'successful' || data.status === 'failed' || data.status === 'canceled')) {
-                    project.scm_update_tooltip = vm.strings.get('update.UPDATE_RUNNING');
-                }
                 project.status = data.status;
                 buildTooltips(project);
             }

--- a/awx/ui/client/features/templates/templatesList.controller.js
+++ b/awx/ui/client/features/templates/templatesList.controller.js
@@ -138,6 +138,10 @@ function ListTemplatesController(
                         const recentJob = template.summary_fields.recent_jobs[i];
                         if (recentJob.id === msg.unified_job_id) {
                             recentJob.status = msg.status;
+                            if (msg.finished) {
+                                recentJob.finished = msg.finished;
+                                template.last_job_run = msg.finished;
+                            }
                             break;
                         }
                     };

--- a/awx/ui/client/features/templates/templatesList.controller.js
+++ b/awx/ui/client/features/templates/templatesList.controller.js
@@ -24,7 +24,6 @@ function ListTemplatesController(
     qs,
     GetBasePath,
     ngToast,
-    $timeout
 ) {
     const vm = this || {};
     const [jobTemplate, workflowTemplate] = resolvedModels;
@@ -32,10 +31,6 @@ function ListTemplatesController(
     const choices = workflowTemplate.options('actions.GET.type.choices')
         .concat(jobTemplate.options('actions.GET.type.choices'));
 
-    let launchModalOpen = false;
-    let refreshAfterLaunchClose = false;
-    let pendingRefresh = false;
-    let refreshTimerRunning = false;
     let paginateQuerySet = {};
 
     vm.strings = strings;
@@ -120,25 +115,35 @@ function ListTemplatesController(
         setToolbarSort();
     }, true);
 
-    $scope.$on(`ws-jobs`, () => {
-        if (!launchModalOpen) {
-            if (!refreshTimerRunning) {
-                refreshTemplates();
-            } else {
-                pendingRefresh = true;
-            }
-        } else {
-            refreshAfterLaunchClose = true;
-        }
-    });
+    $scope.$on(`ws-jobs`, (e, msg) => {
+        if (msg.unified_job_template_id && vm.templates) {
+            const template = vm.templates.find((t) => t.id === msg.unified_job_template_id);
+            if (template) {
+                if (msg.status === 'pending') {
+                    // This is a new job - add it to the front of the
+                    // recent_jobs array
+                    if (template.summary_fields.recent_jobs.length === 10) {
+                        template.summary_fields.recent_jobs.pop();
+                    }
 
-    $scope.$on('launchModalOpen', (evt, isOpen) => {
-        evt.stopPropagation();
-        if (!isOpen && refreshAfterLaunchClose) {
-            refreshAfterLaunchClose = false;
-            refreshTemplates();
+                    template.summary_fields.recent_jobs.unshift({
+                        id: msg.unified_job_id,
+                        status: msg.status,
+                        type: msg.type
+                    });
+                } else {
+                    // This is an update to an existing job.  Check to see
+                    // if we have it in our array of recent_jobs
+                    for (let i=0; i<template.summary_fields.recent_jobs.length; i++) {
+                        const recentJob = template.summary_fields.recent_jobs[i];
+                        if (recentJob.id === msg.unified_job_id) {
+                            recentJob.status = msg.status;
+                            break;
+                        }
+                    };
+                }
+            }
         }
-        launchModalOpen = isOpen;
     });
 
     vm.isInvalid = (template) => {
@@ -265,15 +270,6 @@ function ListTemplatesController(
             vm.templates = vm.dataset.results;
         })
         .finally(() => Wait('stop'));
-        pendingRefresh = false;
-        refreshTimerRunning = true;
-        $timeout(() => {
-            if (pendingRefresh) {
-                refreshTemplates();
-            } else {
-                refreshTimerRunning = false;
-            }
-        }, 5000);
     }
 
     function createErrorHandler(path, action) {
@@ -483,8 +479,7 @@ ListTemplatesController.$inject = [
     'Wait',
     'QuerySet',
     'GetBasePath',
-    'ngToast',
-    '$timeout'
+    'ngToast'
 ];
 
 export default ListTemplatesController;

--- a/awx/ui/client/src/home/dashboard/lists/job-templates/job-templates-list.directive.js
+++ b/awx/ui/client/src/home/dashboard/lists/job-templates/job-templates-list.directive.js
@@ -11,7 +11,7 @@ export default
                 templateUrl: templateUrl('home/dashboard/lists/job-templates/job-templates-list')
             };
 
-            function link(scope, element, attr) {
+            function link(scope) {
 
                 scope.$watch("data", function(data) {
                     if (data) {
@@ -22,7 +22,7 @@ export default
                             scope.noJobTemplates = true;
                         }
                     }
-                });
+                }, true);
 
                 scope.canAddJobTemplate = false;
                 let url = GetBasePath('job_templates');

--- a/awx/ui/client/src/home/home.controller.js
+++ b/awx/ui/client/src/home/home.controller.js
@@ -19,6 +19,94 @@ export default ['$scope','Wait', '$timeout', 'i18n',
         let newJobs = [];
         let newTemplates =[];
 
+        const fetchDashboardData = () => {
+            Rest.setUrl(GetBasePath('dashboard'));
+            Rest.get()
+            .then(({data}) => {
+                $scope.dashboardData = data;
+            })
+            .catch(({data, status}) => {
+                ProcessErrors($scope, data, status, null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard host graph data: ${status}`) });
+            });
+
+            if ($scope.graphData) {
+                Rest.setUrl(`${GetBasePath('dashboard')}graphs/jobs/?period=${$scope.graphData.period}&job_type=${$scope.graphData.jobType}`);
+                Rest.setHeader({'X-WS-Session-Quiet': true});
+                Rest.get()
+                .then(function(value) {
+                    if($scope.graphData.status === "successful" || $scope.graphData.status === "failed"){
+                        delete value.data.jobs[$scope.graphData.status];
+                    }
+                    $scope.graphData.jobStatus = value.data;
+                })
+                .catch(function({data, status}) {
+                    ProcessErrors(null, data, status,  null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard graph data: ${status}`)});
+                });
+            }
+
+            pendingDashboardRefresh = false;
+            dashboardTimerRunning = true;
+            $timeout(() => {
+                if (pendingDashboardRefresh) {
+                    fetchDashboardData();
+                } else {
+                    dashboardTimerRunning = false;
+                }
+            }, 5000);
+        };
+
+        const fetchNewJobs = () => {
+            newJobsTimerRunning = true;
+            const newJobIdsFilter = newJobs.join(',');
+            newJobs = [];
+            Rest.setUrl(`${GetBasePath("unified_jobs")}?id__in=${newJobIdsFilter}&order_by=-finished&finished__isnull=false&type=workflow_job,job&count_disabled=1`);
+            Rest.get()
+                .then(({ data }) => {
+                    const joinedJobs = data.results.concat($scope.dashboardJobsListData);
+                    $scope.dashboardJobsListData =
+                        joinedJobs.length > 5 ? joinedJobs.slice(0, 5) : joinedJobs;
+                    $timeout(() => {
+                        if (newJobs.length > 0) {
+                            fetchNewJobs();
+                        } else {
+                            newJobsTimerRunning = false;
+                        }
+                    }, 5000);
+                })
+                .catch(({ data, status }) => {
+                    ProcessErrors($scope, data, status, null, {
+                        hdr: i18n._('Error!'),
+                        msg: i18n._(`Failed to get new jobs for dashboard: ${status}`)
+                    });
+                });
+        };
+
+        const fetchNewTemplates = () => {
+            newTemplatesTimerRunning = true;
+            const newTemplateIdsFilter = newTemplates.join(',');
+            newTemplates = [];
+            Rest.setUrl(`${GetBasePath("unified_job_templates")}?id__in=${newTemplateIdsFilter}&order_by=-last_job_run&last_job_run__isnull=false&type=workflow_job_template,job_template&count_disabled=1"`);
+            Rest.get()
+                .then(({ data }) => {
+                    const joinedTemplates = data.results.concat($scope.dashboardJobTemplatesListData).sort((a, b) => new Date(b.last_job_run) - new Date(a.last_job_run));
+                    $scope.dashboardJobTemplatesListData =
+                        joinedTemplates.length > 5 ? joinedTemplates.slice(0, 5) : joinedTemplates;
+                    $timeout(() => {
+                        if (newTemplates.length > 0 && !launchModalOpen) {
+                            fetchNewTemplates();
+                        } else {
+                            newTemplatesTimerRunning = false;
+                        }
+                    }, 5000);
+                })
+                .catch(({ data, status }) => {
+                    ProcessErrors($scope, data, status, null, {
+                        hdr: i18n._('Error!'),
+                        msg: i18n._(`Failed to get new templates for dashboard: ${status}`)
+                    });
+                });
+        };
+
         $scope.$on('ws-jobs', function (e, msg) {
             if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled') {
                 newJobs.push(msg.unified_job_id);
@@ -59,7 +147,7 @@ export default ['$scope','Wait', '$timeout', 'i18n',
                             }
                             break;
                         }
-                    };
+                    }
 
                     if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled') {
                         $scope.dashboardJobTemplatesListData.sort((a, b) => new Date(b.last_job_run) - new Date(a.last_job_run));
@@ -123,96 +211,6 @@ export default ['$scope','Wait', '$timeout', 'i18n',
             $scope.dashboardJobTemplatesListData = data;
             $scope.$emit('dashboardDataLoadComplete');
         });
-
-        const fetchDashboardData = () => {
-            Rest.setUrl(GetBasePath('dashboard'));
-            Rest.get()
-            .then(({data}) => {
-                $scope.dashboardData = data;
-            })
-            .catch(({data, status}) => {
-                ProcessErrors($scope, data, status, null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard host graph data: ${status}`) });
-            });
-
-            if ($scope.graphData) {
-                Rest.setUrl(`${GetBasePath('dashboard')}graphs/jobs/?period=${$scope.graphData.period}&job_type=${$scope.graphData.jobType}`);
-                Rest.setHeader({'X-WS-Session-Quiet': true});
-                Rest.get()
-                .then(function(value) {
-                    if($scope.graphData.status === "successful" || $scope.graphData.status === "failed"){
-                        delete value.data.jobs[$scope.graphData.status];
-                    }
-                    $scope.graphData.jobStatus = value.data;
-                })
-                .catch(function({data, status}) {
-                    ProcessErrors(null, data, status,  null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard graph data: ${status}`)});
-                });
-            }
-
-            pendingDashboardRefresh = false;
-            dashboardTimerRunning = true;
-            $timeout(() => {
-                if (pendingDashboardRefresh) {
-                    fetchDashboardData();
-                } else {
-                    dashboardTimerRunning = false;
-                }
-            }, 5000);
-        };
-
-        const fetchNewJobs = () => {
-            newJobsTimerRunning = true;
-            const newJobIdsFilter = newJobs.join(',');
-            newJobs = [];
-            Rest.setUrl(`${GetBasePath("unified_jobs")}?id__in=${newJobIdsFilter}&order_by=-finished&finished__isnull=false&type=workflow_job,job&count_disabled=1`);
-            Rest.get()
-                .then(({ data }) => {
-                    const joinedJobs = data.results.concat($scope.dashboardJobsListData);
-                    $scope.dashboardJobsListData = joinedJobs.length > 5
-                        ? joinedJobs.slice(0, 5)
-                        : joinedJobs;
-                    $timeout(() => {
-                        if (newJobs.length > 0) {
-                            fetchNewJobs();
-                        } else {
-                            newJobsTimerRunning = false;
-                        }
-                    }, 5000);
-                })
-                .catch(({ data, status }) => {
-                    ProcessErrors($scope, data, status, null, {
-                        hdr: i18n._('Error!'),
-                        msg: i18n._(`Failed to get new jobs for dashboard: ${status}`)
-                    });
-                });
-        };
-
-        const fetchNewTemplates = () => {
-            newTemplatesTimerRunning = true;
-            const newTemplateIdsFilter = newTemplates.join(',');
-            newTemplates = [];
-            Rest.setUrl(`${GetBasePath("unified_job_templates")}?id__in=${newTemplateIdsFilter}&order_by=-last_job_run&last_job_run__isnull=false&type=workflow_job_template,job_template&count_disabled=1"`);
-            Rest.get()
-                .then(({ data }) => {
-                    const joinedTemplates = data.results.concat($scope.dashboardJobTemplatesListData).sort((a, b) => new Date(b.last_job_run) - new Date(a.last_job_run));
-                    $scope.dashboardJobTemplatesListData = joinedTemplates.length > 5
-                        ? joinedTemplates.slice(0, 5)
-                        : joinedTemplates;
-                    $timeout(() => {
-                        if (newTemplates.length > 0 && !launchModalOpen) {
-                            fetchNewTemplates();
-                        } else {
-                            newTemplatesTimerRunning = false;
-                        }
-                    }, 5000);
-                })
-                .catch(({ data, status }) => {
-                    ProcessErrors($scope, data, status, null, {
-                        hdr: i18n._('Error!'),
-                        msg: i18n._(`Failed to get new templates for dashboard: ${status}`)
-                    });
-                });
-        };
 
         Wait('start');
         Rest.setUrl(GetBasePath('dashboard'));

--- a/awx/ui/client/src/home/home.controller.js
+++ b/awx/ui/client/src/home/home.controller.js
@@ -12,18 +12,64 @@ export default ['$scope','Wait', '$timeout', 'i18n',
         var dataCount = 0;
         let launchModalOpen = false;
         let refreshAfterLaunchClose = false;
-        let pendingRefresh = false;
-        let refreshTimerRunning = false;
+        let pendingDashboardRefresh = false;
+        let dashboardTimerRunning = false;
+        let newJobsTimerRunning = false;
+        let newTemplatesTimerRunning = false;
+        let newJobs = [];
+        let newTemplates =[];
 
-        $scope.$on('ws-jobs', function () {
-            if (!launchModalOpen) {
-                if (!refreshTimerRunning) {
-                    refreshLists();
+        $scope.$on('ws-jobs', function (e, msg) {
+            if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled') {
+                newJobs.push(msg.unified_job_id);
+                if (!newJobsTimerRunning) {
+                    fetchNewJobs();
+                }
+                if (!launchModalOpen) {
+                    if (!dashboardTimerRunning) {
+                        fetchDashboardData();
+                    } else {
+                        pendingDashboardRefresh = true;
+                    }
                 } else {
-                    pendingRefresh = true;
+                    refreshAfterLaunchClose = true;
+                }
+            }
+
+            const template = $scope.dashboardJobTemplatesListData.find((t) => t.id === msg.unified_job_template_id);
+            if (template) {
+                if (msg.status === 'pending') {
+                    if (template.summary_fields.recent_jobs.length === 10) {
+                        template.summary_fields.recent_jobs.pop();
+                    }
+
+                    template.summary_fields.recent_jobs.unshift({
+                        id: msg.unified_job_id,
+                        status: msg.status,
+                        type: msg.type
+                    });
+                } else {
+                    for (let i=0; i<template.summary_fields.recent_jobs.length; i++) {
+                        const recentJob = template.summary_fields.recent_jobs[i];
+                        if (recentJob.id === msg.unified_job_id) {
+                            recentJob.status = msg.status;
+                            if (msg.finished) {
+                                recentJob.finished = msg.finished;
+                                template.last_job_run = msg.finished;
+                            }
+                            break;
+                        }
+                    };
+
+                    if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled') {
+                        $scope.dashboardJobTemplatesListData.sort((a, b) => new Date(b.last_job_run) - new Date(a.last_job_run));
+                    }
                 }
             } else {
-                refreshAfterLaunchClose = true;
+                newTemplates.push(msg.unified_job_template_id);
+                if (!launchModalOpen && !newTemplatesTimerRunning) {
+                    fetchNewTemplates();
+                }
             }
         });
 
@@ -31,7 +77,10 @@ export default ['$scope','Wait', '$timeout', 'i18n',
             evt.stopPropagation();
             if (!isOpen && refreshAfterLaunchClose) {
                 refreshAfterLaunchClose = false;
-                refreshLists();
+                fetchDashboardData();
+                if (newTemplates.length > 0) {
+                    fetchNewTemplates();
+                }
             }
             launchModalOpen = isOpen;
         });
@@ -75,7 +124,7 @@ export default ['$scope','Wait', '$timeout', 'i18n',
             $scope.$emit('dashboardDataLoadComplete');
         });
 
-        function refreshLists () {
+        const fetchDashboardData = () => {
             Rest.setUrl(GetBasePath('dashboard'));
             Rest.get()
             .then(({data}) => {
@@ -83,25 +132,6 @@ export default ['$scope','Wait', '$timeout', 'i18n',
             })
             .catch(({data, status}) => {
                 ProcessErrors($scope, data, status, null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard host graph data: ${status}`) });
-            });
-
-            Rest.setUrl(GetBasePath("unified_jobs") + "?order_by=-finished&page_size=5&finished__isnull=false&type=workflow_job,job&count_disabled=1");
-            Rest.setHeader({'X-WS-Session-Quiet': true});
-            Rest.get()
-            .then(({data}) => {
-                $scope.dashboardJobsListData = data.results;
-            })
-            .catch(({data, status}) => {
-                ProcessErrors($scope, data, status, null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard jobs list: ${status}`) });
-            });
-
-            Rest.setUrl(GetBasePath("unified_job_templates") + "?order_by=-last_job_run&page_size=5&last_job_run__isnull=false&type=workflow_job_template,job_template&count_disabled=1");
-            Rest.get()
-            .then(({data}) => {
-                $scope.dashboardJobTemplatesListData = data.results;
-            })
-            .catch(({data, status}) => {
-                ProcessErrors($scope, data, status, null, { hdr: i18n._('Error!'), msg: i18n._(`Failed to get dashboard jobs list: ${status}`) });
             });
 
             if ($scope.graphData) {
@@ -119,16 +149,70 @@ export default ['$scope','Wait', '$timeout', 'i18n',
                 });
             }
 
-            pendingRefresh = false;
-            refreshTimerRunning = true;
+            pendingDashboardRefresh = false;
+            dashboardTimerRunning = true;
             $timeout(() => {
-                if (pendingRefresh) {
-                    refreshLists();
+                if (pendingDashboardRefresh) {
+                    fetchDashboardData();
                 } else {
-                    refreshTimerRunning = false;
+                    dashboardTimerRunning = false;
                 }
             }, 5000);
-        }
+        };
+
+        const fetchNewJobs = () => {
+            newJobsTimerRunning = true;
+            const newJobIdsFilter = newJobs.join(',');
+            newJobs = [];
+            Rest.setUrl(`${GetBasePath("unified_jobs")}?id__in=${newJobIdsFilter}&order_by=-finished&finished__isnull=false&type=workflow_job,job&count_disabled=1`);
+            Rest.get()
+                .then(({ data }) => {
+                    const joinedJobs = data.results.concat($scope.dashboardJobsListData);
+                    $scope.dashboardJobsListData = joinedJobs.length > 5
+                        ? joinedJobs.slice(0, 5)
+                        : joinedJobs;
+                    $timeout(() => {
+                        if (newJobs.length > 0) {
+                            fetchNewJobs();
+                        } else {
+                            newJobsTimerRunning = false;
+                        }
+                    }, 5000);
+                })
+                .catch(({ data, status }) => {
+                    ProcessErrors($scope, data, status, null, {
+                        hdr: i18n._('Error!'),
+                        msg: i18n._(`Failed to get new jobs for dashboard: ${status}`)
+                    });
+                });
+        };
+
+        const fetchNewTemplates = () => {
+            newTemplatesTimerRunning = true;
+            const newTemplateIdsFilter = newTemplates.join(',');
+            newTemplates = [];
+            Rest.setUrl(`${GetBasePath("unified_job_templates")}?id__in=${newTemplateIdsFilter}&order_by=-last_job_run&last_job_run__isnull=false&type=workflow_job_template,job_template&count_disabled=1"`);
+            Rest.get()
+                .then(({ data }) => {
+                    const joinedTemplates = data.results.concat($scope.dashboardJobTemplatesListData).sort((a, b) => new Date(b.last_job_run) - new Date(a.last_job_run));
+                    $scope.dashboardJobTemplatesListData = joinedTemplates.length > 5
+                        ? joinedTemplates.slice(0, 5)
+                        : joinedTemplates;
+                    $timeout(() => {
+                        if (newTemplates.length > 0 && !launchModalOpen) {
+                            fetchNewTemplates();
+                        } else {
+                            newTemplatesTimerRunning = false;
+                        }
+                    }, 5000);
+                })
+                .catch(({ data, status }) => {
+                    ProcessErrors($scope, data, status, null, {
+                        hdr: i18n._('Error!'),
+                        msg: i18n._(`Failed to get new templates for dashboard: ${status}`)
+                    });
+                });
+        };
 
         Wait('start');
         Rest.setUrl(GetBasePath('dashboard'));

--- a/awx/ui/client/src/home/home.controller.js
+++ b/awx/ui/client/src/home/home.controller.js
@@ -108,7 +108,7 @@ export default ['$scope','Wait', '$timeout', 'i18n',
         };
 
         $scope.$on('ws-jobs', function (e, msg) {
-            if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled') {
+            if (msg.status === 'successful' || msg.status === 'failed' || msg.status === 'canceled' || msg.status === 'error') {
                 newJobs.push(msg.unified_job_id);
                 if (!newJobsTimerRunning) {
                     fetchNewJobs();

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/list/sources-list.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/list/sources-list.controller.js
@@ -42,21 +42,7 @@
             $scope.$on(`ws-jobs`, function(e, data){
                 inventory_source = Find({ list: $scope.inventory_sources, key: 'id', val: data.inventory_source_id });
 
-                if (inventory_source === undefined || inventory_source === null) {
-                    inventory_source = {};
-                }
-
-                if(data.status === 'failed' || data.status === 'successful'){
-                    let path = GetBasePath('inventory') + $stateParams.inventory_id + '/inventory_sources';
-
-                    qs.search(path, $state.params[`${list.iterator}_search`])
-                    .then((searchResponse)=> {
-                        $scope[`${list.iterator}_dataset`] = searchResponse.data;
-                        $scope[list.name] = $scope[`${list.iterator}_dataset`].results;
-                        _.forEach($scope[list.name], buildStatusIndicators);
-                        optionsRequestDataProcessing();
-                    });
-                } else {
+                if (inventory_source) {
                     var status = GetSyncStatusMsg({
                         status: data.status
                     });

--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
@@ -33,6 +33,10 @@ export default ['$scope', '$stateParams', 'Rest', 'GetBasePath', '$state', 'OrgJ
                             const recentJob = template.summary_fields.recent_jobs[i];
                             if (recentJob.id === msg.unified_job_id) {
                                 recentJob.status = msg.status;
+                                if (msg.finished) {
+                                    recentJob.finished = msg.finished;
+                                    template.last_job_run = msg.finished;
+                                }
                                 break;
                             }
                         };

--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
@@ -4,25 +4,41 @@
  * All Rights Reserved
  *************************************************/
 
-export default ['$scope', '$rootScope',
-    '$stateParams', 'Rest', 'ProcessErrors',
-    'GetBasePath', 'Wait',
-    '$state', 'OrgJobTemplateList', 'OrgJobTemplateDataset', 'QuerySet',
-    function($scope, $rootScope,
-        $stateParams, Rest, ProcessErrors,
-        GetBasePath, Wait,
-        $state, OrgJobTemplateList, Dataset, qs) {
+export default ['$scope', '$stateParams', 'Rest', 'GetBasePath', '$state', 'OrgJobTemplateList', 'OrgJobTemplateDataset',
+    function($scope, $stateParams, Rest, GetBasePath, $state, OrgJobTemplateList, Dataset) {
 
         var list = OrgJobTemplateList,
             orgBase = GetBasePath('organizations');
 
-        $scope.$on(`ws-jobs`, function () {
-            let path = GetBasePath(list.basePath) || GetBasePath(list.name);
-            qs.search(path, $state.params[`${list.iterator}_search`])
-            .then(function(searchResponse) {
-                $scope[`${list.iterator}_dataset`] = searchResponse.data;
-                $scope[list.name] = $scope[`${list.iterator}_dataset`].results;
-            });
+        $scope.$on(`ws-jobs`, function (e, msg) {
+            if (msg.unified_job_template_id && $scope[list.name]) {
+                const template = $scope[list.name].find((t) => t.id === msg.unified_job_template_id);
+                if (template) {
+                    if (msg.status === 'pending') {
+                        // This is a new job - add it to the front of the
+                        // recent_jobs array
+                        if (template.summary_fields.recent_jobs.length === 10) {
+                            template.summary_fields.recent_jobs.pop();
+                        }
+    
+                        template.summary_fields.recent_jobs.unshift({
+                            id: msg.unified_job_id,
+                            status: msg.status,
+                            type: msg.type
+                        });
+                    } else {
+                        // This is an update to an existing job.  Check to see
+                        // if we have it in our array of recent_jobs
+                        for (let i=0; i<template.summary_fields.recent_jobs.length; i++) {
+                            const recentJob = template.summary_fields.recent_jobs[i];
+                            if (recentJob.id === msg.unified_job_id) {
+                                recentJob.status = msg.status;
+                                break;
+                            }
+                        };
+                    }
+                }
+            }
         });
 
         init();

--- a/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
+++ b/awx/ui/client/src/organizations/linkout/controllers/organizations-job-templates.controller.js
@@ -39,7 +39,7 @@ export default ['$scope', '$stateParams', 'Rest', 'GetBasePath', '$state', 'OrgJ
                                 }
                                 break;
                             }
-                        };
+                        }
                     }
                 }
             }

--- a/awx/ui/client/src/smart-status/smart-status.controller.js
+++ b/awx/ui/client/src/smart-status/smart-status.controller.js
@@ -90,9 +90,9 @@ export default ['$scope', '$filter', 'i18n', 'JobsStrings',
             $scope.sparkArray = sparkData;
             $scope.placeholders = new Array(10 - sparkData.length);
         }
-        $scope.$watchCollection('jobs', function(){
+        $scope.$watch('jobs', function(){
             init();
-        });
+        }, true);
 
 }];
 


### PR DESCRIPTION
##### SUMMARY
Part of #5883 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
It might be easiest for me to outline the expected behavior with these changes in order to illustrate what's changed and pose questions.

1. UI gets a socket message with a `status` _other than_ `pending`.
    - UI takes that message, loops across the available rows attempting to find a row that matches up with the `unified_job_id` provided in the socket message.  If it finds a matching row, we update the status of the row to match the status in the message.  (This same pattern will extend out to other fields (started/finished/etc) when provided by the api).

2. UI gets a socket message with at `status` of `pending`.
    - This is where things get interesting
    - This code treats this message like: This is a new job and you don't have it in your list.
        - Although now that I think about it, maybe this isn't quite true.  Could there be scenarios where we _do_ have this job in the list already but it's status is `new`?  If so, the code as it currently stands would potentially insert an extra job for this row (we don't check for this job in our existing list rows).
    - When we get a message like this, we have to go out and perform a GET in order to determine whether or not this particular user has sufficient privileges to see this job _and_ whether or not it fits in with the current search filters.
        - We only do this if the user is on page 1 of the jobs list
        - We only do this if the user has the default `-finished` or similar `-started` `order_by` filter applied to the list.  If they're sorting by something else we have no idea where this potential new row fits into the list.
        - We only do this if the user hasn't already filtered the list down by `id__in`.
            - There's a corner case here - if the user provided an `id__in` filter that matched a future job id.  This probably isn't a realistic scenario though.
        - These GET requests are time-banded on a 5 second interval.  For example, lets say a new job comes in over the websocket and we make a GET request for it: `/api/v2/unified_jobs?id__in=9000&count_disabled=1`.  Over the next 5 seconds, we hold on to all the id's of new jobs that come in and bundle them up into a single request to be executed 5 seconds after the initial request (id=9000).  That second request would look like `/api/v2/unified_jobs?id=9001,9002,9003`&count_disabled=1.  The cycle continues until there are no more new jobs in the past 5 seconds.
        - If we get rows back, this code adds them to the top of the list (this is why the sort order is important).  Page size is maintained by bumping the corresponding number of rows off the bottom.
        - Once the rows are added, future socket messages with updates to these rows fall into scenario 1 above.

**A special note about the launch modal**: while it's open we will still **update** rows underneath the modal (because this no longer requires making GET requests and re-rendering the entire row).  We don't add any new rows to the list while this modal is open though.  This is because the modal itself (it's element) lives within the row.  If this row were to get bumped out of the list the modal would disappear.  As such, we hold on to new job id's and fire off the corresponding request only _after_ the launch modal is closed.  This behavior is consistent with the way we handle messages while the launch modal is open currently.

### Question(s)

Probably for @wenottingham but I'm curious what others think as well.

1) Adding rows to the top of the list when the sort order is `-finished` (the default sort value) is not exactly "right".  In reality, we're adding rows to the top of the list in the order which we receive the socket messages telling us that a new job has been created.  This is probably OK until the job actually finishes.  Once the jobs finish, they may be out of order based on the `-finished` `order_by` filter.  Is that OK?

Alternatively we could try to do something like:

```
[new jobs ordered by whatever order they came in first (or something else?)]
[new jobs that we learned about from sockets but they've finished running, ordered by -finished (ordering would happen by the UI)]
[api jobs ordered by -finished]
```