### PR TITLE
Fixes bug where users without read access on a creds org cannot edit the cred

### DIFF
--- a/awx/ui/client/features/credentials/add-edit-credentials.controller.js
+++ b/awx/ui/client/features/credentials/add-edit-credentials.controller.js
@@ -72,7 +72,7 @@ function AddEditCredentialsController (
         vm.form.credential_type._displayValue = credentialType.get('name');
         vm.isTestable = (isEditable && credentialType.get('kind') === 'external');
 
-        if (credential.get('related.input_sources.results.length' > 0)) {
+        if (credential.get('related.input_sources.results').length > 0) {
             vm.form.credential_type._disabled = true;
         }
 

--- a/awx/ui/client/features/credentials/index.js
+++ b/awx/ui/client/features/credentials/index.js
@@ -40,7 +40,6 @@ function CredentialsResolve (
     return $q.all(promises)
         .then(models => {
             const typeId = models.credential.get('credential_type');
-            const orgId = models.credential.get('organization');
 
             Rest.setUrl(GetBasePath('credentials'));
             const params = { target_input_sources__target_credential: id };
@@ -48,7 +47,9 @@ function CredentialsResolve (
 
             const dependents = {
                 credentialType: new CredentialType('get', typeId),
-                organization: new Organization('get', orgId),
+                organization: new Organization('get', {
+                    resource: models.credential.get('summary_fields.organization')
+                }),
                 credentialInputSources: models.credential.extend('GET', 'input_sources'),
                 sourceCredentials: sourceCredentialsPromise
             };


### PR DESCRIPTION
##### SUMMARY
What was happening here was that a request was being made in the resolve block for the edit state that would go out and fetch the organization.  This request failed and we were falling into a `catch` which threw an error and stopped the transition to the state.

We actually don't need to go out and fetch the org - we have some basic org info in the `summary_fields` of the credential.  These changes use the condensed object from the `summary_fields` to populate the model and mitigate the need for a GET.

Once I got the form rendering, I noticed that the credential type field was disabled.  This was due to a syntax error when fetching `input_sources` from the model.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
