### PR TITLE
Get current cloud sources working from collection

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1629,6 +1629,11 @@ class PluginFileInjector(object):
     # base injector should be one of None, "managed", or "template"
     # this dictates which logic to borrow from playbook injectors
     base_injector = None
+    # every source should have collection, but these are set here
+    # so that a source without a collection will have null values
+    namespace = None
+    collection = None
+    collection_migration = '2.10'  # In this version, content moved to collections
 
     def __init__(self, ansible_version):
         # This is InventoryOptions instance, could be source or inventory update
@@ -1655,7 +1660,11 @@ class PluginFileInjector(object):
         """
         if self.plugin_name is None:
             raise NotImplementedError('At minimum the plugin name is needed for inventory plugin use.')
-        return {'plugin': self.plugin_name}
+        if self.initial_version is None or Version(self.ansible_version) >= Version(self.collection_migration):
+            proper_name = f'{self.namespace}.{self.collection}.{self.plugin_name}'
+        else:
+            proper_name = self.plugin_name
+        return {'plugin': proper_name}
 
     def inventory_contents(self, inventory_update, private_data_dir):
         """Returns a string that is the content for the inventory file for the inventory plugin
@@ -1710,7 +1719,13 @@ class PluginFileInjector(object):
         return injected_env
 
     def get_plugin_env(self, inventory_update, private_data_dir, private_data_files):
-        return self._get_shared_env(inventory_update, private_data_dir, private_data_files)
+        env = self._get_shared_env(inventory_update, private_data_dir, private_data_files)
+        if self.initial_version is None or Version(self.ansible_version) >= Version(self.collection_migration):
+            env['ANSIBLE_COLLECTIONS_PATHS'] = os.path.abspath(os.path.join(
+                os.path.dirname(__file__), os.path.pardir, os.path.pardir,  # awx folder
+                'plugins', 'collections'
+            ))
+        return env
 
     def get_script_env(self, inventory_update, private_data_dir, private_data_files):
         injected_env = self._get_shared_env(inventory_update, private_data_dir, private_data_files)
@@ -1755,6 +1770,8 @@ class azure_rm(PluginFileInjector):
     initial_version = '2.8'  # Driven by unsafe group names issue, hostvars, host names
     ini_env_reference = 'AZURE_INI_PATH'
     base_injector = 'managed'
+    namespace = 'azure'
+    collection = 'azcollection'
 
     def get_plugin_env(self, *args, **kwargs):
         ret = super(azure_rm, self).get_plugin_env(*args, **kwargs)
@@ -1889,6 +1906,8 @@ class ec2(PluginFileInjector):
     # initial_version = '2.8'  # Driven by unsafe group names issue, parent_group templating, hostvars
     ini_env_reference = 'EC2_INI_PATH'
     base_injector = 'managed'
+    namespace = 'ansible'
+    collection = 'amazon'
 
     def get_plugin_env(self, *args, **kwargs):
         ret = super(ec2, self).get_plugin_env(*args, **kwargs)
@@ -2125,6 +2144,8 @@ class gce(PluginFileInjector):
     initial_version = '2.8'  # Driven by unsafe group names issue, hostvars
     ini_env_reference = 'GCE_INI_PATH'
     base_injector = 'managed'
+    namespace = 'google'
+    collection = 'cloud'
 
     def get_plugin_env(self, *args, **kwargs):
         ret = super(gce, self).get_plugin_env(*args, **kwargs)
@@ -2228,6 +2249,8 @@ class vmware(PluginFileInjector):
     # plugin_name = 'vmware_vm_inventory'  # FIXME: implement me
     ini_env_reference = 'VMWARE_INI_PATH'
     base_injector = 'managed'
+    namespace = 'community'
+    collection = 'vmware'
 
     @property
     def script_name(self):
@@ -2263,6 +2286,8 @@ class openstack(PluginFileInjector):
     plugin_name = 'openstack'
     # minimum version of 2.7.8 may be theoretically possible
     initial_version = '2.8'  # Driven by consistency with other sources
+    namespace = 'openstack'
+    collection = 'cloud'
 
     @property
     def script_name(self):
@@ -2326,12 +2351,10 @@ class openstack(PluginFileInjector):
             else:
                 return 'uuid'
 
-        ret = dict(
-            plugin=self.plugin_name,
-            fail_on_errors=True,
-            expand_hostvars=True,
-            inventory_hostname=use_host_name_for_name(False),
-        )
+        ret = super(openstack, self).inventory_as_dict(inventory_update, private_data_dir)
+        ret['fail_on_errors'] = True
+        ret['expand_hostvars'] = True
+        ret['inventory_hostname'] = use_host_name_for_name(False)
         # Note: mucking with defaults will break import integrity
         # For the plugin, we need to use the same defaults as the old script
         # or else imports will conflict. To find script defaults you have
