### PR TITLE
Remove "Manual" option from search filters

### DIFF
--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
@@ -76,7 +76,6 @@ function InventorySourcesList({
           name: i18n._(t`Source`),
           key: 'source',
           options: [
-            [``, i18n._(t`Manual`)],
             [`file`, i18n._(t`File, Directory or Script`)],
             [`scm`, i18n._(t`Sourced from a Project`)],
             [`ec2`, i18n._(t`Amazon EC2`)],

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx
@@ -71,7 +71,6 @@ function ProjectsList({ history, i18n, nodeResource, onUpdateNodeResource }) {
           name: i18n._(t`Type`),
           key: 'type',
           options: [
-            [``, i18n._(t`Manual`)],
             [`git`, i18n._(t`Git`)],
             [`hg`, i18n._(t`Mercurial`)],
             [`svn`, i18n._(t`Subversion`)],

--- a/awx/ui_next/src/util/qs.js
+++ b/awx/ui_next/src/util/qs.js
@@ -159,7 +159,7 @@ export function removeParams(config, oldParams, paramsToRemove) {
   };
   Object.keys(oldParams).forEach(key => {
     const value = removeParam(oldParams[key], paramsToRemove[key]);
-    if (value) {
+    if (value !== null) {
       updated[key] = value;
     }
   });
@@ -205,7 +205,7 @@ export function mergeParams(oldParams, newParams) {
 }
 
 function mergeParam(oldVal, newVal) {
-  if (!newVal) {
+  if (!newVal && newVal !== '') {
     return oldVal;
   }
   if (!oldVal) {

--- a/awx/ui_next/src/util/qs.test.js
+++ b/awx/ui_next/src/util/qs.test.js
@@ -310,6 +310,21 @@ describe('qs (qs.js)', () => {
         page_size: 15,
       });
     });
+
+    test('should parse empty string values', () => {
+      const config = {
+        namespace: 'bee',
+        defaultParams: { page: 1, page_size: 15 },
+        integerFields: ['page', 'page_size'],
+      };
+      const query = '?bee.baz=bar&bee.or__source=';
+      expect(parseQueryString(config, query)).toEqual({
+        baz: 'bar',
+        page: 1,
+        page_size: 15,
+        or__source: '',
+      });
+    });
   });
 
   describe('removeParams', () => {
@@ -528,6 +543,21 @@ describe('qs (qs.js)', () => {
       const toRemove = { baz: 'bust', pat: 'pal' };
       expect(removeParams(config, oldParams, toRemove)).toEqual({
         baz: ['bar', 'bang'],
+        page: 3,
+        page_size: 15,
+      });
+    });
+
+    test('should retain empty string', () => {
+      const config = {
+        namespace: null,
+        defaultParams: { page: 1, page_size: 15 },
+        integerFields: ['page', 'page_size'],
+      };
+      const oldParams = { baz: '', page: 3, bag: 'boom', page_size: 15 };
+      const toRemove = { bag: 'boom' };
+      expect(removeParams(config, oldParams, toRemove)).toEqual({
+        baz: '',
         page: 3,
         page_size: 15,
       });


### PR DESCRIPTION
##### SUMMARY
Removes "Manual" option from the Inventory Sources & Project search bar filters, as this value has been deprecated.

Additionally, I updated the qs utils to handle an empty string parameter — Manual was an empty string for these search filters, which surfaced these bugs before they were removed.

addresses #5963 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
