### PR TITLE
Setup development environment for testing inventory in collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ use_dev_supervisor.txt
 /awx_collection/galaxy.yml
 /sanity/
 
+# Inventory plugin collection testing
+/awx/plugins/collections/
+
 .idea/*
 *.unison.tmp
 *.#

--- a/Makefile
+++ b/Makefile
@@ -725,6 +725,50 @@ clean-elk:
 	docker rm tools_elasticsearch_1
 	docker rm tools_kibana_1
 
+awx/plugins/collections/ansible_collections/azure/azcollection:
+	mkdir -p awx/plugins/collections/ansible_collections/azure
+	git clone https://github.com/ansible-collections/azure.git awx/plugins/collections/ansible_collections/azure/azcollection
+
+awx/plugins/collections/ansible_collections/ansible/amazon:
+	mkdir -p awx/plugins/collections/ansible_collections/ansible
+	git clone https://github.com/ansible-collections/ansible.amazon.git awx/plugins/collections/ansible_collections/ansible/amazon
+
+awx/plugins/collections/ansible_collections/theforeman/foreman:
+	mkdir -p awx/plugins/collections/ansible_collections/theforeman
+	git clone https://github.com/theforeman/foreman-ansible-modules.git awx/plugins/collections/ansible_collections/theforeman/foreman
+
+awx/plugins/collections/ansible_collections/google/cloud:
+	mkdir -p awx/plugins/collections/ansible_collections/google
+	git clone https://github.com/ansible-collections/ansible_collections_google.git awx/plugins/collections/ansible_collections/google/cloud
+
+awx/plugins/collections/ansible_collections/openstack/cloud:
+	mkdir -p awx/plugins/collections/ansible_collections/openstack
+	git clone https://github.com/openstack/ansible-collections-openstack.git awx/plugins/collections/ansible_collections/openstack/cloud
+
+awx/plugins/collections/ansible_collections/community/vmware:
+	mkdir -p awx/plugins/collections/ansible_collections/community
+	git clone https://github.com/ansible-collections/vmware.git awx/plugins/collections/ansible_collections/community/vmware
+
+awx/plugins/collections/ansible_collections/ovirt/ovirt_collection:
+	mkdir -p awx/plugins/collections/ansible_collections/ovirt
+	git clone https://github.com/ovirt/ovirt-ansible-collection.git awx/plugins/collections/ansible_collections/ovirt/ovirt_collection
+
+awx/plugins/collections/ansible_collections/awx/awx:
+	mkdir -p awx/plugins/collections/ansible_collections/awx
+	ln -s $(shell pwd)/awx_collection awx/plugins/collections/ansible_collections/awx/awx
+
+# this is for development purposes only
+develop_inventory: awx/plugins/collections/ansible_collections/google/cloud\
+									 awx/plugins/collections/ansible_collections/azure/azcollection\
+									 awx/plugins/collections/ansible_collections/ansible/amazon\
+									 awx/plugins/collections/ansible_collections/theforeman/foreman\
+									 awx/plugins/collections/ansible_collections/google/cloud\
+									 awx/plugins/collections/ansible_collections/openstack/cloud\
+									 awx/plugins/collections/ansible_collections/community/vmware\
+									 awx/plugins/collections/ansible_collections/ovirt/ovirt_collection\
+									 awx/plugins/collections/ansible_collections/awx/awx
+	ANSIBLE_COLLECTIONS_PATHS=awx/plugins/collections ansible-galaxy collection list
+
 psql-container:
 	docker run -it --net tools_default --rm postgres:10 sh -c 'exec psql -h "postgres" -p "5432" -U postgres'
 


### PR DESCRIPTION
##### SUMMARY
This will lay down git clones for everything we need for inventory imports.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
demo

```
(awx_collection) arominge-OSX:tower alancoding$ make develop_inventory
ANSIBLE_COLLECTIONS_PATHS=awx/plugins/collections ansible-galaxy collection list
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features
under development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/openstack/cloud' does not have a MANIFEST.json file, cannot detect
version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/azure/azcollection' does not have a MANIFEST.json file, cannot
detect version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/google/cloud' does not have a MANIFEST.json file, cannot detect
version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/awx/awx' does not have a MANIFEST.json file, cannot detect version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/ansible/amazon' does not have a MANIFEST.json file, cannot detect
version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/theforeman/foreman' does not have a MANIFEST.json file, cannot
detect version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/community/vmware' does not have a MANIFEST.json file, cannot detect
version.
[WARNING]: Collection at '/Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections/ovirt/ovirt_collection' does not have a MANIFEST.json file, cannot
detect version.

# /Users/alancoding/Documents/tower/awx/plugins/collections/ansible_collections
Collection             Version
---------------------- -------
ansible.amazon         *      
awx.awx                *      
azure.azcollection     *      
community.vmware       *      
google.cloud           *      
openstack.cloud        *      
ovirt.ovirt_collection *      
theforeman.foreman     *  
```

As Ansible so-helpfully informs us, these are not installed via the proper tool. Since it's from source, these are inherently un-versioned. Proper installs should be versioned with the FILES/MANIFEST files. I want to quickly mention that the proper tool is very slow.

Let's check that all the inventory plugins are there:

```
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/ansible/amazon/plugins/inventory/
__init__.py	aws_ec2.py	aws_rds.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/awx/awx/plugins/inventory/
tower.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/azure/azcollection/plugins/inventory/
azure_rm.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/community/vmware/plugins/inventory/
__init__.py		vmware_vm_inventory.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/google/cloud/plugins/inventory/
gcp_compute.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/openstack/cloud/plugins/inventory/
__init__.py	openstack.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/ovirt/ovirt_collection/plugins/inventory/
ovirt.py
(awx_collection) arominge-OSX:tower alancoding$ ls awx/plugins/collections/ansible_collections/theforeman/foreman/plugins/inventory/
foreman.py
```

One of these was just merged today/last night. Thus, the need for cloning source.
