### PR TITLE
Hookup WF documentation button to visualizer toolbar

### DIFF
--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.jsx
@@ -46,6 +46,9 @@ const ActionButton = styled(Button)`
 `;
 ActionButton.displayName = 'ActionButton';
 
+const DOCLINK =
+  'https://docs.ansible.com/ansible-tower/latest/html/userguide/workflow_templates.html#ug-wf-editor';
+
 function VisualizerToolbar({
   i18n,
   onClose,
@@ -95,9 +98,12 @@ function VisualizerToolbar({
             </ActionButton>
           </Tooltip>
           <ActionButton
+            aria-label={i18n._(t`Workflow Documentation`)}
             id="visualizer-documentation"
             variant="plain"
-            isDisabled
+            component="a"
+            target="_blank"
+            href={DOCLINK}
           >
             <BookIcon />
           </ActionButton>

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.test.jsx
@@ -62,6 +62,14 @@ describe('VisualizerToolbar', () => {
     expect(wrapper.find('Badge').text()).toBe('1');
   });
 
+  test('Should display action buttons', () => {
+    expect(wrapper.find('CompassIcon')).toHaveLength(1);
+    expect(wrapper.find('WrenchIcon')).toHaveLength(1);
+    expect(wrapper.find('BookIcon')).toHaveLength(1);
+    expect(wrapper.find('RocketIcon')).toHaveLength(1);
+    expect(wrapper.find('TrashAltIcon')).toHaveLength(1);
+  });
+
   test('Toggle Legend button dispatches as expected', () => {
     wrapper.find('CompassIcon').simulate('click');
     expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_LEGEND' });


### PR DESCRIPTION
##### SUMMARY
Issue: #5992 

Button should link out to workflow visualizer docs. 

<img width="426" alt="Screen Shot 2020-03-25 at 5 45 21 PM" src="https://user-images.githubusercontent.com/15881645/77588587-87d6d100-6ec0-11ea-8968-94eb4d52857c.png">

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI