### PR TITLE
Replace verify_ssl test that did not work right

### DIFF
--- a/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
@@ -80,31 +80,19 @@
       - "result is not changed"
 
 # Test behaviour common to all tower modules
-- name: Check that SSL is available
-  tower_organization:
-    name: Default
-  register: result
-
-- assert:
-    that: result is not changed
-
 - name: Check that SSL is available and verify_ssl is enabled (task must fail)
   tower_organization:
     name: Default
     validate_certs: true
-  environment:
-    TOWER_CERTIFICATE: /dev/null  # force check failure
   ignore_errors: true
   register: check_ssl_is_used
 
 - name: Check that connection failed
   assert:
     that:
-      - check_ssl_is_used is failed
+      - "'CERTIFICATE_VERIFY_FAILED' in check_ssl_is_used['msg']"
 
 - name: Check that verify_ssl is disabled (task must not fail)
   tower_organization:
     name: Default
     validate_certs: false
-  environment:
-    TOWER_CERTIFICATE: /dev/null  # should not fail because verify_ssl is disabled


### PR DESCRIPTION
##### SUMMARY
the cert thing is not a parameter we honor anymore

##### ISSUE TYPE
 - Bugfix Pull Request

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
This pre-assumes that you do not have a valid cert set up.
