### PR TITLE
Replaces Chips with linkable PF Labels

### DIFF
--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -4,7 +4,7 @@ import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { shape } from 'prop-types';
 
-import { Button, List, ListItem } from '@patternfly/react-core';
+import { Button, List, ListItem, Label } from '@patternfly/react-core';
 import AlertModal from '@components/AlertModal';
 import { CardBody, CardActionsRow } from '@components/Card';
 import ContentError from '@components/ContentError';
@@ -78,7 +78,11 @@ function CredentialDetail({ i18n, credential }) {
         <Detail
           key={id}
           label={i18n._(t`Options`)}
-          value={<List>{inputs[id] && <ListItem>{label}</ListItem>}</List>}
+          value={
+            inputs[id] ? (
+              <List>{inputs[id] && <ListItem>{label}</ListItem>}</List>
+            ) : null
+          }
         />
       );
     } else if (inputs[id] === '$encrypted$') {
@@ -116,7 +120,7 @@ function CredentialDetail({ i18n, credential }) {
             label={i18n._(t`Organization`)}
             value={
               <Link to={`/organizations/${organization.id}/details`}>
-                {organization.name}
+                <Label>{organization.name}</Label>
               </Link>
             }
           />
@@ -128,7 +132,7 @@ function CredentialDetail({ i18n, credential }) {
               credential_type.name
             ) : (
               <Link to={`/credential_types/${credential_type.id}/details`}>
-                {credential_type.name}
+                <Label>{credential_type.name}</Label>
               </Link>
             )
           }

--- a/awx/ui_next/src/screens/Host/HostDetail/HostDetail.jsx
+++ b/awx/ui_next/src/screens/Host/HostDetail/HostDetail.jsx
@@ -3,7 +3,7 @@ import { Link, useHistory, useParams, useLocation } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Host } from '@types';
-import { Button } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
 import { CardBody, CardActionsRow } from '@components/Card';
 import AlertModal from '@components/AlertModal';
 import ErrorDetail from '@components/ErrorDetail';
@@ -94,7 +94,7 @@ function HostDetail({ host, i18n, onUpdateHost }) {
                   kind === 'smart' ? 'smart_inventory' : 'inventory'
                 }/${inventoryId}/details`}
               >
-                {inventory.name}
+                <Label>{inventory.name}</Label>
               </Link>
             }
           />

--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button, Chip, ChipGroup } from '@patternfly/react-core';
+import { Button, ChipGroup, Label } from '@patternfly/react-core';
 import { CardBody, CardActionsRow } from '@components/Card';
 import { DetailList, Detail, UserDateDetail } from '@components/DetailList';
 import { VariablesDetail } from '@components/CodeMirrorInput';
@@ -66,7 +66,7 @@ function InventoryDetail({ inventory, i18n }) {
           label={i18n._(t`Organization`)}
           value={
             <Link to={`/organizations/${organization.id}/details`}>
-              {organization.name}
+              <Label>{organization.name}</Label>
             </Link>
           }
         />
@@ -76,9 +76,11 @@ function InventoryDetail({ inventory, i18n }) {
           value={
             <ChipGroup numChips={5}>
               {instanceGroups.map(ig => (
-                <Chip key={ig.id} isReadOnly>
-                  {ig.name}
-                </Chip>
+                <div css="padding-right: 5px" key={ig.id} isReadOnly>
+                  <Link to={`/instance_groups/${ig.id}/details`}>
+                    <Label>{ig.name}</Label>
+                  </Link>
+                </div>
               ))}
             </ChipGroup>
           }

--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
@@ -93,7 +93,9 @@ describe('<InventoryDetail />', () => {
             <ForwardRef
               to="/organizations/1/details"
             >
-              The Organization
+              <Label>
+                The Organization
+              </Label>
             </ForwardRef>
         `);
     const vars = wrapper.find('VariablesDetail');
