### PR TITLE
Host list hooks

### DIFF
--- a/awx/ui_next/src/components/AlertModal/AlertModal.jsx
+++ b/awx/ui_next/src/components/AlertModal/AlertModal.jsx
@@ -16,7 +16,13 @@ const Header = styled.div`
   }
 `;
 
-export default ({ isOpen = null, title, variant, children, ...props }) => {
+export default function AlertModal({
+  isOpen = null,
+  title,
+  variant,
+  children,
+  ...props
+}) {
   const variantIcons = {
     danger: <ExclamationCircleIcon size="lg" css="color: #c9190b" />,
     error: <TimesCircleIcon size="lg" css="color: #c9190b" />,
@@ -44,4 +50,4 @@ export default ({ isOpen = null, title, variant, children, ...props }) => {
       {children}
     </Modal>
   );
-};
+}

--- a/awx/ui_next/src/components/ResourceAccessList/__snapshots__/DeleteRoleConfirmationModal.test.jsx.snap
+++ b/awx/ui_next/src/components/ResourceAccessList/__snapshots__/DeleteRoleConfirmationModal.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`<DeleteRoleConfirmationModal /> should render initially 1`] = `
   }
   username="jane"
 >
-  <_default
+  <AlertModal
     actions={
       Array [
         <Unknown
@@ -648,6 +648,6 @@ exports[`<DeleteRoleConfirmationModal /> should render initially 1`] = `
         </ModalContent>
       </Portal>
     </Modal>
