### PR TITLE
Fix flaky workflow test & set junit family

### DIFF
--- a/awx/main/tests/unit/test_access.py
+++ b/awx/main/tests/unit/test_access.py
@@ -183,6 +183,9 @@ def test_change_jt_sensitive_data(job_template_with_ids, mocker, user_unit):
     """Assure that can_add is called with all ForeignKeys."""
 
     class RoleReturnsTrue(Role):
+        class Meta:
+            proxy = True
+            
         def __contains__(self, accessor):
             return True
 

--- a/awxkit/tox.ini
+++ b/awxkit/tox.ini
@@ -43,3 +43,4 @@ max-line-length = 120
 
 [pytest]
 addopts = -v --tb=native
+junit_family=xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ markers =
     ac: access control test
     survey: tests related to survey feature
     inventory_import: tests of code used by inventory import command
+junit_family=xunit2


### PR DESCRIPTION
##### SUMMARY
We have been seeing some flake with the following test:
```
_______________________________________________________________________ TestWorkflowDAGFunctional.test_workflow_done ________________________________________________________________________
[gw4] linux -- Python 3.6.8 /venv/awx/bin/python3
Traceback (most recent call last):
  File "/venv/awx/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/venv/awx/lib/python3.6/site-packages/django/db/backends/sqlite3/base.py", line 383, in execute
    return Database.Cursor.execute(self, query, params)
sqlite3.OperationalError: no such table: main_rolereturnstrue
```
This was because of how we "mocked" a model.  The fix was to let django know that this is not a _real_ model, and to not create it in the db (by setting `proxy = True`)

And after cleaning that up, I noticed this warning:
```
================================================================================================ warnings summary =================================================================================================
.tox/py3/lib/python3.6/site-packages/_pytest/junitxml.py:417
  /awx_devel/awxkit/.tox/py3/lib/python3.6/site-packages/_pytest/junitxml.py:417: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
-------------------------------------------------------------------------------- generated xml file: /awx_devel/awxkit/report.xml ---------------------------------------------------------------------------------
```

This PR takes care of both of those.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.0.3
```

