### PR TITLE
Optionally add the webhook_credential link to related

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2900,6 +2900,8 @@ class JobTemplateSerializer(JobTemplateMixin, UnifiedJobTemplateSerializer, JobO
             res['callback'] = self.reverse('api:job_template_callback', kwargs={'pk': obj.pk})
         if obj.organization_id:
             res['organization'] = self.reverse('api:organization_detail',   kwargs={'pk': obj.organization_id})
+        if obj.webhook_credential_id:
+            res['webhook_credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.webhook_credential_id})
         return res
 
     def validate(self, attrs):
@@ -3390,6 +3392,8 @@ class WorkflowJobTemplateSerializer(JobTemplateMixin, LabelsListMixin, UnifiedJo
         )
         if obj.organization:
             res['organization'] = self.reverse('api:organization_detail',   kwargs={'pk': obj.organization.pk})
+        if obj.webhook_credential_id:
+            res['webhook_credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.webhook_credential_id})
         return res
 
     def validate_extra_vars(self, value):

--- a/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
@@ -31,6 +31,7 @@ def job_template(mocker):
     mock_jt.validation_errors = mock_JT_resource_data
     mock_jt.webhook_service = ''
     mock_jt.organization_id = None
+    mock_jt.webhook_credential_id = None
     return mock_jt
 
 


### PR DESCRIPTION
##### SUMMARY
We need the webhook_credential link in the related section on JTs and WFJTs.  Otherwise, programmatic consumers of the API will need to special-case construct the url if they need to get to the underlying credential.

related #6125 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 9.3.0
```