### PR TITLE
awx-api-lint: Fix setup.cfg syntax for linter test

### DIFF
--- a/awxkit/awxkit/api/pages/credentials.py
+++ b/awxkit/awxkit/api/pages/credentials.py
@@ -182,7 +182,8 @@ class CredentialType(HasCreate, base.Base):
         response = self.connection.post(urljoin(str(self.url), 'test/'), data)
         exception = exception_from_status_code(response.status_code)
         exc_str = "%s (%s) received" % (
-                http.responses[response.status_code], response.status_code)
+            http.responses[response.status_code], response.status_code
+        )
         if exception:
             raise exception(exc_str, response.json())
         elif response.status_code == http.FORBIDDEN:
@@ -328,7 +329,8 @@ class Credential(HasCopy, HasCreate, base.Base):
         response = self.connection.post(urljoin(str(self.url), 'test/'), data)
         exception = exception_from_status_code(response.status_code)
         exc_str = "%s (%s) received" % (
-                http.responses[response.status_code], response.status_code)
+            http.responses[response.status_code], response.status_code
+        )
         if exception:
             raise exception(exc_str, response.json())
         elif response.status_code == http.FORBIDDEN:

--- a/awxkit/awxkit/scripts/basic_session.py
+++ b/awxkit/awxkit/scripts/basic_session.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-import traceback
 import logging
 import pdb  # noqa
 import sys
@@ -92,8 +91,8 @@ def main():
                 exc = e
                 raise
     except Exception as e:
-        exc = e
-        rc = 1
+        exc = e  # noqa
+        rc = 1  # noqa
         raise
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,5 @@ deps =
   flake8
   yamllint
 commands =
-  - flake8
-  - yamllint -s .
+  flake8
+  yamllint -s .

--- a/tools/scripts/firehose.py
+++ b/tools/scripts/firehose.py
@@ -33,7 +33,6 @@ import subprocess
 import sys
 from io import StringIO
 from time import time
-from random import randint
 from uuid import uuid4
 
 import psycopg2
@@ -200,7 +199,9 @@ def generate_events(events, job):
         cursor.execute("SELECT indexname, indexdef FROM pg_indexes WHERE tablename='main_jobevent' AND indexname != 'main_jobevent_pkey';")
         indexes = cursor.fetchall()
 
-        cursor.execute("SELECT conname, contype, pg_catalog.pg_get_constraintdef(r.oid, true) as condef FROM pg_catalog.pg_constraint r WHERE r.conrelid = 'main_jobevent'::regclass AND conname != 'main_jobevent_pkey';")
+        cursor.execute(
+            "SELECT conname, contype, pg_catalog.pg_get_constraintdef(r.oid, true) as condef FROM pg_catalog.pg_constraint r WHERE r.conrelid = 'main_jobevent'::regclass AND conname != 'main_jobevent_pkey';"  # noqa
+        )
         constraints = cursor.fetchall()
 
         # drop all indexes for speed


### PR DESCRIPTION
An incorrect syntax on `setup.cfg` was only relying on latest call for status, meaning any `flake8` error were ignored.

Before:
```
2020-02-26 09:19:01.650171 | TASK [run_awx_tests : Run the specified command]
2020-02-26 09:19:03.222755 | static | GLOB sdist-make: /awx_devel/setup.py
2020-02-26 09:19:04.904158 | static | linters create: /awx_devel/.tox/linters
2020-02-26 09:19:06.006108 | static | linters installdeps: flake8, yamllint
2020-02-26 09:19:10.741596 | static | linters inst: /awx_devel/.tox/.tmp/package/1/awx-9.2.0.zip
2020-02-26 09:19:16.729793 | static | linters installed: awx==9.2.0,entrypoints==0.3,flake8==3.7.9,mccabe==0.6.1,pathspec==0.7.0,pycodestyle==2.5.0,pyflakes==2.1.1,PyYAML==5.3,yamllint==1.20.0
2020-02-26 09:19:16.730249 | static | linters run-test-pre: PYTHONHASHSEED='634484547'
2020-02-26 09:19:16.730364 | static | linters run-test: commands[0] | - flake8
2020-02-26 09:19:44.728847 | static | ./tools/scripts/firehose.py:36:1: F401 'random.randint' imported but unused
2020-02-26 09:19:44.729015 | static | ./tools/scripts/firehose.py:203:161: E501 line too long (219 > 160 characters)
2020-02-26 09:19:44.729098 | static | ./awxkit/awxkit/scripts/basic_session.py:2:1: F401 'traceback' imported but unused
2020-02-26 09:19:44.729180 | static | ./awxkit/awxkit/scripts/basic_session.py:95:9: F841 local variable 'exc' is assigned to but never used
2020-02-26 09:19:44.729280 | static | ./awxkit/awxkit/scripts/basic_session.py:96:9: F841 local variable 'rc' is assigned to but never used
2020-02-26 09:19:44.729364 | static | ./awxkit/awxkit/api/pages/credentials.py:185:17: E126 continuation line over-indented for hanging indent
2020-02-26 09:19:44.729471 | static | ./awxkit/awxkit/api/pages/credentials.py:331:17: E126 continuation line over-indented for hanging indent
2020-02-26 09:19:44.757494 | static | linters run-test: commands[1] | - yamllint -s .
2020-02-26 09:19:46.331575 | static | ___________________________________ summary ____________________________________
2020-02-26 09:19:46.331697 | static |   linters: commands succeeded
2020-02-26 09:19:46.331726 | static |   congratulations :)
2020-02-26 09:19:46.922823 | static | ok: Runtime: 0:00:44.174101
```

After:
```
2020-02-26 10:14:31.121540 | TASK [run_awx_tests : Run the specified command]
2020-02-26 10:14:32.749122 | static | GLOB sdist-make: /awx_devel/setup.py
2020-02-26 10:14:34.372822 | static | linters create: /awx_devel/.tox/linters
2020-02-26 10:14:35.394385 | static | linters installdeps: flake8, yamllint
2020-02-26 10:14:40.485887 | static | linters inst: /awx_devel/.tox/.tmp/package/1/awx-9.2.0.zip
2020-02-26 10:14:46.946707 | static | linters installed: awx==9.2.0,entrypoints==0.3,flake8==3.7.9,mccabe==0.6.1,pathspec==0.7.0,pycodestyle==2.5.0,pyflakes==2.1.1,PyYAML==5.3,yamllint==1.20.0
2020-02-26 10:14:46.946873 | static | linters run-test-pre: PYTHONHASHSEED='2364541155'
2020-02-26 10:14:46.946921 | static | linters run-test: commands[0] | flake8
2020-02-26 10:15:36.263200 | static | linters run-test: commands[1] | yamllint -s .
2020-02-26 10:15:38.868675 | static | ___________________________________ summary ____________________________________
2020-02-26 10:15:38.868812 | static |   linters: commands succeeded
2020-02-26 10:15:38.868842 | static |   congratulations :)
2020-02-26 10:15:39.433216 | static | ok: Runtime: 0:01:07.433448
```
Signed-off-by: Yanis Guenane <yguenane@redhat.com>
