### PR TITLE
Improve error handling related to authentication

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -78,10 +78,15 @@ def run_module(request, collection_import):
         def new_request(self, method, url, **kwargs):
             kwargs_copy = kwargs.copy()
             if 'data' in kwargs:
-                if not isinstance(kwargs['data'], dict):
+                if isinstance(kwargs['data'], dict):
+                    kwargs_copy['data'] = kwargs['data']
+                elif kwargs['data'] is None:
+                    pass
+                elif isinstance(kwargs['data'], str):
                     kwargs_copy['data'] = json.loads(kwargs['data'])
                 else:
-                    kwargs_copy['data'] = kwargs['data']
+                    raise RuntimeError('Expected data to be dict or str, got {0}, data: {1}'.format(
+                        type(kwargs['data']), kwargs['data']))
             if 'params' in kwargs and method == 'GET':
                 # query params for GET are handled a bit differently by
                 # tower-cli and python requests as opposed to REST framework APIRequestFactory


### PR DESCRIPTION
##### SUMMARY
Related to https://github.com/ansible/awx/issues/6437 but doesn't fix the full issue

##### ISSUE TYPE
 - Bugfix Pull Request

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
For one artificial case:

```
TASK [Users AWX] ********************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to get token: HTTP Error 400: Bad Request"}
```

new:

```
TASK [Users AWX] ********************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to get token: HTTP Error 400: Bad Request response: b'<html>\\r\\n<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>\\r\\n<body bgcolor=\"white\">\\r\\n<center><h1>400 Bad Request</h1></center>\\r\\n<center>The plain HTTP request was sent to HTTPS port</center>\\r\\n<hr><center>nginx</center>\\r\\n</body>\\r\\n</html>\\r\\n'"}
```

Also fixes the warning where the query params were not cleared.