### PR TITLE
Cancel jobs if they were deleted in the database

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1809,7 +1809,7 @@ class RunJob(BaseTask):
                 current_revision = git_repo.head.commit.hexsha
                 if desired_revision == current_revision:
                     job_revision = desired_revision
-                    logger.info('Skipping project sync for {} because commit is locally available'.format(job.log_format))
+                    logger.debug('Skipping project sync for {} because commit is locally available'.format(job.log_format))
                 else:
                     sync_needs = all_sync_needs
             except (ValueError, BadGitName):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1180,7 +1180,11 @@ class BaseTask(object):
         '''
         Ansible runner callback to tell the job when/if it is canceled
         '''
-        self.instance = self.update_model(self.instance.pk)
+        unified_job_id = self.instance.pk
+        self.instance = self.update_model(unified_job_id)
+        if not self.instance:
+            logger.error('unified job {} was deleted while running, canceling'.format(unified_job_id))
+            return True
         if self.instance.cancel_flag or self.instance.status == 'canceled':
             cancel_wait = (now() - self.instance.modified).seconds if self.instance.modified else 0
             if cancel_wait > 5:


### PR DESCRIPTION
##### SUMMARY
This silences some concerning log statements, no other observable symptoms are known. Make the behavior in this situation clear to user.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
logs:

```
2020-02-27 16:45:29,973 ERROR    awx.main.dispatch PID:32659 Worker failed to run task awx.main.tasks.RunJob(*[2986], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/ansible_runner/runner.py", line 212, in run
    self.canceled = self.cancel_callback()
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1184, in cancel_callback
    if self.instance.cancel_flag or self.instance.status == 'canceled':
AttributeError: 'NoneType' object has no attribute 'cancel_flag'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1401, in run
    res = ansible_runner.interface.run(**params)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/ansible_runner/interface.py", line 178, in run
    r.run()
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/ansible_runner/runner.py", line 217, in run
    raise CallbackError("Exception in Cancel Callback: {}".format(e))
ansible_runner.exceptions.CallbackError: Exception in Cancel Callback: 'NoneType' object has no attribute 'cancel_flag'

During handling of the above exception, another exception occurred:
```

This is a very rare case. Normally the API tries to prevent you from deleting things that are still running, but something gets past that.

Anyway, if this undesirable situation happens, I don't want behavior to be ambiguous. We don't want untracked ansible-playbook processes making changes, thus, it should be canceled as soon as possible.