### PR TITLE
cli: add the ability to specify a token description w/ `awx login`

### DIFF
--- a/awxkit/awxkit/api/pages/base.py
+++ b/awxkit/awxkit/api/pages/base.py
@@ -140,6 +140,7 @@ class Base(Page):
     load_default_authtoken = load_authtoken
 
     def get_oauth2_token(self, username='', password='', client_id=None,
+                         description='AWX CLI',
                          client_secret=None, scope='write'):
         default_cred = config.credentials.default
         username = username or default_cred.username
@@ -176,7 +177,7 @@ class Base(Page):
             resp = self.connection.post(
                 '/api/v2/users/{}/personal_tokens/'.format(username),
                 json={
-                    "description": "Tower CLI",
+                    "description": description,
                     "application": None,
                     "scope": scope
                 },

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -76,6 +76,7 @@ class Login(CustomCommand):
 
     def handle(self, client, parser):
         auth = parser.add_argument_group('OAuth2.0 Options')
+        auth.add_argument('--description', help='description of the generated OAuth2.0 token', metavar='TEXT')
         auth.add_argument('--conf.client_id', metavar='TEXT')
         auth.add_argument('--conf.client_secret', metavar='TEXT')
         auth.add_argument(
@@ -90,6 +91,8 @@ class Login(CustomCommand):
             'client_secret': getattr(parsed, 'conf.client_secret', None),
             'scope': getattr(parsed, 'conf.scope', None),
         }
+        if getattr(parsed, 'description', None):
+            kwargs['description'] = parsed.description
         try:
             token = api.Api().get_oauth2_token(**kwargs)
         except Exception as e:


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/6122