### PR TITLE
Jobs not running with external PostgreSQL database after PR #6034

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -75,7 +75,9 @@ def pg_bus_conn():
     conn = psycopg2.connect(dbname=conf['NAME'],
                             host=conf['HOST'],
                             user=conf['USER'],
-                            password=conf['PASSWORD'])
+                            password=conf['PASSWORD'],
+                            port=conf['PORT'],
+                            **conf["OPTIONS"])
     # Django connection.cursor().connection doesn't have autocommit=True on
     conn.set_session(autocommit=True)
     pubsub = PubSub(conn)

--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -77,7 +77,7 @@ def pg_bus_conn():
                             user=conf['USER'],
                             password=conf['PASSWORD'],
                             port=conf['PORT'],
-                            **conf["OPTIONS"])
+                            **conf.get("OPTIONS", {}))
     # Django connection.cursor().connection doesn't have autocommit=True on
     conn.set_session(autocommit=True)
     pubsub = PubSub(conn)


### PR DESCRIPTION
##### SUMMARY
Adds missing options for PostgreSQL port and options 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`- awx/main/dispatch/__init__.py`

##### AWX VERSION
awx: 9.3.0


##### ADDITIONAL INFORMATION
see: #6340
