### PR TITLE
Limit added to fields reported in activity stream when creating a schedule for a job

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2734,7 +2734,7 @@ class JobOptionsSerializer(LabelsListMixin, BaseSerializer):
         fields = ('*', 'job_type', 'inventory', 'project', 'playbook', 'scm_branch',
                   'forks', 'limit', 'verbosity', 'extra_vars', 'job_tags',
                   'force_handlers', 'skip_tags', 'start_at_task', 'timeout',
-                  'use_fact_cache', 'organization',)
+                  'use_fact_cache', 'organization', 'limit',)
         read_only_fields = ('organization',)
 
     def get_related(self, obj):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
added limit to the fields for the job options serializer so that it could be included in the initial activity stream record of the schedule creation
should address: #2387 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 9.3.0
```