### PR TITLE
Update dev container to be consistent with other installation methods

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     container_name: tools_awx_1
     hostname: awx
-    command: /start_development.sh
+    command: launch_awx.sh
     environment:
       CURRENT_UID:
       OS:

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -121,9 +121,9 @@ ENV LC_ALL en_US.UTF-8
 
 ADD tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
 ADD tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
-ADD tools/docker-compose/start_development.sh /start_development.sh
+ADD tools/docker-compose/launch_awx.sh /usr/bin/launch_awx.sh
 ADD tools/docker-compose/start_tests.sh /start_tests.sh
-ADD tools/docker-compose/bootstrap_development.sh /bootstrap_development.sh
+ADD tools/docker-compose/bootstrap_development.sh /usr/bin/bootstrap_development.sh
 
 EXPOSE 8043 8013 8080 22
 

--- a/tools/docker-compose/launch_awx.sh
+++ b/tools/docker-compose/launch_awx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set +x
 
-/bootstrap_development.sh
+bootstrap_development.sh
 
 cd /awx_devel
 # Start the services


### PR DESCRIPTION
 - rename `start_development.sh` script to `launch_awx.sh`, like it is in k8 installations

##### SUMMARY

Renaming for consistency.  The `docker-compose-test` make command workflow will still work, but instead of running `./start_development.sh` once in the container, you should now run `launch_awx.sh`