### PR TITLE
Fix job_list all_pages next value

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -231,6 +231,7 @@ class TowerModule(AnsibleModule):
             next_response = self.get_endpoint(next_page)
             response['json']['results'] = response['json']['results'] + next_response['json']['results']
             next_page = next_response['json']['next']
+            response['json']['next'] = next_page
         return response
 
     def get_one(self, endpoint, *args, **kwargs):


### PR DESCRIPTION
##### SUMMARY
This change sets the `next` value in the jobs list to value of the last page when retrieving all pages, previously it would always be set to the `next` value of the first page

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
awx: 9.2.0
```