### PR TITLE
Add IDs to survey list items

### DIFF
--- a/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
@@ -39,7 +39,10 @@ function SurveyListItem({
   onMoveDown,
 }) {
   return (
-    <DataListItem aria-labelledby={i18n._(t`Survey questions`)}>
+    <DataListItem
+      aria-labelledby={i18n._(t`Survey questions`)}
+      id={`survey-list-item-${question.variable}`}
+    >
       <DataListItemRow css="padding-left:16px">
         <DataListAction
           id="sortQuestions"


### PR DESCRIPTION
##### SUMMARY

E2E selectors in the survey list require that each survey item is individually identified. Since the unique ID os based on the variable it modifies, this handles that for us.