### PR TITLE
Remove some rogue awaits

### DIFF
--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
@@ -77,7 +77,7 @@ describe('<SelectResourceStep />', () => {
         '/organizations/1/access?resource.page=1&resource.order_by=-username',
       ],
     });
-    const wrapper = await mountWithContexts(
+    const wrapper = mountWithContexts(
       <SelectResourceStep
         searchColumns={searchColumns}
         sortColumns={sortColumns}

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.jsx
@@ -33,7 +33,7 @@ describe('<WorkflowJobTemplateAdd/>', () => {
         initialEntries: ['/templates/workflow_job_template/add'],
       });
       await act(async () => {
-        wrapper = await mountWithContexts(
+        wrapper = mountWithContexts(
           <Route
             path="/templates/workflow_job_template/add"
             component={() => <WorkflowJobTemplateAdd />}

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.test.jsx
@@ -12,7 +12,7 @@ describe('<WorkflowJobTemplateDetail/>', () => {
   const template = {
     id: 1,
     name: 'WFJT Template',
-    description: 'It is a wfjt template, yo!',
+    description: 'Yo, it is a wfjt template!',
     type: 'workflow_job_template',
     extra_vars: '1: 2',
     created: '2015-07-07T17:21:26.429745Z',
@@ -35,7 +35,7 @@ describe('<WorkflowJobTemplateDetail/>', () => {
         { id: 2, status: 'run' },
         { id: 3, status: 'run' },
       ],
-      webhook_credential: { id: '1', name: 'Credentaial', kind: 'machine' },
+      webhook_credential: { id: '1', name: 'Credential', kind: 'machine' },
       user_capabilities: { edit: true, delete: true },
     },
     webhook_service: 'Github',
@@ -46,7 +46,7 @@ describe('<WorkflowJobTemplateDetail/>', () => {
       initialEntries: ['/templates/workflow_job_template/1/details'],
     });
     await act(async () => {
-      wrapper = await mountWithContexts(
+      wrapper = mountWithContexts(
         <Route
           path="/templates/workflow_job_template/:id/details"
           component={() => (
@@ -120,7 +120,7 @@ describe('<WorkflowJobTemplateDetail/>', () => {
       {
         element: 'Detail[label="Description"]',
         prop: 'value',
-        value: 'It is a wfjt template, yo!',
+        value: 'Yo, it is a wfjt template!',
       },
       {
         element: 'Detail[label="Job Type"]',

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.test.jsx
@@ -152,7 +152,7 @@ describe('<WorkflowJobTemplateEdit/>', () => {
 
     let newWrapper;
     await act(async () => {
-      newWrapper = await mountWithContexts(
+      newWrapper = mountWithContexts(
         <WorkflowJobTemplateEdit template={templateWithoutOrg} />,
         {
           context: {

--- a/awx/ui_next/src/screens/Template/shared/SurveyList.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/SurveyList.test.jsx
@@ -16,7 +16,7 @@ describe('<SurveyList />', () => {
   test('expect component to mount successfully', async () => {
     let wrapper;
     await act(async () => {
-      wrapper = await mountWithContexts(
+      wrapper = mountWithContexts(
         <SurveyList template={mockJobTemplateData} />
       );
     });
@@ -25,7 +25,7 @@ describe('<SurveyList />', () => {
   test('expect api to be called to get survey', async () => {
     let wrapper;
     await act(async () => {
-      wrapper = await mountWithContexts(
+      wrapper = mountWithContexts(
         <SurveyList template={mockJobTemplateData} />
       );
     });
@@ -37,7 +37,7 @@ describe('<SurveyList />', () => {
     JobTemplatesAPI.readSurvey.mockRejectedValue(new Error());
     let wrapper;
     await act(async () => {
-      wrapper = await mountWithContexts(
+      wrapper = mountWithContexts(
         <SurveyList template={{ ...mockJobTemplateData, id: 'a' }} />
       );
     });

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.test.jsx
@@ -66,7 +66,7 @@ describe('<WorkflowJobTemplateForm/>', () => {
       initialEntries: ['/templates/workflow_job_template/6/edit'],
     });
     await act(async () => {
-      wrapper = await mountWithContexts(
+      wrapper = mountWithContexts(
         <Route
           path="/templates/workflow_job_template/:id/edit"
           component={() => (


### PR DESCRIPTION
##### SUMMARY
The `mountWithContexts` helper [calls enzyme's mount function](https://github.com/ansible/awx/blob/devel/awx/ui_next/testUtils/enzymeHelpers.jsx#L136). Enyme's mount function [returns a ReactWrapper instance](https://github.com/enzymejs/enzyme/blob/master/docs/api/mount.md#returns), not a promise object, so it's not something you can `await`.
