### PR TITLE
update Django to address CVE-2020-9402

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,7 +6,7 @@ boto  # replacement candidate https://github.com/ansible/awx/issues/2115
 channels
 channels-redis
 daphne
-django==2.2.10  # see UPGRADE BLOCKERs
+django==2.2.11  # see UPGRADE BLOCKERs
 django-auth-ldap
 django-cors-headers
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ django-radius==1.3.3      # via -r /awx_devel/requirements/requirements.in
 django-solo==1.1.3        # via -r /awx_devel/requirements/requirements.in
 django-split-settings==1.0.0  # via -r /awx_devel/requirements/requirements.in
 django-taggit==1.2.0      # via -r /awx_devel/requirements/requirements.in
-django==2.2.10            # via -r /awx_devel/requirements/requirements.in, channels, django-auth-ldap, django-cors-headers, django-crum, django-jsonfield, django-oauth-toolkit, django-polymorphic, django-taggit, djangorestframework
+django==2.2.11            # via -r /awx_devel/requirements/requirements.in, channels, django-auth-ldap, django-cors-headers, django-crum, django-jsonfield, django-oauth-toolkit, django-polymorphic, django-taggit, djangorestframework
 djangorestframework-yaml==1.0.3  # via -r /awx_devel/requirements/requirements.in
 djangorestframework==3.11.0  # via -r /awx_devel/requirements/requirements.in
 docutils==0.16            # via python-daemon


### PR DESCRIPTION
we don't use Oracle GIS, so this isn't really applicable, but it'll make
security scanners happy <shrug>

see: https://docs.djangoproject.com/en/3.0/releases/2.2.11/