### PR TITLE
save approval node start time *before* sending "started" notifications

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -749,9 +749,9 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
 
     def signal_start(self, **kwargs):
         can_start = super(WorkflowApproval, self).signal_start(**kwargs)
-        self.send_approval_notification('running')
         self.started = self.created
         self.save(update_fields=['started'])
+        self.send_approval_notification('running')
         return can_start
 
     def send_approval_notification(self, approval_status):


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/6267

Whoops 😄!

Thanks for spotting this @appuk.