### PR TITLE
Fix host event type and reference errors

### DIFF
--- a/awx/ui_next/src/screens/Job/JobOutput/HostEventModal.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/HostEventModal.jsx
@@ -97,7 +97,9 @@ const processCodeMirrorValue = value => {
 };
 
 const processStdOutValue = hostEvent => {
-  const { taskAction, res } = hostEvent.event_data;
+  const taskAction = hostEvent?.event_data?.taskAction;
+  const res = hostEvent?.event_data?.res;
+
   let stdOut;
   if (taskAction === 'debug' && res.result && res.result.stdout) {
     stdOut = res.result.stdout;
@@ -107,7 +109,7 @@ const processStdOutValue = hostEvent => {
     Array.isArray(res.results)
   ) {
     [stdOut] = res.results;
-  } else {
+  } else if (res) {
     stdOut = res.stdout;
   }
   return stdOut;
@@ -125,8 +127,8 @@ function HostEventModal({ onClose, hostEvent = {}, isOpen = false, i18n }) {
     setActiveTabKey(tabIndex);
   };
 
-  const jsonObj = processCodeMirrorValue(hostEvent.event_data.res);
-  const stdErr = processCodeMirrorValue(hostEvent.event_data.res.stderr);
+  const jsonObj = processCodeMirrorValue(hostEvent?.event_data?.res);
+  const stdErr = processCodeMirrorValue(hostEvent?.event_data?.res?.stderr);
   const stdOut = processCodeMirrorValue(processStdOutValue(hostEvent));
 
   return (
@@ -167,7 +169,7 @@ function HostEventModal({ onClose, hostEvent = {}, isOpen = false, i18n }) {
             />
             <Detail
               label={i18n._(t`Command`)}
-              value={hostEvent.event_data.res.cmd}
+              value={hostEvent?.event_data?.res?.cmd}
             />
           </DetailList>
         </Tab>


### PR DESCRIPTION
##### SUMMARY
for #6380 

I noticed that occasionally the host details modal doesn't load because expected fields are missing. This PR adds optional chaining and extra checking in a few places to avoid referencing fields that might not be there.