@@ -116,8 +118,11 @@ describe('<InventoryDetail />', () => {
     expect(InventoriesAPI.readInstanceGroups).toHaveBeenCalledWith(
       mockInventory.id
     );
-    const chip = wrapper.find('Chip').at(0);
-    expect(chip.prop('isReadOnly')).toEqual(true);
-    expect(chip.prop('children')).toEqual('Foo');
+    const chip = wrapper
+      .find('ChipGroup')
+      .find('Link')
+      .at(0);
+    expect(chip.prop('to')).toEqual('/instance_groups/1/details');
+    expect(chip.find('Label').text()).toEqual('Foo');
   });
 });

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -2,13 +2,12 @@ import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button, Chip, ChipGroup } from '@patternfly/react-core';
+import { Button, Chip, ChipGroup, Label } from '@patternfly/react-core';
 import styled from 'styled-components';
 
 import AlertModal from '@components/AlertModal';
 import { DetailList, Detail } from '@components/DetailList';
 import { CardBody, CardActionsRow } from '@components/Card';
-import CredentialChip from '@components/CredentialChip';
 import { VariablesInput as _VariablesInput } from '@components/CodeMirrorInput';
 import DeleteButton from '@components/DeleteButton';
 import ErrorDetail from '@components/ErrorDetail';
