### PR TITLE
Add functionality for kubernetes Service Account annotations

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: awx
   namespace: {{ kubernetes_namespace }}
+{% if kubernetes_service_account_annotations is defined %}
+  annotations:
+{% for key, value in kubernetes_service_account_annotations.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
 {% if kubernetes_image_pull_secrets is defined %}
 imagePullSecrets:
   - name: "{{ kubernetes_image_pull_secrets }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When running on AWS EKS, there is functionality to give pods IAM permissions to access AWS resources. Part of setting this functionality up is to give the service account an annotation as to which IAM Role it should have. [The AWS Documentation on this can be found here.](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html) I made the modification in this PR to make that a fluid process inside of the AWX installer instead of a post step. This allows users running in a similar environment to use IAM roles to use AWS resources instead of embedding API keys inside of AWX.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
