### PR TITLE
[doc] credential plugins documentation: mention setup_managed_credential_types command & fix entry point example

### DIFF
--- a/docs/credentials/credential_plugins.md
+++ b/docs/credentials/credential_plugins.md
@@ -123,6 +123,16 @@ setuptools.setup(
 )
 ```
 
+Enable Custom Credential Plugins
+--------------------------------
+
+Once the Python package has been installed, `awx-manage` must be used in order
+to take in account the new credential plugin:
+
+```shell
+# awx-manage setup_managed_credential_types
+```
+
 Programmatic Secret Fetching
 ----------------------------
 If you want to programmatically fetch secrets from a supported external secret

--- a/docs/credentials/credential_plugins.md
+++ b/docs/credentials/credential_plugins.md
@@ -117,7 +117,7 @@ setuptools.setup(
     entry_points = {
         ...,
         'awx.credential_plugins': [
-            'fancy_plugin = awx.main.credential_plugins.fancy:some_fancy_plugin',
+            'fancy = my_fancy_project.my_fancy_module:some_fancy_plugin',  # some_fancy_plugin = CredentialPlugin(...)
         ]
     }
 )


### PR DESCRIPTION
##### SUMMARY
Credential plugins documentation:
* mention `setup_managed_credential_types` command
* fix `awx.credential_plugins`  entry point example

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- docs