### PR TITLE
Do not fail a successful project update if inventory update fails

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -584,7 +584,7 @@ def handle_work_error(task_id, *args, **kwargs):
                 first_instance = instance
                 first_instance_type = each_task['type']
 
-            if instance.celery_task_id != task_id and not instance.cancel_flag:
+            if instance.celery_task_id != task_id and not instance.cancel_flag and not instance.status == 'successful':
                 instance.status = 'failed'
                 instance.failed = True
                 if not instance.job_explanation:
@@ -1692,7 +1692,7 @@ class RunJob(BaseTask):
             if settings.MAX_FORKS > 0 and job.forks > settings.MAX_FORKS:
                 logger.warning(f'Maximum number of forks ({settings.MAX_FORKS}) exceeded.')
                 args.append('--forks=%d' % settings.MAX_FORKS)
-            else: 
+            else:
                 args.append('--forks=%d' % job.forks)
         if job.force_handlers:
             args.append('--force-handlers')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
issue #4418 

Scenario - job is launched and spawns inventory update and project update.
If the inventory update fails, then it will fail the job and the project update.
It will fail the project update even if that update already ran and was successful.

This code change will not fail the project update if it has already ran successfully.

In cases where other jobs depend on that project update (but not the failed inventory
update), then we don't want those jobs to fail.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
