### PR TITLE
Automatically hack sys.path to make running tests easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ test_collection:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	PYTHONPATH=$(COLLECTION_VENV):/awx_devel/awx_collection:$PYTHONPATH:/usr/lib/python3.6/site-packages py.test $(COLLECTION_TEST_DIRS)
+	PYTHONPATH=$(COLLECTION_VENV):$PYTHONPATH:/usr/lib/python3.6/site-packages py.test $(COLLECTION_TEST_DIRS)
 
 flake8_collection:
 	flake8 awx_collection/  # Different settings, in main exclude list

--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -53,26 +53,11 @@ The following notes are changes that may require changes to playbooks:
 
 ## Running Unit Tests
 
-Tests to verify compatibility with the most recent AWX code are
-in `awx_collection/test/awx`. These tests require that Python packages
-are available for all of `awx`, `ansible`, `tower_cli`, and the collection
-itself.
+Tests to verify compatibility with the most recent AWX code are in `awx_collection/test/awx`.
+These can be ran by `make test_collection` in the development container.
 
-### Inside Development Container
-
-The target `make prepare_collection_venv` will prepare some requirements
-in the `awx_collection_test_venv` folder so that `make test_collection` can
-be executed to actually run the tests. A single test can be run via:
-
-```
-make test_collection COLLECTION_TEST_DIRS=awx_collection/test/awx/test_organization.py
-```
-
-### Manually
-
-As a faster alternative (if you do not want to use the container), or to
-run against Ansible or `tower-cli` source, it is possible to set up a
-working environment yourself:
+To run outside of the development container, or to run against
+Ansible or `tower-cli` source, set up a working environment:
 
 ```
 mkvirtualenv my_new_venv
@@ -80,10 +65,11 @@ mkvirtualenv my_new_venv
 pip install -r requirements/requirements.txt -r requirements/requirements_dev.txt -r requirements/requirements_git.txt
 make clean-api
 pip install -e <path to your Ansible>
-pip install -e <path to your tower-cli>
 pip install -e .
-PYTHONPATH=awx_collection:$PYTHONPATH py.test awx_collection/test/awx/
+py.test awx_collection/test/awx/
 ```
+
+If you do not install tower-cli, it will skip tests for modules that require it.
 
 ## Running Integration Tests
 

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import io
+import os
 import json
 import datetime
 import importlib
@@ -46,10 +47,22 @@ def sanitize_dict(din):
         return str(din)  # translation proxies often not string but stringlike
 
 
+@pytest.fixture(autouse=True)
+def collection_path_set(monkeypatch):
+    """Monkey patch sys.path, insert the root of the collection folder
+    so that content can be imported without being fully packaged
+    """
+    base_folder = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+    )
+    monkeypatch.syspath_prepend(base_folder)
+
+
 @pytest.fixture
 def collection_import():
     """These tests run assuming that the awx_collection folder is inserted
-    into the PATH before-hand. But all imports internally to the collection
+    into the PATH before-hand by collection_path_set.
+    But all imports internally to the collection
     go through this fixture so that can be changed if needed.
     For instance, we could switch to fully-qualified import paths.
     """


### PR DESCRIPTION
##### SUMMARY
There's a good chance that this is just plain a better way to run these.

Need results from Zuul first.

##### ISSUE TYPE
 - Feature Pull Request

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
Look forward to when we stop installing tower-cli to run tests too. That will further reduce the test system complexity.

Since the monkeypatch is function scope, it shouldn't interfere with other tests ran in the same command.

Where I'm going with this... if we can get all those changes in, we could combine this test target with the main API tests.
