### PR TITLE
Limit disable-on-load to single notifications

### DIFF
--- a/awx/ui_next/src/components/NotificationList/NotificationList.jsx
+++ b/awx/ui_next/src/components/NotificationList/NotificationList.jsx
@@ -25,7 +25,7 @@ class NotificationList extends Component {
       contentError: null,
       hasContentLoading: true,
       toggleError: false,
-      toggleLoading: false,
+      loadingToggleIds: [],
       itemCount: 0,
       notifications: [],
       startedTemplateIds: [],
@@ -147,7 +147,9 @@ class NotificationList extends Component {
       });
     }
 
-    this.setState({ toggleLoading: true });
+    this.setState(({ loadingToggleIds }) => ({
+      loadingToggleIds: loadingToggleIds.concat([notificationId]),
+    }));
     try {
       if (isCurrentlyOn) {
         await apiModel.disassociateNotificationTemplate(
@@ -166,7 +168,11 @@ class NotificationList extends Component {
     } catch (err) {
       this.setState({ toggleError: err });
     } finally {
-      this.setState({ toggleLoading: false });
+      this.setState(({ loadingToggleIds }) => ({
+        loadingToggleIds: loadingToggleIds.filter(
+          item => item !== notificationId
+        ),
+      }));
     }
   }
 
@@ -180,7 +186,7 @@ class NotificationList extends Component {
       contentError,
       hasContentLoading,
       toggleError,
-      toggleLoading,
+      loadingToggleIds,
       itemCount,
       notifications,
       startedTemplateIds,
@@ -240,7 +246,10 @@ class NotificationList extends Component {
               key={notification.id}
               notification={notification}
               detailUrl={`/notifications/${notification.id}`}
-              canToggleNotifications={canToggleNotifications && !toggleLoading}
+              canToggleNotifications={
+                canToggleNotifications &&
+                !loadingToggleIds.includes(notification.id)
+              }
               toggleNotification={this.handleNotificationToggle}
               errorTurnedOn={errorTemplateIds.includes(notification.id)}
               startedTurnedOn={startedTemplateIds.includes(notification.id)}
@@ -252,7 +261,7 @@ class NotificationList extends Component {
         <AlertModal
           variant="error"
           title={i18n._(t`Error!`)}
-          isOpen={toggleError && !toggleLoading}
+          isOpen={toggleError && loadingToggleIds.length === 0}
           onClose={this.handleNotificationErrorClose}
         >
           {i18n._(t`Failed to toggle notification.`)}


### PR DESCRIPTION
##### SUMMARY
for #6435 

Originally my intent was to put _some_ sort of guard around button mashing all the toggles, but disabling everything is probably going a little too far. Plus it absolutely does look weird.

This change keeps some amount of sanity check in place for these toggles without disabling everything all of the time. It also looks much less flashy.

![notification_togglez](https://user-images.githubusercontent.com/9753817/77762216-8ec02980-700f-11ea-9f35-26119af84077.gif)
