### PR TITLE
Show Japanese message-bar when adding container group

### DIFF
--- a/awx/ui/client/src/instance-groups/container-groups/add-container-group.view.html
+++ b/awx/ui/client/src/instance-groups/container-groups/add-container-group.view.html
@@ -2,7 +2,7 @@
 <a class="containerGroups-messageBar-link" href="https://docs.ansible.com/ansible-tower/latest/html/administration/external_execution_envs.html#container-groups" target="_blank" style="color: white">
   <div class="Section-messageBar">
       <i class="Section-messageBar-warning fa fa-warning"></i>
-      <span class="Section-messageBar-text">This feature is currently in tech preview and is subject to change in a future release.  Click here for documentation.</span>
+      <span class="Section-messageBar-text" translate>This feature is currently in tech preview and is subject to change in a future release.  Click here for documentation.</span>
   </div>
 </a>
 <at-panel>

--- a/awx/ui/po/ja.po
+++ b/awx/ui/po/ja.po
@@ -689,6 +689,10 @@ msgstr "ホストの作成"
 msgid "CREATE INSTANCE GROUP"
 msgstr "インスタンスグループの作成"
 
+#: client/src/instance-groups/instance-groups.strings.js:13
+msgid "CREATE CONTAINER GROUP"
+msgstr "コンテナグループの作成"
+
 #: client/src/inventories-hosts/inventories/related/sources/add/sources-add.route.js:8
 msgid "CREATE INVENTORY SOURCE"
 msgstr "インベントリーソースの作成"
@@ -6699,3 +6703,8 @@ msgstr "{{::state._hint}}"
 msgid "{{pageSize}}"
 msgstr "{{pageSize}}"
 
+#: client/src/instance-groups/container-groups/add-container-group.view.html:5
+msgid "This feature is currently in tech preview and is subject to change in a future release.  Click here for documentation."
+msgstr ""
+"この機能は現在テクニカルプレビューであり、将来のリリースで変更される可能性があります。"
+"ドキュメントを確認するには、ここをクリックしてください。"


### PR DESCRIPTION
##### SUMMARY
Show Japanese message-bar when adding container group:


1. Translate `CREATE CONTAINER GROUP` (Dashboard > Instance Groups > Press "+" button:
![instance_group](https://user-images.githubusercontent.com/7360578/75097300-7dd56000-55ec-11ea-8957-73dcc3637709.png)

2. Translate message-bar (Darshbard > Instance Group > CREATE CONTAINER GROUP):
![add_container_group](https://user-images.githubusercontent.com/7360578/75097318-afe6c200-55ec-11ea-8574-ff12a92df7fc.png)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
- AWX devel
- Ansible Tower 3.6.3
```

##### ADDITIONAL INFORMATION
None