### PR TITLE
Add collection integration tests

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -37,7 +37,7 @@ To use this collection in AWX, you should create a custom virtual environment in
 to set the job template `extra_vars` to include `ansible_python_interpreter`
 to be the Python in that virtual environment.
 
-## Running Tests
+## Running Unit Tests
 
 Tests to verify compatibility with the most recent AWX code are
 in `awx_collection/test/awx`. These tests require that Python packages
@@ -69,6 +69,30 @@ pip install -e <path to your Ansible>
 pip install -e <path to your tower-cli>
 pip install -e .
 PYTHONPATH=awx_collection:$PYTHONPATH py.test awx_collection/test/awx/
+```
+
+## Running Integration tests Tests
+
+The integration tests require a virtualenv with `ansible` >= 2.9 and `tower_cli`.
+The collection must first be installed, which can be done using `make install_collection`.
+You also need a configuration file at `~/.tower_cli.cfg` or
+`/etc/tower/tower_cli.cfg` with the credentials for accessing tower. This can
+be populated using `tower-cli`:
+
+```
+tower-cli config host $HOST
+tower-cli config username $USERNAME
+tower-cli config password $PASSWORD
+# This tells the tower-cli not to veriffy the ssl certs in the tower, if your tower has good certs you should leave this to true
+tower-cli config verify_ssl false
+```
+
+Finally you can run the tests:
+
+```
+# ansible-test must be run from the directory in which the collection is installed
+cd ~/.ansible/collections/ansible_collections/awx/awx/
+ansible-test integration
 ```
 
 ## Building

--- a/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
@@ -1,0 +1,538 @@
+- name: create a tempdir for an SSH key
+  local_action: shell mktemp -d
+  register: tempdir
+
+- name: Generate a local SSH key
+  local_action: "shell ssh-keygen -b 2048 -t rsa -f {{ tempdir.stdout }}/id_rsa -q -N 'passphrase'"
+
+- name: Read the generated key
+  set_fact:
+    ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
+
+- name: Create a User-specific credential
+  tower_credential:
+    name: SSH Credential
+    organization: Default
+    user: admin
+    state: present
+    kind: ssh
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a User-specific credential
+  tower_credential:
+    name: SSH Credential
+    organization: Default
+    user: admin
+    state: absent
+    kind: ssh
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid SSH credential
+  tower_credential:
+    name: SSH Credential
+    organization: Default
+    state: present
+    kind: ssh
+    description: An example SSH credential
+    username: joe
+    password: secret
+    become_method: sudo
+    become_username: superuser
+    become_password: supersecret
+    ssh_key_data: "{{ ssh_key_data }}"
+    ssh_key_unlock: "passphrase"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid SSH credential from lookup source
+  tower_credential:
+    name: SSH Credential from lookup source
+    organization: Default
+    state: present
+    kind: ssh
+    description: An example SSH credential from lookup source
+    username: joe
+    password: secret
+    become_method: sudo
+    become_username: superuser
+    become_password: supersecret
+    ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
+    ssh_key_unlock: "passphrase"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid SSH credential from file source
+  tower_credential:
+    name: SSH Credential from file source
+    organization: Default
+    state: present
+    kind: ssh
+    description: An example SSH credential from file source
+    username: joe
+    password: secret
+    become_method: sudo
+    become_username: superuser
+    become_password: supersecret
+    ssh_key_data: "{{ tempdir.stdout }}/id_rsa"
+    ssh_key_unlock: "passphrase"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result is not failed"
+      - "'ssh_key_data should be a string, not a path to a file.' in result.deprecations[0].msg"
+
+- name: Create an invalid SSH credential (passphrase required)
+  tower_credential:
+    name: SSH Credential
+    organization: Default
+    state: present
+    kind: ssh
+    username: joe
+    ssh_key_data: "{{ ssh_key_data }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result is failed"
+      - "'must be set when SSH key is encrypted' in result.msg"
+
+- name: Create an invalid SSH credential (Organization not found)
+  tower_credential:
+    name: SSH Credential
+    organization: Missing Organization
+    state: present
+    kind: ssh
+    username: joe
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result is failed"
+      - "'The requested object could not be found' in result.msg"
+
+- name: Delete an SSH credential
+  tower_credential:
+    name: SSH Credential
+    organization: Default
+    state: absent
+    kind: ssh
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Vault credential
+  tower_credential:
+    name: Vault Credential
+    organization: Default
+    state: present
+    kind: vault
+    description: An example Vault credential
+    vault_password: secret-vault
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Vault credential w/ kind=ssh (deprecated)
+  tower_credential:
+    name: Vault Credential
+    organization: Default
+    state: present
+    kind: ssh
+    description: An example Vault credential
+    vault_password: secret-vault
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Vault credential
+  tower_credential:
+    name: Vault Credential
+    organization: Default
+    state: absent
+    kind: vault
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Network credential
+  tower_credential:
+    name: Network Credential
+    organization: Default
+    state: present
+    kind: net
+    username: joe
+    password: secret
+    authorize: true
+    authorize_password: authorize-me
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Network credential
+  tower_credential:
+    name: Network Credential
+    organization: Default
+    state: absent
+    kind: net
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid SCM credential
+  tower_credential:
+    name: SCM Credential
+    organization: Default
+    state: present
+    kind: scm
+    username: joe
+    password: secret
+    ssh_key_data: "{{ ssh_key_data }}"
+    ssh_key_unlock: "passphrase"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an SCM credential
+  tower_credential:
+    name: SCM Credential
+    organization: Default
+    state: absent
+    kind: scm
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid AWS credential
+  tower_credential:
+    name: AWS Credential
+    organization: Default
+    state: present
+    kind: aws
+    username: joe
+    password: secret
+    security_token: aws-token
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an AWS credential
+  tower_credential:
+    name: AWS Credential
+    organization: Default
+    state: absent
+    kind: aws
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid VMWare credential
+  tower_credential:
+    name: VMWare Credential
+    organization: Default
+    state: present
+    kind: vmware
+    host: https://example.org
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an VMWare credential
+  tower_credential:
+    name: VMWare Credential
+    organization: Default
+    state: absent
+    kind: vmware
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Satellite6 credential
+  tower_credential:
+    name: Satellite6 Credential
+    organization: Default
+    state: present
+    kind: satellite6
+    host: https://example.org
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Satellite6 credential
+  tower_credential:
+    name: Satellite6 Credential
+    organization: Default
+    state: absent
+    kind: satellite6
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid CloudForms credential
+  tower_credential:
+    name: CloudForms Credential
+    organization: Default
+    state: present
+    kind: cloudforms
+    host: https://example.org
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a CloudForms credential
+  tower_credential:
+    name: CloudForms Credential
+    organization: Default
+    state: absent
+    kind: cloudforms
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid GCE credential
+  tower_credential:
+    name: GCE Credential
+    organization: Default
+    state: present
+    kind: gce
+    username: joe
+    project: ABC123
+    ssh_key_data: "{{ ssh_key_data }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a GCE credential
+  tower_credential:
+    name: GCE Credential
+    organization: Default
+    state: absent
+    kind: gce
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid AzureRM credential
+  tower_credential:
+    name: AzureRM Credential
+    organization: Default
+    state: present
+    kind: azure_rm
+    username: joe
+    password: secret
+    subscription: some-subscription
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid AzureRM credential with a tenant
+  tower_credential:
+    name: AzureRM Credential
+    organization: Default
+    state: present
+    kind: azure_rm
+    client: some-client
+    secret: some-secret
+    tenant: some-tenant
+    subscription: some-subscription
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an AzureRM credential
+  tower_credential:
+    name: AzureRM Credential
+    organization: Default
+    state: absent
+    kind: azure_rm
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid OpenStack credential
+  tower_credential:
+    name: OpenStack Credential
+    organization: Default
+    state: present
+    kind: openstack
+    host: https://keystone.example.org
+    username: joe
+    password: secret
+    project: tenant123
+    domain: some-domain
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a OpenStack credential
+  tower_credential:
+    name: OpenStack Credential
+    organization: Default
+    state: absent
+    kind: openstack
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid RHV credential
+  tower_credential:
+    name: RHV Credential
+    organization: Default
+    state: present
+    kind: rhv
+    host: https://example.org
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an RHV credential
+  tower_credential:
+    name: RHV Credential
+    organization: Default
+    state: absent
+    kind: rhv
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Insights credential
+  tower_credential:
+    name: Insights Credential
+    organization: Default
+    state: present
+    kind: insights
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an Insights credential
+  tower_credential:
+    name: Insights Credential
+    organization: Default
+    state: absent
+    kind: insights
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a valid Tower-to-Tower credential
+  tower_credential:
+    name: Tower Credential
+    organization: Default
+    state: present
+    kind: tower
+    host: https://tower.example.org
+    username: joe
+    password: secret
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Tower-to-Tower credential
+  tower_credential:
+    name: Tower Credential
+    organization: Default
+    state: absent
+    kind: tower
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Check module fails with correct msg
+  tower_credential:
+    name: test-credential
+    description: Credential Description
+    kind: ssh
+    organization: test-non-existing-org
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update credential, organization not found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: create a tempdir for an SSH key
   local_action: shell mktemp -d
   register: tempdir
@@ -105,7 +106,7 @@
     kind: ssh
     username: joe
     ssh_key_data: "{{ ssh_key_data }}"
-  ignore_errors: yes
+  ignore_errors: true
   register: result
 
 - assert:
@@ -120,7 +121,7 @@
     state: present
     kind: ssh
     username: joe
-  ignore_errors: yes
+  ignore_errors: true
   register: result
 
 - assert:

--- a/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Add Tower credential type
+  tower_credential_type:
+    description: Credential type for Test
+    name: test-credential-type
+    kind: cloud
+    inputs: {"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": True, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}
+    injectors: {"extra_vars": {"test": "foo"}}
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove a Tower credential type
+  tower_credential_type:
+    name: test-credential-type
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
@@ -4,7 +4,7 @@
     description: Credential type for Test
     name: test-credential-type
     kind: cloud
-    inputs: {"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": True, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}
+    inputs: {"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": true, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}
     injectors: {"extra_vars": {"test": "foo"}}
   register: result
 

--- a/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
@@ -1,14 +1,4 @@
-- name: create a tempdir for hostvars
-  local_action: shell mktemp -d
-  register: tempdir
-
-- name: write a file w/ hostvars
-  local_action:
-    module: lineinfile
-    dest: "{{ tempdir.stdout }}/vars"
-    line: '{"foo": "bar"}'
-    create: true
-
+---
 - name: Generate an inventory name
   set_fact:
     inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
@@ -24,8 +14,8 @@
     name: Some Group
     inventory: "{{ inv_name }}"
     state: present
-    source: ec2
-    variables: "@{{ tempdir.stdout }}/vars"
+    variables:
+      foo: bar
   register: result
 
 - assert:
@@ -54,4 +44,5 @@
 
 - assert:
     that:
-      - "result.msg =='Failed to update the group, inventory not found: The requested object could not be found.'"
+      - "result.msg =='Failed to update the group, inventory not found: The requested object could not be found.' or
+        result.msg =='The inventories test-non-existing-inventory was not found on the Tower server'"

--- a/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
@@ -1,0 +1,57 @@
+- name: create a tempdir for hostvars
+  local_action: shell mktemp -d
+  register: tempdir
+
+- name: write a file w/ hostvars
+  local_action:
+    module: lineinfile
+    dest: "{{ tempdir.stdout }}/vars"
+    line: '{"foo": "bar"}'
+    create: true
+
+- name: Generate an inventory name
+  set_fact:
+    inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: Create an Inventory
+  tower_inventory:
+    name: "{{ inv_name }}"
+    organization: Default
+    state: present
+
+- name: Create a Group
+  tower_group:
+    name: Some Group
+    inventory: "{{ inv_name }}"
+    state: present
+    source: ec2
+    variables: "@{{ tempdir.stdout }}/vars"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Group
+  tower_group:
+    name: Some Group
+    inventory: "{{ inv_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Check module fails with correct msg
+  tower_group:
+    name: test-group
+    description: Group Description
+    inventory: test-non-existing-inventory
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update the group, inventory not found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
@@ -1,0 +1,56 @@
+- name: create a tempdir for hostvars
+  local_action: shell mktemp -d
+  register: tempdir
+
+- name: write a file w/ hostvars
+  local_action:
+    module: lineinfile
+    dest: "{{ tempdir.stdout }}/vars"
+    line: '{"foo": "bar"}'
+    create: true
+
+- name: Generate an inventory name
+  set_fact:
+    inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: Create an Inventory
+  tower_inventory:
+    name: "{{ inv_name }}"
+    organization: Default
+    state: present
+
+- name: Create a Host
+  tower_host:
+    name: "some-host"
+    inventory: "{{ inv_name }}"
+    state: present
+    variables: "@{{ tempdir.stdout }}/vars"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Host
+  tower_host:
+    name: "some-host"
+    inventory: "{{ inv_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Check module fails with correct msg
+  tower_host:
+    name: test-host
+    description: Host Description
+    inventory: test-non-existing-inventory
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update host, inventory not found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
@@ -1,14 +1,4 @@
-- name: create a tempdir for hostvars
-  local_action: shell mktemp -d
-  register: tempdir
-
-- name: write a file w/ hostvars
-  local_action:
-    module: lineinfile
-    dest: "{{ tempdir.stdout }}/vars"
-    line: '{"foo": "bar"}'
-    create: true
-
+---
 - name: Generate an inventory name
   set_fact:
     inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
@@ -24,7 +14,8 @@
     name: "some-host"
     inventory: "{{ inv_name }}"
     state: present
-    variables: "@{{ tempdir.stdout }}/vars"
+    variables:
+      foo: bar
   register: result
 
 - assert:
@@ -53,4 +44,5 @@
 
 - assert:
     that:
-      - "result.msg =='Failed to update host, inventory not found: The requested object could not be found.'"
+      - "result.msg =='The inventories test-non-existing-inventory was not found on the Tower server' or
+        result.msg =='Failed to update host, inventory not found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
@@ -1,0 +1,78 @@
+- name: Clean up any pre-existing test Inventory
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    state: absent
+  ignore_errors: True
+
+
+- name: Create an Inventory
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Test Inventory module idempotency
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
+- name: Fail Change Regular to Smart
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    kind: smart
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - "result is failed"
+
+- name: Delete an Inventory
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Non-Existent Inventory
+  tower_inventory:
+    name: my-inventory
+    organization: Default
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
+- name: Check module fails with correct msg
+  tower_inventory:
+    name: test-inventory
+    description: Inventory Description
+    organization: test-non-existing-org
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result is not changed"
+      - "result.msg =='Failed to update inventory, organization not found: The requested object could not be found.'
+        or result.msg =='The organizations test-non-existing-org was not found on the Tower server'"

--- a/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
@@ -1,9 +1,10 @@
+---
 - name: Clean up any pre-existing test Inventory
   tower_inventory:
     name: my-inventory
     organization: Default
     state: absent
-  ignore_errors: True
+  ignore_errors: true
 
 
 - name: Create an Inventory
@@ -34,7 +35,7 @@
     organization: Default
     kind: smart
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Add a Tower credential
+  tower_credential:
+    description: Credentials for Openstack Test project
+    name: openstack-test-credential
+    kind: openstack
+    organization: Default
+    project: Test
+    username: admin
+    host: https://example.org:5000
+    password: passw0rd
+    domain: test
+
+- name: Add a Tower inventory
+  tower_inventory:
+    description: Test inventory
+    name: openstack-test-inventory
+    organization: Default
+
+- name: Create a source inventory
+  tower_inventory_source:
+    name: "source-test-inventory {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    description: Source for Test inventory
+    inventory: openstack-test-inventory
+    credential: openstack-test-credential
+    overwrite: True
+    update_on_launch: True
+    source_vars: "---\nprivate: false"
+    source: openstack
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
@@ -14,8 +14,8 @@
 - name: Add a Tower inventory
   tower_inventory:
     description: Test inventory
-    name: openstack-test-inventory
     organization: Default
+    name: openstack-test-inventory
 
 - name: Create a source inventory
   tower_inventory_source:
@@ -23,12 +23,27 @@
     description: Source for Test inventory
     inventory: openstack-test-inventory
     credential: openstack-test-credential
-    overwrite: True
-    update_on_launch: True
-    source_vars: "---\nprivate: false"
+    overwrite: true
+    update_on_launch: true
+    source_vars:
+      private: false
     source: openstack
   register: result
 
 - assert:
     that:
       - "result is changed"
+
+- name: Delete the source inventory
+  tower_inventory_source:
+    name: "{{ result.name }}"
+    description: Source for Test inventory
+    inventory: openstack-test-inventory
+    credential: openstack-test-credential
+    overwrite: true
+    update_on_launch: true
+    source_vars:
+      private: false
+    source: openstack
+    state: absent
+  ignore_errors: true

--- a/awx_collection/tests/integration/targets/tower_job_cancel/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_cancel/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: Launch a Job Template
+  tower_job_launch:
+    job_template: "Demo Job Template"
+  register: job
+
+- assert:
+    that:
+      - "job is changed"
+
+- name: Cancel the job
+  tower_job_cancel:
+    job_id: "{{ job.id }}"
+  register: results
+
+- assert:
+    that:
+      - results is changed
+
+- name: Cancel an already canceled job (assert failure)
+  tower_job_cancel:
+    job_id: "{{ job.id }}"
+    fail_if_not_running: True
+  register: results
+  ignore_errors: True
+
+- assert:
+    that:
+      - results is failed
+
+- name: Check module fails with correct msg
+  tower_job_cancel:
+    job_id: 9999999999
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Unable to cancel job_id/9999999999: The requested object could not be found.'
+        or result.msg =='Unable to find job with id 9999999999'"

--- a/awx_collection/tests/integration/targets/tower_job_cancel/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_cancel/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
@@ -19,9 +20,9 @@
 - name: Cancel an already canceled job (assert failure)
   tower_job_cancel:
     job_id: "{{ job.id }}"
-    fail_if_not_running: True
+    fail_if_not_running: true
   register: results
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
@@ -1,0 +1,101 @@
+- name: Launch a Job Template
+  tower_job_launch:
+    job_template: "Demo Job Template"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.status == 'pending'"
+
+- name: Wait for a job template to complete
+  tower_job_wait:
+    job_id: "{{ result.id }}"
+    max_interval: 10
+    timeout: 120
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+      - "result.status == 'successful'"
+
+- name: Check module fails with correct msg
+  tower_job_launch:
+     job_template: "Non Existing Job Template"
+     inventory: "Test Inventory"
+     credential: "Test Credential"
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Unable to launch job, job_template/Non Existing Job Template was not found: The requested object could not be found.'
+        or result.msg == 'The inventories Test Inventory was not found on the Tower server'"
+
+- name: Create a Job Template for testing prompt on launch
+  tower_job_template:
+    name: "Demo Job Template - ask inventory and credential"
+    project: Demo Project
+    playbook: hello_world.yml
+    job_type: run
+    ask_credential: yes
+    ask_inventory: yes
+    state: present
+  register: result
+
+- name: Launch job template with inventory and credential for prompt on launch
+  tower_job_launch:
+    job_template: "Demo Job Template - ask inventory and credential"
+    inventory: "Demo Inventory"
+    credential: "Demo Credential"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.status == 'pending'"
+
+- name: Create a project for testing extra_vars
+  tower_project:
+    name: test-playbooks
+    organization: Default
+    scm_type: git
+    scm_url: https://github.com/ansible/test-playbooks
+
+- name: Create a Job Template for testing extra_vars
+  tower_job_template:
+    name: "Demo Job Template - extra_vars"
+    project: test-playbooks
+    playbook: debug.yml
+    job_type: run
+    state: present
+    inventory: "Demo Inventory"
+    extra_vars:
+      foo: bar
+  register: result
+
+- name: Launch job template with inventory and credential for prompt on launch
+  tower_job_launch:
+    job_template: "Demo Job Template - extra_vars"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Get the job
+  tower_job_list:
+    query: {"id": "{{result.id}}" }
+  register: result
+
+- assert:
+    that:
+      - '{"foo": "bar"} | to_json in result.results[0].extra_vars'
+
+- name: Delete the job
+  tower_project:
+    name: "Demo Job Template - extra_vars"
+    organization: Default
+    state: absent
+  ignore_errors: True

--- a/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
@@ -22,9 +23,9 @@
 
 - name: Check module fails with correct msg
   tower_job_launch:
-     job_template: "Non Existing Job Template"
-     inventory: "Test Inventory"
-     credential: "Test Credential"
+    job_template: "Non Existing Job Template"
+    inventory: "Test Inventory"
+    credential: "Test Credential"
   register: result
   ignore_errors: true
 
@@ -39,8 +40,8 @@
     project: Demo Project
     playbook: hello_world.yml
     job_type: run
-    ask_credential: yes
-    ask_inventory: yes
+    ask_credential: true
+    ask_inventory: true
     state: present
   register: result
 
@@ -86,7 +87,7 @@
 
 - name: Get the job
   tower_job_list:
-    query: {"id": "{{result.id}}" }
+    query: {"id": "{{result.id}}"}
   register: result
 
 - assert:
@@ -98,4 +99,4 @@
     name: "Demo Job Template - extra_vars"
     organization: Default
     state: absent
-  ignore_errors: True
+  ignore_errors: true

--- a/awx_collection/tests/integration/targets/tower_job_list/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_list/tasks/main.yml
@@ -1,0 +1,37 @@
+- name: Launch a Job Template
+  tower_job_launch:
+    job_template: "Demo Job Template"
+  register: job
+
+- assert:
+    that:
+      - "job is changed"
+      - "job.status == 'pending'"
+
+- name: List jobs w/ a matching primary key
+  tower_job_list:
+    query: {"id": "{{ job.id }}"}
+  register: matching_jobs
+
+- assert:
+    that:
+      - "{{ matching_jobs.count }} == 1"
+
+- name: List failed jobs (which don't exist)
+  tower_job_list:
+    status: failed
+    query: {"id": "{{ job.id }}"}
+  register: successful_jobs
+
+- assert:
+    that:
+      - "{{ successful_jobs.count }} == 0"
+
+- name: Get ALL result pages!
+  tower_job_list:
+    all_pages: True
+  register: all_page_query
+
+- assert:
+    that:
+      - 'not all_page_query.next'

--- a/awx_collection/tests/integration/targets/tower_job_list/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_list/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
@@ -29,7 +30,7 @@
 
 - name: Get ALL result pages!
   tower_job_list:
-    all_pages: True
+    all_pages: true
   register: all_page_query
 
 - assert:

--- a/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Create an SCM Credential
   tower_credential:
     name: SCM Credential for JT
@@ -13,20 +14,6 @@
     scm_url: https://github.com/ansible/ansible-tower-samples.git
     scm_credential: SCM Credential for JT
   register: result
-
-- name: Wait for the project to be status=successful
-  uri:
-    url: "{{ lookup('ENV', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
-    method: GET
-    user: "{{ lookup('ENV', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('ENV', 'TOWER_PASSWORD') }}"
-    validate_certs: false
-    force_basic_auth: true
-    return_content: true
-  register: result
-  until: result.json.summary_fields.last_update is defined and result.json.summary_fields.last_update.status == "successful"
-  retries: 60
-  delay: 1
 
 - name: Create a Job Template
   tower_job_template:

--- a/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Create an SCM Credential
+  tower_credential:
+    name: SCM Credential for JT
+    organization: Default
+    kind: scm
+
+- name: Create a Demo Project
+  tower_project:
+    name: Job Template Test Project
+    organization: Default
+    state: present
+    scm_type: git
+    scm_url: https://github.com/ansible/ansible-tower-samples.git
+    scm_credential: SCM Credential for JT
+  register: result
+
+- name: Wait for the project to be status=successful
+  uri:
+    url: "{{ lookup('ENV', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
+    method: GET
+    user: "{{ lookup('ENV', 'TOWER_USERNAME') }}"
+    password: "{{ lookup('ENV', 'TOWER_PASSWORD') }}"
+    validate_certs: false
+    force_basic_auth: true
+    return_content: true
+  register: result
+  until: result.json.summary_fields.last_update is defined and result.json.summary_fields.last_update.status == "successful"
+  retries: 60
+  delay: 1
+
+- name: Create a Job Template
+  tower_job_template:
+    name: "hello-world {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Launch a Job Template
+  tower_job_launch:
+    job_template: "Demo Job Template"
+  register: job
+
+- assert:
+    that:
+      - "job is changed"
+      - "job.status == 'pending'"
+
+- name: Wait for the Job to finish
+  tower_job_wait:
+    job_id: "{{ job.id }}"
+    timeout: 60
+
+- name: Check module fails with correct msg
+  tower_job_wait:
+    job_id: "99999999"
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Unable to wait, no job_id 99999999 found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"

--- a/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Create a Label
+  tower_label:
+    name: important
+    organization: Default
+    state: present
+
+- name: Check module fails with correct msg
+  tower_label:
+    name: "Test Label"
+    organization: "Non existing org"
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg == 'Failed to update label, organization not found: The requested object could not be found.'"
+
+# TODO: Deleting labels doesn't seem to work currently

--- a/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Create a Label
   tower_label:
     name: important

--- a/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
@@ -1,0 +1,205 @@
+- name: Create Slack notification
+  tower_notification:
+    name: notification1
+    organization: Default
+    notification_type: slack
+    token: a_token
+    channels:
+      - general
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete Slack notification
+  tower_notification:
+    name: notification1
+    organization: Default
+    notification_type: slack
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add webhook notification
+  tower_notification:
+    name: notification2
+    organization: Default
+    notification_type: webhook
+    url: http://www.example.com/hook
+    headers:
+      X-Custom-Header: value123
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete webhook notification
+  tower_notification:
+    name: notification2
+    organization: Default
+    notification_type: webhook
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add email notification
+  tower_notification:
+    name: notification3
+    organization: Default
+    notification_type: email
+    username: user
+    password: s3cr3t
+    sender: tower@example.com
+    recipients:
+      - user1@example.com
+    host: smtp.example.com
+    port: 25
+    use_tls: no
+    use_ssl: no
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete email notification
+  tower_notification:
+    name: notification3
+    organization: Default
+    notification_type: email
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add twilio notification
+  tower_notification:
+    name: notification4
+    organization: Default
+    notification_type: twilio
+    account_token: a_token
+    account_sid: a_sid
+    from_number: '+15551112222'
+    to_numbers:
+      - '+15553334444'
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete twilio notification
+  tower_notification:
+    name: notification4
+    organization: Default
+    notification_type: twilio
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add PagerDuty notification
+  tower_notification:
+    name: notification5
+    organization: Default
+    notification_type: pagerduty
+    token: a_token
+    subdomain: sub
+    client_name: client
+    service_key: a_key
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete PagerDuty notification
+  tower_notification:
+    name: notification5
+    organization: Default
+    notification_type: pagerduty
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add HipChat notification
+  tower_notification:
+    name: notification6
+    organization: Default
+    notification_type: hipchat
+    token: a_token
+    message_from: user1
+    api_url: https://hipchat.example.com
+    color: red
+    rooms:
+      - room-A
+    notify: yes
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete HipChat notification
+  tower_notification:
+    name: notification6
+    organization: Default
+    notification_type: hipchat
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Add IRC notification
+  tower_notification:
+    name: notification7
+    organization: Default
+    notification_type: irc
+    nickname: tower
+    password: s3cr3t
+    targets:
+      - user1
+    port: 8080
+    server: irc.example.com
+    use_ssl: no
+    state: present
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete IRC notification
+  tower_notification:
+    name: notification7
+    organization: Default
+    notification_type: irc
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed

--- a/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Create Slack notification
   tower_notification:
     name: notification1
@@ -64,8 +65,8 @@
       - user1@example.com
     host: smtp.example.com
     port: 25
-    use_tls: no
-    use_ssl: no
+    use_tls: false
+    use_ssl: false
     state: present
   register: result
 
@@ -153,7 +154,7 @@
     color: red
     rooms:
       - room-A
-    notify: yes
+    notify: true
     state: present
   register: result
 
@@ -184,7 +185,7 @@
       - user1
     port: 8080
     server: irc.example.com
-    use_ssl: no
+    use_ssl: false
     state: present
   register: result
 

--- a/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
@@ -1,6 +1,7 @@
+---
 - name: Generate an org name
   set_fact:
-    org_name: "org-{{ lookup('randstr') }}"
+    org_name: "org-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Make sure {{ org_name }} is not there
   tower_organization:
@@ -30,7 +31,7 @@
     name: "{{ org_name }}"
     custom_virtualenv: "/does/not/exit"
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:
@@ -90,9 +91,9 @@
 - name: Check that SSL is available and verify_ssl is enabled (task must fail)
   tower_organization:
     name: Default
+    validate_certs: true
   environment:
     TOWER_CERTIFICATE: /dev/null  # force check failure
-    TOWER_VERIFY_SSL: True
   ignore_errors: true
   register: check_ssl_is_used
 
@@ -101,22 +102,9 @@
     that:
       - check_ssl_is_used is failed
 
-- name: Disable verify_ssl in ~/.tower_cli.cfg
-  copy:
-    dest: ~/.tower_cli.cfg
-    content: |
-      [general]
-      verify_ssl = False
-    force: false  # ensure remote file doesn't exist
-
-- block:
-  - name: Check that verify_ssl is disabled (task must not fail)
-    tower_organization:
-      name: Default
-    environment:
-      TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled
-  always:
-    - name: Delete ~/.tower_cli.cfg
-      file:
-        path: ~/.tower_cli.cfg
-        state: absent
+- name: Check that verify_ssl is disabled (task must not fail)
+  tower_organization:
+    name: Default
+    validate_certs: false
+  environment:
+    TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled

--- a/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
@@ -1,0 +1,122 @@
+- name: Generate an org name
+  set_fact:
+    org_name: "org-{{ lookup('randstr') }}"
+
+- name: Make sure {{ org_name }} is not there
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result
+
+- name: "Create a new organization"
+  tower_organization:
+    name: "{{ org_name }}"
+  register: result
+
+- assert:
+    that: "result is changed"
+
+- name: "Make sure making the same org is not a change"
+  tower_organization:
+    name: "{{ org_name }}"
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
+- name: "Try adding a bad custom_virtualenv"
+  tower_organization:
+    name: "{{ org_name }}"
+    custom_virtualenv: "/does/not/exit"
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - "result is failed"
+
+- name: "Pass in all parameters"
+  tower_organization:
+    name: "{{ org_name }}"
+    description: "A description"
+    custom_virtualenv: ""
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: "Change the description"
+  tower_organization:
+    name: "{{ org_name }}"
+    description: "A new description"
+    custom_virtualenv: ""
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: "Remove the organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: "Remove a missing organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
+# Test behaviour common to all tower modules
+- name: Check that SSL is available
+  tower_organization:
+    name: Default
+  register: result
+
+- assert:
+    that: result is not changed
+
+- name: Check that SSL is available and verify_ssl is enabled (task must fail)
+  tower_organization:
+    name: Default
+  environment:
+    TOWER_CERTIFICATE: /dev/null  # force check failure
+    TOWER_VERIFY_SSL: True
+  ignore_errors: true
+  register: check_ssl_is_used
+
+- name: Check that connection failed
+  assert:
+    that:
+      - check_ssl_is_used is failed
+
+- name: Disable verify_ssl in ~/.tower_cli.cfg
+  copy:
+    dest: ~/.tower_cli.cfg
+    content: |
+      [general]
+      verify_ssl = False
+    force: false  # ensure remote file doesn't exist
+
+- block:
+  - name: Check that verify_ssl is disabled (task must not fail)
+    tower_organization:
+      name: Default
+    environment:
+      TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled
+  always:
+    - name: Delete ~/.tower_cli.cfg
+      file:
+        path: ~/.tower_cli.cfg
+        state: absent

--- a/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
@@ -1,0 +1,95 @@
+- name: Create an SCM Credential
+  tower_credential:
+    name: SCM Credential for Project
+    organization: Default
+    kind: scm
+
+- name: Create a Project
+  tower_project:
+    name: my-project
+    organization: Default
+    state: present
+    scm_credential: SCM Credential for Project
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Project
+  tower_project:
+    name: my-project
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a git project without credentials
+  tower_project:
+    name: git project
+    organization: Default
+    scm_type: git
+    scm_url: https://github.com/ansible/ansible
+
+- name: "Create {{ item }}"
+  tower_organization:
+    name: "{{ item }}"
+  loop:
+    - TestOrg1
+    - TestOrg2
+
+- name: "Create credential"
+  tower_credential:
+    kind: scm
+    name: TestCred1
+    organization: "{{ item }}"
+  loop:
+    - TestOrg2
+    - TestOrg1
+
+- name: Generate random project name appender
+  set_fact:
+    project_name_rand: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: Create project TestProject
+  tower_project:
+    name: "TestProject {{ project_name_rand }}"
+    organization: TestOrg1
+    scm_type: git
+    scm_url: "https://github.com/ansible/ansible"
+    scm_credential: TestCred1
+  register: multi_org_cred_project
+
+- assert:
+    that:
+      - "multi_org_cred_project is changed"
+
+- name: Check module fails with correct msg
+  tower_project:
+    name: "TestProject {{ project_name_rand }}"
+    organization: Non Existing Org
+    scm_type: git
+    scm_url: "https://github.com/ansible/ansible"
+    scm_credential: TestCred1
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg == 'Failed to update project, organization not found: Non Existing Org'"
+
+- name: Check module fails with correct msg
+  tower_project:
+    name: "TestProject {{ project_name_rand }}"
+    organization: TestOrg1
+    scm_type: git
+    scm_url: "https://github.com/ansible/ansible"
+    scm_credential: Non Existing Credential
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update project, credential not found: Non Existing Credential'"

--- a/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
@@ -1,95 +1,115 @@
+---
+- name: Delete old git project from any previous test runs
+  tower_project:
+    name: "git project"
+    organization: Default
+    state: absent
+  ignore_errors: true
+
 - name: Create an SCM Credential
   tower_credential:
     name: SCM Credential for Project
     organization: Default
     kind: scm
 
-- name: Create a Project
+- name: Create a git project without credentials without waiting
   tower_project:
-    name: my-project
-    organization: Default
-    state: present
-    scm_credential: SCM Credential for Project
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Project
-  tower_project:
-    name: my-project
-    state: absent
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a git project without credentials
-  tower_project:
-    name: git project
+    name: "git project"
     organization: Default
     scm_type: git
-    scm_url: https://github.com/ansible/ansible
+    scm_url: https://github.com/ansible/test-playbooks
+    wait: false
+  register: result
 
-- name: "Create {{ item }}"
+- assert:
+    that:
+      - result is changed
+
+- name: Recreate the project to validate not changed
+  tower_project:
+    name: "git project"
+    organization: Default
+    scm_type: git
+    scm_url: https://github.com/ansible/test-playbooks
+    wait: true
+  register: result
+
+- assert:
+    that:
+      - result is not changed
+
+- name: Create organizations
   tower_organization:
-    name: "{{ item }}"
-  loop:
-    - TestOrg1
-    - TestOrg2
+    name: TestOrg
 
-- name: "Create credential"
+- name: Create credential
   tower_credential:
     kind: scm
-    name: TestCred1
-    organization: "{{ item }}"
-  loop:
-    - TestOrg2
-    - TestOrg1
+    name: TestCred
+    organization: TestOrg
+
+  register: new_credentials
 
 - name: Generate random project name appender
   set_fact:
     project_name_rand: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
-- name: Create project TestProject
+- name: Create a new test project in check_mode
   tower_project:
     name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg1
+    organization: TestOrg
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
-    scm_credential: TestCred1
-  register: multi_org_cred_project
+    scm_url: https://github.com/ansible/test-playbooks
+    scm_credential: TestCred
+  check_mode: true
 
+- name: Create a new test project
+  tower_project:
+    name: "TestProject {{ project_name_rand }}"
+    organization: TestOrg
+    scm_type: git
+    scm_url: https://github.com/ansible/test-playbooks
+    scm_credential: TestCred
+  register: result
+
+# If this fails it may be because the check_mode task actually already created
+# the project, or it could be because the module actually failed somehow
 - assert:
     that:
-      - "multi_org_cred_project is changed"
+      - "result is changed"
 
-- name: Check module fails with correct msg
+- name: Check module fails with correct msg when given non-existing org as param
   tower_project:
     name: "TestProject {{ project_name_rand }}"
     organization: Non Existing Org
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
-    scm_credential: TestCred1
+    scm_url: https://github.com/ansible/test-playbooks
+    scm_credential: TestCred
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg == 'Failed to update project, organization not found: Non Existing Org'"
+      - "result.msg == 'The organizations Non Existing Org was not found on the Tower server' or
+        result.msg == 'Failed to update project, organization not found: Non Existing Org'"
 
-- name: Check module fails with correct msg
+- name: Check module fails with correct msg when given non-existing credential as param
   tower_project:
     name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg1
+    organization: TestOrg
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
+    scm_url: https://github.com/ansible/test-playbooks
     scm_credential: Non Existing Credential
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg =='Failed to update project, credential not found: Non Existing Credential'"
+      - "result.msg =='The credentials Non Existing Credential was not found on the Tower server' or
+        result.msg =='Failed to update project, credential not found: Non Existing Credential'"
+
+- name: Delete the test project
+  tower_project:
+    name: "TestProject {{ project_name_rand }}"
+    organization: TestOrg
+    state: absent

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
@@ -1,0 +1,45 @@
+- name: Fetch project_base_dir
+  uri:
+    url: "{{ lookup('env', 'TOWER_HOST') }}/api/v2/config/"
+    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
+    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    validate_certs: false
+    return_content: true
+    force_basic_auth: true
+  register: awx_config
+
+- tower_inventory:
+    name: localhost
+    organization: Default
+
+- tower_host:
+    name: localhost
+    inventory: localhost
+    variables:
+      ansible_connection: local
+
+- name: create an unused SSH / Machine credential
+  tower_credential:
+    name: dummy
+    kind: ssh
+    ssh_key_data: |
+      -----BEGIN EC PRIVATE KEY-----
+      MHcCAQEEIIUl6R1xgzR6siIUArz4XBPtGZ09aetma2eWf1v3uYymoAoGCCqGSM49
+      AwEHoUQDQgAENJNjgeZDAh/+BY860s0yqrLDprXJflY0GvHIr7lX3ieCtrzOMCVU
+      QWzw35pc5tvuP34SSi0ZE1E+7cVMDDOF3w==
+      -----END EC PRIVATE KEY-----
+    organization: Default
+
+- name: Disable bubblewrap
+  command: tower-cli setting modify AWX_PROOT_ENABLED false
+
+- block:
+    - name: Create a directory for manual project
+      vars:
+        project_base_dir: "{{ awx_config.json.project_base_dir }}"
+      command: tower-cli ad_hoc launch --wait --inventory localhost
+        --credential dummy --module-name shell
+        --module-args "mkdir -p {{ project_base_dir }}/{{ project_dir_name }} || true"
+  always:
+    - name: enable bubblewrap
+      command: tower-cli setting modify AWX_PROOT_ENABLED true

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
@@ -1,8 +1,21 @@
+---
+- name: get tower host variable
+  shell: tower-cli config host | cut -d ' ' -f2
+  register: host
+
+- name: get tower username variable
+  shell: tower-cli config username | cut -d ' ' -f2
+  register: username
+
+- name: get tower password variable
+  shell: tower-cli config password | cut -d ' ' -f2
+  register: password
+
 - name: Fetch project_base_dir
   uri:
-    url: "{{ lookup('env', 'TOWER_HOST') }}/api/v2/config/"
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
+    url: "{{ host.stdout }}/api/v2/config/"
+    user: "{{ username.stdout }}"
+    password: "{{ password.stdout }}"
     validate_certs: false
     return_content: true
     force_basic_auth: true
@@ -38,8 +51,8 @@
       vars:
         project_base_dir: "{{ awx_config.json.project_base_dir }}"
       command: tower-cli ad_hoc launch --wait --inventory localhost
-        --credential dummy --module-name shell
-        --module-args "mkdir -p {{ project_base_dir }}/{{ project_dir_name }} || true"
+        --credential dummy --module-name command
+        --module-args "mkdir -p {{ project_base_dir }}/{{ project_dir_name }}"
   always:
     - name: enable bubblewrap
       command: tower-cli setting modify AWX_PROOT_ENABLED true

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/main.yml
@@ -1,10 +1,14 @@
+---
+- name: generate random string for project
+  set_fact:
+    rand_string: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 - name: Generate manual project dir name
   set_fact:
-    project_name: "manual project {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    project_name: "manual project {{ rand_string }}"
 
 - name: Generate manual project dir name
   set_fact:
-    project_dir_name: "proj {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    project_dir_name: "proj_{{ rand_string }}"
 
 - name: create a project directory for manual project
   import_tasks: create_project_dir.yml
@@ -24,6 +28,7 @@
 - name: Delete a manual project
   tower_project:
     name: "{{ project_name }}"
+    organization: Default
     state: absent
   register: result
 

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Generate manual project dir name
+  set_fact:
+    project_name: "manual project {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: Generate manual project dir name
+  set_fact:
+    project_dir_name: "proj {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: create a project directory for manual project
+  import_tasks: create_project_dir.yml
+
+- name: Create a manual project
+  tower_project:
+    name: "{{ project_name }}"
+    organization: Default
+    scm_type: manual
+    local_path: "{{ project_dir_name }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a manual project
+  tower_project:
+    name: "{{ project_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_receive/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_receive/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Export all Tower assets
+  tower_receive:
+    all: True
+  register: result
+
+- assert:
+    that:
+      - "result is successful"
+
+- name: Extract names from output
+  set_fact:
+    object_names: "{{ result.assets | map(attribute='name') | list }}"
+
+- assert:
+    that:
+      - "result is successful"
+      - "'Default' in object_names"

--- a/awx_collection/tests/integration/targets/tower_receive/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_receive/tasks/main.yml
@@ -1,6 +1,7 @@
+---
 - name: Export all Tower assets
   tower_receive:
-    all: True
+    all: true
   register: result
 
 - assert:

--- a/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: Create a User
+  tower_user:
+    first_name: Joe
+    last_name: User
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Add Joe to the update role of the default Project
+  tower_role:
+    user: joe
+    role: update
+    project: Demo Project
+    state: "{{ item }}"
+  register: result
+  with_items:
+    - "present"
+    - "absent"
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a User
+  tower_user:
+    username: joe
+    email: joe@example.org
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Create a User
   tower_user:
     first_name: Joe

--- a/awx_collection/tests/integration/targets/tower_send/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_send/tasks/main.yml
@@ -1,0 +1,80 @@
+- name: Test no parameters
+  tower_send:
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result is failed"
+
+- name: Create user json
+  set_fact:
+    user:
+      - username: "jowestco"
+        first_name: "John"
+        last_name: "Westcott"
+        asset_type: "user"
+        email: "john.westcott.iv@redhat.com"
+
+- name: Test a new import of asset
+  tower_send:
+    assets: "{{ user | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Test an existing import of asset
+  tower_send:
+    assets: "{{ user | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is successful"
+      - "result is not changed"
+
+- name: Change an existing asset
+  tower_send:
+    assets: "{{ user | combine({'last_name': 'Westcott IV'}) | to_json() }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Ensure the organization is not created
+  tower_organization:
+    name: "Red Hat"
+    state: absent
+
+- name: Create organization json
+  set_fact:
+    organization:
+      - asset_type: organization
+        name: "Red Hat"
+
+- name: Create temp file
+  tempfile:
+    state: file
+  register: my_temp_file
+
+- name: Drop down a file to import
+  copy:
+    dest: "{{ my_temp_file.path }}"
+    content: "{{ organization | to_nice_json() }}"
+
+- name: Create org via files
+  tower_send:
+    files: "{{ my_temp_file.path }}"
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Remove Temp File
+  file:
+    path: "{{ my_temp_file.path }}"
+    state: absent

--- a/awx_collection/tests/integration/targets/tower_send/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_send/tasks/main.yml
@@ -1,7 +1,8 @@
+---
 - name: Test no parameters
   tower_send:
   register: result
-  ignore_errors: yes
+  ignore_errors: true
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
@@ -1,0 +1,77 @@
+- name: Set the value of AWX_PROOT_SHOW_PATHS to a baseline
+  tower_settings:
+    name: AWX_PROOT_SHOW_PATHS
+    value: '["/var/lib/awx/projects/"]'
+
+- name: Set the value of AWX_PROOT_SHOW_PATHS to get an error back from Tower
+  tower_settings:
+    settings:
+      AWX_PROOT_SHOW_PATHS:
+        'not': 'a valid'
+        'tower': 'setting'
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - "result is failed"
+
+- name: Set the value of AWX_PROOT_SHOW_PATHS
+  tower_settings:
+    name: AWX_PROOT_SHOW_PATHS
+    value: '["/var/lib/awx/projects/", "/tmp"]'
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Attempt to set the value of AWX_PROOT_BASE_PATH to what it already is
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: /tmp
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result is not changed"
+
+- name: Apply a single setting via settings
+  tower_settings:
+    name: AWX_PROOT_SHOW_PATHS
+    value: '["/var/lib/awx/projects/", "/var/tmp"]'
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Apply multiple setting via settings with no change
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: /tmp
+    name: AWX_PROOT_SHOW_PATHS
+    value: '["/var/lib/awx/projects/", "/var/tmp"]'
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result is not changed"
+
+- name: Apply multiple setting via settings with change
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: /tmp
+    name: AWX_PROOT_SHOW_PATHS
+    value: '["/var/lib/awx/new_projects/", "/tmp"]'
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Set the value of AWX_PROOT_SHOW_PATHS to a baseline
   tower_settings:
     name: AWX_PROOT_SHOW_PATHS
@@ -10,7 +11,7 @@
         'not': 'a valid'
         'tower': 'setting'
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
 - assert:
     that:
@@ -51,10 +52,9 @@
 
 - name: Apply multiple setting via settings with no change
   tower_settings:
-    name: AWX_PROOT_BASE_PATH
-    value: /tmp
-    name: AWX_PROOT_SHOW_PATHS
-    value: '["/var/lib/awx/projects/", "/var/tmp"]'
+    settings:
+      AWX_PROOT_BASE_PATH: /tmp
+      AWX_PROOT_SHOW_PATHS: ["/var/lib/awx/projects/", "/var/tmp"]
   register: result
 
 - debug:
@@ -66,10 +66,9 @@
 
 - name: Apply multiple setting via settings with change
   tower_settings:
-    name: AWX_PROOT_BASE_PATH
-    value: /tmp
-    name: AWX_PROOT_SHOW_PATHS
-    value: '["/var/lib/awx/new_projects/", "/tmp"]'
+    settings:
+      AWX_PROOT_BASE_PATH: /tmp
+      AWX_PROOT_SHOW_PATHS: []
   register: result
 
 - assert:

--- a/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
@@ -1,0 +1,48 @@
+- name: Attempt to add a Tower team to a non-existant Organization
+  tower_team:
+    name: Test Team
+    organization: Missing Organization
+    state: present
+  register: result
+  ignore_errors: yes
+
+- name: Assert a meaningful error was provided for the failed Tower team creation
+  assert:
+    that:
+      - result is failed
+      - "result.msg =='Failed to update team, organization not found: The requested object could not be found.' or
+        result.msg =='The organizations Missing Organization was not found on the Tower server'"
+
+- name: Create a Tower team
+  tower_team:
+    name: Test Team
+    organization: Default
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Tower team
+  tower_team:
+    name: Test Team
+    organization: Default
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Check module fails with correct msg
+  tower_team:
+    name: Test Team
+    organization: Non Existing Org
+    state: present
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update team, organization not found: The requested object could not be found.' or
+        result.msg =='The organizations Non Existing Org was not found on the Tower server'"

--- a/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
@@ -1,10 +1,11 @@
+---
 - name: Attempt to add a Tower team to a non-existant Organization
   tower_team:
     name: Test Team
     organization: Missing Organization
     state: present
   register: result
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Assert a meaningful error was provided for the failed Tower team creation
   assert:

--- a/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Create a User
   tower_user:
     first_name: Joe

--- a/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
@@ -1,0 +1,94 @@
+- name: Create a User
+  tower_user:
+    first_name: Joe
+    last_name: User
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a User
+  tower_user:
+    username: joe
+    email: joe@example.org
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create an Auditor
+  tower_user:
+    first_name: Joe
+    last_name: Auditor
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+    auditor: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an Auditor
+  tower_user:
+    username: joe
+    email: joe@example.org
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Create a Superuser
+  tower_user:
+    first_name: Joe
+    last_name: Super
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+    superuser: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Superuser
+  tower_user:
+    username: joe
+    email: joe@example.org
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Test tower SSL parameter
+  tower_user:
+    first_name: Joe
+    last_name: User
+    username: joe
+    password: "{{ 65535 | random | to_uuid }}"
+    email: joe@example.org
+    state: present
+    validate_certs: true
+    tower_host: http://foo.invalid
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - "'Unable to resolve tower_host' in result.msg or
+        'Can not verify ssl with non-https protocol' in result.exception"

--- a/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- name: Create an SCM Credential
+  tower_credential:
+    name: SCM Credential for JT
+    organization: Default
+    kind: scm
+
+- name: Create a Demo Project
+  tower_project:
+    name: Job Template Test Project
+    organization: Default
+    state: present
+    scm_type: git
+    scm_url: https://github.com/ansible/ansible-tower-samples.git
+    scm_credential: SCM Credential for JT
+  register: result
+
+- name: Create a Job Template
+  tower_job_template:
+    name: my-job-1
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+
+- name: Create a second Job Template
+  tower_job_template:
+    name: my-job-2
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+
+- name: Add a Survey to second Job Template
+  tower_job_template:
+    name: my-job-2
+    project: Job Template Test Project
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: present
+    survey_enabled: yes
+    survey_spec: '{"spec": [{"index": 0, "question_name": "my question?", "default": "mydef", "variable": "myvar", "type": "text", "required": false}], "description": "test", "name": "test"}'
+
+
+- name: Create a workflow job template
+  tower_workflow_template:
+    name: my-workflow
+    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a workflow job template
+  tower_workflow_template:
+    name: my-workflow
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Check module fails with correct msg
+  tower_workflow_template:
+    name: my-workflow
+    organization: Non Existing Organization
+    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update organization source,organization not found: The requested object could not be found.'"

--- a/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
@@ -44,7 +44,7 @@
     credential: Demo Credential
     job_type: run
     state: present
-    survey_enabled: yes
+    survey_enabled: true
     survey_spec: '{"spec": [{"index": 0, "question_name": "my question?", "default": "mydef", "variable": "myvar", "type": "text", "required": false}], "description": "test", "name": "test"}'
 
 


### PR DESCRIPTION
##### SUMMARY
In previous times the awx collection was in ansible core, when that was the case there were integration tests in the collection, however when the modules were migrated out of the core repo, those tests ended up in https://github.com/ansible/test-playbooks/tree/master/tower_modules . This has become a hassle to maintain and it makes more sense for those tests to be in the repo and runnable by `ansible-test integration`. This PR moves those tests to the collection with some changes to make it compatible with the environment that `ansible-test integration` provides us:

* Removing the `randstr` plugin and using the `password` plugin instead
* Removing the use of environmental variables -- `ansible-test integration` runs in an environment that doesnt inherit your environmental variables
* Not deleting or modifying the `~/.tower_cli.cfg` file, which must contain the auth variables for tower as a work around for the lack of environment variables

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Collection