### PR TITLE
Added support for K8S imagePullSecrets

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -203,6 +203,10 @@ spec:
             - name: custom-venvs
               mountPath: {{ custom_venvs_path }}
 {% endif %}
+{% if kubernetes_image_pull_secrets is defined %}
+      imagePullSecrets:
+        - name: "{{ kubernetes_image_pull_secrets }}"
+{% endif %}
       containers:
         - name: {{ kubernetes_deployment_name }}-web
           image: "{{ kubernetes_web_image }}:{{ kubernetes_web_version }}"

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: awx
   namespace: {{ kubernetes_namespace }}
+{% if kubernetes_image_pull_secrets is defined %}
+imagePullSecrets:
+  - name: "{{ kubernetes_image_pull_secrets }}"
+{% endif %}
 
 ---
 kind: Service
@@ -202,10 +206,6 @@ spec:
           volumeMounts:
             - name: custom-venvs
               mountPath: {{ custom_venvs_path }}
-{% endif %}
-{% if kubernetes_image_pull_secrets is defined %}
-      imagePullSecrets:
-        - name: "{{ kubernetes_image_pull_secrets }}"
 {% endif %}
       containers:
         - name: {{ kubernetes_deployment_name }}-web

--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -5,6 +5,10 @@ metadata:
   name: ansible-tower-management
   namespace: {{ kubernetes_namespace }}
 spec:
+{% if kubernetes_image_pull_secrets is defined %}
+  imagePullSecrets:
+    - name: "{{ kubernetes_image_pull_secrets }}"
+{% endif %}
   containers:
     - name: ansible-tower-management
       image: "{{ kubernetes_task_image }}:{{ kubernetes_task_version }}"


### PR DESCRIPTION
##### SUMMARY
This PR adds support for pulling images from private registries when installing AWX in Kubernetes. Based on https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod I've added support for `imagePullSecrets` throgh an optional variable. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 9.2.0

##### ADDITIONAL INFORMATION

