### PR TITLE
fix broken grafana notifications

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4303,7 +4303,7 @@ class NotificationTemplateTest(GenericAPIView):
         msg = "Tower Notification Test {} {}".format(obj.id, settings.TOWER_URL_BASE)
         if obj.notification_type in ('email', 'pagerduty'):
             body = "Ansible Tower Test Notification {} {}".format(obj.id, settings.TOWER_URL_BASE)
-        elif obj.notification_type == 'webhook':
+        elif obj.notification_type in ('webhook', 'grafana'):
             body = '{{"body": "Ansible Tower Test Notification {} {}"}}'.format(obj.id, settings.TOWER_URL_BASE)
         else:
             body = {"body": "Ansible Tower Test Notification {} {}".format(obj.id, settings.TOWER_URL_BASE)}


### PR DESCRIPTION
since the custom notification template refactor late last year, grafana notification
support has been broken; this is largely because grafana functions more
like the webhooks, and needs to send JSON in its notification body

see: https://github.com/ansible/awx/issues/6137

cc @crab86 (who wrote the original PR, and may care to weigh in here)