### PR TITLE
Collection test refactor

### DIFF
--- a/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
@@ -1,4 +1,25 @@
 ---
+- name: Generate names
+  set_fact:
+    ssh_cred_name1: "AWX-Collection-tests-tower_credential-ssh-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    ssh_cred_name2: "AWX-Collection-tests-tower_credential-ssh-cred2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    ssh_cred_name3: "AWX-Collection-tests-tower_credential-ssh-cred-lookup-source-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    ssh_cred_name4: "AWX-Collection-tests-tower_credential-ssh-cred-file-source-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    vault_cred_name1: "AWX-Collection-tests-tower_credential-vault-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    vault_cred_name2: "AWX-Collection-tests-tower_credential-vault-ssh-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    net_cred_name1: "AWX-Collection-tests-tower_credential-net-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    scm_cred_name1: "AWX-Collection-tests-tower_credential-scm-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    aws_cred_name1: "AWX-Collection-tests-tower_credential-aws-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    vmware_cred_name1: "AWX-Collection-tests-tower_credential-vmware-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    sat6_cred_name1: "AWX-Collection-tests-tower_credential-sat6-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    cf_cred_name1: "AWX-Collection-tests-tower_credential-cf-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    gce_cred_name1: "AWX-Collection-tests-tower_credential-gce-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    azurerm_cred_name1: "AWX-Collection-tests-tower_credential-azurerm-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    openstack_cred_name1: "AWX-Collection-tests-tower_credential-openstack-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    rhv_cred_name1: "AWX-Collection-tests-tower_credential-rhv-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    insights_cred_name1: "AWX-Collection-tests-tower_credential-insights-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    tower_cred_name1: "AWX-Collection-tests-tower_credential-tower-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: create a tempdir for an SSH key
   local_action: shell mktemp -d
   register: tempdir
@@ -12,7 +33,7 @@
 
 - name: Create a User-specific credential
   tower_credential:
-    name: SSH Credential
+    name: "{{ ssh_cred_name1 }}"
     organization: Default
     user: admin
     state: present
@@ -25,7 +46,7 @@
 
 - name: Delete a User-specific credential
   tower_credential:
-    name: SSH Credential
+    name: "{{ ssh_cred_name1 }}"
     organization: Default
     user: admin
     state: absent
@@ -38,7 +59,7 @@
 
 - name: Create a valid SSH credential
   tower_credential:
-    name: SSH Credential
+    name: "{{ ssh_cred_name2 }}"
     organization: Default
     state: present
     kind: ssh
@@ -58,7 +79,7 @@
 
 - name: Create a valid SSH credential from lookup source
   tower_credential:
-    name: SSH Credential from lookup source
+    name: "{{ ssh_cred_name3 }}"
     organization: Default
     state: present
     kind: ssh
@@ -78,7 +99,7 @@
 
 - name: Create a valid SSH credential from file source
   tower_credential:
-    name: SSH Credential from file source
+    name: "{{ ssh_cred_name4 }}"
     organization: Default
     state: present
     kind: ssh
@@ -131,7 +152,31 @@
 
 - name: Delete an SSH credential
   tower_credential:
-    name: SSH Credential
+    name: "{{ ssh_cred_name2 }}"
+    organization: Default
+    state: absent
+    kind: ssh
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an SSH credential
+  tower_credential:
+    name: "{{ ssh_cred_name3 }}"
+    organization: Default
+    state: absent
+    kind: ssh
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete an SSH credential
+  tower_credential:
+    name: "{{ ssh_cred_name4 }}"
     organization: Default
     state: absent
     kind: ssh
@@ -143,7 +188,7 @@
 
 - name: Create a valid Vault credential
   tower_credential:
-    name: Vault Credential
+    name: "{{ vault_cred_name1 }}"
     organization: Default
     state: present
     kind: vault
@@ -155,9 +200,10 @@
     that:
       - "result is changed"
 
+# We should decide when to delete this test
 - name: Create a valid Vault credential w/ kind=ssh (deprecated)
   tower_credential:
-    name: Vault Credential
+    name: "{{ vault_cred_name2 }}"
     organization: Default
     state: present
     kind: ssh
@@ -171,7 +217,19 @@
 
 - name: Delete a Vault credential
   tower_credential:
-    name: Vault Credential
+    name: "{{ vault_cred_name1 }}"
+    organization: Default
+    state: absent
+    kind: vault
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Vault credential
+  tower_credential:
+    name: "{{ vault_cred_name2 }}"
     organization: Default
     state: absent
     kind: vault
@@ -183,7 +241,7 @@
 
 - name: Create a valid Network credential
   tower_credential:
-    name: Network Credential
+    name: "{{ net_cred_name1 }}"
     organization: Default
     state: present
     kind: net
@@ -199,7 +257,7 @@
 
 - name: Delete a Network credential
   tower_credential:
-    name: Network Credential
+    name: "{{ net_cred_name1 }}"
     organization: Default
     state: absent
     kind: net
@@ -211,7 +269,7 @@
 
 - name: Create a valid SCM credential
   tower_credential:
-    name: SCM Credential
+    name: "{{ scm_cred_name1 }}"
     organization: Default
     state: present
     kind: scm
@@ -227,7 +285,7 @@
 
 - name: Delete an SCM credential
   tower_credential:
-    name: SCM Credential
+    name: "{{ scm_cred_name1 }}"
     organization: Default
     state: absent
     kind: scm
@@ -239,7 +297,7 @@
 
 - name: Create a valid AWS credential
   tower_credential:
-    name: AWS Credential
+    name: "{{ aws_cred_name1 }}"
     organization: Default
     state: present
     kind: aws
@@ -254,7 +312,7 @@
 
 - name: Delete an AWS credential
   tower_credential:
-    name: AWS Credential
+    name: "{{ aws_cred_name1 }}"
     organization: Default
     state: absent
     kind: aws
@@ -266,7 +324,7 @@
 
 - name: Create a valid VMWare credential
   tower_credential:
-    name: VMWare Credential
+    name: "{{ vmware_cred_name1 }}"
     organization: Default
     state: present
     kind: vmware
@@ -281,7 +339,7 @@
 
 - name: Delete an VMWare credential
   tower_credential:
-    name: VMWare Credential
+    name: "{{ vmware_cred_name1 }}"
     organization: Default
     state: absent
     kind: vmware
@@ -293,7 +351,7 @@
 
 - name: Create a valid Satellite6 credential
   tower_credential:
-    name: Satellite6 Credential
+    name: "{{ sat6_cred_name1 }}"
     organization: Default
     state: present
     kind: satellite6
@@ -308,7 +366,7 @@
 
 - name: Delete a Satellite6 credential
   tower_credential:
-    name: Satellite6 Credential
+    name: "{{ sat6_cred_name1 }}"
     organization: Default
     state: absent
     kind: satellite6
@@ -320,7 +378,7 @@
 
 - name: Create a valid CloudForms credential
   tower_credential:
-    name: CloudForms Credential
+    name: "{{ cf_cred_name1 }}"
     organization: Default
     state: present
     kind: cloudforms
@@ -335,7 +393,7 @@
 
 - name: Delete a CloudForms credential
   tower_credential:
-    name: CloudForms Credential
+    name: "{{ cf_cred_name1 }}"
     organization: Default
     state: absent
     kind: cloudforms
@@ -347,7 +405,7 @@
 
 - name: Create a valid GCE credential
   tower_credential:
-    name: GCE Credential
+    name: "{{ gce_cred_name1 }}"
     organization: Default
     state: present
     kind: gce
@@ -362,7 +420,7 @@
 
 - name: Delete a GCE credential
   tower_credential:
-    name: GCE Credential
+    name: "{{ gce_cred_name1 }}"
     organization: Default
     state: absent
     kind: gce
@@ -374,7 +432,7 @@
 
 - name: Create a valid AzureRM credential
   tower_credential:
-    name: AzureRM Credential
+    name: "{{ azurerm_cred_name1 }}"
     organization: Default
     state: present
     kind: azure_rm
@@ -389,7 +447,7 @@
 
 - name: Create a valid AzureRM credential with a tenant
   tower_credential:
-    name: AzureRM Credential
+    name: "{{ azurerm_cred_name1 }}"
     organization: Default
     state: present
     kind: azure_rm
@@ -405,7 +463,7 @@
 
 - name: Delete an AzureRM credential
   tower_credential:
-    name: AzureRM Credential
+    name: "{{ azurerm_cred_name1 }}"
     organization: Default
     state: absent
     kind: azure_rm
@@ -417,7 +475,7 @@
 
 - name: Create a valid OpenStack credential
   tower_credential:
-    name: OpenStack Credential
+    name: "{{ openstack_cred_name1 }}"
     organization: Default
     state: present
     kind: openstack
@@ -434,7 +492,7 @@
 
 - name: Delete a OpenStack credential
   tower_credential:
-    name: OpenStack Credential
+    name: "{{ openstack_cred_name1 }}"
     organization: Default
     state: absent
     kind: openstack
@@ -446,7 +504,7 @@
 
 - name: Create a valid RHV credential
   tower_credential:
-    name: RHV Credential
+    name: "{{ rhv_cred_name1 }}"
     organization: Default
     state: present
     kind: rhv
@@ -461,7 +519,7 @@
 
 - name: Delete an RHV credential
   tower_credential:
-    name: RHV Credential
+    name: "{{ rhv_cred_name1 }}"
     organization: Default
     state: absent
     kind: rhv
@@ -473,7 +531,7 @@
 
 - name: Create a valid Insights credential
   tower_credential:
-    name: Insights Credential
+    name: "{{ insights_cred_name1 }}"
     organization: Default
     state: present
     kind: insights
@@ -487,7 +545,7 @@
 
 - name: Delete an Insights credential
   tower_credential:
-    name: Insights Credential
+    name: "{{ insights_cred_name1 }}"
     organization: Default
     state: absent
     kind: insights
@@ -499,7 +557,7 @@
 
 - name: Create a valid Tower-to-Tower credential
   tower_credential:
-    name: Tower Credential
+    name: "{{ tower_cred_name1 }}"
     organization: Default
     state: present
     kind: tower
@@ -514,7 +572,7 @@
 
 - name: Delete a Tower-to-Tower credential
   tower_credential:
-    name: Tower Credential
+    name: "{{ tower_cred_name1 }}"
     organization: Default
     state: absent
     kind: tower

--- a/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential_type/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
+- name: Generate names
+  set_fact:
+    cred_type_name: "AWX-Collection-tests-tower_credential_type-cred-type-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Add Tower credential type
   tower_credential_type:
     description: Credential type for Test
-    name: test-credential-type
+    name: "{{ cred_type_name }}"
     kind: cloud
     inputs: {"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": true, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}
     injectors: {"extra_vars": {"test": "foo"}}
@@ -14,7 +18,7 @@
 
 - name: Remove a Tower credential type
   tower_credential_type:
-    name: test-credential-type
+    name: "{{ cred_type_name }}"
     state: absent
   register: result
 

--- a/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: Generate an inventory name
+- name: Generate names
   set_fact:
-    inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    group_name: "AWX-Collection-tests-tower_group-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    inv_name: "AWX-Collection-test-tower_group-inv-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Create an Inventory
   tower_inventory:
@@ -11,7 +12,7 @@
 
 - name: Create a Group
   tower_group:
-    name: Some Group
+    name: "{{ group_name }}"
     inventory: "{{ inv_name }}"
     state: present
     variables:
@@ -24,7 +25,7 @@
 
 - name: Delete a Group
   tower_group:
-    name: Some Group
+    name: "{{ group_name }}"
     inventory: "{{ inv_name }}"
     state: absent
   register: result

--- a/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: Generate an inventory name
+- name: Generate names
   set_fact:
-    inv_name: "inv-for-group-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    host_name: "AWX-Collection-tests-tower_host-host-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    inv_name: "AWX-Collection-tests-tower_host-inv-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Create an Inventory
   tower_inventory:
@@ -11,7 +12,7 @@
 
 - name: Create a Host
   tower_host:
-    name: "some-host"
+    name: "{{ host_name }}"
     inventory: "{{ inv_name }}"
     state: present
     variables:
@@ -24,7 +25,7 @@
 
 - name: Delete a Host
   tower_host:
-    name: "some-host"
+    name: "{{ host_name }}"
     inventory: "{{ inv_name }}"
     state: absent
   register: result

--- a/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
@@ -1,15 +1,12 @@
 ---