-  </_default>
+  </AlertModal>
 </DeleteRoleConfirmationModal>
 `;

--- a/awx/ui_next/src/screens/Host/HostDetail/HostDetail.jsx
+++ b/awx/ui_next/src/screens/Host/HostDetail/HostDetail.jsx
@@ -3,7 +3,7 @@ import { Link, useHistory, useParams, useLocation } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Host } from '@types';
-import { Button, Switch } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { CardBody, CardActionsRow } from '@components/Card';
 import AlertModal from '@components/AlertModal';
 import ErrorDetail from '@components/ErrorDetail';
@@ -12,6 +12,7 @@ import { VariablesDetail } from '@components/CodeMirrorInput';
 import Sparkline from '@components/Sparkline';
 import DeleteButton from '@components/DeleteButton';
 import { HostsAPI } from '@api';
+import HostToggle from '../shared/HostToggle';
 
 function HostDetail({ host, i18n, onUpdateHost }) {
   const {
@@ -20,7 +21,6 @@ function HostDetail({ host, i18n, onUpdateHost }) {
     id,
     modified,
     name,
-    enabled,
     summary_fields: {
       inventory,
       recent_jobs,
@@ -36,24 +36,8 @@ function HostDetail({ host, i18n, onUpdateHost }) {
   const { id: inventoryId, hostId: inventoryHostId } = useParams();
   const [isLoading, setIsloading] = useState(false);
   const [deletionError, setDeletionError] = useState(false);
-  const [toggleLoading, setToggleLoading] = useState(false);
-  const [toggleError, setToggleError] = useState(false);
 
   const recentPlaybookJobs = recent_jobs.map(job => ({ ...job, type: 'job' }));
-
-  const handleHostToggle = async () => {
-    setToggleLoading(true);
-    try {
-      const { data } = await HostsAPI.update(id, {
-        enabled: !enabled,
-      });
-      onUpdateHost(data);
-    } catch (err) {
-      setToggleError(err);
-    } finally {
-      setToggleLoading(false);
-    }
-  };
 
   const handleHostDelete = async () => {
     setIsloading(true);
@@ -66,19 +50,6 @@ function HostDetail({ host, i18n, onUpdateHost }) {
     }
   };
 
-  if (toggleError && !toggleLoading) {
-    return (
-      <AlertModal
-        variant="error"
-        title={i18n._(t`Error!`)}
-        isOpen={toggleError && !toggleLoading}
-        onClose={() => setToggleError(false)}
-      >
-        {i18n._(t`Failed to toggle host.`)}
-        <ErrorDetail error={toggleError} />
-      </AlertModal>
-    );
-  }
   if (!isLoading && deletionError) {
     return (
       <AlertModal
@@ -94,15 +65,15 @@ function HostDetail({ host, i18n, onUpdateHost }) {
   }
   return (
     <CardBody>
-      <Switch
+      <HostToggle
+        host={host}
+        onToggle={enabled =>
+          onUpdateHost({
+            ...host,
+            enabled,
+          })
+        }
         css="padding-bottom: 40px"
-        id={`host-${id}-toggle`}
-        label={i18n._(t`On`)}
-        labelOff={i18n._(t`Off`)}
-        isChecked={enabled}
-        isDisabled={!user_capabilities.edit}
-        onChange={() => handleHostToggle()}
-        aria-label={i18n._(t`Toggle Host`)}
       />
       <DetailList gutter="sm">
         <Detail label={i18n._(t`Name`)} value={name} />

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useState, useEffect, useCallback } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Card } from '@patternfly/react-core';
@@ -25,7 +25,7 @@ const QS_CONFIG = getQSConfig('host', {
 
 function HostList({ i18n }) {
   const location = useLocation();
-  const match = useParams();
+  const match = useRouteMatch();
   const [selected, setSelected] = useState([]);
 
   const {
@@ -146,13 +146,13 @@ function HostList({ i18n }) {
               ]}
             />
           )}
-          renderItem={o => (
+          renderItem={host => (
             <HostListItem
-              key={o.id}
-              host={o}
-              detailUrl={`${match.url}/${o.id}/details`}
-              isSelected={selected.some(row => row.id === o.id)}
-              onSelect={() => handleSelect(o)}
+              key={host.id}
+              host={host}
+              detailUrl={`${match.url}/${host.id}/details`}
+              isSelected={selected.some(row => row.id === host.id)}
+              onSelect={() => handleSelect(host)}
             />
           )}
           emptyStateControls={
@@ -177,4 +177,5 @@ function HostList({ i18n }) {
   );
 }
 
+export { HostList as _HostList };
 export default withI18n()(HostList);

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -140,9 +140,9 @@ function HostList({ i18n }) {
                   itemsToDelete={selected}
                   pluralizedItemName={i18n._(t`Hosts`)}
                 />,
-                ...(canAdd ? [(
-                  <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />]
-                ) : [],
+                ...(canAdd
+                  ? [<ToolbarAddButton key="add" linkTo={`${match.url}/add`} />]
+                  : []),
               ]}
             />
           )}

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -1,5 +1,5 @@
-import React, { Component, Fragment } from 'react';
-import { withRouter } from 'react-router-dom';
+import React, { Fragment, useState, useEffect, useCallback } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Card } from '@patternfly/react-core';
@@ -12,6 +12,7 @@ import PaginatedDataList, {
   ToolbarAddButton,
   ToolbarDeleteButton,
 } from '@components/PaginatedDataList';
+import useRequest, { useDeleteItems } from '@util/useRequest';
 import { getQSConfig, parseQueryString } from '@util/qs';
 
 import HostListItem from './HostListItem';
@@ -22,263 +23,158 @@ const QS_CONFIG = getQSConfig('host', {
   order_by: 'name',
 });
 
-class HostsList extends Component {
-  constructor(props) {
-    super(props);
+function HostList({ i18n }) {
+  const location = useLocation();
+  const match = useParams();
+  const [selected, setSelected] = useState([]);
 
-    this.state = {
-      hasContentLoading: true,
-      contentError: null,
-      deletionError: null,
+  const {
+    result: { hosts, count, actions },
+    error: contentError,
+    isLoading,
+    request: fetchHosts,
+  } = useRequest(
+    useCallback(async () => {
+      const params = parseQueryString(QS_CONFIG, location.search);
+      const results = await Promise.all([
+        HostsAPI.read(params),
+        HostsAPI.readOptions(),
+      ]);
+      return {
+        hosts: results[0].data.results,
+        count: results[0].data.count,
+        actions: results[1].data.actions,
+      };
+    }, [location]),
+    {
       hosts: [],
-      selected: [],
-      itemCount: 0,
-      actions: null,
-      toggleError: null,
-      toggleLoading: null,
-    };
-
-    this.handleSelectAll = this.handleSelectAll.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
-    this.handleHostDelete = this.handleHostDelete.bind(this);
-    this.handleDeleteErrorClose = this.handleDeleteErrorClose.bind(this);
-    this.loadActions = this.loadActions.bind(this);
-    this.loadHosts = this.loadHosts.bind(this);
-    this.handleHostToggle = this.handleHostToggle.bind(this);
-    this.handleHostToggleErrorClose = this.handleHostToggleErrorClose.bind(
-      this
-    );
-  }
-
-  componentDidMount() {
-    this.loadHosts();
-  }
-
-  componentDidUpdate(prevProps) {
-    const { location } = this.props;
-    if (location !== prevProps.location) {
-      this.loadHosts();
+      count: 0,
+      actions: {},
     }
-  }
+  );
 
-  handleSelectAll(isSelected) {
-    const { hosts } = this.state;
+  useEffect(() => {
+    fetchHosts();
+  }, [fetchHosts]);
 
-    const selected = isSelected ? [...hosts] : [];
-    this.setState({ selected });
-  }
+  const isAllSelected = selected.length === hosts.length && selected.length > 0;
+  const {
+    isLoading: isDeleteLoading,
+    deleteItems: deleteHosts,
+    deletionError,
+    clearDeletionError,
+  } = useDeleteItems(
+    useCallback(async () => {
+      return Promise.all(selected.map(host => HostsAPI.destroy(host.id)));
+    }, [selected]),
+    {
+      qsConfig: QS_CONFIG,
+      allItemsSelected: isAllSelected,
+      fetchItems: fetchHosts,
+    }
+  );
 
-  handleSelect(row) {
-    const { selected } = this.state;
+  const handleHostDelete = async () => {
+    await deleteHosts();
+    setSelected([]);
+  };
 
-    if (selected.some(s => s.id === row.id)) {
-      this.setState({ selected: selected.filter(s => s.id !== row.id) });
+  const handleSelectAll = isSelected => {
+    setSelected(isSelected ? [...hosts] : []);
+  };
+
+  const handleSelect = host => {
+    if (selected.some(h => h.id === host.id)) {
+      setSelected(selected.filter(h => h.id !== host.id));
     } else {
-      this.setState({ selected: selected.concat(row) });
+      setSelected(selected.concat(host));
     }
-  }
+  };
 
-  handleDeleteErrorClose() {
-    this.setState({ deletionError: null });
-  }
+  const canAdd =
+    actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
 
-  handleHostToggleErrorClose() {
-    this.setState({ toggleError: null });
-  }
-
-  async handleHostDelete() {
-    const { selected } = this.state;
-
-    this.setState({ hasContentLoading: true });
-    try {
-      await Promise.all(selected.map(host => HostsAPI.destroy(host.id)));
-    } catch (err) {
-      this.setState({ deletionError: err });
-    } finally {
-      await this.loadHosts();
-    }
-  }
-
-  async handleHostToggle(hostToToggle) {
-    const { hosts } = this.state;
-    this.setState({ toggleLoading: hostToToggle.id });
-    try {
-      const { data: updatedHost } = await HostsAPI.update(hostToToggle.id, {
-        enabled: !hostToToggle.enabled,
-      });
-      this.setState({
-        hosts: hosts.map(host =>
-          host.id === updatedHost.id ? updatedHost : host
-        ),
-      });
-    } catch (err) {
-      this.setState({ toggleError: err });
-    } finally {
-      this.setState({ toggleLoading: null });
-    }
-  }
-
-  async loadActions() {
-    const { actions: cachedActions } = this.state;
-    let optionsPromise;
-    if (cachedActions) {
-      optionsPromise = Promise.resolve({ data: { actions: cachedActions } });
-    } else {
-      optionsPromise = HostsAPI.readOptions();
-    }
-
-    return optionsPromise;
-  }
-
-  async loadHosts() {
-    const { location } = this.props;
-    const params = parseQueryString(QS_CONFIG, location.search);
-
-    const promises = Promise.all([HostsAPI.read(params), this.loadActions()]);
-
-    this.setState({ contentError: null, hasContentLoading: true });
-    try {
-      const [
-        {
-          data: { count, results },
-        },
-        {
-          data: { actions },
-        },
-      ] = await promises;
-      this.setState({
-        actions,
-        itemCount: count,
-        hosts: results,
-        selected: [],
-      });
-    } catch (err) {
-      this.setState({ contentError: err });
-    } finally {
-      this.setState({ hasContentLoading: false });
-    }
-  }
-
-  render() {
-    const {
-      actions,
-      itemCount,
-      contentError,
-      hasContentLoading,
-      deletionError,
-      selected,
-      hosts,
-      toggleLoading,
-      toggleError,
-    } = this.state;
-    const { match, i18n } = this.props;
-
-    const canAdd =
-      actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
-    const isAllSelected =
-      selected.length > 0 && selected.length === hosts.length;
-
-    return (
-      <Fragment>
-        <Card>
-          <PaginatedDataList
-            contentError={contentError}
-            hasContentLoading={hasContentLoading}
-            items={hosts}
-            itemCount={itemCount}
-            pluralizedItemName={i18n._(t`Hosts`)}
-            qsConfig={QS_CONFIG}
-            onRowClick={this.handleSelect}
-            toolbarSearchColumns={[
-              {
-                name: i18n._(t`Name`),
-                key: 'name',
-                isDefault: true,
-              },
-              {
-                name: i18n._(t`Created By (Username)`),
-                key: 'created_by__username',
-              },
-              {
-                name: i18n._(t`Modified By (Username)`),
-                key: 'modified_by__username',
-              },
-            ]}
-            toolbarSortColumns={[
-              {
-                name: i18n._(t`Name`),
-                key: 'name',
-              },
-            ]}
-            renderToolbar={props => (
-              <DataListToolbar
-                {...props}
-                showSelectAll
-                isAllSelected={isAllSelected}
-                onSelectAll={this.handleSelectAll}
-                qsConfig={QS_CONFIG}
-                additionalControls={[
-                  <ToolbarDeleteButton
-                    key="delete"
-                    onDelete={this.handleHostDelete}
-                    itemsToDelete={selected}
-                    pluralizedItemName={i18n._(t`Hosts`)}
-                  />,
-                  ...(canAdd
-                    ? [
-                        <ToolbarAddButton
-                          key="add"
-                          linkTo={`${match.url}/add`}
-                        />,
-                      ]
-                    : []),
-                ]}
-              />
-            )}
-            renderItem={o => (
-              <HostListItem
-                key={o.id}
-                host={o}
-                detailUrl={`${match.url}/${o.id}/details`}
-                isSelected={selected.some(row => row.id === o.id)}
-                onSelect={() => this.handleSelect(o)}
-                onToggleHost={this.handleHostToggle}
-                toggleLoading={toggleLoading === o.id}
-              />
-            )}
-            emptyStateControls={
-              canAdd ? (
-                <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />
-              ) : null
-            }
-          />
-        </Card>
-        {toggleError && !toggleLoading && (
-          <AlertModal
-            variant="error"
-            title={i18n._(t`Error!`)}
-            isOpen={toggleError && !toggleLoading}
-            onClose={this.handleHostToggleErrorClose}
-          >
-            {i18n._(t`Failed to toggle host.`)}
-            <ErrorDetail error={toggleError} />
-          </AlertModal>
-        )}
-        {deletionError && (
-          <AlertModal
-            isOpen={deletionError}
-            variant="error"
-            title={i18n._(t`Error!`)}
-            onClose={this.handleDeleteErrorClose}
-          >
-            {i18n._(t`Failed to delete one or more hosts.`)}
-            <ErrorDetail error={deletionError} />
-          </AlertModal>
-        )}
-      </Fragment>
-    );
-  }
+  return (
+    <Fragment>
+      <Card>
+        <PaginatedDataList
+          contentError={contentError}
+          hasContentLoading={isLoading || isDeleteLoading}
+          items={hosts}
+          itemCount={count}
+          pluralizedItemName={i18n._(t`Hosts`)}
+          qsConfig={QS_CONFIG}
+          onRowClick={handleSelect}
+          toolbarSearchColumns={[
+            {
+              name: i18n._(t`Name`),
+              key: 'name',
+              isDefault: true,
+            },
+            {
+              name: i18n._(t`Created By (Username)`),
+              key: 'created_by__username',
+            },
+            {
+              name: i18n._(t`Modified By (Username)`),
+              key: 'modified_by__username',
+            },
+          ]}
+          toolbarSortColumns={[
+            {
+              name: i18n._(t`Name`),
+              key: 'name',
+            },
+          ]}
+          renderToolbar={props => (
+            <DataListToolbar
+              {...props}
+              showSelectAll
+              isAllSelected={isAllSelected}
+              onSelectAll={handleSelectAll}
+              qsConfig={QS_CONFIG}
+              additionalControls={[
+                <ToolbarDeleteButton
+                  key="delete"
+                  onDelete={handleHostDelete}
+                  itemsToDelete={selected}
+                  pluralizedItemName={i18n._(t`Hosts`)}
+                />,
+                ...(canAdd ? [(
+                  <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />]
+                ) : [],
+              ]}
+            />
+          )}
+          renderItem={o => (
+            <HostListItem
+              key={o.id}
+              host={o}
+              detailUrl={`${match.url}/${o.id}/details`}
+              isSelected={selected.some(row => row.id === o.id)}
+              onSelect={() => handleSelect(o)}
+            />
+          )}
+          emptyStateControls={
+            canAdd ? (
+              <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />
+            ) : null
+          }
+        />
+      </Card>
+      {deletionError && (
+        <AlertModal
+          isOpen={deletionError}
+          variant="error"
+          title={i18n._(t`Error!`)}
+          onClose={clearDeletionError}
+        >
+          {i18n._(t`Failed to delete one or more hosts.`)}
+          <ErrorDetail error={deletionError} />
+        </AlertModal>
+      )}
+    </Fragment>
+  );
 }
 
-export { HostsList as _HostsList };
-export default withI18n()(withRouter(HostsList));
+export default withI18n()(HostList);

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -177,5 +177,4 @@ function HostList({ i18n }) {
   );
 }
 
-export { HostList as _HostList };
 export default withI18n()(HostList);

--- a/awx/ui_next/src/screens/Host/HostList/HostListItem.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostListItem.jsx
@@ -10,7 +10,6 @@ import {
   DataListItem,
   DataListItemRow,
   DataListItemCells,
-  Switch,
   Tooltip,
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
@@ -18,6 +17,7 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 
 import Sparkline from '@components/Sparkline';
 import { Host } from '@types';
+import HostToggle from './HostToggle';
 import styled from 'styled-components';
 
 const DataListAction = styled(_DataListAction)`