@@ -2358,6 +2381,8 @@ class rhv(PluginFileInjector):
     """
     # plugin_name = 'FIXME'  # contribute inventory plugin to Ansible
     base_injector = 'template'
+    namespace = 'ovirt'
+    collection = 'ovirt_collection'
 
     @property
     def script_name(self):
@@ -2369,6 +2394,8 @@ class satellite6(PluginFileInjector):
     ini_env_reference = 'FOREMAN_INI_PATH'
     # initial_version = '2.8'  # FIXME: turn on after plugin is validated
     # No base injector, because this does not work in playbooks. Bug??
+    namespace = 'theforeman'
+    collection = 'foreman'
 
     @property
     def script_name(self):
@@ -2442,6 +2469,8 @@ class cloudforms(PluginFileInjector):
     # plugin_name = 'FIXME'  # contribute inventory plugin to Ansible
     ini_env_reference = 'CLOUDFORMS_INI_PATH'
     # Also no base_injector because this does not work in playbooks
+    # namespace = ''  # does not have a collection
+    # collection = ''
 
     def build_script_private_data(self, inventory_update, private_data_dir):
         cp = configparser.RawConfigParser()
@@ -2477,6 +2506,8 @@ class tower(PluginFileInjector):
     plugin_name = 'tower'
     base_injector = 'template'
     initial_version = '2.8'  # Driven by "include_metadata" hostvars
+    namespace = 'awx'
+    collection = 'awx'
 
     def get_script_env(self, inventory_update, private_data_dir, private_data_files):
         env = super(tower, self).get_script_env(inventory_update, private_data_dir, private_data_files)
@@ -2485,6 +2516,7 @@ class tower(PluginFileInjector):
         return env
 
     def inventory_as_dict(self, inventory_update, private_data_dir):
+        ret = super(tower, self).inventory_as_dict(inventory_update, private_data_dir)
         # Credentials injected as env vars, same as script
         try:
             # plugin can take an actual int type
@@ -2492,11 +2524,9 @@ class tower(PluginFileInjector):
         except ValueError:
             # inventory_id could be a named URL
             identifier = iri_to_uri(inventory_update.instance_filters)
-        return {
-            'plugin': self.plugin_name,
-            'inventory_id': identifier,
-            'include_metadata': True  # used for license check
-        }
+        ret['inventory_id'] = identifier
+        ret['include_metadata'] = True  # used for license check
+        return ret
 
 
 for cls in PluginFileInjector.__subclasses__():

--- a/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/files/azure_rm.yml
@@ -39,5 +39,5 @@ keyed_groups:
   prefix: ''
   separator: ''
 plain_host_names: true
-plugin: azure_rm
+plugin: azure.azcollection.azure_rm
 use_contrib_script_compatible_sanitization: true

--- a/awx/main/tests/data/inventory/plugins/ec2/files/aws_ec2.yml
+++ b/awx/main/tests/data/inventory/plugins/ec2/files/aws_ec2.yml
@@ -75,7 +75,7 @@ keyed_groups:
   parent_group: '{{ placement.region }}'
   prefix: ''
   separator: ''
-plugin: aws_ec2
+plugin: ansible.amazon.aws_ec2
 regions:
 - us-east-2
 - ap-south-1

--- a/awx/main/tests/data/inventory/plugins/gce/files/gcp_compute.yml
+++ b/awx/main/tests/data/inventory/plugins/gce/files/gcp_compute.yml
@@ -40,7 +40,7 @@ keyed_groups:
 - key: image
   prefix: ''
   separator: ''
-plugin: gcp_compute
+plugin: google.cloud.gcp_compute
 projects:
 - fooo
 retrieve_image_info: true

--- a/awx/main/tests/data/inventory/plugins/openstack/files/openstack.yml
+++ b/awx/main/tests/data/inventory/plugins/openstack/files/openstack.yml
@@ -1,4 +1,4 @@
 expand_hostvars: true
 fail_on_errors: true
 inventory_hostname: uuid
-plugin: openstack
+plugin: openstack.cloud.openstack

--- a/awx/main/tests/data/inventory/plugins/satellite6/files/foreman.yml
+++ b/awx/main/tests/data/inventory/plugins/satellite6/files/foreman.yml
@@ -1,1 +1,1 @@
-plugin: foreman
+plugin: theforeman.foreman.foreman

--- a/awx/main/tests/data/inventory/plugins/tower/files/tower.yml
+++ b/awx/main/tests/data/inventory/plugins/tower/files/tower.yml
@@ -1,3 +1,3 @@
 include_metadata: true
 inventory_id: 42
-plugin: tower
+plugin: awx.awx.tower

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -315,9 +315,10 @@ def test_inventory_update_injected_content(this_kind, script_or_plugin, inventor
         with mock.patch('awx.main.models.inventory.PluginFileInjector.should_use_plugin', return_value=use_plugin):
             # Also do not send websocket status updates
             with mock.patch.object(UnifiedJob, 'websocket_emit_status', mock.Mock()):
-                # The point of this test is that we replace run with assertions
-                with mock.patch('awx.main.tasks.ansible_runner.interface.run', substitute_run):
-                    # mocking the licenser is necessary for the tower source
-                    with mock.patch('awx.main.models.inventory.get_licenser', mock_licenser):
-                        # so this sets up everything for a run and then yields control over to substitute_run
-                        task.run(inventory_update.pk)
+                with mock.patch.object(task, 'get_ansible_version', return_value='2.13'):
+                    # The point of this test is that we replace run with assertions
+                    with mock.patch('awx.main.tasks.ansible_runner.interface.run', substitute_run):
+                        # mocking the licenser is necessary for the tower source
+                        with mock.patch('awx.main.models.inventory.get_licenser', mock_licenser):
+                            # so this sets up everything for a run and then yields control over to substitute_run
+                            task.run(inventory_update.pk)


### PR DESCRIPTION
##### SUMMARY
This requires https://github.com/ansible/awx/pull/6206

I just want to put it up early as a draft so that I do not leave anyone in the dark on it. @jladdjr 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.2.0
```


##### ADDITIONAL INFORMATION
Currently "works" with the gcp_compute inventory plugin if you use my branch from that.

Will need to do a once-through of all the rest

I hope to pull in some changes from https://github.com/ansible/awx/pull/6088, but will tread carefully there. Do not plan on deprecating any scripts with this go-around.
