### PR TITLE
Fail on launch for scenario where job cannot run

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4054,6 +4054,13 @@ class JobLaunchSerializer(BaseSerializer):
             **attrs)
         self._ignored_fields = rejected
 
+        # Basic validation - cannot run a playbook without a playbook
+        if not template.project:
+            errors['project'] = _("A project is required to run a job.")
+        elif template.project.status in ('error', 'failed'):
+            errors['playbook'] = _("Missing a revision to run due to failed project update.")
+
+        # cannot run a playbook without an inventory
         if template.inventory and template.inventory.pending_deletion is True:
             errors['inventory'] = _("The inventory associated with this Job Template is being deleted.")
         elif 'inventory' in accepted and accepted['inventory'].pending_deletion:


### PR DESCRIPTION
##### SUMMARY
This tries to close a hole where we _should_ have thrown a 400 error when user attempted launch, but instead launched and gave a traceback.

![Screen Shot 2020-02-27 at 4 17 03 PM](https://user-images.githubusercontent.com/1385596/75487604-b1adde00-597c-11ea-9d7c-17ce6cc834f6.png)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
New behavior:

![Screen Shot 2020-02-27 at 4 18 50 PM](https://user-images.githubusercontent.com/1385596/75487678-dc983200-597c-11ea-8337-7dd1bfac1663.png)

