### PR TITLE
Fix job template form bugs r/t saving without an inventory

### DIFF
--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -57,7 +57,7 @@ function Template({ i18n, me, setBreadcrumb }) {
   );
   useEffect(() => {
     loadTemplateAndRoles();
-  }, [loadTemplateAndRoles]);
+  }, [loadTemplateAndRoles, location.pathname]);
 
   const loadScheduleOptions = () => {
     return JobTemplatesAPI.readScheduleOptions(templateId);

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -109,12 +109,15 @@ function JobTemplateForm({
     return undefined;
   };
 
-  const handleProjectUpdate = newProject => {
-    setProject(newProject);
-    setFieldValue('project', newProject.id);
-    setFieldValue('playbook', 0);
-    setFieldValue('scm_branch', '');
-  };
+  const handleProjectUpdate = useCallback(
+    newProject => {
+      setProject(newProject);
+      setFieldValue('project', newProject.id);
+      setFieldValue('playbook', 0);
+      setFieldValue('scm_branch', '');
+    },
+    [setFieldValue, setProject]
+  );
 
   const jobTypeOptions = [
     {
@@ -245,7 +248,7 @@ function JobTemplateForm({
             )}
           </Field>
         </FieldWithPrompt>
-        <Field name="project" validate={() => handleProjectValidation()}>
+        <Field name="project" validate={handleProjectValidation}>
           {({ form }) => (
             <ProjectLookup
               value={project}
@@ -631,9 +634,11 @@ const FormikApp = withFormik({
         inventory: { organization: null },
       },
     } = template;
+
     const hasInventory = summary_fields.inventory
       ? summary_fields.inventory.organization_id
       : null;
+
     return {
       ask_credential_on_launch: template.ask_credential_on_launch || false,
       ask_diff_mode_on_launch: template.ask_diff_mode_on_launch || false,
@@ -648,7 +653,7 @@ const FormikApp = withFormik({
       name: template.name || '',
       description: template.description || '',
       job_type: template.job_type || 'run',
-      inventory: template.inventory || '',
+      inventory: template.inventory || null,
       project: template.project || '',
       scm_branch: template.scm_branch || '',
       playbook: template.playbook || '',


### PR DESCRIPTION
##### SUMMARY
Addresses Issues:
https://github.com/ansible/awx/issues/6362
https://github.com/ansible/awx/issues/6366

In this PR:
* When no Inventory is selected, the form sends `null` instead of an empty string to the API
* Wraps `handleProjectUpdate` in a useCallback hook to prevent the project lookup from firing requests every time the form changes
* Template.jsx fetches a new template when the location path changes

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

