### PR TITLE
Filter for active cloudforms vm's.

### DIFF
--- a/awx/plugins/inventory/cloudforms.py
+++ b/awx/plugins/inventory/cloudforms.py
@@ -274,7 +274,8 @@ class CloudFormsInventory(object):
 
         while not last_page:
             offset = page * limit
-            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses" % (self.cloudforms_url, offset, limit))
+            ret = self._get_json("%s/api/vms?offset=%s&limit=%s&expand=resources,tags,hosts,&attributes=ipaddresses,"
+                                 "active&filter[]=active=true" % (self.cloudforms_url, offset, limit))
             results += ret['resources']
             if ret['subcount'] < limit:
                 last_page = True


### PR DESCRIPTION
##### SUMMARY
This PR changes the api call from cloudforms inventory script when reading vm's from cloudforms. This bug hit me very hard before I realized that something was missing here. I added a filter to make sure that only active vm's are synchronized with AWX. 

Cloudforms has a concept of moving deleted vm's to an archive where they still reside in the database for whatever reasons. However, if it happens to be that there is an archived vm and a normally running vm with the same name in the cloudforms database it may happen that the data from the archived vm is synchronized and the running vm instance is skipped.

As AWX and underlying Ansible is a tool to connect to up and running vm's, it doesn't make any sense to sync deleted vm's to an AWX inventory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Inventory script

##### AWX VERSION
Rather version independent.


##### ADDITIONAL INFORMATION

