### PR TITLE
add in summary fields to activity stream logging output

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -103,8 +103,7 @@ class ActivityStreamMiddleware(threading.local, MiddlewareMixin):
         for instance in ActivityStream.objects.filter(id__in=self.instance_ids):
             if drf_user and drf_user.id:       
                 from awx.api.serializers import ActivityStreamSerializer
-                ActStr = ActivityStreamSerializer(instance).to_representation(instance)
-                summary_fields = ActStr.get('summary_fields', {})
+                summary_fields = ActivityStreamSerializer(instance).get_summary_fields(instance)
                 instance.actor = drf_user
                 try:
                     instance.save(update_fields=['actor'])

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -101,14 +101,17 @@ class ActivityStreamMiddleware(threading.local, MiddlewareMixin):
             post_save.disconnect(dispatch_uid=self.disp_uid)
 
         for instance in ActivityStream.objects.filter(id__in=self.instance_ids):
-            if drf_user and drf_user.id:
+            if drf_user and drf_user.id:       
+                from awx.api.serializers import ActivityStreamSerializer
+                ActStr = ActivityStreamSerializer(instance).to_representation(instance)
+                summary_fields = ActStr.get('summary_fields', {})
                 instance.actor = drf_user
                 try:
                     instance.save(update_fields=['actor'])
                     analytics_logger.info('Activity Stream update entry for %s' % str(instance.object1),
                                           extra=dict(changes=instance.changes, relationship=instance.object_relationship_type,
                                           actor=drf_user.username, operation=instance.operation,
-                                          object1=instance.object1, object2=instance.object2))
+                                          object1=instance.object1, object2=instance.object2, summary_fields=summary_fields))
                 except IntegrityError:
                     logger.debug("Integrity Error saving Activity Stream instance for id : " + str(instance.id))
             # else:


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related to several issues in the Activity Stream.
#1761
#1668
~#1513 (possibly, need to test)~ nope

Added in a call to the ActivityStreamSerializer to get the summary field data to provide more context in loggers.
That being said in the main conversation this is related to (#1761) this approach was debated broadly. I'm opening this PR to spark more debate about the best way to handle this issue. 
Currently this _works_. However there will be some performance cost due to the use of the serializer, is there a better way?

The argument beyond 'it works' for this PR is that it works for multiple desired outputs mentioned by users such as label data, settings specification updates, etc.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
9.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Prior outputs would not include summary fields
```
{"@timestamp": "2020-03-18T19:01:22.032Z", "message": "Activity Stream update entry for setting", "host": "awx", "level": "INFO", "logger_name": "awx.analytics.activity_stream", "stack_info": null, "changes": {"value": true, "id": 14}, "relationship": "", "actor": "root", "operation": "create", "object1": "setting", "object2": "", "cluster_host_id": "awx", "tower_uuid": "00000000-0000-0000-0000-000000000000"}

```

They do now:
```
{"@timestamp": "2020-03-18T19:01:41.085Z", "message": "Activity Stream update entry for setting", "host": "awx", "level": "INFO", "logger_name": "awx.analytics.activity_stream", "stack_info": null, "changes": {"value": true, "id": 14}, "relationship": "", "actor": "root", "operation": "create", "object1": "setting", "object2": "", "summary_fields": {"actor": {"id": 3, "username": "root", "first_name": "", "last_name": ""}, "setting": [{"category": "logging", "name": "LOG_AGGREGATOR_ENABLED"}]}, "cluster_host_id": "awx", "tower_uuid": "00000000-0000-0000-0000-000000000000"}

```
