### PR TITLE
Adds aria-label attrs to buttons without inner text

### DIFF
--- a/awx/ui/client/features/applications/applications.strings.js
+++ b/awx/ui/client/features/applications/applications.strings.js
@@ -16,10 +16,6 @@ function ApplicationsStrings (BaseString) {
         USERS: t.s('Tokens')
     };
 
-    ns.tooltips = {
-        ADD: t.s('Create a new Application')
-    };
-
     ns.add = {
         PANEL_TITLE: t.s('NEW APPLICATION'),
         CLIENT_ID_LABEL: t.s('CLIENT ID'),
@@ -32,7 +28,8 @@ function ApplicationsStrings (BaseString) {
         PANEL_TITLE: t.s('APPLICATIONS'),
         ROW_ITEM_LABEL_EXPIRED: t.s('EXPIRATION'),
         ROW_ITEM_LABEL_ORGANIZATION: t.s('ORG'),
-        ROW_ITEM_LABEL_MODIFIED: t.s('LAST MODIFIED')
+        ROW_ITEM_LABEL_MODIFIED: t.s('LAST MODIFIED'),
+        ADD: t.s('Create a new Application')
     };
 
     ns.inputs = {

--- a/awx/ui/client/features/applications/list-applications.controller.js
+++ b/awx/ui/client/features/applications/list-applications.controller.js
@@ -43,10 +43,6 @@ function ListApplicationsController (
         paginateQuerySet = queryset;
     });
 
-    vm.tooltips = {
-        add: strings.get('tooltips.ADD')
-    };
-
     const toolbarSortDefault = {
         label: `${strings.get('sort.NAME_ASCENDING')}`,
         value: 'name'

--- a/awx/ui/client/features/applications/list-applications.view.html
+++ b/awx/ui/client/features/applications/list-applications.view.html
@@ -19,11 +19,12 @@
             </smart-search>
             <div class="at-List-toolbarAction" ng-show="canAdd">
                 <button
+                    aria-label="{{:: vm.strings.get('list.ADD') }}"
                     type="button"
                     ui-sref="applications.add"
                     class="at-Button--add"
                     id="button-add"
-                    aw-tool-tip="{{vm.tooltips.add}}"
+                    aw-tool-tip="{{:: vm.strings.get('list.ADD') }}"
                     data-placement="top"
                     aria-haspopup="true"
                     aria-expanded="false">

--- a/awx/ui/client/features/output/details.partial.html
+++ b/awx/ui/client/features/output/details.partial.html
@@ -9,13 +9,14 @@
 
         <!-- CANCEL ACTION -->
         <button
+            aria-label="{{:: vm.strings.get('details.CANCEL_JOB')}}"
             class="List-actionButton List-actionButton--delete"
             data-placement="top"
             ng-click="vm.cancelJob()"
             ng-show="vm.status.unmapped === 'pending' ||
                      vm.status.unmapped === 'waiting' ||
                      vm.status.unmapped === 'running'"
-            aw-tool-tip="{{:: vm.strings.get('tooltips.CANCEL') }}"
+            aw-tool-tip="{{:: vm.strings.get('details.CANCEL_JOB') }}"
             data-original-title=""
             title="">
             <i class="fa fa-minus-circle"></i>
@@ -23,6 +24,7 @@
 
         <!-- DELETE ACTION -->
         <button
+            aria-label="{{:: vm.strings.get('details.DELETE_JOB')}}"
             class="List-actionButton List-actionButton--delete"
             data-placement="top"
             ng-click="vm.deleteJob()"
@@ -32,7 +34,7 @@
                    vm.status.unmapped === 'failed' ||
                    vm.status.unmapped === 'error' ||
                    vm.status.unmapped === 'canceled')"
-            aw-tool-tip="{{:: vm.strings.get('tooltips.DELETE') }}"
+            aw-tool-tip="{{:: vm.strings.get('details.DELETE_JOB') }}"
             data-original-title=""
             title="">
             <i class="fa fa-trash-o"></i>

--- a/awx/ui/client/features/output/host-event/host-event-modal.partial.html
+++ b/awx/ui/client/features/output/host-event/host-event-modal.partial.html
@@ -9,7 +9,7 @@
 				</a>
 				<span class="HostEvent-title">{{event.host_name}}</span>
 				<!-- close -->
-				<button ng-click="closeHostEvent()" type="button" class="close">
+				<button aria-label="{{:: strings.get('host_event_modal.CLOSE_HOST_EVENT_MODAL')}}" ng-click="closeHostEvent()" type="button" class="close">
 					<i class="fa fa-times-circle"></i>
 				</button>
 			</div>

--- a/awx/ui/client/features/output/output.strings.js
+++ b/awx/ui/client/features/output/output.strings.js
@@ -51,6 +51,8 @@ function OutputStrings (BaseString) {
         SHOW_MORE: t.s('Show More'),
         UNKNOWN: t.s('Finished'),
         WEBHOOK: t.s('Webhook'),
+        CANCEL_JOB: t.s('Cancel Job'),
+        DELETE_JOB: t.s('Delete Job'),
     };
 
     ns.labels = {
@@ -107,13 +109,15 @@ function OutputStrings (BaseString) {
         PLACEHOLDER_RUNNING: t.s('JOB IS STILL RUNNING'),
         REJECT_DEFAULT: t.s('Failed to update search results.'),
         REJECT_INVALID: t.s('Invalid search filter provided.'),
+        SUBMIT: t.s('Submit search')
     };
 
     ns.stats = {
         ELAPSED: t.s('Elapsed'),
         PLAYS: t.s('Plays'),
         TASKS: t.s('Tasks'),
-        HOSTS: t.s('Hosts')
+        HOSTS: t.s('Hosts'),
+        TOGGLE_EXPANDED_OUTPUT: t.s('Toggle expanded output')
     };
 
     ns.stdout = {
@@ -128,7 +132,8 @@ function OutputStrings (BaseString) {
         MODULE: t.s('MODULE'),
         NO_RESULT_FOUND: t.s('No result found'),
         STANDARD_OUT: t.s('Standard Out'),
-        STANDARD_ERROR: t.s('Standard Error')
+        STANDARD_ERROR: t.s('Standard Error'),
+        CLOSE_HOST_EVENT_MODAL: t.s('Close host event modal')
     };
 
     ns.workflow_status = {

--- a/awx/ui/client/features/output/search.partial.html
+++ b/awx/ui/client/features/output/search.partial.html
@@ -14,6 +14,7 @@
             <button class="btn at-ButtonHollow--default at-Input-button"
                 ng-click="vm.submitSearch()"
                 ng-disabled="vm.disabled || !vm.value || vm.value === ''"
+                aria-label="{{:: vm.strings.get('search.SUBMIT') }}"
                 type="button">
                 <i class="fa fa-search"></i>
             </button>

--- a/awx/ui/client/features/output/stats.partial.html
+++ b/awx/ui/client/features/output/stats.partial.html
@@ -19,6 +19,7 @@
 
     <a ng-show="vm.download && !vm.running" href="{{ vm.download }}?format=txt_download">
         <button class="btn at-Input-button at-u-noBorder"
+            aria-label="Download output"
             aw-tool-tip="{{:: vm.strings.get('tooltips.DOWNLOAD_OUTPUT') }}"
             data-placement="top">
             <i class="fa fa-download"></i>
@@ -26,6 +27,7 @@
     </a>
 
     <button class="btn at-Input-button at-u-noBorder"
+        aria-label="{{:: vm.strings.get('stats.TOGGLE_EXPANDED_OUTPUT') }}"
         aw-tool-tip="{{ vm.tooltips.toggleExpand }}"
         data-tip-watch="vm.tooltips.toggleExpand"
         data-placement="top"

--- a/awx/ui/client/features/projects/projects.strings.js
+++ b/awx/ui/client/features/projects/projects.strings.js
@@ -11,6 +11,7 @@ function ProjectsStrings (BaseString) {
         ROW_ITEM_LABEL_ORGANIZATION: t.s('ORGANIZATION'),
         ROW_ITEM_LABEL_MODIFIED: t.s('LAST MODIFIED'),
         ROW_ITEM_LABEL_USED: t.s('LAST USED'),
+        ADD: t.s('Add a new project')
     };
 
     ns.update = {

--- a/awx/ui/client/features/projects/projectsList.view.html
+++ b/awx/ui/client/features/projects/projectsList.view.html
@@ -12,6 +12,7 @@
         </smart-search>
         <div class="at-List-toolbarAction" ng-show="canAdd">
             <button
+                aria-label="{{:: vm.strings.get('list.ADD')}}"
                 type="button"
                 class="at-Button--add"
                 id="button-add"

--- a/awx/ui/client/features/templates/templates.strings.js
+++ b/awx/ui/client/features/templates/templates.strings.js
@@ -20,6 +20,7 @@ function TemplatesStrings (BaseString) {
         ROW_ITEM_LABEL_CREDENTIALS: t.s('Credentials'),
         ROW_ITEM_LABEL_MODIFIED: t.s('Last Modified'),
         ROW_ITEM_LABEL_RAN: t.s('Last Ran'),
+        ADD: t.s('Add a new template')
     };
 
     ns.prompt = {

--- a/awx/ui/client/features/templates/templatesList.view.html
+++ b/awx/ui/client/features/templates/templatesList.view.html
@@ -14,6 +14,7 @@
         </smart-search>
         <div class="at-List-toolbarAction" ng-show="!vm.isPortalMode && canAdd">
             <button
+                aria-label="{{:: vm.strings.get('list.ADD')}}"
                 type="button"
                 class="at-Button--add"
                 id="button-add"

--- a/awx/ui/client/features/users/tokens/tokens.strings.js
+++ b/awx/ui/client/features/users/tokens/tokens.strings.js
@@ -40,6 +40,7 @@ function TokensStrings (BaseString) {
         ROW_ITEM_LABEL_APPLICATION: t.s('APPLICATION'),
         PERSONAL_ACCESS_TOKEN: t.s('Personal Access Token'),
         HEADER: appName => t.s('{{ appName }} Token', { appName }),
+        ADD: t.s('Add a new token')
     };
 }
 

--- a/awx/ui/client/features/users/tokens/users-tokens-list.partial.html
+++ b/awx/ui/client/features/users/tokens/users-tokens-list.partial.html
@@ -11,6 +11,7 @@
     </smart-search>
     <div class="at-List-toolbarAction">
         <button
+            aria-label="{{:: vm.strings.get('list.ADD')}}"
             type="button"
             ui-sref=".add"
             class="at-Button--add"

--- a/awx/ui/client/index.template.ejs
+++ b/awx/ui/client/index.template.ejs
@@ -19,6 +19,7 @@
 </head>
 
 <body data-user-agent="{{userAgent}}">
+    {% verbatim %}
     <at-layout>
         <bread-crumb></bread-crumb>
         <toast></toast>
@@ -40,7 +41,7 @@
                                 <span class="Modal-titleResourceName" ng-bind="promptResourceName"></span>
                             </div>
                             <div class="Modal-exitHolder">
-                                <button class="close Modal-exit" data-target="#prompt-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                                <button aria-label="{{:: appStrings.get('CLOSE')}}" class="close Modal-exit" data-target="#prompt-modal" data-dismiss="modal"><i class="fa fa-times-circle"></i></button>
                             </div>
                         </div>
                         <div class="Modal-body" ng-bind-html="promptBody" id="prompt-body">
@@ -61,7 +62,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h3 id="alertHeader" ng-bind="alertHeader"></h3>
-                            <button type="button" class="close" ng-hide="disableButtons" data-target="#alert-modal" data-dismiss="modal" class="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                            <button aria-label="{{:: appStrings.get('CLOSE')}}" type="button" class="close" ng-hide="disableButtons" data-target="#alert-modal" data-dismiss="modal" class="modal"><i class="fa fa-times-circle"></i></button>
                         </div>
                         <div class="modal-body">
                             <div id="alert-modal-msg" class="alert" ng-bind-html="alertBody"></div>
@@ -79,7 +80,7 @@
                 <div class="modal-dialog">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <button type="button" class="close" data-target="#alert-modal2" data-dismiss="modal" ng-hide="disableButtons2" aria-hidden="true">&times;</button>
+                            <button aria-label="{{:: appStrings.get('CLOSE')}}" type="button" class="close" data-target="#alert-modal2" data-dismiss="modal" ng-hide="disableButtons2">&times;</button>
                             <h3 id="alertHeader2" ng-bind="alertHeader2"></h3>
                         </div>
                         <div class="modal-body">
@@ -158,6 +159,7 @@
             </div>
         </div>
     </at-layout>
+    {% endverbatim %}
 </body>
 
 </html>

--- a/awx/ui/client/lib/components/approvalsDrawer/approvalsDrawer.partial.html
+++ b/awx/ui/client/lib/components/approvalsDrawer/approvalsDrawer.partial.html
@@ -10,7 +10,7 @@
                 </span>
             </div>
             <div class="at-ApprovalsDrawer--exit">
-                <button class="close" ng-click="closeApprovals()">
+                <button aria-label="{{:: vm.strings.get('approvals.CLOSE_APPROVALS') }}" class="close" ng-click="closeApprovals()">
                 <i class="fa fa-times-circle"></i>
                 </button>
             </div>

--- a/awx/ui/client/lib/components/code-mirror/code-mirror.strings.js
+++ b/awx/ui/client/lib/components/code-mirror/code-mirror.strings.js
@@ -4,6 +4,8 @@ function CodeMirrorStrings (BaseString) {
     const { t } = this;
     const ns = this.code_mirror;
 
+    ns.CLOSE_MODAL = t.s('Close variables modal');
+
     ns.label = {
         EXTRA_VARIABLES: t.s('EXTRA VARIABLES'),
         VARIABLES: t.s('VARIABLES'),

--- a/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.partial.html
+++ b/awx/ui/client/lib/components/code-mirror/modal/code-mirror-modal.partial.html
@@ -46,7 +46,7 @@
                         <div class="at-RowItem-tag at-RowItem-tag--header atCodeMirror-badge" ng-show="disabled === 'true' || disabled === true">
                             {{ vm.strings.get('label.READONLY')}}
                         </div>
-                        <button type="button" class="close" ng-click="close()">
+                        <button aria-label="{{:: vm.strings.get('CLOSE_MODAL')}}" type="button" class="close" ng-click="close()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>
@@ -63,7 +63,7 @@
             </div>
             <div class="modal-footer">
                 <div class="CodeMirror-modalControls">
-                    <button ng-click="close()" class="btn btn-sm btn-default">Close</button>
+                    <button ng-click="close()" class="btn btn-sm btn-default" translate>Close</button>
                 </div>
             </div>
         </div>

--- a/awx/ui/client/lib/components/components.strings.js
+++ b/awx/ui/client/lib/components/components.strings.js
@@ -17,7 +17,8 @@ function ComponentsStrings (BaseString) {
     };
 
     ns.file = {
-        PLACEHOLDER: t.s('CHOOSE A FILE')
+        PLACEHOLDER: t.s('CHOOSE A FILE'),
+        SELECT_FILE: t.s('Select file')
     };
 
     ns.form = {
@@ -44,7 +45,8 @@ function ComponentsStrings (BaseString) {
     };
 
     ns.lookup = {
-        NOT_FOUND: t.s('That value was not found. Please enter or select a valid value.')
+        NOT_FOUND: t.s('That value was not found. Please enter or select a valid value.'),
+        PERFORM_LOOKUP: t.s('Perform lookup')
     };
 
     ns.truncate = {
@@ -129,7 +131,12 @@ function ComponentsStrings (BaseString) {
         NOTIFICATIONS: t.s('NOTIFICATIONS'),
         WORKFLOW_TEMPLATE: t.s('Workflow Template'),
         EXPIRES: t.s('Expires:'),
-        EXPIRES_NEVER: t.s('Expires: Never')
+        EXPIRES_NEVER: t.s('Expires: Never'),
+        CLOSE_APPROVALS: t.s('Close Approvals')
+    };
+
+    ns.secret = {
+        REPLACE: t.s('Replace secret')
     };
 }
 

--- a/awx/ui/client/lib/components/input/file.partial.html
+++ b/awx/ui/client/lib/components/input/file.partial.html
@@ -4,9 +4,12 @@
         <input class="at-InputFile--hidden" type="file"/>
         <div class="input-group">
             <span class="input-group-btn input-group-prepend">
-                <button class="btn at-ButtonHollow--default at-Input-button"
-                        ng-disabled="state._disabled || form.disabled"
-                        ng-click="vm.onButtonClick()">
+                <button
+                    class="btn at-ButtonHollow--default at-Input-button"
+                    aria-label="{{:: vm.strings.get('file.SELECT_FILE')}}"
+                    ng-disabled="state._disabled || form.disabled"
+                    ng-click="vm.onButtonClick()"
+                >
                   <i class="fa fa-folder-open" ng-if="!state._value"></i>
                   <i class="fa fa-trash" ng-if="state._value"></i>
                 </button>

--- a/awx/ui/client/lib/components/input/lookup.partial.html
+++ b/awx/ui/client/lib/components/input/lookup.partial.html
@@ -3,9 +3,12 @@
         <at-input-label></at-input-label>
 
         <div class="at-InputLookup">
-            <button class="at-InputLookup-button"
-                    ng-disabled="state._disabled || form.disabled"
-                    ng-click="vm.lookup()">
+            <button
+                aria-label="{{:: vm.strings.get('lookup.PERFORM_LOOKUP')}}"
+                class="at-InputLookup-button"
+                ng-disabled="state._disabled || form.disabled"
+                ng-click="vm.lookup()"
+            >
                 <i class="fa fa-search"></i>
             </button>
             <input type="text"

--- a/awx/ui/client/lib/components/input/secret.partial.html
+++ b/awx/ui/client/lib/components/input/secret.partial.html
@@ -5,6 +5,7 @@
         <div class="input-group">
             <span ng-if="state.tagMode" class="input-group-btn input-group-prepend">
                 <button
+                  aria-label="{{:: vm.strings.get('lookup.PERFORM_LOOKUP')}}"
                   class="btn at-ButtonHollow--default at-Input-button"
                   ng-disabled="state._disabled || form.disabled"
                   ng-click="vm.onLookupClick()">
@@ -42,6 +43,7 @@
             />
             <span ng-show="mode == 'encrypted'" class="input-group-btn input-group-append">
                 <button
+                  aria-label="{{:: vm.strings.get('secret.REPLACE')}}"
                   class="btn at-ButtonHollow--default at-Input-button"
                   ng-disabled="state.asTag || (!state._enableToggle && (state._disabled || form.disabled))"
                   ng-click="vm.toggleRevertReplace()"
@@ -54,6 +56,7 @@
             </span>
             <span class="input-group-btn input-group-append">
                 <button
+                  aria-label="Toggle show/hide text"
                   class="btn at-ButtonHollow--default at-Input-button"
                   ng-disabled="state.asTag || state._disabled || form.disabled"
                   ng-click="vm.toggleShowHide()"

--- a/awx/ui/client/lib/components/input/text.partial.html
+++ b/awx/ui/client/lib/components/input/text.partial.html
@@ -4,6 +4,7 @@
         <div ng-if="state.tagMode" class="input-group">
           <span class="input-group-btn input-group-prepend">
               <button
+                aria-label="{{:: vm.strings.get('lookup.PERFORM_LOOKUP')}}"
                 class="btn at-ButtonHollow--default at-Input-button"
                 ng-disabled="state._disabled || form.disabled"
                 ng-click="vm.onLookupClick()">

--- a/awx/ui/client/lib/components/input/textarea-secret.partial.html
+++ b/awx/ui/client/lib/components/input/textarea-secret.partial.html
@@ -4,6 +4,7 @@
         <div class="input-group">
             <div class="input-group-btn at-InputGroup-button input-group-prepend" ng-show="state.tagMode">
                 <button
+                  aria-label="{{:: vm.strings.get('lookup.PERFORM_LOOKUP')}}"
                   class="btn at-ButtonHollow--white at-Input-button--long-sm"
                   ng-disabled="state._disabled || form.disabled"
                   ng-click="vm.onLookupClick()"
@@ -51,6 +52,7 @@
             />
             <div ng-if="state._edit" class="input-group-btn at-InputGroup-button input-group-append">
                 <button
+                  aria-label="{{:: vm.strings.get('secret.REPLACE')}}"
                   class="btn at-ButtonHollow--white at-Input-button--long-sm"
                   ng-disabled="state.asTag || (!state._enableToggle && (state._disabled || form.disabled))"
                   ng-click="state._isBeingReplaced = !state._isBeingReplaced"

--- a/awx/ui/client/lib/components/launchTemplateButton/launchTemplateButton.partial.html
+++ b/awx/ui/client/lib/components/launchTemplateButton/launchTemplateButton.partial.html
@@ -1,12 +1,15 @@
 <div class="at-LaunchTemplate">
-    <button type="button"
-            ng-class="{'at-LaunchTemplate--button': !vm.showTextButton, 'btn btn-sm Form-primaryButton': vm.showTextButton, 'Form-button--disabled': vm.disabled}"
-            ng-click="vm.startLaunchTemplate()"
-            aw-tool-tip="{{ vm.launchTooltip }}"
-            data-tip-watch="vm.launchTooltip"
-            data-placement="top">
-            <i class="icon-launch" ng-show="!vm.showTextButton"></i>
-            <span ng-show="vm.showTextButton">{{:: vm.strings.get('launchTemplate.BUTTON_LABEL') }}</span>
+    <button
+        type="button"
+        aria-label="{{:: vm.strings.get('launchTemplate.BUTTON_LABEL') }}"
+        ng-class="{'at-LaunchTemplate--button': !vm.showTextButton, 'btn btn-sm Form-primaryButton': vm.showTextButton, 'Form-button--disabled': vm.disabled}"
+        ng-click="vm.startLaunchTemplate()"
+        aw-tool-tip="{{ vm.launchTooltip }}"
+        data-tip-watch="vm.launchTooltip"
+        data-placement="top"
+    >
+        <i class="icon-launch" ng-show="!vm.showTextButton"></i>
+        <span ng-show="vm.showTextButton">{{:: vm.strings.get('launchTemplate.BUTTON_LABEL') }}</span>
     </button>
     <prompt prompt-data="vm.promptData" on-finish="vm.launchTemplateWithPrompts()"></prompt>
 </div>

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.component.js
@@ -20,6 +20,7 @@ function atRelaunchCtrl (
     $state, $q, $scope
 ) {
     const vm = this;
+    vm.strings = strings;
     const jobObj = new Job();
     const jobTemplate = new JobTemplate();
 

--- a/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
+++ b/awx/ui/client/lib/components/relaunchButton/relaunchButton.partial.html
@@ -5,10 +5,13 @@
     data-placement="top">
 
     <div class="btn-group" role="group" ng-if="vm.job.type === 'job' && vm.job.status === 'failed'">
-        <button class="at-Relaunch--button"
+        <button 
+            aria-label="{{:: vm.strings.get('relaunch.DROPDOWN_TITLE') }}"
+            class="at-Relaunch--button"
             data-toggle="dropdown"
             aria-expanded="false"
-            id="relaunchDropdown">
+            id="relaunchDropdown"
+        >
             <i class="{{ vm.icon }}"></i>
         </button>
 
@@ -26,9 +29,12 @@
         </ul>
     </div>
 
-    <button class="at-Relaunch--button"
-            ng-click="vm.relaunchJob()"
-            ng-if="!(vm.job.type === 'job' && vm.job.status === 'failed')">
+    <button
+        aria-label="{{:: vm.strings.get('relaunch.DEFAULT') }}"
+        class="at-Relaunch--button"
+        ng-click="vm.relaunchJob()"
+        ng-if="!(vm.job.type === 'job' && vm.job.status === 'failed')"
+    >
             <i class="{{ vm.icon }}"></i>
     </button>
     <prompt prompt-data="vm.promptData" on-finish="vm.relaunchJobWithPassword()"></prompt>

--- a/awx/ui/client/lib/services/base-string.service.js
+++ b/awx/ui/client/lib/services/base-string.service.js
@@ -76,6 +76,7 @@ function BaseStringService (namespace) {
     this.YES = t.s('YES');
     this.CLOSE = t.s('CLOSE');
     this.TEST = t.s('TEST');
+    this.REMOVE = t.s('REMOVE');
     this.SUCCESSFUL_CREATION = resource => t.s('{{ resource }} successfully created', { resource: $filter('sanitize')(resource) });
 
     this.deleteResource = {

--- a/awx/ui/client/src/about/about.partial.html
+++ b/awx/ui/client/src/about/about.partial.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog About-modalDialog">
         <div class="modal-content">
             <div class="modal-header About-modalHeader">
-                <button data-dismiss="modal" type="button" class="close About-close">
+                <button aria-label="{{:: $root.appStrings.get('CLOSE') }}" data-dismiss="modal" type="button" class="close About-close">
                     <span class="fa fa-times-circle"></span>
                 </button>
             </div>

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.controller.js
@@ -27,6 +27,8 @@ export default ['$rootScope', '$scope', 'GetBasePath', 'Rest', '$q', 'Wait', 'Pr
         // array for all possible roles for the object
         scope.roles = angular.copy(scope.object.summary_fields.object_roles);
 
+        scope.appStrings = rootScope.appStrings;
+
         const objectType = _.get(scope, ['object', 'type']);
         const teamRoles = _.get(scope, ['object', 'summary_fields', 'object_roles'], {});
 

--- a/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
+++ b/awx/ui/client/src/access/add-rbac-resource/rbac-resource.partial.html
@@ -12,7 +12,7 @@
                         </div>
                     </div>
                     <div class="Form-exitHolder">
-                        <button class="Form-exit" ng-click="closeModal()">
+                        <button aria-label="{{:: appStrings.get('CLOSE') }}" class="Form-exit" ng-click="closeModal()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>
@@ -90,8 +90,11 @@
                                     </div>
                                     <rbac-multiselect-role class="AddPermissions-roleSelect" roles="tab.teams ? teamRoles : roles" model="obj.roles">
                                     </rbac-multiselect-role>
-                                    <button class="AddPermissions-roleRemove"
-                                        ng-click="removeObject(obj)">
+                                    <button
+                                        aria-label="{{:: appStrings.get('REMOVE') }}"
+                                        class="AddPermissions-roleRemove"
+                                        ng-click="removeObject(obj)"
+                                    >
                                         <i class="fa fa-times"></i>
                                     </button>
                                 </div>

--- a/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.controller.js
+++ b/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.controller.js
@@ -11,12 +11,14 @@
  * Controller for handling permissions adding
  */
 
-export default ['$scope', '$state', 'i18n', 'CreateSelect2', 'Rest', '$q', 'Wait', 'ProcessErrors',
-function(scope, $state, i18n, CreateSelect2, Rest, $q, Wait, ProcessErrors) {
+export default ['$scope', '$state', 'i18n', 'CreateSelect2', 'Rest', '$q', 'Wait', 'ProcessErrors', '$rootScope',
+function(scope, $state, i18n, CreateSelect2, Rest, $q, Wait, ProcessErrors, rootScope) {
 
     init();
 
     function init(){
+
+        scope.appStrings = rootScope.appStrings;
 
         let resources = ['job_templates', 'workflow_templates', 'projects', 'inventories', 'credentials', 'organizations'];
 

--- a/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.partial.html
+++ b/awx/ui/client/src/access/add-rbac-user-team/rbac-user-team.partial.html
@@ -14,7 +14,7 @@
                         </div>
                     </div>
                     <div class="Form-exitHolder">
-                        <button class="Form-exit" ng-click="closeModal()">
+                        <button aria-label="{{:: appStrings.get('CLOSE') }}" class="Form-exit" ng-click="closeModal()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>

--- a/awx/ui/client/src/activity-stream/streamDetailModal/streamDetailModal.partial.html
+++ b/awx/ui/client/src/activity-stream/streamDetailModal/streamDetailModal.partial.html
@@ -4,7 +4,9 @@
             <div class="Modal-header">
                 <div class="Modal-title" id="detail-header" ng-bind-html="header"></div>
                 <div class="Modal-exitHolder">
-                    <button class="close Modal-exit" data-target="#stream-detail-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                    <button aria-label="{{:: appStrings.get('CLOSE') }}" class="close Modal-exit" data-target="#stream-detail-modal" data-dismiss="modal" aria-hidden="true">
+                        <i class="fa fa-times-circle"></i>
+                    </button>
                 </div>
             </div>
             <div class="Modal-body" id="detail-body">

--- a/awx/ui/client/src/app.js
+++ b/awx/ui/client/src/app.js
@@ -195,6 +195,7 @@ angular
             $rootScope.breadcrumb = {};
             $rootScope.BRAND_NAME = AppStrings.get('BRAND_NAME');
             $rootScope.tabTitle = `Ansible ${$rootScope.BRAND_NAME}`;
+            $rootScope.appStrings = AppStrings;
             $rootScope.$watch('$state.current.ncyBreadcrumbLabel', function(title) {
                 title = (title) ? "| " + title : "";
                 document.title = `Ansible ${$rootScope.BRAND_NAME} ${title}`;

--- a/awx/ui/client/src/configuration/forms/settings-form.partial.html
+++ b/awx/ui/client/src/configuration/forms/settings-form.partial.html
@@ -1,7 +1,7 @@
 <div class="Section-messageBar" ng-if="show_auditor_bar">
     <i class="fa fa-warning"></i>
     <span translate>System auditors have read-only permissions in this section.</span>
-    <button class="Section-messageBar--close" ng-click="vm.closeMessageBar()"><i class="fa fa-times-circle"></i></button>
+    <button aria-label="{{:: appStrings.get('CLOSE') }}" class="Section-messageBar--close" ng-click="vm.closeMessageBar()"><i class="fa fa-times-circle"></i></button>
 </div>
 
 <div class="tab-pane" id="configuration-panel">

--- a/awx/ui/client/src/instance-groups/instance-groups.strings.js
+++ b/awx/ui/client/src/instance-groups/instance-groups.strings.js
@@ -20,7 +20,8 @@ function InstanceGroupsStrings(BaseString) {
         ROW_ITEM_LABEL_ISOLATED: t.s('ISOLATED'),
         ROW_ITEM_LABEL_RUNNING_JOBS: t.s('Running Jobs'),
         ROW_ITEM_LABEL_TOTAL_JOBS: t.s('Total Jobs'),
-        ROW_ITEM_LABEL_USED_CAPACITY: t.s('Used Capacity')
+        ROW_ITEM_LABEL_USED_CAPACITY: t.s('Used Capacity'),
+        ADD: t.s('Add a new instance group')
     };
 
     ns.tab = {
@@ -38,7 +39,8 @@ function InstanceGroupsStrings(BaseString) {
 
     ns.instance = {
         PANEL_TITLE: t.s('SELECT INSTANCE'),
-        BADGE_TEXT: t.s('Instance Group')
+        BADGE_TEXT: t.s('Instance Group'),
+        ADD: t.s('Add a new instance')
     };
 
     ns.capacityBar = {

--- a/awx/ui/client/src/instance-groups/instances/instances-list.partial.html
+++ b/awx/ui/client/src/instance-groups/instances/instances-list.partial.html
@@ -22,6 +22,7 @@
 
             <div class="at-List-toolbarAction">
                 <button
+                    aria-label="{{:: vm.strings.get('instance.ADD') }}"
                     type="button"
                     ng-click= "vm.addInstances()"
                     class="at-Button--add"

--- a/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
+++ b/awx/ui/client/src/instance-groups/list/instance-groups-list.partial.html
@@ -18,8 +18,17 @@
                 search-tags="searchTags">
             </smart-search>
             <div class="at-List-toolbarAction">
-                <button type="button" class="at-Button--add" id="button-add" ng-show="vm.isSuperuser"
-                    data-toggle="dropdown" data-placement="top" aria-haspopup="true" aria-expanded="false">
+                <button
+                    aria-label="{{:: vm.strings.get('list.ADD') }}"
+                    type="button"
+                    class="at-Button--add"
+                    id="button-add"
+                    ng-show="vm.isSuperuser"
+                    data-toggle="dropdown"
+                    data-placement="top"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                >
                 </button>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="button-add">
                     <a class="dropdown-item" ui-sref="instanceGroups.add">

--- a/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/hosts.partial.html
@@ -79,13 +79,13 @@
                                 </div>
                                 <div class="List-actionsContainer col-md-3 col-sm-4">
                                     <div class="List-actionButtonCell List-tableCell">
-                                        <button id="insights-action" class="List-actionButton " ng-class="{'List-actionButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit.insights')}" data-placement="top" ng-click="goToInsights(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_INSIGHTS')}}" data-tip-watch="strings.get('inventory.VIEW_INSIGHTS')" ng-show="host.insights_system_id && host.summary_fields.inventory.hasOwnProperty('insights_credential_id')">
+                                        <button id="insights-action" aria-label="{{strings.get('insights.VIEW')}}" class="List-actionButton " ng-class="{'List-actionButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit.insights')}" data-placement="top" ng-click="goToInsights(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_INSIGHTS')}}" data-tip-watch="strings.get('inventory.VIEW_INSIGHTS')" ng-show="host.insights_system_id && host.summary_fields.inventory.hasOwnProperty('insights_credential_id')">
                                             <i class="fa fa-info"></i>
                                         </button>
-                                        <button id="edit-action" class="List-actionButton " ng-class="{'List-editButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit') }" data-placement="top" ng-click="editHost(host.id)" aw-tool-tip="{{strings.get('inventory.EDIT_HOST')}}"   data-tip-watch="strings.get('inventory.VIEW_HOST')" ng-show="host.summary_fields.user_capabilities.edit">
+                                        <button id="edit-action" aria-label="{{strings.get('inventory.EDIT_HOST')}}" class="List-actionButton " ng-class="{'List-editButton--selected' : $stateParams['host_id'] == host.id && $state.is('hosts.edit') }" data-placement="top" ng-click="editHost(host.id)" aw-tool-tip="{{strings.get('inventory.EDIT_HOST')}}"   data-tip-watch="strings.get('inventory.VIEW_HOST')" ng-show="host.summary_fields.user_capabilities.edit">
                                             <i class="fa fa-pencil"></i>
                                         </button>
-                                        <button id="view-action" class="List-actionButton " data-placement="top" ng-click="editHost(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_HOST')}}" data-tip-watch="strings.get('inventory.VIEW_HOST')" ng-show="!host.summary_fields.user_capabilities.edit"><i class="fa fa-search-plus"></i>
+                                        <button id="view-action" aria-label="{{strings.get('inventory.VIEW_HOST')}}" class="List-actionButton " data-placement="top" ng-click="editHost(host.id)" aw-tool-tip="{{strings.get('inventory.VIEW_HOST')}}" data-tip-watch="strings.get('inventory.VIEW_HOST')" ng-show="!host.summary_fields.user_capabilities.edit"><i class="fa fa-search-plus"></i>
                                         </button>
                                     </div>
                                 </div>

--- a/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.controller.js
+++ b/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.controller.js
@@ -4,9 +4,9 @@
  * All Rights Reserved
  *************************************************/
  export default
-    ['$scope', '$rootScope', '$state', '$stateParams', 'HostsRelatedGroupsList', 'InventoryUpdate',
+    ['$scope', '$rootScope', '$state', '$stateParams', 'HostsRelatedGroupsList', 'InventoryHostsStrings',
     'CancelSourceUpdate', 'rbacUiControlService', 'GetBasePath', 'Dataset', 'Find', 'QuerySet', 'inventoryData', 'host', 'GroupsService',
-    function($scope, $rootScope, $state, $stateParams, HostsRelatedGroupsList, InventoryUpdate,
+    function($scope, $rootScope, $state, $stateParams, HostsRelatedGroupsList, InventoryHostsStrings,
         CancelSourceUpdate, rbacUiControlService, GetBasePath, Dataset, Find, qs, inventoryData, host, GroupsService){
 
         let list = HostsRelatedGroupsList;
@@ -16,6 +16,7 @@
         function init(){
             $scope.inventory_id = inventoryData.id;
             $scope.canAdd = false;
+            $scope.strings = InventoryHostsStrings;
 
             rbacUiControlService.canAdd(GetBasePath('inventory') + $scope.inventory_id + "/groups")
                 .then(function(canAdd) {

--- a/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.partial.html
+++ b/awx/ui/client/src/inventories-hosts/hosts/related/groups/hosts-related-groups.partial.html
@@ -14,7 +14,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#host-disassociate-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                      <button aria-label="{{strings.get('CLOSE')}}" class="close Modal-exit" data-target="#host-disassociate-modal" data-dismiss="modal"><i class="fa fa-times-circle"></i></button>
                   </div>
             </div>
             <div class="Modal-body">

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/list/groups-list.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/list/groups-list.controller.js
@@ -21,7 +21,8 @@
             $scope.canAdd = canAdd;
 
             $scope.strings = {
-                deleteModal: {}
+                deleteModal: {},
+                close: InventoryHostsStrings.get('CLOSE')
             };
 
             // Search init

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/list/groups-list.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/list/groups-list.partial.html
@@ -14,7 +14,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#group-delete-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                      <button aria-label="{{:: strings.close }}" class="close Modal-exit" data-target="#group-delete-modal" data-dismiss="modal"><i class="fa fa-times-circle"></i></button>
                   </div>
             </div>
             <div class="Modal-body">

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups-disassociate.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-groups/group-nested-groups-disassociate.partial.html
@@ -15,7 +15,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#group-disassociate-modal" data-dismiss="modal" aria-hidden="true">
+                      <button aria-label="{{:: appStrings.get('CLOSE') }}" class="close Modal-exit" data-target="#group-disassociate-modal" data-dismiss="modal">
                           <i class="fa fa-times-circle"></i>
                       </button>
                   </div>

--- a/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts-disassociate.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/groups/related/nested-hosts/group-nested-hosts-disassociate.partial.html
@@ -15,7 +15,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#host-disassociate-modal" data-dismiss="modal" aria-hidden="true">
+                      <button aria-label="{{:: appStrings.get('CLOSE') }}" class="close Modal-exit" data-target="#host-disassociate-modal" data-dismiss="modal">
                           <i class="fa fa-times-circle"></i>
                       </button>
                   </div>

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-disassociate.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-disassociate.partial.html
@@ -15,7 +15,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#group-disassociate-modal" data-dismiss="modal" aria-hidden="true">
+                      <button aria-label="{{:: appStrings.get('CLOSE') }}" class="close Modal-exit" data-target="#group-disassociate-modal" data-dismiss="modal" aria-hidden="true">
                           <i class="fa fa-times-circle"></i>
                       </button>
                   </div>

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-list.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-list.controller.js
@@ -20,6 +20,7 @@
             $scope.inventory_id = $stateParams.inventory_id;
             $scope.canAdhoc = inventoryData.summary_fields.user_capabilities.adhoc;
             $scope.canAdd = canAdd;
+            console.log($scope.appStrings);
 
             // Search init
             $scope.list = list;

--- a/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-list.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/hosts/related/nested-groups/host-nested-groups-list.controller.js
@@ -20,7 +20,6 @@
             $scope.inventory_id = $stateParams.inventory_id;
             $scope.canAdhoc = inventoryData.summary_fields.user_capabilities.adhoc;
             $scope.canAdd = canAdd;
-            console.log($scope.appStrings);
 
             // Search init
             $scope.list = list;

--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/list/sources-list.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/list/sources-list.partial.html
@@ -14,7 +14,7 @@
                       </a>
                   </div>
                   <div class="Modal-exitHolder">
-                      <button class="close Modal-exit" data-target="#group-delete-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
+                      <button aria-label="{{:: appStrings.get('CLOSE') }}" class="close Modal-exit" data-target="#group-delete-modal" data-dismiss="modal" aria-hidden="true"><i class="fa fa-times-circle"></i></button>
                   </div>
             </div>
             <div class="Modal-body">

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.directive.js
@@ -22,9 +22,11 @@ export default ['templateUrl', function(templateUrl) {
             };
 
         },
-        controller: ['$scope', 'QuerySet', 'GetBasePath', 'HostsList', '$compile', 'generateList', 'i18n', function($scope, qs, GetBasePath, HostsList, $compile, GenerateList, i18n) {
+        controller: ['$scope', 'QuerySet', 'GetBasePath', 'HostsList', '$compile', 'generateList', 'i18n', '$rootScope', function($scope, qs, GetBasePath, HostsList, $compile, GenerateList, i18n, $rootScope) {
 
             function init() {
+
+                $scope.appStrings = $rootScope.appStrings;
 
                 $scope.host_default_params = {
                     order_by: 'name',

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/host-filter-modal/host-filter-modal.partial.html
@@ -6,7 +6,7 @@
                 <!-- optional: transclude header fields -->
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="cancelForm()">
+                    <button aria-label="{{:: appStrings.get('CLOSE') }}" type="button" class="Form-exit" ng-click="cancelForm()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/smart-inventory-host-filter.controller.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/smart-inventory-host-filter.controller.js
@@ -7,6 +7,7 @@
 export default ['$scope', 'QuerySet', 'InventoryHostsStrings',
     function($scope, qs, InventoryHostsStrings) {
         $scope.hostFilterTags = [];
+        $scope.strings = InventoryHostsStrings;
 
         $scope.$watch('organization', function(){
             if($scope.hasEditPermissions) {

--- a/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/smart-inventory-host-filter.partial.html
+++ b/awx/ui/client/src/inventories-hosts/inventories/smart-inventory/smart-inventory-host-filter/smart-inventory-host-filter.partial.html
@@ -1,6 +1,6 @@
 <div class="input-group Form-mixedInputGroup">
     <span class="input-group-btn Form-variableHeightButtonGroup input-group-prepend">
-        <button type="button" class="Form-lookupButton Form-lookupButton--variableHeight btn btn-default" ng-click="openHostFilterModal()" ng-disabled="!hasEditPermissions || !organization">
+        <button aria-label="{{:: strings.get('smartinventories.hostfilter.OPEN')}} " type="button" class="Form-lookupButton Form-lookupButton--variableHeight btn btn-default" ng-click="openHostFilterModal()" ng-disabled="!hasEditPermissions || !organization">
             <i class="fa fa-search"></i>
         </button>
     </span>

--- a/awx/ui/client/src/inventories-hosts/inventory-hosts.strings.js
+++ b/awx/ui/client/src/inventories-hosts/inventory-hosts.strings.js
@@ -38,13 +38,18 @@ function InventoryHostsStrings (BaseString) {
         hostfilter: {
             MISSING_ORG: t.s('Please select an organization before editing the host filter.'),
             INSTRUCTIONS: t.s('Please click the icon to edit the host filter.'),
-            MISSING_PERMISSIONS: t.s('You do not have sufficient permissions to edit the host filter.')
+            MISSING_PERMISSIONS: t.s('You do not have sufficient permissions to edit the host filter.'),
+            OPEN: t.s('Open host filter')
         }
     };
 
     ns.smartinventorybutton = {
         DISABLED_INSTRUCTIONS: t.s("Please enter at least one search term to create a new Smart Inventory."),
         ENABLED_INSTRUCTIONS: t.s("Create a new Smart Inventory from search results.<br /><br />Note: changing the organization of the Smart Inventory could change the hosts included in the Smart Inventory.")
+    };
+
+    ns.insights = {
+        VIEW: t.s("View Insights")
     };
 }
 

--- a/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.controller.js
@@ -13,6 +13,7 @@
          init();
 
          function init(){
+             $scope.appStrings = $rootScope.appStrings;
              $scope.associate_group_default_params = {
                  order_by: 'name',
                  page_size: 5

--- a/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.partial.html
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-groups/associate-groups.partial.html
@@ -6,7 +6,7 @@
                 <div class="Form-title Form-title--uppercase" translate>SELECT GROUPS</div>
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="closeModal()">
+                    <button aria-label="{{:: appStrings.get('CLOSE') }}" type="button" class="Form-exit" ng-click="closeModal()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.controller.js
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.controller.js
@@ -13,6 +13,7 @@
          init();
 
          function init(){
+             $scope.appStrings = $rootScope.appStrings;
              $scope.associate_host_default_params = {
                  order_by: 'name',
                  page_size: 5

--- a/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.partial.html
+++ b/awx/ui/client/src/inventories-hosts/shared/associate-hosts/associate-hosts.partial.html
@@ -6,7 +6,7 @@
                 <div class="Form-title Form-title--uppercase" translate>SELECT HOSTS</div>
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="closeModal()">
+                    <button aria-label="{{:: appStrings.get('CLOSE') }}" type="button" class="Form-exit" ng-click="closeModal()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/license/license.controller.js
+++ b/awx/ui/client/src/license/license.controller.js
@@ -7,10 +7,12 @@
 import {N_} from "../i18n";
 
 export default
-    ['Wait', '$state', '$scope', '$rootScope', 'ProcessErrors', 'CheckLicense', 'moment', '$timeout', 'Rest',
+    ['Wait', '$state', '$scope', '$rootScope', 'ProcessErrors', 'CheckLicense', 'moment', '$timeout', 'Rest', 'LicenseStrings',
     '$window', 'ConfigService', 'pendoService', 'insightsEnablementService', 'i18n', 'config', 'rhCreds', 'GetBasePath',
-    function(Wait, $state, $scope, $rootScope, ProcessErrors, CheckLicense, moment, $timeout, Rest,
+    function(Wait, $state, $scope, $rootScope, ProcessErrors, CheckLicense, moment, $timeout, Rest, LicenseStrings,
     $window, ConfigService, pendoService, insightsEnablementService, i18n, config, rhCreds, GetBasePath) {
+
+        $scope.strings = LicenseStrings;
 
         const calcDaysRemaining = function(seconds) {
       	 		// calculate the number of days remaining on the license

--- a/awx/ui/client/src/license/license.partial.html
+++ b/awx/ui/client/src/license/license.partial.html
@@ -137,7 +137,7 @@
 								<div class="input-group Form-mixedInputGroup" ng-if="showPlaceholderPassword">
 									<input class="form-control Form-textInput" type="text" value="ENCRYPTED" disabled />
 									<span class="input-group-btn input-group-append">
-										<button class="btn at-ButtonHollow--default at-Input-button" ng-disabled="!user_is_superuser || newLicense.file" ng-click="replacePassword()" aw-tool-tip="Replace" data-placement="top" data-original-title="Replace">
+										<button aria-label="{{:: strings.get('REPLACE_PASSWORD') }}" class="btn at-ButtonHollow--default at-Input-button" ng-disabled="!user_is_superuser || newLicense.file" ng-click="replacePassword()" aw-tool-tip="Replace" data-placement="top" data-original-title="Replace">
 											<i class="fa fa-undo"></i>
 										</button>
 									</span>
@@ -215,7 +215,7 @@
 										Select a license
 								</div>
 								<div class="Modal-exitHolder">
-										<button class="close Modal-exit" ng-click="cancelLicenseLookup()">
+										<button aria-label="{{:: strings.get('CANCEL_LOOKUP')}}" class="close Modal-exit" ng-click="cancelLicenseLookup()">
 												<i class="fa fa-times-circle"></i>
 										</button>
 								</div>

--- a/awx/ui/client/src/license/license.strings.js
+++ b/awx/ui/client/src/license/license.strings.js
@@ -1,0 +1,13 @@
+function LicenseStrings (BaseString) {
+  BaseString.call(this, 'license');
+
+  let t = this.t;
+  let ns = this.license;
+
+  ns.REPLACE_PASSWORD = t.s('Replace password');
+  ns.CANCEL_LOOKUP = t.s('Cancel license lookup');
+}
+
+LicenseStrings.$inject = ['BaseStringService'];
+
+export default LicenseStrings;

--- a/awx/ui/client/src/license/main.js
+++ b/awx/ui/client/src/license/main.js
@@ -8,12 +8,14 @@ import route from './license.route';
 import controller from './license.controller';
 import CheckLicense from './checkLicense.factory';
 import fileOnChange from './fileOnChange.directive';
+import LicenseStrings from './license.strings';
 
 export default
 	angular.module('license', [])
 		.controller('licenseController', controller)
 		.directive('fileOnChange', fileOnChange)
 		.factory('CheckLicense', CheckLicense)
+		.service('LicenseStrings', LicenseStrings)
 		.run(['$stateExtender', function($stateExtender) {
 			$stateExtender.addState(route);
 		}]);

--- a/awx/ui/client/src/login/loginModal/thirdPartySignOn/thirdPartySignOn.partial.html
+++ b/awx/ui/client/src/login/loginModal/thirdPartySignOn/thirdPartySignOn.partial.html
@@ -4,6 +4,7 @@
     </div>
     <div ng-repeat="item in loginItems" class="ThirdPartySignOn-item">
         <button type="button" class="ThirdPartySignOn-button"
+            aria-label="{{ item.tooltip }}"
             ng-class="item.button" data-placement="top"
             ng-attr-aw-tool-tip="{{ item.tooltip }}"
             ng-click="goTo(item.link)">

--- a/awx/ui/client/src/management-jobs/card/card.partial.html
+++ b/awx/ui/client/src/management-jobs/card/card.partial.html
@@ -18,17 +18,20 @@
 					<h3 class="MgmtCards-label"> {{ card.name }}</h3>
 					<div class="MgmtCards-actionItems">
 						<button class="MgmtCards-actionItem List-actionButton"
+							aria-label="{{'Launch Management Job'|translate}}"
 							ng-click='submitJob(card.id, card.name)'
 							ng-show='current_user.is_superuser'
 							data-placement="top" aw-tool-tip="{{'Launch Management Job'|translate}}" data-original-title="" title="">
 							<i class="MgmtCards-actionItemIcon icon-launch"></i>
 						</button>
 						<button class="MgmtCards-actionItem List-actionButton"
+							aria-label="{{'Schedule Management Job'|translate}}"
 							ng-click='configureSchedule(card.id)'
 							data-placement="top" aw-tool-tip="{{'Schedule Management Job'|translate}}" data-original-title="" title="">
 							<i class="MgmtCards-actionItemIcon fa fa-calendar"></i>
 						</button>
 						<button class="MgmtCards-actionItem List-actionButton"
+							aria-label="{{'Configure Notifications'|translate}}"
 							ng-click='goToNotifications(card, card.id)'
 							ng-show='current_user.is_superuser'
 							data-placement="top" aw-tool-tip="{{'Configure Notifications'|translate}}" data-original-title="" title="" ng-class="{'List-editButton--selected': activeCard === card.id && cardAction === 'notifications'}">

--- a/awx/ui/client/src/management-jobs/scheduler/schedulerForm.partial.html
+++ b/awx/ui/client/src/management-jobs/scheduler/schedulerForm.partial.html
@@ -4,7 +4,7 @@
         <div class="Form-title" ng-show="isEdit">{{ schedulerName || "EDIT SCHEDULE"}}</div>
         <div class="Form-header--fields"></div>
         <div class="Form-exitHolder">
-            <button class="Form-exit" ng-click="formCancel()">
+            <button aria-label="{{'Close'|translate}}" class="Form-exit" ng-click="formCancel()">
                 <i class="fa fa-times-circle"></i>
             </button>
         </div>

--- a/awx/ui/client/src/organizations/linkout/addUsers/addUsers.partial.html
+++ b/awx/ui/client/src/organizations/linkout/addUsers/addUsers.partial.html
@@ -8,7 +8,7 @@
                         </div>
                     </div>
                     <div class="Form-exitHolder">
-                        <button class="Form-exit" ng-click="closeModal()">
+                        <button aria-label="{{'Close'|translate}}" class="Form-exit" ng-click="closeModal()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>

--- a/awx/ui/client/src/organizations/list/organizations-list.partial.html
+++ b/awx/ui/client/src/organizations/list/organizations-list.partial.html
@@ -17,6 +17,7 @@
             <div class="List-actionHolder">
                 <div class="List-actions">
                     <button class="at-Button--add"
+                        aria-label="{{'Add a new organization'|translate}}"
                         id="button-add"
                         aw-tool-tip="{{'Create a new organization'|translate}}"
                         ng-show="canAdd"
@@ -51,6 +52,7 @@
                         <div class="OrgCards-actionItems">
                             <button class="OrgCards-actionItem
                                 List-actionButton"
+                                aria-label="{{'Edit Organization'|translate}}"
                                 ng-show="card.user_capabilities.edit"
                                 ng-class="{'List-editButton--selected': $stateParams.organization_id == card.id}"
                                 ng-click="editOrganization(card.id)">
@@ -59,6 +61,7 @@
                             </button>
                             <button class="OrgCards-actionItem
                                 List-actionButton"
+                                aria-label="{{'View Organization'|translate}}"
                                 ng-show="!card.user_capabilities.edit"
                                 ng-class="{'List-editButton--selected': $stateParams.organization_id == card.id}"
                                 ng-click="editOrganization(card.id)">
@@ -67,6 +70,7 @@
                             </button>
                             <button class="OrgCards-actionItem List-actionButton
                                 List-actionButton--delete"
+                                aria-label="{{'Delete Organization'|translate}}"
                                 ng-show="card.user_capabilities.delete"
                                 ng-click="deleteOrganization(card.id, card.name)">
                                 <i class="OrgCards-actionItemIcon

--- a/awx/ui/client/src/partials/survey-maker-modal.html
+++ b/awx/ui/client/src/partials/survey-maker-modal.html
@@ -4,7 +4,7 @@
                 <div class="Modal-header">
                     <div class="Modal-title" ng-bind="deleteMode === 'survey' ? 'Delete Survey' : (deleteMode === 'question' ? 'Delete Question' : '')"></div>
                     <div class="Modal-exitHolder">
-                        <button class="close Modal-exit" ng-click="hideDeleteOverlay()">
+                        <button aria-label="{{'Close'|translate}}" class="close Modal-exit" ng-click="hideDeleteOverlay()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>
@@ -25,7 +25,7 @@
             <at-switch on-toggle="toggleSurveyEnabled()" switch-on="survey_enabled" switch-disabled="(!job_template_obj.summary_fields.user_capabilities.edit && !workflow_job_template_obj.summary_fields.user_capabilities.edit && !canAdd)" tooltip="surveyEnabledTooltip" tooltip-placement="right" tooltip-watch="surveyEnabledTooltip"></at-switch>
         </div>
         <div class="SurveyMaker-close">
-            <button class="SurveyMaker-exit" ng-click="closeSurvey('survey-modal-dialog')"><i class="fa fa-times-circle"></i></button>
+            <button aria-label="{{'Close'|translate}}" class="SurveyMaker-exit" ng-click="closeSurvey('survey-modal-dialog')"><i class="fa fa-times-circle"></i></button>
         </div>
     </div>
     <div class="SurveyMaker-content">
@@ -61,10 +61,10 @@
                                     </span>
                                     <survey-question class="SurveyMaker-previewInput" preview="true" question="question" ng-required="question.required" ng-disabled=true></survey-question>
                                     <div class="SurveyMaker-previewActions" ng-show="(job_template_obj.summary_fields.user_capabilities.edit || workflow_job_template_obj.summary_fields.user_capabilities.edit || canAdd)">
-                                        <button class="List-actionButton" data-placement="top" ng-class="{'SurveyMaker-previewActions--selected' : editQuestionIndex == $index}" ng-click="editQuestion($index)" aw-tool-tip="{{editQuestionTooltip}}" data-tip-watch="editQuestionTooltip" data-container="#survey-modal-dialog" data-original-title="" title="">
+                                        <button aria-label="{{'Edit question'|translate}}" class="List-actionButton" data-placement="top" ng-class="{'SurveyMaker-previewActions--selected' : editQuestionIndex == $index}" ng-click="editQuestion($index)" aw-tool-tip="{{editQuestionTooltip}}" data-tip-watch="editQuestionTooltip" data-container="#survey-modal-dialog" data-original-title="" title="">
                                             <i class="fa fa-pencil"></i>
                                         </button>
-                                        <button class="List-actionButton List-actionButton--delete" data-placement="top" ng-click="showDeleteQuestion($index)" aw-tool-tip="deleteQuestionTooltip" data-tip-watch="deleteQuestionTooltip" data-container="#survey-modal-dialog" data-original-title="" title="">
+                                        <button aria-label="{{'Delete question'|translate}}" class="List-actionButton List-actionButton--delete" data-placement="top" ng-click="showDeleteQuestion($index)" aw-tool-tip="deleteQuestionTooltip" data-tip-watch="deleteQuestionTooltip" data-container="#survey-modal-dialog" data-original-title="" title="">
                                             <i class="fa fa-trash-o"></i>
                                         </button>
                                     </div>

--- a/awx/ui/client/src/scheduler/schedulerDatePicker.partial.html
+++ b/awx/ui/client/src/scheduler/schedulerDatePicker.partial.html
@@ -1,5 +1,5 @@
 <div class="DatePicker">
-    <button class="DatePicker-icon" ng-disabled="disabled"><i class="fa fa-calendar"></i></button>
+    <button aria-label="{{'Select date'|translate}}" class="DatePicker-icon" ng-disabled="disabled"><i class="fa fa-calendar"></i></button>
     <input
         ng-disabled="disabled"
         class="DatePicker-input"

--- a/awx/ui/client/src/scheduler/schedulerForm.partial.html
+++ b/awx/ui/client/src/scheduler/schedulerForm.partial.html
@@ -4,7 +4,7 @@
         <div class="Form-title" ng-show="isEdit">{{ schedulerName || strings.get('state.EDIT_SCHEDULE') }}</div>
         <div class="Form-header--fields"></div>
         <div class="Form-exitHolder">
-            <button class="Form-exit" ng-click="formCancel()">
+            <button aria-label="{{'Close'|translate}}" class="Form-exit" ng-click="formCancel()">
                 <i class="fa fa-times-circle"></i>
             </button>
         </div>

--- a/awx/ui/client/src/shared/form-generator.js
+++ b/awx/ui/client/src/shared/form-generator.js
@@ -684,7 +684,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                     html += (field.ngShow) ? this.attr(field, 'ngShow') : "";
                     html += ">\n";
                     html += (field.closeable === undefined || field.closeable === true) ?
-                        "<button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-hidden=\"true\">&times;</button>\n" : "";
+                        "<button aria-label=\"{{'Close'|translate}}\" type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-hidden=\"true\">&times;</button>\n" : "";
                     html += field.alertTxt;
                     html += "</div>\n";
                     html += "</div>\n";
@@ -784,7 +784,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                         }
 
                         if (field.clear) {
-                            html += "<span class=\"input-group-btn\"><button type=\"button\" ";
+                            html += "<span class=\"input-group-btn\"><button aria-label=\"{{'Clear field'|translate}}\" type=\"button\" ";
                             html += "id=\"" + this.form.name + "_" + fld + "_clear_btn\" ";
                             html += "class=\"btn btn-default\" ng-click=\"clear('" + fld + "','" + field.associated + "')\" " +
                                 "aw-tool-tip=\"Clear " + field.label + "\" id=\"" + fld + "-clear-btn\" ";
@@ -797,6 +797,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                             const defaultGenHashButtonTemplate = `
                                 <span class="input-group-btn input-group-prepend">
                                     <button
+                                        aria-label="{{'Generate field'|translate}}"
                                         type="button"
                                         class="btn Form-lookupButton"
                                         ng-click="genHash('${fld}')"
@@ -1298,7 +1299,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
 
                         html += `<div class="input-group Form-mixedInputGroup">`;
                         html += "<span class=\"input-group-btn input-group-prepend\">\n";
-                        html += `<button type="button" class="Form-lookupButton btn" ng-click="${field.ngClick || defaultLookupNgClick}"
+                        html += `<button aria-label="{{'Lookup field'|translate}}" type="button" class="Form-lookupButton btn" ng-click="${field.ngClick || defaultLookupNgClick}"
                         ${field.readonly || field.showonly}
                         ${this.attr(field, "ngDisabled")}
                         id="${fld}-lookup-btn"><i class="fa fa-search"></i></button>`;
@@ -1463,7 +1464,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                         html += "</div></div>";
                     } else {
                         html += "<div class=\"Form-exitHolder\">";
-                        html += "<button class=\"Form-exit\" ng-click=\"formCancel()\">";
+                        html += "<button aria-label=\"{{'Close'|translate}}\" class=\"Form-exit\" ng-click=\"formCancel()\">";
                         html += "<i class=\"fa fa-times-circle\"></i>";
                         html += "</button></div>\n";
                     }
@@ -1817,7 +1818,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
 
                 if (collection.instructions) {
                     html += "<div class=\"alert alert-info alert-block\">\n";
-                    html += "<button type=\"button\" class=\"close\" data-dismiss=\"alert\">&times;</button>\n";
+                    html += "<button aria-label=\"{{'Close'|translate}}\" type=\"button\" class=\"close\" data-dismiss=\"alert\">&times;</button>\n";
                     html += "<strong>Hint: </strong>" + collection.instructions + "\n";
                     html += "</div>\n";
                 }
@@ -1942,7 +1943,7 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                     for (act in collection.fieldActions) {
                         if (act !== 'columnClass') {
                             fAction = collection.fieldActions[act];
-                            html += "<button id=\"" + ((fAction.id) ? fAction.id : act + "-action") + "\" ";
+                            html += "<button aria-label=\"{{act}}\" id=\"" + ((fAction.id) ? fAction.id : act + "-action") + "\" ";
                             html += (fAction.awToolTip) ? 'aw-tool-tip="' + fAction.awToolTip + '"' : '';
                             html += (fAction.dataPlacement) ? 'data-placement="' + fAction.dataPlacement + '"' : '';
                             html += (fAction.href) ? "href=\"" + fAction.href + "\" " : "";

--- a/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups-modal/instance-groups-modal.partial.html
+++ b/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups-modal/instance-groups-modal.partial.html
@@ -5,7 +5,7 @@
                 <div class="Form-title Form-title--uppercase" translate>Select Instance Groups</div>
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="cancelForm()">
+                    <button aria-label="{{'Close'|translate}}" type="button" class="Form-exit" ng-click="cancelForm()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
+++ b/awx/ui/client/src/shared/instance-groups-multiselect/instance-groups.partial.html
@@ -1,6 +1,6 @@
 <div class="input-group Form-mixedInputGroup">
     <span class="input-group-btn input-group-prepend Form-variableHeightButtonGroup">
-        <button type="button" class="Form-lookupButton Form-lookupButton--variableHeight btn btn-default" ng-click="openInstanceGroupsModal()"
+        <button aria-label="{{'Open instance groups'|translate}}" type="button" class="Form-lookupButton Form-lookupButton--variableHeight btn btn-default" ng-click="openInstanceGroupsModal()"
             ng-disabled="fieldIsDisabled">
             <i class="fa fa-search"></i>
         </button>

--- a/awx/ui/client/src/shared/list-generator/list-actions.partial.html
+++ b/awx/ui/client/src/shared/list-generator/list-actions.partial.html
@@ -56,13 +56,14 @@
 
 </span>
 <button
+    aria-label="{{'Click for help'|translate}}"
     toolbar-button
     icon-name="help"
     aw-pop-over="{{list.selectInstructions}}"
     data-placement="left"
     data-container="body"
     class="btn-xs btn-help"
-    aw-tool-tip="Click for help"
+    aw-tool-tip="{{'Click for help'|translate}}"
     data-title="Help"
     icon-size="fa-lg"
     toolbar="true"

--- a/awx/ui/client/src/shared/list-generator/list-generator.factory.js
+++ b/awx/ui/client/src/shared/list-generator/list-generator.factory.js
@@ -147,7 +147,7 @@ export default ['$compile', 'Attr', 'Icon',
                         html += "</div>";
                         if (options.cancelButton === true) {
                             html += "<div class=\"Form-exitHolder\">";
-                            html += "<button class=\"Form-exit\" ng-click=\"formCancel()\">";
+                            html += "<button aria-label=\"{{'Close'|translate}}\" class=\"Form-exit\" ng-click=\"formCancel()\">";
                             html += "<i class=\"fa fa-times-circle\"></i>";
                             html += "</button></div>\n";
                         }
@@ -157,7 +157,7 @@ export default ['$compile', 'Attr', 'Icon',
 
                 if (options.mode === 'edit' && list.editInstructions) {
                     html += "<div class=\"alert alert-info alert-block\">\n";
-                    html += "<button type=\"button\" class=\"close\" data-dismiss=\"alert\"><i class=\"fa fa-times-circle\"></i></button>\n";
+                    html += "<button aria-label=\"{{'Close'|translate}}\" type=\"button\" class=\"close\" data-dismiss=\"alert\"><i class=\"fa fa-times-circle\"></i></button>\n";
                     html += "<strong>Hint: </strong>" + list.editInstructions + "\n";
                     html += "</div>\n";
                 }
@@ -491,7 +491,7 @@ export default ['$compile', 'Attr', 'Icon',
 
                 if (options.mode === 'select' && (options.selectButton === undefined || options.selectButton)) {
                     html += "<div class=\"navigation-buttons\">\n";
-                    html += " <button class=\"btn btn-sm btn-primary pull-right\" id=\"select_btn\" aw-tool-tip=\"Complete your selection\" " +
+                    html += " <button aria-label=\"{{'Complete your selection'|translate}}\" class=\"btn btn-sm btn-primary pull-right\" id=\"select_btn\" aw-tool-tip=\"Complete your selection\" " +
                         "ng-click=\"finishSelection()\" ng-disabled=\"disableSelectBtn\"><i class=\"fa fa-check\"></i> Select</button>\n";
                     html += "</div>\n";
                 }

--- a/awx/ui/client/src/shared/lookup/lookup-modal.partial.html
+++ b/awx/ui/client/src/shared/lookup/lookup-modal.partial.html
@@ -6,7 +6,7 @@
                 <!-- optional: transclude header fields -->
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="cancelForm()">
+                    <button aria-label="{{'Close'|translate}}" type="button" class="Form-exit" ng-click="cancelForm()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/templates/job_templates/job-template.form.js
+++ b/awx/ui/client/src/templates/job_templates/job-template.form.js
@@ -437,6 +437,7 @@ function(NotificationsList, i18n) {
                             class="input-group-btn input-group-prepend"
                         >
                             <button
+                                aria-label="${i18n._('Rotate Webhook Key')}"
                                 type="button"
                                 class="btn Form-lookupButton"
                                 ng-click="handleWebhookKeyButtonClick()"

--- a/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.partial.html
+++ b/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential-modal.partial.html
@@ -7,7 +7,7 @@
                 </div>
                 <div class="Form-header--fields"></div>
                 <div class="Form-exitHolder">
-                    <button type="button" class="Form-exit" ng-click="vm.cancelForm()">
+                    <button aria-label="{{'Close'|translate}}" type="button" class="Form-exit" ng-click="vm.cancelForm()">
                         <i class="fa fa-times-circle"></i>
                     </button>
                 </div>

--- a/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential.partial.html
+++ b/awx/ui/client/src/templates/job_templates/multi-credential/multi-credential.partial.html
@@ -1,6 +1,7 @@
 <div class="input-group Form-mixedInputGroup">
     <span class="input-group-btn Form-variableHeightButtonGroup input-group-prepend">
         <button type="button"
+            aria-label="{{'Open credential lookup'|translate}}"
             class="Form-lookupButton
                 Form-lookupButton--variableHeight btn btn-default"
                 ng-click="openModal()"

--- a/awx/ui/client/src/templates/job_templates/webhook-credential/webhook-credential-input.partial.html
+++ b/awx/ui/client/src/templates/job_templates/webhook-credential/webhook-credential-input.partial.html
@@ -1,6 +1,7 @@
 <div class="input-group Form-mixedInputGroup">
     <span class="input-group-btn Form-variableHeightButtonGroup input-group-prepend">
         <button type="button"
+            aria-label="{{'Open webhook credential lookup'|translate}}"
             class="Form-lookupButton
                 Form-lookupButton--variableHeight btn btn-default"
                 ng-click="vm.onLookupClick()"

--- a/awx/ui/client/src/templates/workflows.form.js
+++ b/awx/ui/client/src/templates/workflows.form.js
@@ -210,6 +210,7 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n) {
                             class="input-group-btn input-group-prepend"
                         >
                             <button
+                                aria-label="${i18n._('Rotate Webhook Key')}"
                                 type="button"
                                 class="btn Form-lookupButton"
                                 ng-click="handleWebhookKeyButtonClick()"

--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.partial.html
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.partial.html
@@ -8,7 +8,7 @@
                         <span class="Modal-titleResourceName" ng-bind="nodeToBeDeleted.unifiedJobTemplate.name"></span>
                     </div>
                     <div class="Modal-exitHolder">
-                        <button class="close Modal-exit" ng-click="cancelDeleteNode()">
+                        <button aria-label="{{'Close'|translate}}" class="close Modal-exit" ng-click="cancelDeleteNode()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>
@@ -31,7 +31,7 @@
                         <span>{{strings.get('workflow_maker.UNSAVED_CHANGES_HEADER')}}</span>
                     </div>
                     <div class="Modal-exitHolder">
-                        <button class="close Modal-exit" ng-click="cancelUnsavedChanges()">
+                        <button aria-label="{{'Cancel unsaved changes'|translate}}" class="close Modal-exit" ng-click="cancelUnsavedChanges()">
                             <i class="fa fa-times-circle"></i>
                         </button>
                     </div>
@@ -58,7 +58,7 @@
             <div class="WorkflowMaker-titleText">{{strings.get('workflow_maker.TITLE')}} | {{ workflowJobTemplateObj.name }}</div>
         </div>
         <div class="WorkflowMaker-exitHolder">
-            <button class="WorkflowMaker-exit" ng-click="closeDialog()">
+            <button aria-label="{{'Close'|translate}}" class="WorkflowMaker-exit" ng-click="closeDialog()">
                 <i class="fa fa-times-circle"></i>
             </button>
         </div>

--- a/awx/ui/client/src/workflow-results/workflow-results.partial.html
+++ b/awx/ui/client/src/workflow-results/workflow-results.partial.html
@@ -23,6 +23,7 @@
 
                         <!-- RELAUNCH ACTION -->
                         <button class="List-actionButton"
+                            aria-label="{{'Relaunch job'|translate}}"
                             data-placement="top"
                             mode="all"
                             ng-click="relaunchJob()"
@@ -35,6 +36,7 @@
                         <!-- CANCEL ACTION -->
                         <button class="List-actionButton
                                 List-actionButton--delete"
+                            aria-label="{{'Cancel job'|translate}}"
                             data-placement="top"
                             ng-click="cancelJob()"
                             ng-show="workflow.status == 'running' ||
@@ -47,6 +49,7 @@
                         <!-- DELETE ACTION -->
                         <button class="List-actionButton
                                 List-actionButton--delete"
+                            aria-label="{{'Delete job'|translate}}"
                             data-placement="top"
                             ng-click="deleteJob()"
                             ng-hide="workflow.status == 'running' ||
@@ -349,6 +352,7 @@
 
                             <!-- FULL-SCREEN TOGGLE ACTION -->
                             <button class="StandardOut-actionButton"
+                                aria-label="{{ strings.tooltips.TOGGLE_STDOUT_FULLSCREEN }}"
                                 aw-tool-tip="{{ strings.tooltips.TOGGLE_STDOUT_FULLSCREEN }}"
                                 data-tip-watch="strings.tooltips.TOGGLE_STDOUT_FULLSCREEN"
                                 data-placement="top"


### PR DESCRIPTION
##### SUMMARY
See: https://dequeuniversity.com/rules/axe/3.3/button-name

I tried to find as many buttons without text as possible and add an aria-label to them.  For the most part this applied to buttons where we display an icon instead of text.

At first, I didn't think I could translate the attribute in-line so I was adding strings to `.strings` files and pulling them in off of scope.  Later I discovered that I could do something like `aria-label="{{'Refresh the page'|translate}}"`.  The first way should work so I didn't circle back and make them all uniform.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
