### PR TITLE
Mark user password as no_log to silence warning

### DIFF
--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -127,7 +127,7 @@ def main():
         email=dict(required=False, type='str'),
         is_superuser=dict(required=False, type='bool', default=False, aliases=['superuser']),
         is_system_auditor=dict(required=False, type='bool', default=False, aliases=['auditor']),
-        password=dict(required=False, type='str'),
+        password=dict(required=False, type='str', no_log=True),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 


### PR DESCRIPTION
##### SUMMARY
Ansible would give a warning

> [WARNING]: Module did not set no_log for password

It was not actually a security issue, but I add this to make the warning stop

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- AWX collection

##### AWX VERSION
```
9.3.0
```


