### PR TITLE
Show API choice field metadata more correctly for null vs ''

### DIFF
--- a/awx/api/metadata.py
+++ b/awx/api/metadata.py
@@ -101,8 +101,10 @@ class Metadata(metadata.SimpleMetadata):
                 (choice_value, choice_name) for choice_value, choice_name in field.choices.items()
             ]
             if not any(choice in ('', None) for choice, _ in choices):
-                if field.allow_blank or (field.allow_null and not isinstance(field, ChoiceNullField)):
+                if field.allow_blank:
                     choices = [("", "---------")] + choices
+                if field.allow_null and not isinstance(field, ChoiceNullField):
+                    choices = [(None, "---------")] + choices
             field_info['choices'] = choices
 
         # Indicate if a field is write-only.


### PR DESCRIPTION
##### SUMMARY
The `verbosity` field for `WorkflowJobTemplateNodes` allows null as an option, but does not support `''` getting coerced to null.  We need to therefore reflect that in the empty option in the choices list provided by the API.

related #6196 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```
