### PR TITLE
Fix bug where Inventory Host Add form doesn't save

### DIFF
--- a/awx/ui_next/src/screens/Host/HostAdd/HostAdd.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostAdd/HostAdd.test.jsx
@@ -20,7 +20,7 @@ describe('<HostAdd />', () => {
 
   beforeEach(async () => {
     history = createMemoryHistory({
-      initialEntries: ['/hosts/1/add'],
+      initialEntries: ['/hosts/add'],
     });
     await act(async () => {
       wrapper = mountWithContexts(<HostAdd />, {

--- a/awx/ui_next/src/screens/Host/shared/HostForm.jsx
+++ b/awx/ui_next/src/screens/Host/shared/HostForm.jsx
@@ -18,78 +18,48 @@ import { required } from '@util/validators';
 import { InventoryLookup } from '@components/Lookup';
 import { FormColumnLayout, FormFullWidthLayout } from '@components/FormLayout';
 
-function HostFormFields({ host, i18n }) {
+const InventoryLookupField = withI18n()(({ i18n, host }) => {
   const [inventory, setInventory] = useState(
     host ? host.summary_fields.inventory : ''
   );
 
-  const hostAddMatch = useRouteMatch('/hosts/add');
-  const inventoryFieldArr = useField({
+  const [, inventoryMeta, inventoryHelpers] = useField({
     name: 'inventory',
     validate: required(i18n._(t`Select a value for this field`), i18n),
   });
-  const inventoryMeta = inventoryFieldArr[1];
-  const inventoryHelpers = inventoryFieldArr[2];
 
   return (
-    <>
-      <FormField
-        id="host-name"
-        name="name"
-        type="text"
-        label={i18n._(t`Name`)}
-        validate={required(null, i18n)}
-        isRequired
+    <FormGroup
+      label={i18n._(t`Inventory`)}
+      isRequired
+      fieldId="inventory-lookup"
+      isValid={!inventoryMeta.touched || !inventoryMeta.error}
+      helperTextInvalid={inventoryMeta.error}
+    >
+      <FieldTooltip
+        content={i18n._(t`Select the inventory that this host will belong to.`)}
       />
-      <FormField
-        id="host-description"
-        name="description"
-        type="text"
-        label={i18n._(t`Description`)}
+      <InventoryLookup
+        value={inventory}
+        onBlur={() => inventoryHelpers.setTouched()}
+        tooltip={i18n._(t`Select the inventory that this host will belong to.`)}
+        isValid={!inventoryMeta.touched || !inventoryMeta.error}
+        helperTextInvalid={inventoryMeta.error}
+        onChange={value => {
+          inventoryHelpers.setValue(value.id);
+          setInventory(value);
+        }}
+        required
+        touched={inventoryMeta.touched}
+        error={inventoryMeta.error}
       />
-      {hostAddMatch && (
-        <FormGroup
-          label={i18n._(t`Inventory`)}
-          isRequired
-          fieldId="inventory-lookup"
-          isValid={!inventoryMeta.touched || !inventoryMeta.error}
-          helperTextInvalid={inventoryMeta.error}
-        >
-          <FieldTooltip
-            content={i18n._(
-              t`Select the inventory that this host will belong to.`
-            )}
-          />
-          <InventoryLookup
-            value={inventory}
-            onBlur={() => inventoryHelpers.setTouched()}
-            tooltip={i18n._(
-              t`Select the inventory that this host will belong to.`
-            )}
-            isValid={!inventoryMeta.touched || !inventoryMeta.error}
-            helperTextInvalid={inventoryMeta.error}
-            onChange={value => {
-              inventoryHelpers.setValue(value.id);
-              setInventory(value);
-            }}
-            required
-            touched={inventoryMeta.touched}
-            error={inventoryMeta.error}
-          />
-        </FormGroup>
-      )}
-      <FormFullWidthLayout>
-        <VariablesField
-          id="host-variables"
-          name="variables"
-          label={i18n._(t`Variables`)}
-        />
-      </FormFullWidthLayout>
-    </>
+    </FormGroup>
   );
-}
+});
 
-function HostForm({ handleSubmit, host, submitError, handleCancel, ...rest }) {
+const HostForm = ({ handleCancel, handleSubmit, host, i18n, submitError }) => {
+  const hostAddMatch = useRouteMatch('/hosts/add');
+
   return (
     <Formik
       initialValues={{
@@ -103,7 +73,28 @@ function HostForm({ handleSubmit, host, submitError, handleCancel, ...rest }) {
       {formik => (
         <Form autoComplete="off" onSubmit={formik.handleSubmit}>
           <FormColumnLayout>
-            <HostFormFields host={host} {...rest} />
+            <FormField
+              id="host-name"
+              name="name"
+              type="text"
+              label={i18n._(t`Name`)}
+              validate={required(null, i18n)}
+              isRequired
+            />
+            <FormField
+              id="host-description"
+              name="description"
+              type="text"
+              label={i18n._(t`Description`)}
+            />
+            {hostAddMatch && <InventoryLookupField host={host} />}
+            <FormFullWidthLayout>
+              <VariablesField
+                id="host-variables"
+                name="variables"
+                label={i18n._(t`Variables`)}
+              />
+            </FormFullWidthLayout>
             <FormSubmitError error={submitError} />
             <FormActionGroup
               onCancel={handleCancel}
@@ -114,11 +105,11 @@ function HostForm({ handleSubmit, host, submitError, handleCancel, ...rest }) {
       )}
     </Formik>
   );
-}
+};
 
 HostForm.propTypes = {
-  handleSubmit: func.isRequired,
   handleCancel: func.isRequired,
+  handleSubmit: func.isRequired,
   host: shape({}),
   submitError: shape({}),
 };


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/6184

This PR moves the inventory lookup field outside of HostForm to prevent Formik from hooking up to the inventory `useField` hook. 

Discovered this was due to where we called `useField` because even though the inventory wasn't rendered, the formik error object contained the inventory error `{inventory: "Select a value for this field"}`.

_Bug Recording_ 
![bug](https://user-images.githubusercontent.com/15881645/76000281-7c9c1100-5ed1-11ea-8f70-1d1e342415ee.gif)



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
