### PR TITLE
Fix Shebang Error in Collections Tools

### DIFF
--- a/awx_collection/tools/templates/tower_module.j2
+++ b/awx_collection/tools/templates/tower_module.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8 -*-
 
 {# The following is set by the generate.yml file:


### PR DESCRIPTION
##### SUMMARY

This Ansible module error was popping up during sanity checks:
https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/shebang.html

Changing the shebang line in `awx_collection/tools/templates/tower_module.j2` to `#!/usr/bin/env python` _should_ fix this issue.

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
