### PR TITLE
Named URL contextual filters in lookups made by AWX collection

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -343,7 +343,6 @@ class TowerModule(AnsibleModule):
             if not (id_value.isdigit() and allow_id):
                 if allow_none:
                     return None
-                # raise Exception(1)
                 self.fail_json(msg="No objects found at /api/v2/{0}/ with data {1}".format(endpoint, lookup_data))
             # If we got 0 items by name, maybe they gave us an ID, let's try looking it up by ID
             response = self.get_endpoint(endpoint, data={'id': id_value}, return_none_on_404=True)
@@ -351,27 +350,13 @@ class TowerModule(AnsibleModule):
                 return response
             self.fail_json(msg="No objects found at {0} with data {1} or data {2}".format(
                 endpoint, lookup_data, {'id': id_value}))
-            # except ValueError:
-            #     # if len(lookup_data) > 1:
-            #     #     # Query was too specific, try without the contextual data
-            #     #     value = lookup_data[identity_field]
-            #     #     response = self.get_endpoint(endpoint, data={identity_field: value})
-            #     #     if response['json']['count'] == 1:
-            #     #         return response['json']['results'][0]
-            #     #     else:
-            #     #         # raise Exception('alan1')
-            #     #         self.fail_json(msg="No objects found at {0} with data {1} or {2}".format(
-            #     #             endpoint, lookup_data, {identity_field: value}))
-            #     # else:
-            #     self.fail_json(msg="No objects found at {0} with data {1}".format(
-            #         endpoint, lookup_data))
         else:
             if fk_lookup and len(lookup_data) == 1:
                 self.fail_json(msg="Obtained {0} objects at endpoint {1} with data {2}, try ID or context param {3}".format(
                     response['json']['count'], endpoint, lookup_data, fk_lookup
                 ))
