### PR TITLE
fix smart inventory duplicate hosts

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -78,8 +78,7 @@ class HostManager(models.Manager):
                 self.core_filters = {}
 
                 qs = qs & q
-                unique_by_name = qs.order_by('name', 'pk').distinct('name')
-                return qs.filter(pk__in=unique_by_name)
+                return qs.order_by('name', 'pk').distinct('name')
         return qs
 
 


### PR DESCRIPTION
##### SUMMARY
This fixes the issue where smart inventory pulls duplicate hosts, if the hosts is part of two different groups.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


