### PR TITLE
Set setuid bit on bwrap in development Dockerfile

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -112,6 +112,9 @@ RUN dnf -y clean all
 
 RUN rm -rf /root/.cache
 
+# https://github.com/ansible/awx/issues/5224
+RUN chmod u+s /usr/bin/bwrap
+
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Signed-off-by: Philip Douglass <philip.douglass@amadeus.com>

##### SUMMARY
Related: #5224 

As noted, due to a change in the way the bubblewrap package installs on CentOS 8 and RHEL 8, the setuid bit must be set on the bwrap binary. While this was fixed for the installer, it was not fixed in the development Dockerfile.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 9.2.0
```

##### ADDITIONAL INFORMATION
The problem can be seen as described in #5224 with the development image by following the instructions given in the [CONTRIBUTING.md](https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md#build-the-base-image) guide to build the development image.
