### PR TITLE
Add CA trust volume to k8s installer management pod

### DIFF
--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -15,6 +15,12 @@ spec:
       imagePullPolicy: Always
       command: ["sleep", "infinity"]
       volumeMounts:
+{% if ca_trust_dir is defined %}
+        - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+          mountPath: "/etc/pki/ca-trust/source/anchors/"
+          readOnly: true
+
+{% endif %}
         - name: {{ kubernetes_deployment_name }}-application-config
           mountPath: "/etc/tower/settings.py"
           subPath: settings.py
@@ -51,6 +57,13 @@ spec:
 {{ affinity | to_nice_yaml(indent=2) | indent(width=4, indentfirst=True) }}
 {% endif %}
   volumes:
+{% if ca_trust_dir is defined %}
+    - name: {{ kubernetes_deployment_name }}-ca-trust-dir
+      hostPath:
+        path: "{{ ca_trust_dir }}"
+        type: Directory
+
+{% endif %}
     - name: {{ kubernetes_deployment_name }}-application-config
       configMap:
         name: {{ kubernetes_deployment_name }}-config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
I previously closed #5702 because I thought there was no interest but I realize it was likely due to very poor explanation on my part. I'll try to do better, bear with me.

I currently have Postgres in require SSL/TLS mode and I pass the `pg_sslmode: verify-full` variable to the AWX kubernetes installer, along with the `ca_trust_dir` and `ca_trust_bundle` variables. These variables point to the correct path of the CA certificate for the Postgres server certificate. From my understanding, this is the intended use (along with adding SSL/TLS to nginx for some people). Because of the `verify-full` value in the `pg_sslmode` variable, this CA cert must exist. However, the `ca_trust_dir` volume is not passed to the management pod, and when that pod goes to run database migrations, the connection fails.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