-            raise Exception('Uniqueness rules did not work as expected GET {0} at {0}'.format(
-                lookup_data, endpoint
+            raise RuntimeError('Uniqueness rules did not work as expected GET /api/v2/{0}/ with data {0}'.format(
+                endpoint, lookup_data
             ))
 
     def resolve_name_to_id(self, endpoint, name_or_id):

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -213,6 +213,8 @@ class TowerModule(AnsibleModule):
 
     @staticmethod
     def param_to_endpoint(name):
+        if name.endswith('s'):
+            return name  # already in plural endpoint format
         exceptions = {
             'inventory': 'inventories',
             'target_team': 'teams',
@@ -253,6 +255,8 @@ class TowerModule(AnsibleModule):
                     continue
                 if len(self.named_url_formats[related_endpoint].split('++')) != dep_ct:
                     continue
+                if isinstance(value, list):
+                    continue  # TODO: implement lookups of many related params
                 lookup_data = {}
                 identity_field, fk_lookup = self.find_lookup_fields(related_endpoint)
                 lookup_data[identity_field] = value

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -137,20 +137,8 @@ def main():
 
     association_fields = {}
     for relationship in ('hosts', 'children'):
-        endpoint = module.param_to_endpoint(relationship)
-        name_list = module.params.get(relationship)
-        if name_list is None:
-            continue
-        id_list = []
-        for sub_name in name_list:
-            sub_obj = module.get_one(endpoint, **{
-                'data': {'inventory': inventory_id, 'name': sub_name}
-            })
-            if sub_obj is None:
-                module.fail_json(msg='Could not find {0} with name {1}'.format(endpoint, sub_name))
-            id_list.append(sub_obj['id'])
-        if id_list:
-            association_fields[relationship] = id_list
+        if relationship in related_data:
+            association_fields[relationship] = [item['id'] for item in related_data[relationship]]
 
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -116,21 +116,14 @@ def main():
     # Extract our parameters
     name = module.params.get('name')
     new_name = module.params.get('new_name')
-    inventory = module.params.get('inventory')
     description = module.params.get('description')
     state = module.params.pop('state')
     variables = module.params.get('variables')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
-    inventory_id = module.resolve_name_to_id('inventories', inventory)
-
     # Attempt to look up the object based on the provided name and inventory ID
-    group = module.get_one('groups', **{
-        'data': {
-            'name': name,
-            'inventory': inventory_id
-        }
-    })
+    group, related_data = module.lookup_resource_data('groups', module.params)
+    inventory_id = related_data['inventory']['id']
 
     # Create the data that gets sent for create and update
     group_fields = {
@@ -144,7 +137,7 @@ def main():
 
     association_fields = {}
     for relationship in ('hosts', 'children'):
-        endpoint = module.param_to_endpoint(relationship[:-1])
+        endpoint = module.param_to_endpoint(relationship)
         name_list = module.params.get(relationship)
         if name_list is None:
             continue

--- a/awx_collection/plugins/modules/tower_host.py
+++ b/awx_collection/plugins/modules/tower_host.py
@@ -94,12 +94,12 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        new_name=dict(required=False),
-        description=dict(required=False),
+        new_name=dict(),
+        description=dict(),
         inventory=dict(required=True),
         organization=dict(),
         enabled=dict(type='bool', default=True),
-        variables=dict(type='dict', required=False),
+        variables=dict(type='dict'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 

--- a/awx_collection/test/awx/test_host.py
+++ b/awx_collection/test/awx/test_host.py
@@ -1,0 +1,50 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from awx.main.models import Organization, Inventory, Host
+
+
+@pytest.mark.django_db
+def test_duplicate_inventories(run_module, admin_user):
+    org = Organization.objects.create(name='test-org')
+    decoy_org = Organization.objects.create(name='decoy')
+    for this_org in (decoy_org, org):
+        inv = Inventory.objects.create(name='test-inv', organization=this_org)
+
+    result = run_module('tower_host', dict(
+        name='Test Host',
+        inventory=inv.name,
+        state='present'
+    ), admin_user)
+    assert result.get('failed', True)
+    msg = result.get('msg', '')
+    assert 'Obtained 2 objects at endpoint inventories with data' in msg
+    assert 'try ID or context param organization' in msg
+
+
+@pytest.mark.django_db
+def test_create_host(run_module, admin_user):
+    org = Organization.objects.create(name='test-org')
+    decoy_org = Organization.objects.create(name='decoy')
+    for this_org in (decoy_org, org):
+        inv = Inventory.objects.create(name='test-inv', organization=this_org)
+    variables = {"ansible_network_os": "iosxr"}
+
+    result = run_module('tower_host', dict(
+        name='Test Host',
+        inventory=inv.name,
+        organization=org.name,
+        variables=variables,
+        state='present'
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+
+    host = Host.objects.get(name='Test Host')
+    assert host.inventory == inv
+    assert host.inventory.organization == org
+
+    assert result['id'] == host.id
+    assert result['name'] == 'Test Host'

--- a/awx_collection/test/awx/test_inventory_source.py
+++ b/awx_collection/test/awx/test_inventory_source.py
@@ -81,7 +81,7 @@ def test_create_inventory_source_multiple_orgs(run_module, admin_user):
     result = run_module('tower_inventory_source', dict(
         name='Test Inventory Source',
         inventory=inv2.name,
-        organization='test-org',
+        organization=org2.name,
         source='ec2',
         state='present'
     ), admin_user)
@@ -90,11 +90,8 @@ def test_create_inventory_source_multiple_orgs(run_module, admin_user):
     inv_src = InventorySource.objects.get(name='Test Inventory Source')
     assert inv_src.inventory == inv2
 
-    result.pop('invocation')
-    assert result == {
-        "name": "Test Inventory Source",
-        "id": inv_src.id,
-    }
+    assert result['name'] == 'Test Inventory Source'
+    assert result['id'] == inv_src.id
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_inventory_source.py
+++ b/awx_collection/test/awx/test_inventory_source.py
@@ -80,7 +80,8 @@ def test_create_inventory_source_multiple_orgs(run_module, admin_user):
 
     result = run_module('tower_inventory_source', dict(
         name='Test Inventory Source',
-        inventory=inv2.id,
+        inventory=inv2.name,
+        organization='test-org',
         source='ec2',
         state='present'
     ), admin_user)

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -3,6 +3,8 @@ __metaclass__ = type
 
 import sys
 
+import pytest
+
 from unittest import mock
 
 import json
@@ -33,3 +35,15 @@ def test_duplicate_config(collection_import):
         'tower_config_file. Precedence may be unstable, '
         'we suggest either using config file or params.'
     )
+
+
+@pytest.mark.parametrize('endpoint, expect', [
+    ('users', ('username', None,)),
+    ('hosts', ('name', 'inventory',)),
+    ('workflow_job_templates', ('name', 'organization')),
+    ('workflow_job_template_nodes', ('identifier', 'workflow_job_template'))
+])
+def test_find_lookup_fields(collection_import, endpoint, expect):
+    TowerModule = collection_import('plugins.module_utils.tower_api').TowerModule
+    # abuse the self argument here, because initializing a module is hard
+    assert TowerModule.find_lookup_fields(TowerModule, endpoint) == expect


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/5193

Apply a generalized solution for dependency processing, because I believe that addresses the reason it wound up removed in 9955ee6548d0335d44cf18d446d032031fc955e5

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - AWX collection

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
We can absolutely break out the changes to `resolve_name_to_id` in another change set. It is requisite for this feature, in that it needs to turn on and off the parameters to it. But that is pretty minor.

We shouldn't stop there either, `get_one` needs to get gobbled up in that, as well as a few other methods that duplicate logic.
