### PR TITLE
translate a missing string in the license UI

### DIFF
--- a/awx/ui/client/src/license/license.partial.html
+++ b/awx/ui/client/src/license/license.partial.html
@@ -256,7 +256,7 @@
 							</div>
 						</div>
 						<div class="Modal-footer">
-								<button ng-click="cancelLicenseLookup()" class="btn Modal-footerButton Modal-defaultButton">CANCEL</button>
+								<button ng-click="cancelLicenseLookup()" class="btn Modal-footerButton Modal-defaultButton" translate>CANCEL</button>
 								<button
 										ng-click="confirmLicenseSelection()"
 										class="btn Modal-footerButton btn-success"


### PR DESCRIPTION
see: https://github.com/ansible/tower/issues/3949

<img width="794" alt="image" src="https://user-images.githubusercontent.com/214912/75158472-2d412e00-56e4-11ea-869e-cc8c6ad6a0e4.png">
