### PR TITLE
Add workflow to tower_role module

### DIFF
--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -50,6 +50,10 @@ options:
       description:
         - The job template the role acts on.
       type: str
+    workflow:
+      description:
+        - The job template the role acts on.
+      type: str
     credential:
       description:
         - Credential the role acts on.
@@ -108,6 +112,7 @@ def update_resources(module, p):
         'target_team': 'name',
         'inventory': 'name',
         'job_template': 'name',
+        'workflow': 'name',
         'credential': 'name',
         'organization': 'name',
         'project': 'name',
@@ -133,6 +138,7 @@ def main():
         target_team=dict(),
         inventory=dict(),
         job_template=dict(),
+        workflow=dict(),
         credential=dict(),
         organization=dict(),
         project=dict(),

--- a/awx_collection/test/awx/test_role.py
+++ b/awx_collection/test/awx/test_role.py
@@ -1,0 +1,37 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from awx.main.models import WorkflowJobTemplate, User
+
+
+@pytest.mark.django_db
+def test_grant_organization_permission(run_module, admin_user, organization):
+    rando = User.objects.create(username='rando')
+
+    result = run_module('tower_role', {
+        'user': rando.username,
+        'organization': organization.name,
+        'role': 'admin',
+        'state': 'present'
+    }, admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    assert rando in organization.execute_role
+
+
+@pytest.mark.django_db
+def test_grant_workflow_permission(run_module, admin_user, organization):
+    wfjt = WorkflowJobTemplate.objects.create(organization=organization, name='foo-workflow')
+    rando = User.objects.create(username='rando')
+
+    result = run_module('tower_role', {
+        'user': rando.username,
+        'workflow': wfjt.name,
+        'role': 'execute',
+        'state': 'present'
+    }, admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    assert rando in wfjt.execute_role

--- a/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
@@ -28,6 +28,24 @@
     that:
       - "result is changed"
 
+- name: Create a workflow
+  tower_workflow_template:
+    name: test-role-workflow
+    organization: Default
+    state: present
+
+- name: Add Joe to workflow execute role
+  tower_role:
+    user: joe
+    role: execute
+    workflow: test-role-workflow
+    state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Delete a User
   tower_user:
     username: joe


### PR DESCRIPTION
##### SUMMARY
Does https://github.com/ansible/awx/issues/6279

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
As simple as it gets.

Didn't have it before, probably because the modules pre-dated workflows.