-- name: Clean up any pre-existing test Inventory
-  tower_inventory:
-    name: my-inventory
-    organization: Default
-    state: absent
-  ignore_errors: true
-
+- name: Generate names
+  set_fact:
+    inv_name1: "AWX-Collection-tests-tower_inventory-inv1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    inv_name2: "AWX-Collection-tests-tower_inventory-inv2-{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Create an Inventory
   tower_inventory:
-    name: my-inventory
+    name: "{{ inv_name1 }}"
     organization: Default
     state: present
   register: result
@@ -20,7 +17,7 @@
 
 - name: Test Inventory module idempotency
   tower_inventory:
-    name: my-inventory
+    name: "{{ inv_name1 }}"
     organization: Default
     state: present
   register: result
@@ -31,7 +28,7 @@
 
 - name: Fail Change Regular to Smart
   tower_inventory:
-    name: my-inventory
+    name: "{{ inv_name1 }}"
     organization: Default
     kind: smart
   register: result
@@ -41,9 +38,9 @@
     that:
       - "result is failed"
 
-- name: create a smart inventory
+- name: Create a smart inventory
   tower_inventory:
-    name: smart-inventory
+    name: "{{ inv_name2 }}"
     organization: Default
     kind: smart
     host_filter: name=foo
@@ -53,9 +50,22 @@
     that:
       - "result is changed"
 
+- name: Delete a smart inventory
+  tower_inventory:
+    name: "{{ inv_name2 }}"
+    organization: Default
+    kind: smart
+    host_filter: name=foo
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Delete an Inventory
   tower_inventory:
-    name: my-inventory
+    name: "{{ inv_name1 }}"
     organization: Default
     state: absent
   register: result
@@ -66,7 +76,7 @@
 
 - name: Delete a Non-Existent Inventory
   tower_inventory:
-    name: my-inventory
+    name: "{{ inv_name1 }}"
     organization: Default
     state: absent
   register: result

--- a/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
@@ -1,8 +1,14 @@
 ---
+- name: Generate names
+  set_fact:
+    openstack_cred: "AWX-Collection-tests-tower_inventory_source-cred-openstack-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    openstack_inv: "AWX-Collection-tests-tower_inventory_source-inv-openstack-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    openstack_inv_source: "AWX-Collection-tests-tower_inventory_source-inv-source-openstack-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Add a Tower credential
   tower_credential:
     description: Credentials for Openstack Test project
-    name: openstack-test-credential
+    name: "{{ openstack_cred }}"
     kind: openstack
     organization: Default
     project: Test
@@ -15,14 +21,14 @@
   tower_inventory:
     description: Test inventory
     organization: Default
-    name: openstack-test-inventory
+    name: "{{ openstack_inv }}"
 
 - name: Create a source inventory
   tower_inventory_source:
-    name: "source-test-inventory {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    name: "{{ openstack_inv_source }}"
     description: Source for Test inventory
-    inventory: openstack-test-inventory
-    credential: openstack-test-credential
+    inventory: "{{ openstack_inv }}"
+    credential: "{{ openstack_cred }}"
     overwrite: true
     update_on_launch: true
     source_vars:
@@ -36,14 +42,45 @@
 
 - name: Delete the source inventory
   tower_inventory_source:
-    name: "{{ result.name }}"
+    name: "{{ openstack_inv_source }}"
     description: Source for Test inventory
-    inventory: openstack-test-inventory
-    credential: openstack-test-credential
+    inventory: "{{ openstack_inv }}"
+    credential: "{{ openstack_cred }}"
     overwrite: true
     update_on_launch: true
     source_vars:
       private: false
     source: openstack
     state: absent
-  ignore_errors: true
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the credential
+  tower_credential:
+    description: Credentials for Openstack Test project
+    name: "{{ openstack_cred }}"
+    kind: openstack
+    organization: Default
+    project: Test
+    username: admin
+    host: https://example.org:5000
+    password: passw0rd
+    domain: test
+    state: absent
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the inventory
+  tower_inventory:
+    description: Test inventory
+    organization: Default
+    name: "{{ openstack_inv }}"
+    state: absent
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Generate names
+  set_fact:
+    jt_name1: "AWX-Collection-tests-tower_job_launch-jt1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    jt_name2: "AWX-Collection-tests-tower_job_launch-jt2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    proj_name: "AWX-Collection-tests-tower_job_launch-project-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Launch a Job Template
   tower_job_launch:
     job_template: "Demo Job Template"
@@ -36,7 +42,7 @@
 
 - name: Create a Job Template for testing prompt on launch
   tower_job_template:
-    name: "Demo Job Template - ask inventory and credential"
+    name: "{{ jt_name1 }}"
     project: Demo Project
     playbook: hello_world.yml
     job_type: run
@@ -47,7 +53,7 @@
 
 - name: Launch job template with inventory and credential for prompt on launch
   tower_job_launch:
-    job_template: "Demo Job Template - ask inventory and credential"
+    job_template: "{{ jt_name1 }}"
     inventory: "Demo Inventory"
     credential: "Demo Credential"
   register: result
@@ -59,15 +65,15 @@
 
 - name: Create a project for testing extra_vars
   tower_project:
-    name: test-playbooks
+    name: "{{ proj_name }}"
     organization: Default
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
 
 - name: Create a Job Template for testing extra_vars
   tower_job_template:
-    name: "Demo Job Template - extra_vars"
-    project: test-playbooks
+    name: "{{ jt_name2 }}"
+    project: "{{ proj_name }}"
     playbook: debug.yml
     job_type: run
     state: present
@@ -78,7 +84,7 @@
 
 - name: Launch job template with inventory and credential for prompt on launch
   tower_job_launch:
-    job_template: "Demo Job Template - extra_vars"
+    job_template: "{{ jt_name2 }}"
   register: result
 
 - assert:
@@ -94,9 +100,37 @@
     that:
       - '{"foo": "bar"} | to_json in result.results[0].extra_vars'
 
-- name: Delete the job
+- name: Delete the first jt
+  tower_job_template:
+    name: "{{ jt_name1 }}"
+    project: Demo Project
+    playbook: hello_world.yml
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the second jt
+  tower_job_template:
+    name: "{{ jt_name2 }}"
+    project: "{{ proj_name }}"
+    playbook: debug.yml
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the extra_vars project
   tower_project:
-    name: "Demo Job Template - extra_vars"
+    name: "{{ proj_name }}"
     organization: Default
     state: absent
-  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"

--- a/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: generate random string for project
   set_fact:
-    cred1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-    cred2: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-    cred3: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-    proj1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-    jt1: "hello-world {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-    jt2: "hello-world {{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    cred1: "AWX-Collection-tests-tower_job_template-cred1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    cred2: "AWX-Collection-tests-tower_job_template-cred2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    cred3: "AWX-Collection-tests-tower_job_template-cred3-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    proj1: "AWX-Collection-tests-tower_job_template-proj-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    jt1: "AWX-Collection-tests-tower_job_template-jt1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    jt2: "AWX-Collection-tests-tower_job_template-jt2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Create Credential1
   tower_credential:

--- a/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
+- name: Generate names
+  set_fact:
+    label_name: "AWX-Collection-tests-tower_label-label-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Create a Label
   tower_label:
-    name: important
+    name: "{{ label_name }}"
     organization: Default
     state: present
 

--- a/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_notification/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
+- name: Generate names
+  set_fact:
+    slack_not: "AWX-Collection-tests-tower_notification-slack-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    webhook_not: "AWX-Collection-tests-tower_notification-wehbook-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    email_not: "AWX-Collection-tests-tower_notification-email-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    twillo_not: "AWX-Collection-tests-tower_notification-twillo-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    pd_not: "AWX-Collection-tests-tower_notification-pd-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    hipchat_not: "AWX-Collection-tests-tower_notification-hipchat-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    irc_not: "AWX-Collection-tests-tower_notification-irc-not-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Create Slack notification
   tower_notification:
-    name: notification1
+    name: "{{ slack_not }}"
     organization: Default
     notification_type: slack
     token: a_token
@@ -16,7 +26,7 @@
 
 - name: Delete Slack notification
   tower_notification:
-    name: notification1
+    name: "{{ slack_not }}"
     organization: Default
     notification_type: slack
     state: absent
@@ -28,7 +38,7 @@
 
 - name: Add webhook notification
   tower_notification:
-    name: notification2
+    name: "{{ webhook_not }}"
     organization: Default
     notification_type: webhook
     url: http://www.example.com/hook
@@ -43,7 +53,7 @@
 
 - name: Delete webhook notification
   tower_notification:
-    name: notification2
+    name: "{{ webhook_not }}"
     organization: Default
     notification_type: webhook
     state: absent
@@ -55,7 +65,7 @@
 
 - name: Add email notification
   tower_notification:
-    name: notification3
+    name: "{{ email_not }}"
     organization: Default
     notification_type: email
     username: user
@@ -76,7 +86,7 @@
 
 - name: Delete email notification
   tower_notification:
-    name: notification3
+    name: "{{ email_not }}"
     organization: Default
     notification_type: email
     state: absent
@@ -88,7 +98,7 @@
 
 - name: Add twilio notification
   tower_notification:
-    name: notification4
+    name: "{{ twillo_not }}"
     organization: Default
     notification_type: twilio
     account_token: a_token
@@ -105,7 +115,7 @@
 
 - name: Delete twilio notification
   tower_notification:
-    name: notification4
+    name: "{{ twillo_not }}"
     organization: Default
     notification_type: twilio
     state: absent
@@ -117,7 +127,7 @@
 
 - name: Add PagerDuty notification
   tower_notification:
-    name: notification5
+    name: "{{ pd_not }}"
     organization: Default
     notification_type: pagerduty
     token: a_token
@@ -133,7 +143,7 @@
 
 - name: Delete PagerDuty notification
   tower_notification:
-    name: notification5
+    name: "{{ pd_not }}"
     organization: Default
     notification_type: pagerduty
     state: absent
@@ -145,7 +155,7 @@
 
 - name: Add HipChat notification
   tower_notification:
-    name: notification6
+    name: "{{ hipchat_not }}"
     organization: Default
     notification_type: hipchat
     token: a_token
@@ -164,7 +174,7 @@
 
 - name: Delete HipChat notification
   tower_notification:
-    name: notification6
+    name: "{{ hipchat_not }}"
     organization: Default
     notification_type: hipchat
     state: absent
@@ -176,7 +186,7 @@
 
 - name: Add IRC notification
   tower_notification:
-    name: notification7
+    name: "{{ irc_not }}"
     organization: Default
     notification_type: irc
     nickname: tower
@@ -195,7 +205,7 @@
 
 - name: Delete IRC notification
   tower_notification:
-    name: notification7
+    name: "{{ irc_not }}"
     organization: Default
     notification_type: irc
     state: absent

--- a/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Generate an org name
   set_fact:
-    org_name: "org-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    org_name: "AWX-Collection-tests-tower_organization-org-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Make sure {{ org_name }} is not there
   tower_organization:

--- a/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
@@ -1,20 +1,26 @@
 ---
-- name: Delete old git project from any previous test runs
-  tower_project:
-    name: "git project"
-    organization: Default
-    state: absent
-  ignore_errors: true
+- name: Generate names
+  set_fact:
+    project_name1: "AWX-Collection-tests-tower_project-project1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    project_name2: "AWX-Collection-tests-tower_project-project2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    scm_cred_name: "AWX-Collection-tests-tower_project-scm-cred-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    org_name: "AWX-Collection-tests-tower_project-org-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    cred_name: "AWX-Collection-tests-tower_project-cred-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
 - name: Create an SCM Credential
   tower_credential:
-    name: SCM Credential for Project
+    name: "{{ scm_cred_name }}"
     organization: Default
     kind: scm
+  register: result
+
+- assert:
+    that:
+      - result is changed
 
 - name: Create a git project without credentials without waiting
   tower_project:
-    name: "git project"
+    name: "{{ project_name1 }}"
     organization: Default
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
@@ -27,7 +33,7 @@
 
 - name: Recreate the project to validate not changed
   tower_project:
-    name: "git project"
+    name: "{{ project_name1 }}"
     organization: Default
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
@@ -40,36 +46,40 @@
 
 - name: Create organizations
   tower_organization:
-    name: TestOrg
+    name: "{{ org_name }}"
+  register: result
+
+- assert:
+    that:
+      - result is changed
 
 - name: Create credential
   tower_credential:
     kind: scm
-    name: TestCred
-    organization: TestOrg
+    name: "{{ cred_name }}"
+    organization: "{{ org_name }}"
+  register: result
 
-  register: new_credentials
-
-- name: Generate random project name appender
-  set_fact:
-    project_name_rand: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+- assert:
+    that:
+      - result is changed
 
 - name: Create a new test project in check_mode
   tower_project:
-    name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg
+    name: "{{ project_name2 }}"
+    organization: "{{ org_name }}"
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: TestCred
+    scm_credential: "{{ cred_name }}"
   check_mode: true
 
 - name: Create a new test project
   tower_project:
-    name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg
+    name: "{{ project_name2 }}"
+    organization: "{{ org_name }}"
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: TestCred
+    scm_credential: "{{ cred_name }}"
   register: result
 
 # If this fails it may be because the check_mode task actually already created
@@ -80,11 +90,11 @@
 
 - name: Check module fails with correct msg when given non-existing org as param
   tower_project:
-    name: "TestProject {{ project_name_rand }}"
+    name: "{{ project_name2 }}"
     organization: Non Existing Org
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: TestCred
+    scm_credential: "{{ cred_name }}"
   register: result
   ignore_errors: true
 
@@ -95,8 +105,8 @@
 
 - name: Check module fails with correct msg when given non-existing credential as param
   tower_project:
-    name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg
+    name: "{{ project_name2 }}"
+    organization: "{{ org_name }}"
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
     scm_credential: Non Existing Credential
@@ -110,6 +120,51 @@
 
 - name: Delete the test project
   tower_project:
-    name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg
+    name: "{{ project_name2 }}"
+    organization: "{{ org_name }}"
     state: absent
+
+- name: Delete the SCM Credential
+  tower_credential:
+    name: "{{ scm_cred_name }}"
+    organization: Default
+    kind: scm
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete the other test project
+  tower_project:
+    name: "{{ project_name1 }}"
+    organization: Default
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete credential
+  tower_credential:
+    kind: scm
+    name: "{{ cred_name }}"
+    organization: "{{ org_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed
+
+- name: Delete the organization
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is changed

--- a/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_role/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
+- name: Generate names
+  set_fact:
+    username: "AWX-Collection-tests-tower_role-user-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Create a User
   tower_user:
     first_name: Joe
     last_name: User
-    username: joe
+    username: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     email: joe@example.org
     state: present
@@ -15,7 +19,7 @@
 
 - name: Add Joe to the update role of the default Project
   tower_role:
-    user: joe
+    user: "{{ username }}"
     role: update
     project: Demo Project
     state: "{{ item }}"
@@ -30,7 +34,7 @@
 
 - name: Delete a User
   tower_user:
-    username: joe
+    username: "{{ username }}"
     email: joe@example.org
     state: absent
   register: result

--- a/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Generate names
+  set_fact:
+    team_name: "AWX-Collection-tests-tower_team-team-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Attempt to add a Tower team to a non-existant Organization
   tower_team:
     name: Test Team
@@ -16,7 +20,7 @@
 
 - name: Create a Tower team
   tower_team:
-    name: Test Team
+    name: "{{ team_name }}"
     organization: Default
   register: result
 
@@ -26,7 +30,7 @@
 
 - name: Delete a Tower team
   tower_team:
-    name: Test Team
+    name: "{{ team_name }}"
     organization: Default
     state: absent
   register: result
@@ -37,7 +41,7 @@
 
 - name: Check module fails with correct msg
   tower_team:
-    name: Test Team
+    name: "{{ team_name }}"
     organization: Non Existing Org
     state: present
   register: result

--- a/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_user/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
+- name: Generate names
+  set_fact:
+    username: "AWX-Collection-tests-tower_user-user-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Create a User
   tower_user:
-    username: joe
+    username: "{{ username }}"
     first_name: Joe
     password: "{{ 65535 | random | to_uuid }}"
     state: present
@@ -13,7 +17,7 @@
 
 - name: Change a User
   tower_user:
-    username: joe
+    username: "{{ username }}"
     last_name: User
     email: joe@example.org
     state: present
@@ -25,7 +29,7 @@
 
 - name: Check idempotency
   tower_user:
-    username: joe
+    username: "{{ username }}"
     first_name: Joe
     last_name: User
   register: result
@@ -36,7 +40,7 @@
 
 - name: Delete a User
   tower_user:
-    username: joe
+    username: "{{ username }}"
     email: joe@example.org
     state: absent
   register: result
@@ -49,7 +53,7 @@
   tower_user:
     first_name: Joe
     last_name: Auditor
-    username: joe
+    username: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     email: joe@example.org
     state: present
@@ -62,7 +66,7 @@
 
 - name: Delete an Auditor
   tower_user:
-    username: joe
+    username: "{{ username }}"
     email: joe@example.org
     state: absent
   register: result
@@ -75,7 +79,7 @@
   tower_user:
     first_name: Joe
     last_name: Super
-    username: joe
+    username: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     email: joe@example.org
     state: present
@@ -88,7 +92,7 @@
 
 - name: Delete a Superuser
   tower_user:
-    username: joe
+    username: "{{ username }}"
     email: joe@example.org
     state: absent
   register: result
@@ -101,7 +105,7 @@
   tower_user:
     first_name: Joe
     last_name: User
-    username: joe
+    username: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     email: joe@example.org
     state: present

--- a/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml
@@ -1,44 +1,71 @@
 ---
+- name: Generate names
+  set_fact:
+    scm_cred_name: "AWX-Collection-tests-tower_workflow_template-scm-cred-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    demo_project_name: "AWX-Collection-tests-tower_workflow_template-proj-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    jt1_name: "AWX-Collection-tests-tower_workflow_template-jt1-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    jt2_name: "AWX-Collection-tests-tower_workflow_template-jt2-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+    wfjt_name: "AWX-Collection-tests-tower_workflow_template-wfjt-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
 - name: Create an SCM Credential
   tower_credential:
-    name: SCM Credential for JT
+    name: "{{ scm_cred_name }}"
     organization: Default
     kind: scm
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
 
 - name: Create a Demo Project
   tower_project:
-    name: Job Template Test Project
+    name: "{{ demo_project_name }}"
     organization: Default
     state: present
     scm_type: git
     scm_url: https://github.com/ansible/ansible-tower-samples.git
-    scm_credential: SCM Credential for JT
+    scm_credential: "{{ scm_cred_name }}"
   register: result
+
+- assert:
+    that:
+      - "result is changed"
 
 - name: Create a Job Template
   tower_job_template:
-    name: my-job-1
-    project: Job Template Test Project
+    name: "{{ jt1_name }}"
+    project: "{{ demo_project_name }}"
     inventory: Demo Inventory
     playbook: hello_world.yml
     credential: Demo Credential
     job_type: run
     state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
 
 - name: Create a second Job Template
   tower_job_template:
-    name: my-job-2
-    project: Job Template Test Project
+    name: "{{ jt2_name }}"
+    project: "{{ demo_project_name }}"
     inventory: Demo Inventory
     playbook: hello_world.yml
     credential: Demo Credential
     job_type: run
     state: present
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
 
 - name: Add a Survey to second Job Template
   tower_job_template:
-    name: my-job-2
-    project: Job Template Test Project
+    name: "{{ jt2_name }}"
+    project: "{{ demo_project_name }}"
     inventory: Demo Inventory
     playbook: hello_world.yml
     credential: Demo Credential
@@ -46,11 +73,15 @@
     state: present
     survey_enabled: true
     survey_spec: '{"spec": [{"index": 0, "question_name": "my question?", "default": "mydef", "variable": "myvar", "type": "text", "required": false}], "description": "test", "name": "test"}'
+  register: result
 
+- assert:
+    that:
+      - "result is changed"
 
 - name: Create a workflow job template
   tower_workflow_template:
-    name: my-workflow
+    name: "{{ wfjt_name }}"
     schema: [{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]
     extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
   register: result
@@ -61,7 +92,7 @@
 
 - name: Delete a workflow job template
   tower_workflow_template:
-    name: my-workflow
+    name: "{{ wfjt_name }}"
     state: absent
   register: result
 
@@ -71,7 +102,7 @@
 
 - name: Check module fails with correct msg
   tower_workflow_template:
-    name: my-workflow
+    name: "{{ wfjt_name }}"
     organization: Non Existing Organization
     schema: [{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]
   register: result
@@ -80,3 +111,59 @@
 - assert:
     that:
       - "result.msg =='Failed to update organization source,organization not found: The requested object could not be found.'"
+
+- name: Delete the Job Template
+  tower_job_template:
+    name: "{{ jt1_name }}"
+    project: "{{ demo_project_name }}"
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the second Job Template
+  tower_job_template:
+    name: "{{ jt2_name }}"
+    project: "{{ demo_project_name }}"
+    inventory: Demo Inventory
+    playbook: hello_world.yml
+    credential: Demo Credential
+    job_type: run
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the Demo Project
+  tower_project:
+    name: "{{ demo_project_name }}"
+    organization: Default
+    scm_type: git
+    scm_url: https://github.com/ansible/ansible-tower-samples.git
+    scm_credential: "{{ scm_cred_name }}"
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete the SCM Credential
+  tower_credential:
+    name: "{{ scm_cred_name }}"
+    organization: Default
+    kind: scm
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"


### PR DESCRIPTION
##### SUMMARY

In the past we reused a lot of objects in our collection integration tests, this makes it harder to make assertions about the tasks, because they may or may not actually create the object (based on if you have run the test before). This PR uses randomly generated names so we can make more assertions about each task and have more predictable tests