### PR TITLE
Rename group-to-group field to align with API

### DIFF
--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -53,6 +53,8 @@ options:
       required: False
       type: list
       elements: str
+      aliases:
+        - groups
     state:
       description:
         - Desired state of the resource.
@@ -98,7 +100,7 @@ def main():
         inventory=dict(required=True),
         variables=dict(type='dict', required=False),
         hosts=dict(type='list', elements='str'),
-        children=dict(type='list', elements='str'),
+        children=dict(type='list', elements='str', aliases=['groups']),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -47,7 +47,7 @@ options:
       required: False
       type: list
       elements: str
-    groups:
+    children:
       description:
         - List of groups that should be nested inside in this group.
       required: False
@@ -98,7 +98,7 @@ def main():
         inventory=dict(required=True),
         variables=dict(type='dict', required=False),
         hosts=dict(type='list', elements='str'),
-        groups=dict(type='list', elements='str'),
+        children=dict(type='list', elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -136,7 +136,7 @@ def main():
 
     association_fields = {}
     for resource, relationship in (('hosts', 'hosts'), ('groups', 'children')):
-        name_list = module.params.get(resource)
+        name_list = module.params.get(relationship)
         if name_list is None:
             continue
         id_list = []

--- a/awx_collection/test/awx/test_group.py
+++ b/awx_collection/test/awx/test_group.py
@@ -78,6 +78,23 @@ def test_associate_on_create(run_module, admin_user, organization):
 
 
 @pytest.mark.django_db
+def test_children_alias_of_groups(run_module, admin_user, organization):
+    inv = Inventory.objects.create(name='test-inv', organization=organization)
+    group = Group.objects.create(name='Test Group', inventory=inv)
+    child = Group.objects.create(inventory=inv, name='child_group')
+    result = run_module('tower_group', dict(
+        name='Test Group',
+        inventory='test-inv',
+        groups=[child.name],
+        state='present'
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result['changed'] is True
+
+    assert set(group.children.all()) == set([child])
+
+
+@pytest.mark.django_db
 def test_tower_group_idempotent(run_module, admin_user):
     # https://github.com/ansible/ansible/issues/46803
     org = Organization.objects.create(name='test-org')

--- a/awx_collection/test/awx/test_group.py
+++ b/awx_collection/test/awx/test_group.py
@@ -33,7 +33,7 @@ def test_create_group(run_module, admin_user):
 
 
 @pytest.mark.django_db
-def test_associate_hosts_and_groups(run_module, admin_user, organization):
+def test_associate_hosts_and_children(run_module, admin_user, organization):
     inv = Inventory.objects.create(name='test-inv', organization=organization)
     group = Group.objects.create(name='Test Group', inventory=inv)
 
@@ -46,7 +46,7 @@ def test_associate_hosts_and_groups(run_module, admin_user, organization):
         name='Test Group',
         inventory='test-inv',
         hosts=[inv_hosts[1].name, inv_hosts[2].name],
-        groups=[child.name],
+        children=[child.name],
         state='present'
     ), admin_user)
     assert not result.get('failed', False), result.get('msg', result)


### PR DESCRIPTION
##### SUMMARY
We want to be closer to the API structure, part of https://github.com/ansible/awx/issues/5177, just getting that playbook to work.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
9.3.0
```
