### PR TITLE
Disable launch button when there are zero nodes

### DIFF
--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.jsx
@@ -112,7 +112,7 @@ function VisualizerToolbar({
               <ActionButton
                 id="visualizer-launch"
                 variant="plain"
-                isDisabled={!canLaunch}
+                isDisabled={!canLaunch || totalNodes === 0}
                 onClick={handleLaunch}
               >
                 <RocketIcon />


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/6432

Disable launch when workflow visualizer is empty

<img width="376" alt="Screen Shot 2020-03-26 at 10 17 12 AM" src="https://user-images.githubusercontent.com/15881645/77657051-1d1ea780-6f4b-11ea-9fa5-709255757abc.png">


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
