### PR TITLE
fix a bug in OPTIONS /api/v2/schedules/

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2429,6 +2429,11 @@ class ScheduleAccess(BaseAccess):
     def can_add(self, data):
         if not JobLaunchConfigAccess(self.user).can_add(data):
             return False
+        if not data:
+            return UnifiedJobTemplate.accessible_pk_qs(
+                self.user, 'execute_role'
+            ).exists()
+
         return self.check_related('unified_job_template', UnifiedJobTemplate, data, role_field='execute_role', mandatory=True)
 
     @check_superuser


### PR DESCRIPTION
a side effect of this bug is that `awx schedules create` doesn't work
properly for non-admin users (i.e., users who have execute access for
a JT)

see: https://github.com/ansible/awx/issues/5717