### PR TITLE
Add netcat to the dev container

### DIFF
--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -30,6 +30,7 @@ RUN dnf -y update && \
   make \
   mercurial \
   nginx \
+  nmap-ncat \
   nodejs \
   nss \
   openldap-devel \
@@ -45,11 +46,13 @@ RUN dnf -y update && \
   python3-pycurl \
   rsync \
   subversion \
+  strace \
   sudo \
   swig \
+  tcpdump \
   tmux \
   unzip \
-  vim-minimal \
+  vim \
   which \
   xmlsec1 \
   xmlsec1-devel \


### PR DESCRIPTION
##### SUMMARY

We should add nmap-ncat to the development container to make it easier to test logging and check if ports are open.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.0.3
```


