### PR TITLE
Fix several ui_next bugs related to unexpected data types

### DIFF
--- a/awx/ui_next/src/components/FormField/FormSubmitError.jsx
+++ b/awx/ui_next/src/components/FormField/FormSubmitError.jsx
@@ -15,6 +15,8 @@ function FormSubmitError({ error }) {
       setErrors(errorMessages);
       if (errorMessages.__all__) {
         setErrorMessage(errorMessages.__all__);
+      } else if (errorMessages.detail) {
+        setErrorMessage(errorMessages.detail);
       } else {
         setErrorMessage(null);
       }

--- a/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.jsx
+++ b/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.jsx
@@ -203,7 +203,7 @@ class ResourceAccessList extends React.Component {
                         onClick={this.handleAddOpen}
                       />,
                     ]
-                  : null
+                  : []
               }
             />
           )}

--- a/awx/ui_next/src/screens/Project/ProjectAdd/ProjectAdd.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectAdd/ProjectAdd.jsx
@@ -13,6 +13,13 @@ function ProjectAdd() {
     if (values.scm_type === 'manual') {
       values.scm_type = '';
     }
+    if (!values.credential) {
+      // Depending on the permissions of the user submitting the form,
+      // the API might throw an unexpected error if our creation request
+      // has a zero-length string as its credential field. As a work-around,
+      // normalize falsey credential fields by deleting them.
+      delete values.credential;
+    }
     setFormSubmitError(null);
     try {
       const {

--- a/awx/ui_next/src/screens/Project/ProjectEdit/ProjectEdit.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectEdit/ProjectEdit.jsx
@@ -13,6 +13,13 @@ function ProjectEdit({ project }) {
     if (values.scm_type === 'manual') {
       values.scm_type = '';
     }
+    if (!values.credential) {
+      // Depending on the permissions of the user submitting the form,
+      // the API might throw an unexpected error if our creation request
+      // has a zero-length string as its credential field. As a work-around,
+      // normalize falsey credential fields by deleting them.
+      delete values.credential;
+    }
     try {
       const {
         data: { id },


### PR DESCRIPTION
##### SUMMARY
This PR addresses parts of https://github.com/ansible/awx/issues/6054. 

https://github.com/ansible/awx/issues/6054 is actually several bugs, two of which are addressed by this PR:

---

1 - The error returned by the API for this issue uses the **detail** field,  which weren't handling with our error handling util:

![Screenshot from 2020-02-26 12-04-10](https://user-images.githubusercontent.com/9753817/75376955-e8152b80-589e-11ea-8875-dd257950f538.png)

I've updated the util to handle this field as a generic form submission error:

![Screenshot from 2020-02-26 12-12-21](https://user-images.githubusercontent.com/9753817/75376938-e3e90e00-589e-11ea-95a5-dc0f85cf0713.png)

---

2 - The API shouldn't be returning an error for this scenario in the first place. I'm going to create a separate issue for this and, after this PR lands, I'll dig a little deeper and see what's going on.

---

3 - Our DataListToolbar component expects an array for its `additionalControls` prop in _all_ cases. The RBAC list component was sometimes passing in a `null`, which would cause an error and prevent the page from loading.




