### PR TITLE
Identify user-only object roles

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1280,6 +1280,14 @@ class OrganizationSerializer(BaseSerializer):
                     'job_templates': 0, 'admins': 0, 'projects': 0}
             else:
                 summary_dict['related_field_counts'] = counts_dict[obj.id]
+
+        # Organization participation roles (admin, member) can't be assigned
+        # to a team. This provides a hint to the ui so it can know to not
+        # display these roles for team role selection.
+        for key in ('admin_role', 'member_role',):
+            if key in summary_dict.get('object_roles', {}):
+                summary_dict['object_roles'][key]['user_only'] = True
+
         return summary_dict
 
     def validate(self, attrs):


### PR DESCRIPTION
##### SUMMARY
Part 1/2 of a solution to #6433 

Some organization roles can't be assigned to a team. This provides a hint to the ui so it can know to not display them for team role selection.

![Screenshot from 2020-03-26 11-29-15](https://user-images.githubusercontent.com/9753817/77668099-5d852200-6f59-11ea-993c-8a41c577a381.png)

##### ADDITIONAL INFORMATION
Some background if you're curious:

The rbac component used in the new ui is:
  - very generic (it needs to be because almost all resources have an rbac page)
  - _very_ deeply nested in the dom: The nearest parent to the rbac component that _could_ provide the needed context (e.g: "Treat _these_ roles differently when selecting team roles") is the top-level organization component. To support a ui-only fix, we would need to drill extra values through multiple layers of shared component definitions or start wrapping components in a dedicated context manager (not great for testability).


