### PR TITLE
Fixing kubernetes deployment indentation

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -136,10 +136,10 @@ kind: StatefulSet
 metadata:
   name: {{ kubernetes_deployment_name }}
   namespace: {{ kubernetes_namespace }}
-  {% if openshift_host is defined %}
+{% if openshift_host is defined %}
   labels:
     app: {{ kubernetes_deployment_name }}
-  {% endif %}
+{% endif %}
 spec:
   serviceName: {{ kubernetes_deployment_name }}
   replicas: 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Related to Issue #5985 and previous PR #5949. This is to get the `{% if %}` statement at the root indent level so it does not add additional indentation to the next line when the if statement is evaluated to be false.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
