### PR TITLE
Fix test errors running locally with Ansible devel

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -209,3 +209,19 @@ def vault_credential(organization):
         credential_type=ct, name='vault-cred',
         inputs={'vault_id': 'foo', 'vault_password': 'pas4word'}
     )
+
+
+@pytest.fixture
+def silence_deprecation():
+    """The deprecation warnings are stored in a global variable
+    they will create cross-test interference. Use this to turn them off.
+    """
+    with mock.patch('ansible.module_utils.basic.AnsibleModule.deprecate'):
+        yield
+
+
+@pytest.fixture
+def silence_warning():
+    """Warnings use global variable, same as deprecations."""
+    with mock.patch('ansible.module_utils.basic.AnsibleModule.warn'):
+        yield

--- a/awx_collection/test/awx/test_role.py
+++ b/awx_collection/test/awx/test_role.py
@@ -7,7 +7,7 @@ from awx.main.models import WorkflowJobTemplate, User
 
 
 @pytest.mark.django_db
-def test_grant_organization_permission(run_module, admin_user, organization):
+def test_grant_organization_permission(run_module, admin_user, organization, silence_deprecation):
     rando = User.objects.create(username='rando')
 
     result = run_module('tower_role', {
@@ -22,7 +22,7 @@ def test_grant_organization_permission(run_module, admin_user, organization):
 
 
 @pytest.mark.django_db
-def test_grant_workflow_permission(run_module, admin_user, organization):
+def test_grant_workflow_permission(run_module, admin_user, organization, silence_deprecation):
     wfjt = WorkflowJobTemplate.objects.create(organization=organization, name='foo-workflow')
     rando = User.objects.create(username='rando')
 

--- a/awx_collection/test/awx/test_send_receive.py
+++ b/awx_collection/test/awx/test_send_receive.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from unittest import mock
 import json
 
 from awx.main.models import (
@@ -16,8 +15,9 @@ from awx.main.models import (
 )
 
 
+# warns based on password_management param, but not security issue
 @pytest.mark.django_db
-def test_receive_send_jt(run_module, admin_user, mocker):
+def test_receive_send_jt(run_module, admin_user, mocker, silence_deprecation, silence_warning):
     org = Organization.objects.create(name='SRtest')
     proj = Project.objects.create(
         name='SRtest',
@@ -66,9 +66,7 @@ def test_receive_send_jt(run_module, admin_user, mocker):
     # recreate everything
     with mocker.patch('sys.stdin.isatty', return_value=True):
         with mocker.patch('tower_cli.models.base.MonitorableResource.wait'):
-            # warns based on password_management param, but not security issue
-            with mock.patch('ansible.module_utils.basic.AnsibleModule.warn'):
-                result = run_module('tower_send', dict(assets=json.dumps(assets)), admin_user)
+            result = run_module('tower_send', dict(assets=json.dumps(assets)), admin_user)
 
     assert not result.get('failed'), result
 

--- a/awx_collection/test/awx/test_workflow_template.py
+++ b/awx_collection/test/awx/test_workflow_template.py
@@ -10,7 +10,7 @@ from awx.main.models import (
 
 
 @pytest.mark.django_db
-def test_create_workflow_job_template(run_module, admin_user, organization):
+def test_create_workflow_job_template(run_module, admin_user, organization, silence_deprecation):
 
     module_args = {
         'name': 'foo-workflow',
@@ -39,7 +39,7 @@ def test_create_workflow_job_template(run_module, admin_user, organization):
 
 
 @pytest.mark.django_db
-def test_with_nested_workflow(run_module, admin_user, organization):
+def test_with_nested_workflow(run_module, admin_user, organization, silence_deprecation):
     wfjt1 = WorkflowJobTemplate.objects.create(name='first', organization=organization)
 
     result = run_module('tower_workflow_template', {
@@ -59,7 +59,7 @@ def test_with_nested_workflow(run_module, admin_user, organization):
 
 
 @pytest.mark.django_db
-def test_schema_with_branches(run_module, admin_user, organization):
+def test_schema_with_branches(run_module, admin_user, organization, silence_deprecation):
 
     proj = Project.objects.create(organization=organization, name='Ansible Examples')
     inv = Inventory.objects.create(organization=organization, name='test-inv')
@@ -119,7 +119,7 @@ def test_schema_with_branches(run_module, admin_user, organization):
 
 
 @pytest.mark.django_db
-def test_with_missing_ujt(run_module, admin_user, organization):
+def test_with_missing_ujt(run_module, admin_user, organization, silence_deprecation):
     result = run_module('tower_workflow_template', {
         'name': 'foo-workflow',
         'organization': organization.name,


### PR DESCRIPTION
##### SUMMARY
Locally, I have found that these errors can come up when running the collection tests:

```
awx_collection/test/awx/test_credential.py .......                                                                                                                            [ 17%]
awx_collection/test/awx/test_group.py ..                                                                                                                                      [ 21%]
awx_collection/test/awx/test_inventory.py ...                                                                                                                                 [ 29%]
awx_collection/test/awx/test_inventory_source.py .........                                                                                                                    [ 51%]
awx_collection/test/awx/test_job.py ...                                                                                                                                       [ 58%]
awx_collection/test/awx/test_job_template.py ....                                                                                                                             [ 68%]
awx_collection/test/awx/test_organization.py ..                                                                                                                               [ 73%]
awx_collection/test/awx/test_project.py .                                                                                                                                     [ 75%]
awx_collection/test/awx/test_role.py ..                                                                                                                                       [ 80%]
awx_collection/test/awx/test_send_receive.py .                                                                                                                                [ 82%]
awx_collection/test/awx/test_team.py FF                                                                                                                                       [ 87%]
awx_collection/test/awx/test_workflow_template.py F...                                                                                                                        [ 97%]
awx_collection/test/awx/test_module_utils.py .                                                                                                                                [100%]

===================================================================================== FAILURES ======================================================================================
_________________________________________________________________________________ test_create_team __________________________________________________________________________________
Traceback (most recent call last):
  File "/Users/alancoding/Documents/tower/awx_collection/test/awx/test_team.py", line 23, in test_create_team
    assert result == {
AssertionError: assert {'changed': T...': 'foo_team'} == {'changed': T...': 'foo_team'}
  Omitting 3 identical items, use -vv to show
  Left contains 1 more item:
  {'deprecations': [{'msg': 'This module is being moved to a different '
                            'collection. Instead of awx.awx it will be migrated '
                            'into awx.tower_cli',
                     'version': '3.7'},
                    {'msg': 'This module is being moved to a different '...
  
  ...Full output truncated (13 lines hidden), use '-vv' to show

```

With this patch they pass

##### ISSUE TYPE
 - Bugfix Pull Request


##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
I do not know why Zull was _not_ countering these, but I figure that it's probably a matter of time before it does, so let's take care of it now.

```
$ py.test awx_collection/test/awx/test_role.py awx_collection/test/awx/
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-5.2.2, py-1.8.0, pluggy-0.13.0
Django settings: awx.settings.development (from ini file)
rootdir: /Users/alancoding/Documents/tower, inifile: pytest.ini
plugins: django-3.6.0, mock-1.11.2, timeout-1.3.3, forked-1.1.3, pythonpath-0.7.3, cov-2.8.1, xdist-1.27.0, celery-4.3.0
collected 43 items                                                                                                                                                                  

awx_collection/test/awx/test_role.py ..                                                                                                                                       [  4%]
awx_collection/test/awx/test_credential.py .......                                                                                                                            [ 20%]
awx_collection/test/awx/test_group.py ..                                                                                                                                      [ 25%]
awx_collection/test/awx/test_inventory.py ...                                                                                                                                 [ 32%]
awx_collection/test/awx/test_inventory_source.py .........                                                                                                                    [ 53%]
awx_collection/test/awx/test_job.py ...                                                                                                                                       [ 60%]
awx_collection/test/awx/test_job_template.py ....                                                                                                                             [ 69%]
awx_collection/test/awx/test_organization.py ..                                                                                                                               [ 74%]
awx_collection/test/awx/test_project.py .                                                                                                                                     [ 76%]
awx_collection/test/awx/test_role.py ..                                                                                                                                       [ 76%]
awx_collection/test/awx/test_send_receive.py .                                                                                                                                [ 79%]
awx_collection/test/awx/test_team.py ..                                                                                                                                       [ 83%]
awx_collection/test/awx/test_workflow_template.py ....                                                                                                                        [ 93%]
awx_collection/test/awx/test_module_utils.py .

================================================================================= warnings summary ==================================================================================
awx_collection/test/awx/test_role.py::test_grant_organization_permission
awx_collection/test/awx/test_credential.py::test_create_machine_credential
awx_collection/test/awx/test_credential.py::test_create_vault_credential
awx_collection/test/awx/test_credential.py::test_missing_credential_type
awx_collection/test/awx/test_credential.py::test_make_use_of_custom_credential_type
awx_collection/test/awx/test_inventory.py::test_inventory_create
awx_collection/test/awx/test_inventory.py::test_invalid_smart_inventory_create
awx_collection/test/awx/test_inventory.py::test_valid_smart_inventory_create
awx_collection/test/awx/test_project.py::test_create_project
awx_collection/test/awx/test_role.py::test_grant_organization_permission
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt
awx_collection/test/awx/test_team.py::test_create_team
awx_collection/test/awx/test_team.py::test_modify_team
awx_collection/test/awx/test_team.py::test_modify_team
awx_collection/test/awx/test_workflow_template.py::test_create_workflow_job_template
awx_collection/test/awx/test_workflow_template.py::test_with_nested_workflow
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_with_missing_ujt
  /Users/alancoding/.virtualenvs/awx_collection/lib/python3.6/site-packages/django/db/models/query.py:113: RemovedInDjango31Warning: Organization QuerySet won't use Meta.ordering in Django 3.1. Add .order_by('name') to retain the current query.
    for row in compiler.results_iter(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size):

awx_collection/test/awx/test_inventory_source.py::test_create_inventory_source_implied_org
  /Users/alancoding/.virtualenvs/awx_collection/lib/python3.6/site-packages/_pytest/assertion/rewrite.py:142: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    exec(co, module.__dict__)

awx_collection/test/awx/test_workflow_template.py::test_with_nested_workflow
awx_collection/test/awx/test_workflow_template.py::test_with_nested_workflow
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches
awx_collection/test/awx/test_workflow_template.py::test_with_missing_ujt
  /Users/alancoding/.virtualenvs/awx_collection/lib/python3.6/site-packages/rest_framework/pagination.py:198: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'awx.main.models.workflow.WorkflowJobTemplateNode'> QuerySet.
    paginator = self.django_paginator_class(queryset, page_size)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================= 43 passed, 38 warnings in 22.01s =========================================================================
```

(note that these warnings are not the same kind of warning as addressed here, very different thing)