### PR TITLE
Add global setting for max workers

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -306,6 +306,9 @@ class AutoscalePool(WorkerPool):
             # 5 workers per GB of total memory
             self.max_workers = (total_memory_gb * 5)
 
+        # Obey the global constraint, mainly for DB connection limit
+        self.max_workers = min(self.max_workers, settings.JOB_EVENT_MAX_WORKERS)
+
         # max workers can't be less than min_workers
         self.max_workers = max(self.min_workers, self.max_workers)
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -194,6 +194,11 @@ LOCAL_STDOUT_EXPIRE_TIME = 2592000
 # events into the database
 JOB_EVENT_WORKERS = 4
 
+# Maximum number of processes the callback receiver or task dispatcher will spawn
+# To avoid errors with high workloads, keep this (at least) lower than the maximum
+# number of database connections available divided by the instance count
+JOB_EVENT_MAX_WORKERS = 100
+
 # The maximum size of the job event worker queue before requests are blocked
 JOB_EVENT_MAX_QUEUE_SIZE = 10000
 


### PR DESCRIPTION
##### SUMMARY
We might need to write some advice on this, for now, maybe I can add something in the clustering file in the docs folder?

As you increase the size of your instance, or the number of workers in the cluster, it's possible to spin up more processes than there are available connections to the database.

This can be caused by 2 things:

 - stopping the dispatcher, accumulating scheduled jobs in pending state, starting the dispatcher
 - jobs producing a large amount of events (but much harder now that this has been made much faster)

So you could come up with a formula of what is probably safe in terms of database connections and cluster size

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
```
2020-02-24 03:16:59,311 ERROR    awx.main.dispatch PID:13703 Worker failed to run task awx.main.tasks.RunProjectUpdate(*[809], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/django/db/backends/base/base.py", line 195, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/psycopg2/__init__.py", line 126, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: FATAL:  remaining connection slots are reserved for non-replication superuser connections
```
