### PR TITLE
Verbose logging about scaleup events

### DIFF
--- a/awx/main/dispatch/worker/task.py
+++ b/awx/main/dispatch/worker/task.py
@@ -9,6 +9,7 @@ from kubernetes.config import kube_config
 from awx.main.tasks import dispatch_startup, inform_cluster_of_shutdown
 
 from .base import BaseWorker
+from awx.main.dispatch.pool import log_serialize
 
 logger = logging.getLogger('awx.main.dispatch')
 
@@ -57,8 +58,7 @@ class TaskWorker(BaseWorker):
             # the callable is a class, e.g., RunJob; instantiate and
             # return its `run()` method
             _call = _call().run
-        # don't print kwargs, they often contain launch-time secrets
-        logger.debug('task {} starting {}(*{})'.format(uuid, task, args))
+        logger.debug('task {} starting {}'.format(uuid, log_serialize(body)))
         return _call(*args, **kwargs)
 
     def perform_work(self, body):


### PR DESCRIPTION
##### SUMMARY
I remove the old log for scaleup, and replace it with a log at every point that `.up` is called. I _think_ I found all the instances of this.

new:

```
2020-02-25 17:43:58,088 WARNING  awx.main.dispatch PID:13054 worker exiting gracefully pid:13054
2020-02-25 17:43:58,089 WARNING  awx.main.dispatch PID:5445 worker exiting gracefully pid:5445
2020-02-25 17:43:58,111 WARNING  awx.main.dispatch PID:10052 worker exiting gracefully pid:10052
2020-02-25 17:43:58,118 WARNING  awx.main.dispatch PID:27876 scaled up worker 14557, new total: 8, due to awx.main.tasks.awx_k8s_reaper
2020-02-25 17:43:58,131 WARNING  awx.main.dispatch PID:27876 scaled up worker 14560, new total: 9, due to awx.main.tasks.delete_inventory
2020-02-25 17:43:58,161 WARNING  awx.main.dispatch PID:27876 scaled up worker 14568, new total: 10, due to awx.main.scheduler.tasks.run_task_manager
2020-02-25 17:44:04,116 WARNING  awx.main.dispatch PID:14568 job 1001 (error) encountered an error (rc=None), please see task stdout for details.
2020-02-25 17:44:14,482 WARNING  awx.main.dispatch PID:27876 scaled up worker 17239, new total: 11, due to awx.main.scheduler.tasks.run_task_manager
2020-02-25 17:44:14,907 WARNING  awx.main.dispatch PID:27876 scaled up worker 17302, new total: 12, due to awx.main.scheduler.tasks.run_task_manager
2020-02-25 17:44:20,381 WARNING  awx.main.dispatch PID:14557 job 1015 (failed) encountered an error (rc=1), please see task stdout for details.
2020-02-25 17:44:20,684 WARNING  awx.main.dispatch PID:26784 job 1028 (error) encountered an error (rc=None), please see task stdout for details.
2020-02-25 17:44:22,503 WARNING  awx.main.dispatch PID:5996 checking dispatcher running for localhost
2020-02-25 17:44:22,525 WARNING  awx.main.dispatch PID:27876 Consumer received control message {'control': 'running'}
2020-02-25 17:44:22,578 WARNING  awx.main.dispatch PID:5996 checking dispatcher running for localhost
2020-02-25 17:44:22,600 WARNING  awx.main.dispatch PID:27876 Consumer received control message {'control': 'running'}
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
The idea here is to track down a firestorm of events.

That could be because the dispatcher is stopped, and then rabbitmq builds a queue, and then dispatcher is restarted.

Or... this could happen if one of our tasks calls a task recursively. This should never happen, and if we catch it doing such a thing we should fix it. These logs will help us find anything like that, also may help to identify stretches when the workers are unexpectedly occupied, etc.
