### PR TITLE
Modernize types of WFJT module

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -35,15 +35,20 @@ have it function as a collection.
 
 The following notes are changes that may require changes to playbooks:
 
- - Specifying `inputs` or `injectors` as strings in the
-   `tower_credential_type` module is no longer supported. Provide them as dictionaries instead.
+
  - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
  - Creating a "scan" type job template is no longer supported.
- - `extra_vars` in the `tower_job_launch` module worked with a list previously, but is now configured to work solely in a `dict` format.
- - When the `extra_vars` parameter is used with the `tower_job_launch` module, the Job Template launch will fail unless `add_extra_vars` or `survey_enabled` is explicitly set to `True` on the Job Template.
+ - Type changes of variable fields
+   - `extra_vars` in the `tower_job_launch` module worked with a list previously, but is now configured to work solely in a `dict` format.
+   - `extra_vars` in the `tower_workflow_job_template` module worked with a string previously but now expects a dict.
+   - When the `extra_vars` parameter is used with the `tower_job_launch` module, the Job Template launch will fail unless `add_extra_vars` or `survey_enabled` is explicitly set to `True` on the Job Template.
+   - The `variables` parameter in the `tower_group`, `tower_host` and `tower_inventory` modules are now in `dict` format and no longer supports the use of the `C(@)` syntax (for an external `vars` file).
+ - Type changes of other types of fields
+   - Specifying `inputs` or `injectors` as strings in the
+     `tower_credential_type` module is no longer supported. Provide them as dictionaries instead.
+   - Specifying `schema` as in the `tower_workflow_job_template` module is no longer supported. Use a list of dicts instead.
  - `tower_group` used to also service inventory sources, but this functionality has been removed from this module; use `tower_inventory_source` instead.
  - Specified `tower_config` file used to handle `k=v` pairs on a single line; this is no longer supported. Please use a file formatted as `yaml`, `json` or `ini` only.
- - The `variables` parameter in the `tower_group`, `tower_host` and `tower_inventory` modules are now in `dict` format and no longer supports the use of the `C(@)` syntax (for an external `vars` file).
  - Some return values (e.g., `credential_type`) have been removed. Use of `id` is recommended.
 
 ## Running Unit Tests

--- a/awx_collection/test/awx/test_workflow_template.py
+++ b/awx_collection/test/awx/test_workflow_template.py
@@ -1,0 +1,35 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from awx.main.models import WorkflowJobTemplate
+
+
+@pytest.mark.django_db
+def test_create_workflow_job_template(run_module, admin_user, organization):
+
+    module_args = {
+        'name': 'foo-workflow',
+        'organization': organization.name,
+        'extra_vars': {'foo': 'bar', 'another-foo': {'barz': 'bar2'}},
+        'state': 'present'
+    }
+
+    result = run_module('tower_workflow_template', module_args, admin_user)
+
+    wfjt = WorkflowJobTemplate.objects.get(name='foo-workflow')
+    assert wfjt.extra_vars == '{"foo": "bar", "another-foo": {"barz": "bar2"}}'
+
+    result.pop('module_args', None)
+    assert result == {
+        "workflow_template": "foo-workflow",  # TODO: remove after refactor
+        "state": "present",
+        "id": wfjt.id,
+        "changed": True,
+        "invocation": {
+            "module_args": module_args
+        }
+    }
+
+    assert wfjt.organization_id == organization.id

--- a/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: Create a workflow job template
   tower_workflow_template:
     name: my-workflow
-    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+    schema: [{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]
   register: result
 
 - assert:
@@ -72,7 +72,7 @@
   tower_workflow_template:
     name: my-workflow
     organization: Non Existing Organization
-    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+    schema: [{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]
   register: result
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
Proposed fix for https://github.com/ansible/awx/issues/6167

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
I actually have manual testing for this.

```yaml
---
- hosts: localhost
  gather_facts: false
  connection: local
  tasks:
    - name: delete a workflow job template
      awx.awx.tower_workflow_template:
        name: issue-workflow5
        organization: Default
        state: absent

    - name: Create a workflow job template
      awx.awx.tower_workflow_template:
        name: issue-workflow5
        description: created by Ansible Playbook
        organization: Default
        survey_enabled: false
        allow_simultaneous: no
        schema: "{{ lookup('file', '{{ playbook_dir }}/schema.json') }}"
        # schema:
        #   - job_template: Demo Job Template
        # extra_vars:
        #   var1: val1
        #   var2:
        #     var21: val21
        #     var22: val22
        #   var3:
        #     - var4
        #     - var5
        #   var6:
        #     - var7: val7
        #     - var8: val8
        #       var9: val9
      register: new_workflow

    - debug: var=new_workflow
```

with both versions of schema it works.

I produced the schema via

```
tower-cli workflow schema 202 --format=json > sanity/schema.json
```

This is what is documented in the example, so that's good to have.