### PR TITLE
Extend social auth saml team attr with admin and superuser option

### DIFF
--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -741,7 +741,10 @@ class SAMLTeamAttrTeamOrgMapField(HybridDictField):
 
     team = fields.CharField(required=True, allow_null=False)
     organization = fields.CharField(required=True, allow_null=False)
-
+    
+    superusers = fields.BooleanField(required=False)
+    admins = fields.BooleanField(required=False)
+    
     child = _Forbidden()
 
 
@@ -750,5 +753,8 @@ class SAMLTeamAttrField(HybridDictField):
     team_org_map = fields.ListField(required=False, child=SAMLTeamAttrTeamOrgMapField(), allow_null=True)
     remove = fields.BooleanField(required=False)
     saml_attr = fields.CharField(required=False, allow_null=True)
-
+    
+    superusers_remove = fields.BooleanField(required=False)
+    admins_remove = fields.BooleanField(required=False)
+    
     child = _Forbidden()

--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -742,6 +742,7 @@ class SAMLTeamAttrTeamOrgMapField(HybridDictField):
     team = fields.CharField(required=True, allow_null=False)
     organization = fields.CharField(required=True, allow_null=False)
     
+    auditors = fields.BooleanField(required=False)    
     superusers = fields.BooleanField(required=False)
     admins = fields.BooleanField(required=False)
     
@@ -754,6 +755,7 @@ class SAMLTeamAttrField(HybridDictField):
     remove = fields.BooleanField(required=False)
     saml_attr = fields.CharField(required=False, allow_null=True)
     
+    auditors_remove = fields.BooleanField(required=False)    
     superusers_remove = fields.BooleanField(required=False)
     admins_remove = fields.BooleanField(required=False)
     

--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -219,7 +219,19 @@ def update_user_teams_by_saml_attr(backend, details, user=None, *args, **kwargs)
                 user.is_superuser = True
                 user.save()
                 break
+                
+            # Auditors Logic
+            if team_map.get('auditors_remove', True):
+                if user.is_system_auditor:
+                    user.is_system_auditor = False
+                    user.save()
 
+            auditors = team_name_map.get('auditors', '')
+            if auditors:
+                user.is_system_auditor = True
+                user.save()
+                break
+                
     if team_map.get('remove', True):
         [t.member_role.members.remove(user) for t in
             Team.objects.filter(Q(member_role__members=user) & ~Q(id__in=team_ids))]

--- a/docs/auth/saml.md
+++ b/docs/auth/saml.md
@@ -69,6 +69,8 @@ Below is another example of a SAML attribute that contains a Team membership in 
 {
   "saml_attr": "eduPersonAffiliation",
   "remove": true,
+  "admins_remove": true,
+  "superusers_remove": true,
   "team_org_map": [
     {
       "team": "member",
@@ -76,7 +78,9 @@ Below is another example of a SAML attribute that contains a Team membership in 
     },
     {
       "team": "staff",
-      "organization": "Default2"
+      "organization": "Default2",
+      "admins": true,
+      "superusers": true
     }
   ]
 }
@@ -84,5 +88,9 @@ Below is another example of a SAML attribute that contains a Team membership in 
 **saml_attr:** The SAML attribute name where the team array can be found.
 
 **remove:** Set this to `true` to remove user from all Teams before adding the user to the list of Teams. Set this to `false` to keep the user in whatever Team(s) they are in while adding the user to the Team(s) in the SAML attribute.
+
+**admins_remove:** Set this to `true` to remove a user from all Teams that they are administrators of before adding the user to the list of Team admins. Set it to `false` to keep the user in whatever Team(s) they are in as admin while adding the user as an Team aministrator in the SAML attribute.
+
+**superusers_remove:** Set this to `true` to remove a user Superuser status before adding the user to the list of Superusers. Set it to `false` to keep the user Superuser status.
 
 **team_org_map:** An array of dictionaries of the form `{ "team": "<AWX Team Name>", "organization": "<AWX Org Name>" }` which defines mapping from AWX Team -> AWX Organization. This is needed because the same named Team can exist in multiple Organizations in Tower. The organization to which a team listed in a SAML attribute belongs to would be ambiguous without this mapping.

--- a/docs/auth/saml.md
+++ b/docs/auth/saml.md
@@ -71,6 +71,7 @@ Below is another example of a SAML attribute that contains a Team membership in 
   "remove": true,
   "admins_remove": true,
   "superusers_remove": true,
+  "auditors_remove": true,
   "team_org_map": [
     {
       "team": "member",
@@ -79,6 +80,7 @@ Below is another example of a SAML attribute that contains a Team membership in 
     {
       "team": "staff",
       "organization": "Default2",
+      "auditors": true,
       "admins": true,
       "superusers": true
     }
@@ -90,6 +92,8 @@ Below is another example of a SAML attribute that contains a Team membership in 
 **remove:** Set this to `true` to remove user from all Teams before adding the user to the list of Teams. Set this to `false` to keep the user in whatever Team(s) they are in while adding the user to the Team(s) in the SAML attribute.
 
 **admins_remove:** Set this to `true` to remove a user from all Teams that they are administrators of before adding the user to the list of Team admins. Set it to `false` to keep the user in whatever Team(s) they are in as admin while adding the user as an Team aministrator in the SAML attribute.
+
+**auditors_remove:** Set this to `true` to remove a user from all Teams that they are auditors of before adding the user to the list of Team auditors. Set it to `false` to keep the user in whatever Team(s) they are in as auditor while adding the user as an Team auditors in the SAML attribute.
 
 **superusers_remove:** Set this to `true` to remove a user Superuser status before adding the user to the list of Superusers. Set it to `false` to keep the user Superuser status.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I Extended the SOCIAL_AUTH_SAML_TEAM_ATTR so that you can assign admins and/or superuser trough SAML.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - SSO Authentication SAML (SOCIAL_AUTH_SAML_TEAM_ATTR)
 - awx/sso/pipeline.py
 - awx/sso/fields.py
- awx/docs/auth/saml.md

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```
##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

_AttributeStatement:_
 * groupIds                                                           = awx-admins
 * groupIds                                                           = awx-superusers
 * groupIds                                                           = awx-members

```
<saml:AttributeStatement>
            <saml:Attribute Name="groupIds" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
                <saml:AttributeValue xsi:type="xs:string">allUsers</saml:AttributeValue>
                <saml:AttributeValue xsi:type="xs:string">awx-admins</saml:AttributeValue>
                <saml:AttributeValue xsi:type="xs:string">awx-superusers</saml:AttributeValue>
                <saml:AttributeValue xsi:type="xs:string">awx-members</saml:AttributeValue>
                <saml:AttributeValue xsi:type="xs:string">awx-auditors</saml:AttributeValue>
            </saml:Attribute>
</saml:AttributeStatement>
```

_SAML TEAM ATTRIBUTE MAPPING:_
```
{
 "team_org_map": [
  {
   "organization": "awx-members",
   "team": "awx-members"
  },
  {
   "admins": true,
   "organization": "awx-admins",
   "team": "awx-admins"
  },
  {
   "auditors": true,
   "organization": "awx-auditors",
   "team": "awx-auditors"
  },
  {
   "superusers": true,
   "organization": "awx-superusers",
   "team": "awx-superusers"
  }
 ],
 "saml_attr": "groupIds",
 "remove": true,
 "admins_remove": true,
 "auditors_remove": true,
 "superusers_remove": true
}
```
