### PR TITLE
fixed precedence on ansible.cfg

### DIFF
--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -106,7 +106,7 @@ def could_be_inventory(project_path, dir_path, filename):
 def read_ansible_config(project_path, variables_of_interest):
     fnames = ['/etc/ansible/ansible.cfg']
     if project_path:
-        fnames.insert(1, os.path.join(project_path, 'ansible.cfg'))
+        fnames.append(os.path.join(project_path, 'ansible.cfg'))
     values = {}
     try:
         parser = ConfigParser()

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -106,7 +106,7 @@ def could_be_inventory(project_path, dir_path, filename):
 def read_ansible_config(project_path, variables_of_interest):
     fnames = ['/etc/ansible/ansible.cfg']
     if project_path:
-        fnames.insert(0, os.path.join(project_path, 'ansible.cfg'))
+        fnames.insert(1, os.path.join(project_path, 'ansible.cfg'))
     values = {}
     try:
         parser = ConfigParser()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix  to correctly use project directory before /etc/ansible/ansible.cfg in instances where a setting exists in both.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 9.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
