### PR TITLE
update email option notification to select

### DIFF
--- a/awx/ui/client/src/notifications/edit/edit.controller.js
+++ b/awx/ui/client/src/notifications/edit/edit.controller.js
@@ -76,49 +76,48 @@ export default ['Rest', 'Wait',
                             master[fld] = data[fld];
                         }
 
-                        if(form.fields[fld].type === 'radio_group') {
-                            if(data.notification_configuration.use_ssl === true){
-                                $scope.email_options = "use_ssl";
-                                master.email_options = "use_ssl";
-                                $scope.use_ssl = true;
-                                master.use_ssl = true;
-                                $scope.use_tls = false;
-                                master.use_tls = false;
-                            }
-                            if(data.notification_configuration.use_tls === true){
-                                $scope.email_options = "use_tls";
-                                master.email_options = "use_tls";
-                                $scope.use_ssl = false;
-                                master.use_ssl = false;
-                                $scope.use_tls = true;
-                                master.use_tls = true;
-                            }
+                        if(data.notification_configuration.use_ssl === true){
+                            $scope.email_options = "use_ssl";
+                            master.email_options = "use_ssl";
+                            $scope.use_ssl = true;
+                            master.use_ssl = true;
+                            $scope.use_tls = false;
+                            master.use_tls = false;
                         }
-                        else {
-                            if (data.notification_configuration.timeout === null ||
-                              !data.notification_configuration.timeout){
-                                $scope.timeout = 30;
-                            }
-                            if (data.notification_configuration[fld]) {
-                                $scope[fld] = data.notification_configuration[fld];
-                                master[fld] = data.notification_configuration[fld];
 
-                                if (form.fields[fld].type === 'textarea') {
-                                    if (form.fields[fld].name === 'headers') {
-                                        $scope[fld] = JSON.stringify($scope[fld], null, 2);
-                                    } else {
-                                        $scope[fld] = $scope[fld].join('\n');
-                                    }
+                        if(data.notification_configuration.use_tls === true){
+                            $scope.email_options = "use_tls";
+                            master.email_options = "use_tls";
+                            $scope.use_ssl = false;
+                            master.use_ssl = false;
+                            $scope.use_tls = true;
+                            master.use_tls = true;
+                        }
+
+                        if (data.notification_configuration.timeout === null ||
+                            !data.notification_configuration.timeout){
+                            $scope.timeout = 30;
+                        }
+
+                        if (data.notification_configuration[fld]) {
+                            $scope[fld] = data.notification_configuration[fld];
+                            master[fld] = data.notification_configuration[fld];
+
+                            if (form.fields[fld].type === 'textarea') {
+                                if (form.fields[fld].name === 'headers') {
+                                    $scope[fld] = JSON.stringify($scope[fld], null, 2);
+                                } else {
+                                    $scope[fld] = $scope[fld].join('\n');
                                 }
                             }
+                        }
 
-                            if (form.fields[fld].sourceModel && data.summary_fields &&
-                                data.summary_fields[form.fields[fld].sourceModel]) {
-                                $scope[form.fields[fld].sourceModel + '_' + form.fields[fld].sourceField] =
-                                    data.summary_fields[form.fields[fld].sourceModel][form.fields[fld].sourceField];
-                                master[form.fields[fld].sourceModel + '_' + form.fields[fld].sourceField] =
-                                    data.summary_fields[form.fields[fld].sourceModel][form.fields[fld].sourceField];
-                            }
+                        if (form.fields[fld].sourceModel && data.summary_fields &&
+                            data.summary_fields[form.fields[fld].sourceModel]) {
+                            $scope[form.fields[fld].sourceModel + '_' + form.fields[fld].sourceField] =
+                                data.summary_fields[form.fields[fld].sourceModel][form.fields[fld].sourceField];
+                            master[form.fields[fld].sourceModel + '_' + form.fields[fld].sourceField] =
+                                data.summary_fields[form.fields[fld].sourceModel][form.fields[fld].sourceField];
                         }
                     }
                     data.notification_type = (Empty(data.notification_type)) ? '' : data.notification_type;
@@ -132,6 +131,15 @@ export default ['Rest', 'Wait',
                     master.notification_type = $scope.notification_type;
                     CreateSelect2({
                         element: '#notification_template_notification_type',
+                        multiple: false
+                    });
+                    
+                    $scope.emailOptions = [
+                        {'id': 'use_tls', 'name': i18n._('Use TLS')},
+                        {'id': 'use_ssl', 'name': i18n._('Use SSL')},
+                    ];
+                    CreateSelect2({
+                        element: '#notification_template_email_options',
                         multiple: false
                     });
 
@@ -270,29 +278,6 @@ export default ['Rest', 'Wait',
             }
         });
 
-        $scope.emailOptionsChange = function () {
-            if ($scope.email_options === 'use_ssl') {
-                if ($scope.use_ssl) {
-                    $scope.email_options = null;
-                    $scope.use_ssl = false;
-                    return;
-                }
-
-                $scope.use_ssl = true;
-                $scope.use_tls = false;
-            }
-            else if ($scope.email_options === 'use_tls') {
-                if ($scope.use_tls) {
-                    $scope.email_options = null;
-                    $scope.use_tls = false;
-                    return;
-                }
-
-                $scope.use_ssl = false;
-                $scope.use_tls = true;
-            }
-        };
-
         $scope.formSave = function() {
             var params,
                 v = $scope.notification_type.value;
@@ -345,10 +330,10 @@ export default ['Rest', 'Wait',
                 .filter(i => (form.fields[i].ngShow && form.fields[i].ngShow.indexOf(v) > -1))
                 .map(i => [i, processValue($scope[i], i, form.fields[i])]));
 
-                delete params.notification_configuration.email_options;
+            delete params.notification_configuration.email_options;
 
-                params.notification_configuration.use_ssl = Boolean($scope.use_ssl);
-                params.notification_configuration.use_tls = Boolean($scope.use_tls);
+            params.notification_configuration.use_ssl = $scope.email_options === 'use_ssl';
+            params.notification_configuration.use_tls = $scope.email_options === 'use_tls';            
 
             Wait('start');
             Rest.setUrl(url + id + '/');

--- a/awx/ui/client/src/notifications/notificationTemplates.form.js
+++ b/awx/ui/client/src/notifications/notificationTemplates.form.js
@@ -555,23 +555,14 @@ export default ['i18n', function(i18n) {
                 ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)'
             },
             email_options: {
-                label: i18n._('Options'),
-                type: 'radio_group',
-                subForm: 'typeSubForm',
+                label: i18n._('Email Options'),
+                dataTitle: i18n._('Email Options'),
+                defaultText: i18n._('Choose an email option'),
+                type: 'select',
+                ngOptions: 'type.id as type.name for type in emailOptions',
                 ngShow: "notification_type.value == 'email'",
-                ngClick: "emailOptionsChange()",
-                ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)',
-                options: [{
-                    value: 'use_tls',
-                    label: i18n._('Use TLS'),
-                    ngShow: "notification_type.value == 'email' ",
-                    labelClass: 'Form-inputLabel'
-                }, {
-                    value: 'use_ssl',
-                    label: i18n._('Use SSL'),
-                    ngShow: "notification_type.value == 'email'",
-                    labelClass: 'Form-inputLabel'
-                }]
+                subForm: 'typeSubForm',
+                ngDisabled: '!(notification_template.summary_fields.user_capabilities.edit || canAdd)'
             },
             hex_color: {
                 label: i18n._('Notification Color'),

--- a/awx/ui/client/src/shared/form-generator.js
+++ b/awx/ui/client/src/shared/form-generator.js
@@ -93,7 +93,7 @@
  * | sourceModel | Used in conjunction with sourceField when the data for the field is part of the summary_fields object returned by the API. Set to the name of the summary_fields object that contains the field. For example, the job_templates object returned by the API contains summary_fields.inventory. |
  * | sourceField | String containing the summary_field.object.field name from the API summary_field object. For example, if a fields should be associated to the summary_fields.inventory.name, set the sourceModel to 'inventory' and the sourceField to 'name'. |
  * | spinner | true or false. If true, adds aw-spinner directive. Optionally add min and max attributes to control the range of allowed values. |
- * | type | String containing one of the following types defined in buildField: alertblock, hidden, text, password, email, textarea, select, number, checkbox, checkbox_group, radio, radio_group, lookup, custom. |
+ * | type | String containing one of the following types defined in buildField: alertblock, hidden, text, password, email, textarea, select, number, checkbox, checkbox_group, radio, lookup, custom. |
  * | trueValue | For radio buttons and checkboxes. Value to set the model to when the checkbox or radio button is selected. |
  * | hasShowInputButton (sensitive type only) | This creates a button next to the input that toggles the input as text and password types. |
  * The form object contains a buttons object for defining any buttons to be included in the generated HTML. Generally all forms will have a Reset and a Submit button. If no buttons should be generated define buttons as an empty object, or set the showButtons option to false.
@@ -1196,51 +1196,6 @@ angular.module('FormGenerator', [GeneratorHelpers.name, 'Utilities', listGenerat
                         if (horizontal) {
                             html += "</div>\n";
                         }
-                    }
-
-                    //radio group
-                    if (field.type === 'radio_group') {
-
-                        html += label();
-
-                        html += "<div ";
-                        html += (field.ngShow) ? "ng-show=\"" + field.ngShow + "\" " : "";
-                        html += (horizontal) ? "class=\"radio-group " + getFieldWidth() + "\"" : "class=\"radio-group\"";
-                        html += ">\n";
-
-                        for (i = 0; i < field.options.length; i++) {
-                            html += "<label class=\"";
-                            html += (field.options[i].labelClass) ? ` ${field.options[i].labelClass} "` : "\"";
-                            html += (field.options[i].ngShow) ? this.attr(field.options[i], 'ngShow') : "";
-                            html += ">";
-                            html += "<input type=\"radio\" ";
-                            html += "name=\"" + fld + "\" ";
-                            html += "value=\"" + field.options[i].value + "\" ";
-                            html += "ng-model=\"" + fld + "\" ";
-                            html += (field.ngChange) ? this.attr(field, 'ngChange') : "";
-                            html += (field.ngClick) ? this.attr(field, 'ngClick') : "";
-                            html += (field.ngDisabled) ? `ng-disabled="${field.ngDisabled}"` : "";
-                            html += (field.readonly) ? "disabled " : "";
-                            html += (field.required) ? "required " : "";
-                            html += (field.ngshow) ? "ng-show=\"" + field.ngShow + "\" " : "";
-                            if(field.awRequiredWhen) {
-                                html += field.awRequiredWhen.init ? "data-awrequired-init=\"" + field.awRequiredWhen.init + "\" " : "";
-                                html += field.awRequiredWhen.reqExpression ? "aw-required-when=\"" + field.awRequiredWhen.reqExpression + "\" " : "";
-                                html += field.awRequiredWhen.alwaysShowAsterisk ? "data-awrequired-always-show-asterisk=true " : "";
-                            }
-                            html += (field.ngDisabled) ? this.attr(field, 'ngDisabled') : "";
-                            html += " > " + field.options[i].label + "\n";
-                            html += "</label>\n";
-                        }
-                        if (field.required || field.awRequiredWhen) {
-                            html += "<div class=\"error\" id=\"" + this.form.name + "-" + fld + "-required-error\" ng-show=\"" +
-                                this.form.name + '_form.' + fld + ".$dirty && " +
-                                this.form.name + '_form.' + fld + ".$error.required\">" + i18n._("Please select a value.") + "</div>\n";
-                        }
-                        html += "<div class=\"error api-error\" id=\"" + this.form.name + "-" + fld + "-api-error\" ng-bind=\"" +
-                            fld + "_api_error\"></div>\n";
-
-                        html += "</div>\n";
                     }
 
                     // radio button


### PR DESCRIPTION
link #6383 

this converts that radio_group to a select box.  This has the added benefit of allowing you to deselect all options (i.e. set use_tls use_ssl to both false) after you've selected one, which you could not do with the old interface element.

Because this was the only thing using radio_group, I went ahead and excised radio_group from form-generator.