@@ -144,7 +143,7 @@ function JobDetail({ job, i18n }) {
             label={i18n._(t`Template`)}
             value={
               <Link to={`/templates/job_template/${jobTemplate.id}`}>
-                {jobTemplate.name}
+                <Label>{jobTemplate.name}</Label>
               </Link>
             }
           />
@@ -174,7 +173,9 @@ function JobDetail({ job, i18n }) {
             value={
               <StatusDetailValue>
                 {project.status && <StatusIcon status={project.status} />}
-                <Link to={`/projects/${project.id}`}>{project.name}</Link>
+                <Link to={`/projects/${project.id}`}>
+                  <Label>{project.name}</Label>
+                </Link>
               </StatusDetailValue>
             }
           />
@@ -190,7 +191,7 @@ function JobDetail({ job, i18n }) {
             label={i18n._(t`Instance Group`)}
             value={
               <Link to={`/instance_groups/${instanceGroup.id}`}>
-                {instanceGroup.name}
+                <Label>{instanceGroup.name}</Label>
               </Link>
             }
           />
@@ -209,7 +210,14 @@ function JobDetail({ job, i18n }) {
             value={
               <ChipGroup numChips={5}>
                 {credentials.map(c => (
-                  <CredentialChip key={c.id} credential={c} isReadOnly />
+                  <div css="padding-right: 5px" key={c.id}>
+                    <Link to={`/credentials/${c.id}/details`}>
+                      <Label>
+                        <span>{c.kind}: </span>
+                        {c.name}
+                      </Label>
+                    </Link>
+                  </div>
                 ))}
               </ChipGroup>
             }

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -46,14 +46,13 @@ describe('<JobDetail />', () => {
       mockJobData.summary_fields.instance_group.name
     );
     assertDetail('Job Slice', '0/1');
-    assertDetail('Credentials', 'SSH: Demo Credential');
+    assertDetail('Credentials', 'ssh: Demo Credential');
   });
 
   test('should display credentials', () => {
-    const credentialChip = wrapper.find('CredentialChip');
-
-    expect(credentialChip.prop('credential')).toEqual(
-      mockJobData.summary_fields.credentials[0]
+    const credentialChip = wrapper.find('ChipGroup').find('Link');
+    expect(credentialChip.prop('to')).toEqual(
+      `/credentials/${mockJobData.summary_fields.credentials[0].id}/details`
     );
   });
 

--- a/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useHistory, useRouteMatch } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button, Chip, ChipGroup } from '@patternfly/react-core';
+import { Button, ChipGroup, Label } from '@patternfly/react-core';
 import { OrganizationsAPI } from '@api';
 import { DetailList, Detail, UserDateDetail } from '@components/DetailList';
 import { CardBody, CardActionsRow } from '@components/Card';
@@ -98,9 +98,11 @@ function OrganizationDetail({ i18n, organization }) {
             value={
               <ChipGroup numChips={5}>
                 {instanceGroups.map(ig => (
-                  <Chip key={ig.id} isReadOnly>
-                    {ig.name}
-                  </Chip>
+                  <div css="padding-right: 5px" key={ig.id}>
+                    <Link to={`/instance_groups/${ig.id}/details`}>
+                      <Label>{ig.name}</Label>
+                    </Link>
+                  </div>
                 ))}
               </ChipGroup>
             }

--- a/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.test.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.test.jsx
@@ -60,7 +60,7 @@ describe('<OrganizationDetail />', () => {
     await waitForElement(component, 'ContentLoading', el => el.length === 0);
     expect(
       component
-        .find('Chip')
+        .find('Label')
         .findWhere(el => el.text() === 'One')
         .exists()
     ).toBe(true);

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
@@ -5,14 +5,13 @@ import { t } from '@lingui/macro';
 import { Project } from '@types';
 import { Config } from '@contexts/Config';
 
-import { Button, List, ListItem } from '@patternfly/react-core';
+import { Button, List, ListItem, Label } from '@patternfly/react-core';
 import AlertModal from '@components/AlertModal';
 import { CardBody, CardActionsRow } from '@components/Card';
 import ContentLoading from '@components/ContentLoading';
 import DeleteButton from '@components/DeleteButton';
 import { DetailList, Detail, UserDateDetail } from '@components/DetailList';
 import ErrorDetail from '@components/ErrorDetail';
-import CredentialChip from '@components/CredentialChip';
 import { ProjectsAPI } from '@api';
 import { toTitleCase } from '@util/strings';
 
@@ -94,7 +93,7 @@ function ProjectDetail({ project, i18n }) {
               <Link
                 to={`/organizations/${summary_fields.organization.id}/details`}
               >
-                {summary_fields.organization.name}
+                <Label>{summary_fields.organization.name}</Label>
               </Link>
             }
           />
@@ -112,11 +111,15 @@ function ProjectDetail({ project, i18n }) {
           <Detail
             label={i18n._(t`SCM Credential`)}
             value={
-              <CredentialChip
+              <Link
                 key={summary_fields.credential.id}
-                credential={summary_fields.credential}
-                isReadOnly
-              />
+                to={`/credentials/${summary_fields.credential.id}/details`}
+              >
+                <Label>
+                  <span>{summary_fields.credential.kind}: </span>
+                  {summary_fields.credential.name}
+                </Label>
+              </Link>
             }
           />
         )}

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.test.jsx
@@ -95,7 +95,7 @@ describe('<ProjectDetail />', () => {
     assertDetail('SCM Refspec', mockProject.scm_refspec);
     assertDetail(
       'SCM Credential',
-      `Scm: ${mockProject.summary_fields.credential.name}`
+      `scm: ${mockProject.summary_fields.credential.name}`
     );
     assertDetail(
       'Cache Timeout',

--- a/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.jsx
+++ b/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
 
 import AlertModal from '@components/AlertModal';
 import { CardBody, CardActionsRow } from '@components/Card';
@@ -48,7 +48,7 @@ function TeamDetail({ team, i18n }) {
           label={i18n._(t`Organization`)}
           value={
             <Link to={`/organizations/${summary_fields.organization.id}`}>
-              {summary_fields.organization.name}
+              <Label>{summary_fields.organization.name}</Label>
             </Link>
           }
         />

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
@@ -9,6 +9,7 @@ import {
   TextListItem,
   TextListItemVariants,
   TextListVariants,
+  Label,
 } from '@patternfly/react-core';
 import styled from 'styled-components';
 import { t } from '@lingui/macro';
@@ -17,7 +18,6 @@ import AlertModal from '@components/AlertModal';
 import { CardBody, CardActionsRow } from '@components/Card';
 import ContentError from '@components/ContentError';
 import ContentLoading from '@components/ContentLoading';
-import CredentialChip from '@components/CredentialChip';
 import { DetailList, Detail, UserDateDetail } from '@components/DetailList';
 import DeleteButton from '@components/DeleteButton';
 import ErrorDetail from '@components/ErrorDetail';
@@ -143,13 +143,13 @@ function JobTemplateDetail({ i18n, template }) {
     return ask_inventory_on_launch ? (
       <Fragment>
         <Link to={`/inventories/${inventorykind}/${id}/details`}>
-          {summary_fields.inventory.name}
+          <Label>{summary_fields.inventory.name}</Label>
         </Link>
         <span> {i18n._(t`(Prompt on Launch)`)}</span>
       </Fragment>
     ) : (
       <Link to={`/inventories/${inventorykind}/${id}/details`}>
-        {summary_fields.inventory.name}
+        <Label>{summary_fields.inventory.name}</Label>{' '}
       </Link>
     );
   };
@@ -185,7 +185,7 @@ function JobTemplateDetail({ i18n, template }) {
             label={i18n._(t`Project`)}
             value={
               <Link to={`/projects/${summary_fields.project.id}/details`}>
-                {summary_fields.project.name}
+                <Label>{summary_fields.project.name}</Label>
               </Link>
             }
           />
@@ -238,7 +238,13 @@ function JobTemplateDetail({ i18n, template }) {
             value={
               <ChipGroup numChips={5}>
                 {summary_fields.credentials.map(c => (
-                  <CredentialChip key={c.id} credential={c} isReadOnly />
+                  <div css="padding-right: 5px;" key={c.id}>
+                    <Link to={`/credentials/${c.id}/details`}>
+                      <Label>
+                        <span>{c.kind}</span>: {c.name}
+                      </Label>
+                    </Link>
+                  </div>
                 ))}
               </ChipGroup>
             }
@@ -266,9 +272,11 @@ function JobTemplateDetail({ i18n, template }) {
             value={
               <ChipGroup numChips={5}>
                 {instanceGroups.map(ig => (
-                  <Chip key={ig.id} isReadOnly>
-                    {ig.name}
-                  </Chip>
+                  <div key={ig.id}>
+                    <Link to={`/instance_groups/${ig.id}/details`}>
+                      <Label>{ig.name}</Label>
+                    </Link>
+                  </div>
                 ))}
               </ChipGroup>
             }

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
@@ -73,11 +73,11 @@ describe('<JobTemplateDetail />', () => {
   });
 
   test('should render credential chips', () => {
-    const chips = wrapper.find('CredentialChip');
+    const chips = wrapper.find('Detail[label="Credentials"]').find('Link');
     expect(chips).toHaveLength(2);
     chips.forEach((chip, id) => {
-      expect(chip.prop('credential')).toEqual(
-        mockTemplate.summary_fields.credentials[id]
+      expect(chip.prop('to')).toEqual(
+        `/credentials/${mockTemplate.summary_fields.credentials[id].id}/details`
       );
     });
   });


### PR DESCRIPTION

  
##### SUMMARY
This addresses #5977.  
Also fixes a bug where the options field label was rendering with no value.

TODO: Bring in sorted labels via PF Chip Group with Tool bar https://www.patternfly.org/v4/documentation/react/components/chipgroup. 
That work is almost ready to go, but wanted to limit the scope of this PR.  

I have asked for a feature form PF to create a label that is linkable and groupable like the Chips are (issue: https://github.com/patternfly/patternfly-react/issues/3829).
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
9.2.1
```

##### ADDITIONAL INFORMATION
![Screen Shot 2020-02-28 at 10 27 24 AM](https://user-images.githubusercontent.com/39280967/75561884-b5da0a00-5a15-11ea-8d7a-6307814e6899.png)


