### PR TITLE
Stop making rest calls for project sync updates on projects list

### DIFF
--- a/awx/ui/client/features/projects/projectsList.controller.js
+++ b/awx/ui/client/features/projects/projectsList.controller.js
@@ -113,9 +113,7 @@ function projectsListController (
                 // And we found the affected project
                 $log.debug(`Received event for project: ${project.name}`);
                 $log.debug(`Status changed to: ${data.status}`);
-                if (data.status === 'successful' || data.status === 'failed' || data.status === 'canceled') {
-                    reloadList();
-                } else {
+                if (!(data.status === 'successful' || data.status === 'failed' || data.status === 'canceled')) {
                     project.scm_update_tooltip = vm.strings.get('update.UPDATE_RUNNING');
                 }
                 project.status = data.status;


### PR DESCRIPTION
##### SUMMARY
This code didn't make a ton of sense.  We were updating the row _and_ reloading the whole list.  Now we just update the status on the matching row (along with the relevant tooltip).

Part of #5883 

##### ISSUE TYPE
 - Bugfix Pull Request
