### PR TITLE
Modified hashivault.py to support approle

### DIFF
--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -114,7 +114,7 @@ def handle_auth(**kwargs):
     elif kwargs.get('role_id') and kwargs.get('secret_id'):
         token = approle_auth(**kwargs)
     else:
-        raise Exception('Either Vault token or Auth parameters must be set')
+        raise Exception('Either token or AppRole parameters must be set')
 
     return token
 

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -121,10 +121,7 @@ def handle_auth(**kwargs):
 def approle_auth(**kwargs):
     role_id = kwargs['role_id']
     secret_id = kwargs['secret_id']
-    auth_path = "approle"
-
-    if kwargs.get('auth_path'):
-      auth_path = kwargs.get('auth_path', "approle")
+    auth_path = kwargs.get('auth_path') or 'approle'
 
     url = urljoin(kwargs['url'], 'v1')
     cacert = kwargs.get('cacert', None)

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -111,10 +111,9 @@ def handle_auth(**kwargs):
 
     if kwargs.get('token'):
         token = kwargs['token']
-    else:
-      if kwargs.get('role_id') and kwargs.get('secret_id'):
+    elif kwargs.get('role_id') and kwargs.get('secret_id'):
         token = approle_auth(**kwargs)
-      else:
+    else:
         raise Exception('Either Vault token or Auth parameters must be set')
 
     return token

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -32,14 +32,33 @@ base_inputs = {
         'type': 'string',
         'multiline': True,
         'help_text': _('The CA certificate used to verify the SSL certificate of the Vault server')
-    }],
+    }, {
+        'id': 'role_id',
+        'label': _('AppRole role_id'),
+        'type': 'string',
+        'multiline': False,
+        'help_text': _('The Role ID for AppRole Authentication')
+    }, {
+        'id': 'secret_id',
+        'label': _('AppRole secret_id'),
+        'type': 'string',
+        'multiline': False,
+        'secret': True,
+        'help_text': _('The Secret ID for AppRole Authentication')
+    }
+    ],
     'metadata': [{
         'id': 'secret_path',
         'label': _('Path to Secret'),
         'type': 'string',
         'help_text': _('The path to the secret stored in the secret backend e.g, /some/secret/')
+    },{
+        'id': 'auth_path',
+        'label': _('Path to Auth'),
+        'type': 'string',
+        'help_text': _('The path where the Authentication method is mounted e.g, approle')
     }],
-    'required': ['url', 'token', 'secret_path'],
+    'required': ['url', 'secret_path'],
 }
 
 hashi_kv_inputs = copy.deepcopy(base_inputs)
@@ -87,9 +106,45 @@ hashi_ssh_inputs['metadata'] = [{
 }]
 hashi_ssh_inputs['required'].extend(['public_key', 'role'])
 
+def handle_auth(**kwargs):
+    result = None
+
+    if bool(kwargs.get('token')):
+      result = kwargs['token']
+    else:
+      if bool(kwargs.get('role_id')) and bool(kwargs.get('secret_id')):
+        result = approle_auth(**kwargs)
+      else:
+        raise Exception('Either Vault token or Auth parameters must be set')
+
+    return result
+
+def approle_auth(**kwargs):
+    role_id = kwargs['role_id']
+    secret_id = kwargs['secret_id']
+    auth_path = "approle"
+
+    if bool(kwargs.get('auth_path')):
+      auth_path = kwargs.get('auth_path', "approle")
+
+    url = urljoin(kwargs['url'], 'v1')
+    cacert = kwargs.get('cacert', None)
+
+    request_kwargs = {'timeout': 30}
+    if cacert:
+        request_kwargs['verify'] = create_temporary_fifo(cacert.encode())
+
+    # AppRole Login
+    request_kwargs['json'] = {'role_id': role_id, 'secret_id': secret_id}
+    sess = requests.Session()
+    request_url = '/'.join([url, 'auth', auth_path, 'login']).rstrip('/')
+    resp = sess.post(request_url, **request_kwargs)
+    resp.raise_for_status()
+    token = resp.json()['auth']['client_token']
+    return token
 
 def kv_backend(**kwargs):
-    token = kwargs['token']
+    token = handle_auth(**kwargs)
     url = kwargs['url']
     secret_path = kwargs['secret_path']
     secret_backend = kwargs.get('secret_backend', None)
@@ -144,7 +199,7 @@ def kv_backend(**kwargs):
 
 
 def ssh_backend(**kwargs):
-    token = kwargs['token']
+    token = handle_auth(**kwargs)
     url = urljoin(kwargs['url'], 'v1')
     secret_path = kwargs['secret_path']
     role = kwargs['role']

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -106,6 +106,7 @@ hashi_ssh_inputs['metadata'] = [{
 }]
 hashi_ssh_inputs['required'].extend(['public_key', 'role'])
 
+
 def handle_auth(**kwargs):
     token = None
 
@@ -117,6 +118,7 @@ def handle_auth(**kwargs):
         raise Exception('Either token or AppRole parameters must be set')
 
     return token
+
 
 def approle_auth(**kwargs):
     role_id = kwargs['role_id']
@@ -138,6 +140,7 @@ def approle_auth(**kwargs):
     resp.raise_for_status()
     token = resp.json()['auth']['client_token']
     return token
+
 
 def kv_backend(**kwargs):
     token = handle_auth(**kwargs)

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -109,10 +109,10 @@ hashi_ssh_inputs['required'].extend(['public_key', 'role'])
 def handle_auth(**kwargs):
     result = None
 
-    if bool(kwargs.get('token')):
+    if kwargs.get('token'):
       result = kwargs['token']
     else:
-      if bool(kwargs.get('role_id')) and bool(kwargs.get('secret_id')):
+      if kwargs.get('role_id') and kwargs.get('secret_id'):
         result = approle_auth(**kwargs)
       else:
         raise Exception('Either Vault token or Auth parameters must be set')
@@ -124,7 +124,7 @@ def approle_auth(**kwargs):
     secret_id = kwargs['secret_id']
     auth_path = "approle"
 
-    if bool(kwargs.get('auth_path')):
+    if kwargs.get('auth_path'):
       auth_path = kwargs.get('auth_path', "approle")
 
     url = urljoin(kwargs['url'], 'v1')

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -107,17 +107,17 @@ hashi_ssh_inputs['metadata'] = [{
 hashi_ssh_inputs['required'].extend(['public_key', 'role'])
 
 def handle_auth(**kwargs):
-    result = None
+    token = None
 
     if kwargs.get('token'):
-      result = kwargs['token']
+        token = kwargs['token']
     else:
       if kwargs.get('role_id') and kwargs.get('secret_id'):
-        result = approle_auth(**kwargs)
+        token = approle_auth(**kwargs)
       else:
         raise Exception('Either Vault token or Auth parameters must be set')
 
-    return result
+    return token
 
 def approle_auth(**kwargs):
     role_id = kwargs['role_id']


### PR DESCRIPTION
##### SUMMARY
This PR allows for HashiCorp Vault AppRole Authentication with AWX credential plugin as requested in this issue: [https://github.com/ansible/awx/issues/5076](https://github.com/ansible/awx/issues/5076)

The following repo provides steps to test this using Vagrant:
[https://github.com/kawsark/awx-approle-ansible](https://github.com/kawsark/awx-approle-ansible)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

`awx/main/credential_plugins`

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.2.0
```

##### ADDITIONAL INFORMATION
The following repo provides steps to test this using Vagrant:
[https://github.com/kawsark/awx-approle-ansible](https://github.com/kawsark/awx-approle-ansible)
