### PR TITLE
Change local_docker rabbitmq version to match kubernetes deployments

### DIFF
--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 dockerhub_version: "{{ lookup('file', playbook_dir + '/../VERSION') }}"
 
-rabbitmq_version: "3.7.4"
+rabbitmq_version: "3.7.21"
 rabbitmq_image: "ansible/awx_rabbitmq:{{rabbitmq_version}}"
 rabbitmq_default_vhost: "awx"
 rabbitmq_erlang_cookie: "cookiemonster"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update local docker deployments to use a more current rabbitmq, same version used in kuberentes deployments. It seems changing this was forgotten when upgrading the kubernetes rabbitmq version (https://github.com/ansible/awx/commit/1d6f116687aa0e0caf5d4b57569aefc5c6ce839c)

3.7.4 has two open security issues that are fixed in 3.7.21 (CVE-2019-11287, CVE-2019-11281)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.3.0
```