### PR TITLE
Use modified to check if job should be sent to analytics

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -279,7 +279,7 @@ def copy_tables(since, full_path):
                                  JOIN django_content_type ON main_unifiedjob.polymorphic_ctype_id = django_content_type.id
                                  JOIN main_project ON main_project.unifiedjobtemplate_ptr_id = main_job.project_id
                                  JOIN main_organization ON main_organization.id = main_project.organization_id
-                                 WHERE main_unifiedjob.created > {} 
+                                 WHERE main_unifiedjob.modified > {} 
                                  AND main_unifiedjob.launch_type != 'sync'
                                  ORDER BY main_unifiedjob.id ASC) TO STDOUT WITH CSV HEADER'''.format(since.strftime("'%Y-%m-%d %H:%M:%S'"))    
     _copy_table(table='unified_jobs', query=unified_job_query, path=full_path)


### PR DESCRIPTION
### SUMMARY
It can take several hours for a job to go from pending to successful/failed state and we need to also send the job with a changed state, otherwise the analytics will be incorrect.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Analytics

##### Works with current analytics processor?
Will work with processor in current production. The processor detects job_id that was already sent and updates it if the finished_at time is bigger than the current one using atomic upsert. So it always converges to saving last state of the job, even if sent out of order.
 