### PR TITLE
Fix regression in tower_settings module

### DIFF
--- a/awx_collection/test/awx/test_settings.py
+++ b/awx_collection/test/awx/test_settings.py
@@ -1,0 +1,67 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from awx.conf.models import Setting
+
+
+@pytest.mark.django_db
+def test_setting_flat_value(run_module, admin_user):
+    the_value = 'CN=service_account,OU=ServiceAccounts,DC=domain,DC=company,DC=org'
+    result = run_module('tower_settings', dict(
+        name='AUTH_LDAP_BIND_DN',
+        value=the_value
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+
+    assert Setting.objects.get(key='AUTH_LDAP_BIND_DN').value == the_value
+
+
+@pytest.mark.django_db
+def test_setting_dict_value(run_module, admin_user):
+    the_value = {
+        'email': 'mail',
+        'first_name': 'givenName',
+        'last_name': 'surname'
+    }
+    result = run_module('tower_settings', dict(
+        name='AUTH_LDAP_USER_ATTR_MAP',
+        value=the_value
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+
+    assert Setting.objects.get(key='AUTH_LDAP_USER_ATTR_MAP').value == the_value
+
+
+@pytest.mark.django_db
+def test_setting_nested_type(run_module, admin_user):
+    the_value = {
+        'email': 'mail',
+        'first_name': 'givenName',
+        'last_name': 'surname'
+    }
+    result = run_module('tower_settings', dict(
+        settings={
+            'AUTH_LDAP_USER_ATTR_MAP': the_value
+        }
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+
+    assert Setting.objects.get(key='AUTH_LDAP_USER_ATTR_MAP').value == the_value
+
+
+@pytest.mark.django_db
+def test_setting_bool_value(run_module, admin_user):
+    for the_value in (True, False):
+        result = run_module('tower_settings', dict(
+            name='ACTIVITY_STREAM_ENABLED_FOR_INVENTORY_SYNC',
+            value=the_value
+        ), admin_user)
+        assert not result.get('failed', False), result.get('msg', result)
+        assert result.get('changed'), result
+
+        assert Setting.objects.get(key='ACTIVITY_STREAM_ENABLED_FOR_INVENTORY_SYNC').value is the_value


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/6355

This was dropped in the conversion off of tower-cli. Specifically, all of this logic lived there:

https://github.com/ansible/tower-cli/blob/c355a3f477eb8356d402739f10a55a13ba070b91/tower_cli/resources/setting.py#L149-L171

And we don't have that anymore.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
No, I didn't do the gymnastics of the old tower-cli logic, because that's an unmaintainable mess.

Ansible, however, has very specific behaviors here.

If you give it a dict for a string field, it will dump it _as yaml_ and pass it to the module. So no double quotes, single quotes. It certainly feels like gaslighting that the module must add a new requirement to parse that, but I comply, it wasn't as bad as [W504/W503](https://stackoverflow.com/a/57074416/1092940).
