### PR TITLE
fix busted shell_plus in the development environment

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -40,6 +40,7 @@ NOTEBOOK_ARGUMENTS = [
 ]
 
 # print SQL queries in shell_plus
+SHELL_PLUS = 'ipython'
 SHELL_PLUS_PRINT_SQL = False
 
 # show colored logs in the dev environment


### PR DESCRIPTION
we recently bumped to the latest version of `django-extensions` (https://github.com/ansible/awx/commit/7f02e64a0d15fa0f5f8cbc4b94b37cce7c99c24c);  `django-extensions` has begun noticing ipython importability and treating "shell_plus" as "start an IPython
notebook."

it could be that this is a bug in django-extensions that will be fixed
soon, but for now, this fixes the issue

related: https://github.com/django-extensions/django-extensions/commit/e8d5daa06e5b6419e54d6c925f86a0adbe58ce8b