### PR TITLE
Adds Add button to schedules list along with rbac restrictions

### DIFF
--- a/awx/ui_next/src/api/mixins/Schedules.mixin.js
+++ b/awx/ui_next/src/api/mixins/Schedules.mixin.js
@@ -1,0 +1,12 @@
+const SchedulesMixin = parent =>
+  class extends parent {
+    readSchedules(id, params) {
+      return this.http.get(`${this.baseUrl}${id}/schedules/`, { params });
+    }
+
+    readScheduleOptions(id) {
+      return this.http.options(`${this.baseUrl}${id}/schedules/`);
+    }
+  };
+
+export default SchedulesMixin;

--- a/awx/ui_next/src/api/models/JobTemplates.js
+++ b/awx/ui_next/src/api/models/JobTemplates.js
@@ -1,8 +1,11 @@
 import Base from '../Base';
 import NotificationsMixin from '../mixins/Notifications.mixin';
 import InstanceGroupsMixin from '../mixins/InstanceGroups.mixin';
+import SchedulesMixin from '../mixins/Schedules.mixin';
 
-class JobTemplates extends InstanceGroupsMixin(NotificationsMixin(Base)) {
+class JobTemplates extends SchedulesMixin(
+  InstanceGroupsMixin(NotificationsMixin(Base))
+) {
   constructor(http) {
     super(http);
     this.baseUrl = '/api/v2/job_templates/';
@@ -60,10 +63,6 @@ class JobTemplates extends InstanceGroupsMixin(NotificationsMixin(Base)) {
     return this.http.get(`${this.baseUrl}${id}/access_list/`, {
       params,
     });
-  }
-
-  readScheduleList(id, params) {
-    return this.http.get(`${this.baseUrl}${id}/schedules/`, { params });
   }
 }
 

--- a/awx/ui_next/src/api/models/Projects.js
+++ b/awx/ui_next/src/api/models/Projects.js
@@ -1,8 +1,11 @@
 import Base from '../Base';
 import NotificationsMixin from '../mixins/Notifications.mixin';
 import LaunchUpdateMixin from '../mixins/LaunchUpdate.mixin';
+import SchedulesMixin from '../mixins/Schedules.mixin';
 
-class Projects extends LaunchUpdateMixin(NotificationsMixin(Base)) {
+class Projects extends SchedulesMixin(
+  LaunchUpdateMixin(NotificationsMixin(Base))
+) {
   constructor(http) {
     super(http);
     this.baseUrl = '/api/v2/projects/';
@@ -19,10 +22,6 @@ class Projects extends LaunchUpdateMixin(NotificationsMixin(Base)) {
 
   readPlaybooks(id) {
     return this.http.get(`${this.baseUrl}${id}/playbooks/`);
-  }
-
-  readScheduleList(id, params) {
-    return this.http.get(`${this.baseUrl}${id}/schedules/`, { params });
   }
 
   readSync(id) {

--- a/awx/ui_next/src/api/models/WorkflowJobTemplates.js
+++ b/awx/ui_next/src/api/models/WorkflowJobTemplates.js
@@ -1,6 +1,7 @@
 import Base from '../Base';
+import SchedulesMixin from '../mixins/Schedules.mixin';
 
-class WorkflowJobTemplates extends Base {
+class WorkflowJobTemplates extends SchedulesMixin(Base) {
   constructor(http) {
     super(http);
     this.baseUrl = '/api/v2/workflow_job_templates/';
@@ -42,12 +43,6 @@ class WorkflowJobTemplates extends Base {
 
   readNodes(id, params) {
     return this.http.get(`${this.baseUrl}${id}/workflow_nodes/`, {
-      params,
-    });
-  }
-
-  readScheduleList(id, params) {
-    return this.http.get(`${this.baseUrl}${id}/schedules/`, {
       params,
     });
   }

--- a/awx/ui_next/src/components/ScheduleList/ScheduleList.test.jsx
+++ b/awx/ui_next/src/components/ScheduleList/ScheduleList.test.jsx
@@ -11,6 +11,18 @@ SchedulesAPI.destroy = jest.fn();
 SchedulesAPI.update.mockResolvedValue({
   data: mockSchedules.results[0],
 });
+SchedulesAPI.read.mockResolvedValue({ data: mockSchedules });
+SchedulesAPI.readOptions.mockResolvedValue({
+  data: {
+    actions: {
+      GET: {},
+      POST: {},
+    },
+  },
+});
+
+const loadSchedules = params => SchedulesAPI.read(params);
+const loadScheduleOptions = () => SchedulesAPI.readOptions();
 
 describe('ScheduleList', () => {
   let wrapper;
@@ -21,11 +33,12 @@ describe('ScheduleList', () => {
 
   describe('read call successful', () => {
     beforeAll(async () => {
-      SchedulesAPI.read.mockResolvedValue({ data: mockSchedules });
-      const loadSchedules = params => SchedulesAPI.read(params);
       await act(async () => {
         wrapper = mountWithContexts(
-          <ScheduleList loadSchedules={loadSchedules} />
+          <ScheduleList
+            loadSchedules={loadSchedules}
+            loadScheduleOptions={loadScheduleOptions}
+          />
         );
       });
       wrapper.update();
@@ -38,6 +51,10 @@ describe('ScheduleList', () => {
     test('should fetch schedules from api and render the list', () => {
       expect(SchedulesAPI.read).toHaveBeenCalled();
       expect(wrapper.find('ScheduleListItem').length).toBe(5);
+    });
+
+    test('should show add button', () => {
+      expect(wrapper.find('ToolbarAddButton').length).toBe(1);
     });
 
     test('should check and uncheck the row item', async () => {
@@ -153,11 +170,32 @@ describe('ScheduleList', () => {
     });
   });
 
+  describe('hidden add button', () => {
+    test('should hide add button when flag is passed', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleList
+            loadSchedules={loadSchedules}
+            loadScheduleOptions={loadScheduleOptions}
+            hideAddButton
+          />
+        );
+      });
+      wrapper.update();
+      expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    });
+  });
+
   describe('read call unsuccessful', () => {
     test('should show content error when read call unsuccessful', async () => {
       SchedulesAPI.read.mockRejectedValue(new Error());
       await act(async () => {
-        wrapper = mountWithContexts(<ScheduleList />);
+        wrapper = mountWithContexts(
+          <ScheduleList
+            loadSchedules={loadSchedules}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        );
       });
       wrapper.update();
       expect(wrapper.find('ContentError').length).toBe(1);

--- a/awx/ui_next/src/screens/Project/Project.jsx
+++ b/awx/ui_next/src/screens/Project/Project.jsx
@@ -31,6 +31,7 @@ class Project extends Component {
     this.loadProject = this.loadProject.bind(this);
     this.loadProjectAndRoles = this.loadProjectAndRoles.bind(this);
     this.loadSchedules = this.loadSchedules.bind(this);
+    this.loadScheduleOptions = this.loadScheduleOptions.bind(this);
   }
 
   async componentDidMount() {
@@ -104,9 +105,14 @@ class Project extends Component {
     }
   }
 
+  loadScheduleOptions() {
+    const { project } = this.state;
+    return ProjectsAPI.readScheduleOptions(project.id);
+  }
+
   loadSchedules(params) {
     const { project } = this.state;
-    return ProjectsAPI.readScheduleList(project.id, params);
+    return ProjectsAPI.readSchedules(project.id, params);
   }
 
   render() {
@@ -241,7 +247,10 @@ class Project extends Component {
               <Route
                 path="/projects/:id/schedules"
                 render={() => (
-                  <ScheduleList loadSchedules={this.loadSchedules} />
+                  <ScheduleList
+                    loadSchedules={this.loadSchedules}
+                    loadScheduleOptions={this.loadScheduleOptions}
+                  />
                 )}
               />
             )}

--- a/awx/ui_next/src/screens/Schedule/Schedules.jsx
+++ b/awx/ui_next/src/screens/Schedule/Schedules.jsx
@@ -9,6 +9,10 @@ import { SchedulesAPI } from '@api';
 import { PageSection, Card } from '@patternfly/react-core';
 
 function Schedules({ i18n }) {
+  const loadScheduleOptions = () => {
+    return SchedulesAPI.readOptions();
+  };
+
   const loadSchedules = params => {
     return SchedulesAPI.read(params);
   };
@@ -24,7 +28,11 @@ function Schedules({ i18n }) {
         <Route path="/schedules">
           <PageSection>
             <Card>
-              <ScheduleList loadSchedules={loadSchedules} />
+              <ScheduleList
+                loadSchedules={loadSchedules}
+                loadScheduleOptions={loadScheduleOptions}
+                hideAddButton
+              />
             </Card>
           </PageSection>
         </Route>

--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -29,6 +29,7 @@ class Template extends Component {
     this.loadTemplate = this.loadTemplate.bind(this);
     this.loadTemplateAndRoles = this.loadTemplateAndRoles.bind(this);
     this.loadSchedules = this.loadSchedules.bind(this);
+    this.loadScheduleOptions = this.loadScheduleOptions.bind(this);
   }
 
   async componentDidMount() {
@@ -83,9 +84,14 @@ class Template extends Component {
     }
   }
 
+  loadScheduleOptions() {
+    const { template } = this.state;
+    return JobTemplatesAPI.readScheduleOptions(template.id);
+  }
+
   loadSchedules(params) {
     const { template } = this.state;
-    return JobTemplatesAPI.readScheduleList(template.id, params);
+    return JobTemplatesAPI.readSchedules(template.id, params);
   }
 
   render() {
@@ -111,6 +117,13 @@ class Template extends Component {
       });
     }
 
+    if (template) {
+      tabsArray.push({
+        name: i18n._(t`Schedules`),
+        link: `${match.url}/schedules`,
+      });
+    }
+
     tabsArray.push(
       {
         name: i18n._(t`Completed Jobs`),
@@ -121,13 +134,6 @@ class Template extends Component {
         link: '/home',
       }
     );
-
-    if (template) {
-      tabsArray.push({
-        name: i18n._(t`Schedules`),
-        link: `${match.url}/schedules`,
-      });
-    }
 
     tabsArray.forEach((tab, n) => {
       tab.id = n;
@@ -225,7 +231,10 @@ class Template extends Component {
               <Route
                 path="/templates/:templateType/:id/schedules"
                 render={() => (
-                  <ScheduleList loadSchedules={this.loadSchedules} />
+                  <ScheduleList
+                    loadSchedules={this.loadSchedules}
+                    loadScheduleOptions={this.loadScheduleOptions}
+                  />
                 )}
               />
             )}

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
@@ -29,6 +29,7 @@ class WorkflowJobTemplate extends Component {
     };
     this.loadTemplate = this.loadTemplate.bind(this);
     this.loadSchedules = this.loadSchedules.bind(this);
+    this.loadScheduleOptions = this.loadScheduleOptions.bind(this);
   }
 
   async componentDidMount() {
@@ -76,9 +77,14 @@ class WorkflowJobTemplate extends Component {
     }
   }
 
+  loadScheduleOptions() {
+    const { template } = this.state;
+    return WorkflowJobTemplatesAPI.readScheduleOptions(template.id);
+  }
+
   loadSchedules(params) {
     const { template } = this.state;
-    return WorkflowJobTemplatesAPI.readScheduleList(template.id, params);
+    return WorkflowJobTemplatesAPI.readSchedules(template.id, params);
   }
 
   render() {
@@ -199,7 +205,10 @@ class WorkflowJobTemplate extends Component {
               <Route
                 path="/templates/:templateType/:id/schedules"
                 render={() => (
-                  <ScheduleList loadSchedules={this.loadSchedules} />
+                  <ScheduleList
+                    loadSchedules={this.loadSchedules}
+                    loadScheduleOptions={this.loadScheduleOptions}
+                  />
                 )}
               />
             )}


### PR DESCRIPTION
##### SUMMARY
Add button should now be present on the following lists:

1) JT Schedules
2) WFJT Schedules
3) Project Schedules

<img width="850" alt="Screen Shot 2020-03-05 at 12 35 53 PM" src="https://user-images.githubusercontent.com/9889020/76008588-e1f5ff00-5edd-11ea-94a6-6041a552692f.png">

Add button should not be shown on:

1) All Schedules (/#/schedules)

<img width="853" alt="Screen Shot 2020-03-05 at 12 36 13 PM" src="https://user-images.githubusercontent.com/9889020/76008618-ed492a80-5edd-11ea-988b-880beacc9c16.png">

These Add buttons should be hidden for users without the ability to create a schedule for the given resource.  In order to achieve this we need to make an OPTIONS request to see if the user can POST to the given endpoint.  I added this request in each of the lists.

The button links should be configured correctly but the corresponding routes don't exist yet.

I went ahead and created a mixin for schedule related api requests.  In the near future we'll be adding the ability to add/edit schedules and since these methods will apply to multiple endpoints it seemed appropriate to roll a mixin at this time.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI