### PR TITLE
Add parser error handling for settings json

### DIFF
--- a/awx/ui/client/src/configuration/settingsUtils.service.js
+++ b/awx/ui/client/src/configuration/settingsUtils.service.js
@@ -12,13 +12,9 @@ export default ['$q',
                 var payload;
 
                 if (input.indexOf('[') !== -1) {
-                    try {
-                        payload = JSON.parse(input);
+                    payload = JSON.parse(input);
 
-                        if (!Array.isArray(payload)) {
-                            payload = [];
-                        }
-                    } catch(err) {
+                    if (!Array.isArray(payload)) {
                         payload = [];
                     }
                 } else if (input.indexOf('\n') !== -1) {

--- a/awx/ui/client/src/shared/Utilities.js
+++ b/awx/ui/client/src/shared/Utilities.js
@@ -212,7 +212,11 @@ angular.module('Utilities', ['RestServices', 'Utilities'])
                         }
                     } else {
                         if (data[fld]) {
-                            scope[fld + '_api_error'] = data[fld][0];
+                            if (data[fld].message) {
+                                scope[fld + '_api_error'] = data[fld].message;
+                            } else {
+                                scope[fld + '_api_error'] = data[fld][0];
+                            }
                             $('[name="' + fld + '"]').addClass('ng-invalid');
                             $('label[for="' + fld + '"] span').addClass('error-color');
                             $('html, body').animate({scrollTop: $('[name="' + fld + '"]').offset().top}, 0);


### PR DESCRIPTION
##### SUMMARY
On the settings page, we were replacing non-parseable json inputs with an empty array before sending data to the API. This would confusingly make it seem like a user's invalid json input was saved, when in reality it was reset to an empty list.

To fix this, I [removed the try clause](https://github.com/ansible/awx/pull/6257/files#diff-73d2e2d2351837bb822d23e89996e509L15) from the utility function that parses json input. This lets the errors bubble up to the calling function, where we now [catch and collect errors for each field](https://github.com/ansible/awx/pull/6257/files#diff-769a4c36856b951ef3772c839cf292a8R323).

Then, prior to saving the data to the API, we check for any collected errors found when generating the payload. If we have errors, we [show them on the form and return early](https://github.com/ansible/awx/pull/6257/files#diff-769a4c36856b951ef3772c839cf292a8R396) before sending anything to the api.


##### ADDITIONAL INFORMATION
![settings_parse_error](https://user-images.githubusercontent.com/9753817/76433945-68ea2200-638b-11ea-8e7b-c0dff1eb8608.gif)

