### PR TITLE
Remove SCL python from awx-python

### DIFF
--- a/tools/scripts/awx-python
+++ b/tools/scripts/awx-python
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Enable needed Software Collections, if installed
-for scl in rh-python36 rh-postgresql10; do
+for scl in rh-postgresql10; do
   if [ -f /etc/scl/prefixes/$scl ]; then
     if [ -f `cat /etc/scl/prefixes/$scl`/$scl/enable ]; then
       . `cat /etc/scl/prefixes/$scl`/$scl/enable


### PR DESCRIPTION
This really should be created at build time.

