### PR TITLE
Fix for "No warning or notification displayed while changing the only admin user privilege from admin to normal. #5522"

### DIFF
--- a/awx/ui/client/src/users/edit/users-edit.controller.js
+++ b/awx/ui/client/src/users/edit/users-edit.controller.js
@@ -14,9 +14,9 @@ const user_type_options = [
 
 export default ['$scope', '$rootScope', '$stateParams', 'UserForm', 'Rest',
     'ProcessErrors', 'GetBasePath', 'Wait', 'CreateSelect2',
-    '$state', 'i18n', 'resolvedModels', 'resourceData',
+    '$state', 'i18n', 'resolvedModels', 'resourceData', 'Prompt',
     function($scope, $rootScope, $stateParams, UserForm, Rest, ProcessErrors,
-    GetBasePath, Wait, CreateSelect2, $state, i18n, models, resourceData) {
+    GetBasePath, Wait, CreateSelect2, $state, i18n, models, resourceData, Prompt) {
 
         for (var i = 0; i < user_type_options.length; i++) {
             user_type_options[i].label = i18n._(user_type_options[i].label);
@@ -159,19 +159,48 @@ export default ['$scope', '$rootScope', '$stateParams', 'UserForm', 'Rest',
         };
 
         $scope.formSave = function() {
-            $rootScope.flashMessage = null;
-            if ($scope[form.name + '_form'].$valid) {
-                Rest.setUrl(defaultUrl + '/');
-                var data = processNewData(form.fields);
-                Rest.put(data).then(() => {
-                        $state.go($state.current, null, { reload: true });
-                    })
-                    .catch(({data, status}) => {
-                        ProcessErrors($scope, data, status, null, {
-                            hdr: i18n._('Error!'),
-                            msg: i18n.sprintf(i18n._('Failed to retrieve user: %s. GET status: '), $stateParams.id) + status
-                        });
-                    });
+                alert(user_obj.is_superuser);
+                console.log(user_obj.is_superuser);
+                alert($scope.is_superuser);
+                console.log($scope.is_superuser);
+                if (user_obj.is_superuser === true && $scope.is_superuser === false ) {
+                var action = function() {
+                $('#prompt-modal').modal('hide');
+                $rootScope.flashMessage = null;
+                    if ($scope[form.name + '_form'].$valid) {
+                        Rest.setUrl(defaultUrl + '/');
+                        var data = processNewData(form.fields);
+                        Rest.put(data).then(() => {
+                            $state.go($state.current, null, { reload: true });
+                            })
+                            .catch(({data, status}) => {
+                                ProcessErrors($scope, data, status, null, {
+                                    hdr: i18n._('Error!'),
+                                    msg: i18n.sprintf(i18n._('Failed to retrieve user: %s. GET status: '), $stateParams.id) + status
+                                });
+                            });
+                    }
+                };
+                Prompt({
+                    hdr: i18n._('Save'),
+                    body: '<div class="Prompt-bodyQuery">' + i18n._('Are you sure you want to change the permissions of admin user?') + '</div>',
+                    action: action,
+                    actionText: i18n._('SAVE')
+                });
+            } else {
+                    if ($scope[form.name + '_form'].$valid) {
+                        Rest.setUrl(defaultUrl + '/');
+                        var data = processNewData(form.fields);
+                        Rest.put(data).then(() => {
+                            $state.go($state.current, null, { reload: true });
+                            })
+                            .catch(({data, status}) => {
+                                ProcessErrors($scope, data, status, null, {
+                                    hdr: i18n._('Error!'),
+                                    msg: i18n.sprintf(i18n._('Failed to retrieve user: %s. GET status: '), $stateParams.id) + status
+                                });
+                            });
+                    }
             }
         };
 

--- a/awx/ui/client/src/users/edit/users-edit.controller.js
+++ b/awx/ui/client/src/users/edit/users-edit.controller.js
@@ -159,11 +159,7 @@ export default ['$scope', '$rootScope', '$stateParams', 'UserForm', 'Rest',
         };
 
         $scope.formSave = function() {
-                alert(user_obj.is_superuser);
-                console.log(user_obj.is_superuser);
-                alert($scope.is_superuser);
-                console.log($scope.is_superuser);
-                if (user_obj.is_superuser === true && $scope.is_superuser === false ) {
+            if (user_obj.is_superuser === true && $scope.is_superuser === false ) {
                 var action = function() {
                 $('#prompt-modal').modal('hide');
                 $rootScope.flashMessage = null;

--- a/awx/ui/client/src/users/edit/users-edit.controller.js
+++ b/awx/ui/client/src/users/edit/users-edit.controller.js
@@ -161,14 +161,14 @@ export default ['$scope', '$rootScope', '$stateParams', 'UserForm', 'Rest',
         $scope.formSave = function() {
             if (user_obj.is_superuser === true && $scope.is_superuser === false ) {
                 var action = function() {
-                $('#prompt-modal').modal('hide');
-                $rootScope.flashMessage = null;
+                    $('#prompt-modal').modal('hide');
+                    $rootScope.flashMessage = null;
                     if ($scope[form.name + '_form'].$valid) {
                         Rest.setUrl(defaultUrl + '/');
                         var data = processNewData(form.fields);
                         Rest.put(data).then(() => {
                             $state.go($state.current, null, { reload: true });
-                            })
+                        })
                             .catch(({data, status}) => {
                                 ProcessErrors($scope, data, status, null, {
                                     hdr: i18n._('Error!'),
@@ -184,19 +184,19 @@ export default ['$scope', '$rootScope', '$stateParams', 'UserForm', 'Rest',
                     actionText: i18n._('SAVE')
                 });
             } else {
-                    if ($scope[form.name + '_form'].$valid) {
-                        Rest.setUrl(defaultUrl + '/');
-                        var data = processNewData(form.fields);
-                        Rest.put(data).then(() => {
-                            $state.go($state.current, null, { reload: true });
-                            })
-                            .catch(({data, status}) => {
-                                ProcessErrors($scope, data, status, null, {
-                                    hdr: i18n._('Error!'),
-                                    msg: i18n.sprintf(i18n._('Failed to retrieve user: %s. GET status: '), $stateParams.id) + status
-                                });
+                if ($scope[form.name + '_form'].$valid) {
+                    Rest.setUrl(defaultUrl + '/');
+                    var data = processNewData(form.fields);
+                    Rest.put(data).then(() => {
+                        $state.go($state.current, null, { reload: true });
+                    })
+                        .catch(({data, status}) => {
+                            ProcessErrors($scope, data, status, null, {
+                                hdr: i18n._('Error!'),
+                                msg: i18n.sprintf(i18n._('Failed to retrieve user: %s. GET status: '), $stateParams.id) + status
                             });
-                    }
+                        });
+                }
             }
         };
 

--- a/awx/ui/client/src/users/users.form.js
+++ b/awx/ui/client/src/users/users.form.js
@@ -99,7 +99,7 @@ export default ['i18n', function(i18n) {
                     disableChooseOption: true,
                     ngModel: 'user_type',
                     ngShow: 'current_user["is_superuser"]',
-                    ngDisabled: 'user_obj.id == 1 || !(user_obj.summary_fields.user_capabilities.edit || canAdd)'
+                    ngDisabled: '!(user_obj.summary_fields.user_capabilities.edit || canAdd)'
                 },
             },
 

--- a/awx/ui/client/src/users/users.form.js
+++ b/awx/ui/client/src/users/users.form.js
@@ -99,7 +99,7 @@ export default ['i18n', function(i18n) {
                     disableChooseOption: true,
                     ngModel: 'user_type',
                     ngShow: 'current_user["is_superuser"]',
-                    ngDisabled: '!(user_obj.summary_fields.user_capabilities.edit || canAdd)'
+                    ngDisabled: 'user_obj.id == 1 || !(user_obj.summary_fields.user_capabilities.edit || canAdd)'
                 },
             },
 


### PR DESCRIPTION
##### SUMMARY
While changing permissions of admin user from Administrator to any other type a notification or warning message should have displayed on screen. But in code there is no functionality exist for the same. 
To add pop–up message in code we have to write a function in “awx/awx/ui/client/src/users/edit/users-edit.controller.js” file. This file is responsible to edit the user’s functionalities. We have added the below conditional check in this file:
if (user_obj.is_superuser === true && $scope.is_superuser === false )

Addresses Issues:
No warning or notification displayed while changing the only admin user privilege from admin to normal. #5522


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### AWX VERSION
AWX- 9.3.0


##### ADDITIONAL INFORMATION
We have freeze the default user’s permission which have user id ‘1’, so that no user can change the default user’s permissions. And also added a pop-up message while changing the superuser permissions.
