### PR TITLE
Print module standard out in test failure scenarios

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -127,15 +127,22 @@ def run_module(request, collection_import):
                 else:
                     tower_cli_mgr = suppress()
                 with tower_cli_mgr:
-                    # Ansible modules return data to the mothership over stdout
-                    with redirect_stdout(stdout_buffer):
-                        try:
+                    try:
+                        # Ansible modules return data to the mothership over stdout
+                        with redirect_stdout(stdout_buffer):
                             resource_module.main()
-                        except SystemExit:
-                            pass  # A system exit indicates successful execution
+                    except SystemExit:
+                        pass  # A system exit indicates successful execution
+                    except Exception:
+                        # dump the stdout back to console for debugging
+                        print(stdout_buffer.getvalue())
+                        raise
 
         module_stdout = stdout_buffer.getvalue().strip()
-        result = json.loads(module_stdout)
+        try:
+            result = json.loads(module_stdout)
+        except Exception as e:
+            raise Exception('Module did not write valid JSON, error: {}, stdout:\n{}'.format(str(e), module_stdout))
         # A module exception should never be a test expectation
         if 'exception' in result:
             raise Exception('Module encountered error:\n{0}'.format(result['exception']))


### PR DESCRIPTION
##### SUMMARY
This is another incremental improvement to help make errors in the AWX collection tests easier to track down.

We have to capture the standard out from the module in order to load the data from it.

But in cases where the module errors, or didn't give valid JSON, that output got dropped on the floor.

All this does is print that output if we hit an error trying to process it through the normal pipeline.

This will normally not matter, but it's really helpful when you screw the tests up.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
Here's an example where I add `print('foo')` to the module

```
--------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------
INFO     awx.main.tests:conftest.py:98 GET /api/v2/organizations/ by admin, code:200
INFO     awx.main.tests:conftest.py:98 GET /api/v2/workflow_job_templates/ by admin, code:200
INFO     awx.main.tests:conftest.py:98 POST /api/v2/workflow_job_templates/ by admin, code:201
INFO     awx.main.tests:conftest.py:98 GET /api/v2/workflow_job_template_nodes/ by admin, code:200
_______________________________________________________________________________ test_with_missing_ujt _______________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/conftest.py", line 143, in rf
    result = json.loads(module_stdout)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/test_workflow_template.py", line 144, in test_with_missing_ujt
    }, admin_user)
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/conftest.py", line 145, in rf
    raise Exception('Module did not write valid JSON, error: {0}, stdout:\n{1}'.format(str(e), module_stdout))
Exception: Module did not write valid JSON, error: Expecting value: line 1 column 1 (char 0), stdout:
foo

{"msg": "Failed to update workflow template:                     You should provide exactly one of the attributes job_template, project, workflow, inventory_source, or unified_job_template.{'foo': 'bar'}", "changed": false, "failed": true, "invocation": {"module_args": {"name": "foo-workflow", "organization": "Default", "schema": "[{'foo': 'bar'}]", "state": "present", "description": null, "extra_vars": null, "allow_simultaneous": null, "survey": null, "survey_enabled": null, "inventory": null, "ask_inventory": null, "ask_extra_vars": null}}}
------------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------------
```

Before this, it just said it couldn't parse JSON, and at that point you're outright hunting down lines.