@@ -36,15 +36,7 @@ class HostListItem extends React.Component {
   };
 
   render() {
-    const {
-      host,
-      isSelected,
-      onSelect,
-      detailUrl,
-      onToggleHost,
-      toggleLoading,
-      i18n,
-    } = this.props;
+    const { host, isSelected, onSelect, detailUrl, i18n } = this.props;
 
     const recentPlaybookJobs = host.summary_fields.recent_jobs.map(job => ({
       ...job,
@@ -87,6 +79,22 @@ class HostListItem extends React.Component {
                   </Fragment>
                 )}
               </DataListCell>,
+              <DataListCell key="enable" alignRight isFilled={false}>
+                <HostToggle host={host} />
+              </DataListCell>,
+              <DataListCell key="edit" alignRight isFilled={false}>
+                {host.summary_fields.user_capabilities.edit && (
+                  <Tooltip content={i18n._(t`Edit Host`)} position="top">
+                    <Button
+                      variant="plain"
+                      component={Link}
+                      to={`/hosts/${host.id}/edit`}
+                    >
+                      <PencilAltIcon />
+                    </Button>
+                  </Tooltip>
+                )}
+              </DataListCell>,
             ]}
           />
           <DataListAction
@@ -94,25 +102,7 @@ class HostListItem extends React.Component {
             aria-labelledby={labelId}
             id={labelId}
           >
-            <Tooltip
-              content={i18n._(
-                t`Indicates if a host is available and should be included in running jobs.  For hosts that are part of an external inventory, this may be reset by the inventory sync process.`
-              )}
-              position="top"
-            >
-              <Switch
-                css="display: inline-flex;"
-                id={`host-${host.id}-toggle`}
-                label={i18n._(t`On`)}
-                labelOff={i18n._(t`Off`)}
-                isChecked={host.enabled}
-                isDisabled={
-                  toggleLoading || !host.summary_fields.user_capabilities.edit
-                }
-                onChange={() => onToggleHost(host)}
-                aria-label={i18n._(t`Toggle host`)}
-              />
-            </Tooltip>
+            <HostToggle host={host} />
             {host.summary_fields.user_capabilities.edit && (
               <Tooltip content={i18n._(t`Edit Host`)} position="top">
                 <Button

--- a/awx/ui_next/src/screens/Host/HostList/HostListItem.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostListItem.jsx
@@ -17,8 +17,8 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 
 import Sparkline from '@components/Sparkline';
 import { Host } from '@types';
-import HostToggle from './HostToggle';
 import styled from 'styled-components';
+import HostToggle from '../shared/HostToggle';
 
 const DataListAction = styled(_DataListAction)`
   align-items: center;

--- a/awx/ui_next/src/screens/Host/HostList/HostListItem.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostListItem.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { mountWithContexts } from '@testUtils/enzymeHelpers';
 
 import HostsListItem from './HostListItem';
@@ -44,6 +43,7 @@ describe('<HostsListItem />', () => {
     );
     expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
   });
+
   test('edit button hidden from users without edit capabilities', () => {
     const copyMockHost = Object.assign({}, mockHost);
     copyMockHost.summary_fields.user_capabilities.edit = false;
@@ -57,40 +57,5 @@ describe('<HostsListItem />', () => {
       />
     );
     expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
-  });
-  test('handles toggle click when host is enabled', () => {
-    const wrapper = mountWithContexts(
-      <HostsListItem
-        isSelected={false}
-        detailUrl="/host/1"
-        onSelect={() => {}}
-        host={mockHost}
-        onToggleHost={onToggleHost}
-      />
-    );
-    wrapper
-      .find('Switch')
-      .first()
-      .find('input')
-      .simulate('change');
-    expect(onToggleHost).toHaveBeenCalledWith(mockHost);
-  });
-
-  test('handles toggle click when host is disabled', () => {
-    const wrapper = mountWithContexts(
-      <HostsListItem
-        isSelected={false}
-        detailUrl="/host/1"
-        onSelect={() => {}}
-        host={mockHost}
-        onToggleHost={onToggleHost}
-      />
-    );
-    wrapper
-      .find('Switch')
-      .first()
-      .find('input')
-      .simulate('change');
-    expect(onToggleHost).toHaveBeenCalledWith(mockHost);
   });
 });

--- a/awx/ui_next/src/screens/Host/HostList/HostToggle.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostToggle.jsx
@@ -1,0 +1,72 @@
+import React, { Fragment, useState, useEffect, useCallback } from 'react';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import { Switch, Tooltip } from '@patternfly/react-core';
+import AlertModal from '@components/AlertModal';
+import ErrorDetail from '@components/ErrorDetail';
+import useRequest from '@util/useRequest';
+import { HostsAPI } from '@api';
+
+function HostToggle({ host, i18n }) {
+  const [isEnabled, setIsEnabled] = useState(host.enabled);
+  const [showError, setShowError] = useState(false);
+
+  const { result, isLoading, error, request: toggleHost } = useRequest(
+    useCallback(async () => {
+      await HostsAPI.update(host.id, {
+        enabled: !isEnabled,
+      });
+      return !isEnabled;
+    }, [host, isEnabled]),
+    host.enabled
+  );
+
+  useEffect(() => {
+    if (result !== isEnabled) {
+      setIsEnabled(result);
+    }
+  }, [result, isEnabled]);
+
+  useEffect(() => {
+    if (error) {
+      setShowError(true);
+    }
+  }, [error]);
+
+  return (
+    <Fragment>
+      <Tooltip
+        content={i18n._(
+          t`Indicates if a host is available and should be included in running
+          jobs.  For hosts that are part of an external inventory, this may be
+          reset by the inventory sync process.`
+        )}
+        position="top"
+      >
+        <Switch
+          css="display: inline-flex;"
+          id={`host-${host.id}-toggle`}
+          label={i18n._(t`On`)}
+          labelOff={i18n._(t`Off`)}
+          isChecked={isEnabled}
+          isDisabled={isLoading || !host.summary_fields.user_capabilities.edit}
+          onChange={toggleHost}
+          aria-label={i18n._(t`Toggle host`)}
+        />
+      </Tooltip>
+      {showError && error && !isLoading && (
+        <AlertModal
+          variant="danger"
+          title={i18n._(t`Error!`)}
+          isOpen={error && !isLoading}
+          onClose={() => setShowError(false)}
+        >
+          {i18n._(t`Failed to toggle host.`)}
+          <ErrorDetail error={error} />
+        </AlertModal>
+      )}
+    </Fragment>
+  );
+}
+
+export default withI18n()(HostToggle);

--- a/awx/ui_next/src/screens/Host/shared/HostToggle.jsx
+++ b/awx/ui_next/src/screens/Host/shared/HostToggle.jsx
@@ -7,7 +7,7 @@ import ErrorDetail from '@components/ErrorDetail';
 import useRequest from '@util/useRequest';
 import { HostsAPI } from '@api';
 
-function HostToggle({ host, i18n }) {
+function HostToggle({ host, onToggle, className, i18n }) {
   const [isEnabled, setIsEnabled] = useState(host.enabled);
   const [showError, setShowError] = useState(false);
 
@@ -24,8 +24,11 @@ function HostToggle({ host, i18n }) {
   useEffect(() => {
     if (result !== isEnabled) {
       setIsEnabled(result);
+      if (onToggle) {
+        onToggle(result);
+      }
     }
-  }, [result, isEnabled]);
+  }, [result, isEnabled, onToggle]);
 
   useEffect(() => {
     if (error) {
@@ -44,6 +47,7 @@ function HostToggle({ host, i18n }) {
         position="top"
       >
         <Switch
+          className={className}
           css="display: inline-flex;"
           id={`host-${host.id}-toggle`}
           label={i18n._(t`On`)}
@@ -56,7 +60,7 @@ function HostToggle({ host, i18n }) {
       </Tooltip>
       {showError && error && !isLoading && (
         <AlertModal
-          variant="danger"
+          variant="error"
           title={i18n._(t`Error!`)}
           isOpen={error && !isLoading}
           onClose={() => setShowError(false)}

--- a/awx/ui_next/src/screens/Host/shared/HostToggle.test.jsx
+++ b/awx/ui_next/src/screens/Host/shared/HostToggle.test.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { HostsAPI } from '@api';
+import { mountWithContexts } from '@testUtils/enzymeHelpers';
+import HostToggle from './HostToggle';
+
+jest.mock('@api');
+
+const mockHost = {
+  id: 1,
+  name: 'Host 1',
+  url: '/api/v2/hosts/1',
+  inventory: 1,
+  enabled: true,
+  summary_fields: {
+    inventory: {
+      id: 1,
+      name: 'inv 1',
+    },
+    user_capabilities: {
+      delete: true,
+      update: true,
+    },
+    recent_jobs: [],
+  },
+};
+
+describe('<HostToggle>', () => {
+  test('should should toggle off', async () => {
+    const onToggle = jest.fn();
+    const wrapper = mountWithContexts(
+      <HostToggle host={mockHost} onToggle={onToggle} />
+    );
+    expect(wrapper.find('Switch').prop('isChecked')).toEqual(true);
+
+    await act(async () => {
+      wrapper.find('Switch').invoke('onChange')();
+    });
+    expect(HostsAPI.update).toHaveBeenCalledWith(1, {
+      enabled: false,
+    });
+    wrapper.update();
+    expect(wrapper.find('Switch').prop('isChecked')).toEqual(false);
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  test('should should toggle on', async () => {
+    const onToggle = jest.fn();
+    const wrapper = mountWithContexts(
+      <HostToggle
+        host={{
+          ...mockHost,
+          enabled: false,
+        }}
+        onToggle={onToggle}
+      />
+    );
+    expect(wrapper.find('Switch').prop('isChecked')).toEqual(false);
+
+    await act(async () => {
+      wrapper.find('Switch').invoke('onChange')();
+    });
+    expect(HostsAPI.update).toHaveBeenCalledWith(1, {
+      enabled: true,
+    });
+    wrapper.update();
+    expect(wrapper.find('Switch').prop('isChecked')).toEqual(true);
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  test('should show error modal', async () => {
+    HostsAPI.update.mockImplementation(() => {
+      throw new Error('nope');
+    });
+    const wrapper = mountWithContexts(<HostToggle host={mockHost} />);
+    expect(wrapper.find('Switch').prop('isChecked')).toEqual(true);
+
+    await act(async () => {
+      wrapper.find('Switch').invoke('onChange')();
+    });
+    wrapper.update();
+    const modal = wrapper.find('AlertModal');
+    expect(modal).toHaveLength(1);
+    expect(modal.prop('isOpen')).toEqual(true);
+
+    act(() => {
+      modal.invoke('onClose')();
+    });
+    wrapper.update();
+    expect(wrapper.find('AlertModal')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
##### SUMMARY
Refactor HostList to use hooks, applying bug fixes made in `useRequest` and `useDeleteItems`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION

This adds a new component, `HostToggle` to display the toggle switch and make the API call for toggling a host on/off. This new component is used in both the host list and detail views.
