### PR TITLE
Remove field properties which are default values anyway

### DIFF
--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -40,13 +40,11 @@ options:
     organization:
       description:
         - Organization that should own the credential.
-      required: False
       type: str
     credential_type:
       description:
         - Name of credential type.
         - Will be preferred over kind
-      required: False
       version_added: "2.10"
       type: str
     inputs:
@@ -55,7 +53,6 @@ options:
           Credential inputs where the keys are var names used in templating.
           Refer to the Ansible Tower documentation for example syntax.
         - Any fields in this dict will take prescedence over any fields mentioned below (i.e. host, username, etc)
-      required: False
       version_added: "2.9"
       type: dict
     user:
@@ -100,7 +97,6 @@ options:
       description:
         - SSH private key content. To extract the content from a file path, use the lookup function (see examples).
         - Deprecated, please use inputs
-      required: False
       type: str
     ssh_key_unlock:
       description:

--- a/awx_collection/plugins/modules/tower_credential_type.py
+++ b/awx_collection/plugins/modules/tower_credential_type.py
@@ -32,7 +32,6 @@ options:
     description:
       description:
         - The description of the credential type to give more detail about it.
-      required: False
       type: str
     kind:
       description:
@@ -41,33 +40,28 @@ options:
           net can be used for creating credential types. Refer to the Ansible
           for more information.
       choices: [ 'ssh', 'vault', 'net', 'scm', 'cloud', 'insights' ]
-      required: False
       type: str
     inputs:
       description:
         - >-
           Enter inputs using either JSON or YAML syntax. Refer to the Ansible
           Tower documentation for example syntax.
-      required: False
       type: dict
     injectors:
       description:
         - >-
           Enter injectors using either JSON or YAML syntax. Refer to the
           Ansible Tower documentation for example syntax.
-      required: False
       type: dict
     state:
       description:
         - Desired state of the resource.
-      required: False
       default: "present"
       choices: ["present", "absent"]
       type: str
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -109,15 +103,15 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        description=dict(required=False),
-        kind=dict(required=False, choices=list(KIND_CHOICES.keys())),
-        inputs=dict(type='dict', required=False),
-        injectors=dict(type='dict', required=False),
+        description=dict(),
+        kind=dict(choices=list(KIND_CHOICES.keys())),
+        inputs=dict(type='dict'),
+        injectors=dict(type='dict'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -44,13 +44,11 @@ options:
     hosts:
       description:
         - List of hosts that should be put in this group.
-      required: False
       type: list
       elements: str
     children:
       description:
         - List of groups that should be nested inside in this group.
-      required: False
       type: list
       elements: str
       aliases:
@@ -64,13 +62,11 @@ options:
     new_name:
       description:
         - A new name for this group (for renaming)
-      required: False
       type: str
       version_added: "3.7"
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -95,17 +91,17 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        new_name=dict(required=False),
-        description=dict(required=False),
+        new_name=dict(),
+        description=dict(),
         inventory=dict(required=True),
-        variables=dict(type='dict', required=False),
+        variables=dict(type='dict'),
         hosts=dict(type='list', elements='str'),
         children=dict(type='list', elements='str', aliases=['groups']),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_host.py
+++ b/awx_collection/plugins/modules/tower_host.py
@@ -31,7 +31,6 @@ options:
     new_name:
       description:
         - To use when changing a hosts's name.
-      required: False
       type: str
       version_added: "3.7"
     description:
@@ -61,7 +60,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -89,16 +87,16 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        new_name=dict(required=False),
-        description=dict(required=False),
+        new_name=dict(),
+        description=dict(),
         inventory=dict(required=True),
         enabled=dict(type='bool', default=True),
-        variables=dict(type='dict', required=False),
+        variables=dict(type='dict'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_inventory.py
+++ b/awx_collection/plugins/modules/tower_inventory.py
@@ -40,7 +40,6 @@ options:
     variables:
       description:
         - Inventory variables.
-      required: False
       type: dict
     kind:
       description:
@@ -63,7 +62,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -89,16 +87,16 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        description=dict(required=False),
+        description=dict(),
         organization=dict(required=True),
-        variables=dict(type='dict', required=False),
+        variables=dict(type='dict'),
         kind=dict(choices=['', 'smart'], default=''),
         host_filter=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -31,7 +31,6 @@ options:
     new_name:
       description:
         - A new name for this assets (will rename the asset)
-      required: False
       type: str
       version_added: "3.7"
     description:
@@ -48,7 +47,6 @@ options:
         - The source to use for this group.
       choices: [ "scm", "ec2", "gce", "azure_rm", "vmware", "satellite6", "cloudforms", "openstack", "rhv", "tower", "custom" ]
       type: str
-      required: False
     source_path:
       description:
         - For an SCM based inventory source, the source path points to the file within the repo to use as an inventory.
@@ -57,7 +55,6 @@ options:
       description:
         - Inventory script to be used when group type is C(custom).
       type: str
-      required: False
     source_vars:
       description:
         - The variables or environment fields to apply to this source type.
@@ -92,7 +89,6 @@ options:
       description:
         - Local absolute file path containing a custom Python virtualenv to use.
       type: str
-      required: False
       default: ''
     timeout:
       description: The amount of time (in seconds) to run before the task is canceled.
@@ -126,7 +122,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -153,17 +148,17 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        new_name=dict(type='str'),
-        description=dict(required=False),
+        new_name=dict(),
+        description=dict(),
         inventory=dict(required=True),
         #
         # How do we handle manual and file? Tower does not seem to be able to activate them
         #
         source=dict(choices=["scm", "ec2", "gce",
                              "azure_rm", "vmware", "satellite6", "cloudforms",
-                             "openstack", "rhv", "tower", "custom"], required=False),
+                             "openstack", "rhv", "tower", "custom"]),
         source_path=dict(),
-        source_script=dict(required=False),
+        source_script=dict(),
         source_vars=dict(type='dict'),
         credential=dict(),
         source_regions=dict(),
@@ -171,12 +166,12 @@ def main():
         group_by=dict(),
         overwrite=dict(type='bool'),
         overwrite_vars=dict(type='bool'),
-        custom_virtualenv=dict(type='str', default=''),
+        custom_virtualenv=dict(default=''),
         timeout=dict(type='int'),
         verbosity=dict(type='int', choices=[0, 1, 2]),
         update_on_launch=dict(type='bool'),
         update_cache_timeout=dict(type='int'),
-        source_project=dict(type='str'),
+        source_project=dict(),
         update_on_project_update=dict(type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
     )

--- a/awx_collection/plugins/modules/tower_job_cancel.py
+++ b/awx_collection/plugins/modules/tower_job_cancel.py
@@ -36,7 +36,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -90,7 +90,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -142,23 +141,23 @@ from ..module_utils.tower_api import TowerModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(type='str', required=True, aliases=['job_template']),
-        job_type=dict(type='str', choices=['run', 'check']),
-        inventory=dict(type='str', default=None),
+        name=dict(required=True, aliases=['job_template']),
+        job_type=dict(choices=['run', 'check']),
+        inventory=dict(default=None),
         # Credentials will be a str instead of a list for backwards compatability
         credentials=dict(type='list', default=None, aliases=['credential'], elements='str'),
         limit=dict(),
         tags=dict(type='list', elements='str'),
-        extra_vars=dict(type='dict', required=False),
-        scm_branch=dict(type='str', required=False),
-        skip_tags=dict(type='list', required=False, elements='str'),
-        verbosity=dict(type='int', required=False, choices=[0, 1, 2, 3, 4, 5]),
-        diff_mode=dict(type='bool', required=False),
-        credential_passwords=dict(type='dict', required=False),
+        extra_vars=dict(type='dict'),
+        scm_branch=dict(),
+        skip_tags=dict(type='list', elements='str'),
+        verbosity=dict(type='int', choices=[0, 1, 2, 3, 4, 5]),
+        diff_mode=dict(type='bool'),
+        credential_passwords=dict(type='dict'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     optional_args = {}
     # Extract our parameters

--- a/awx_collection/plugins/modules/tower_job_list.py
+++ b/awx_collection/plugins/modules/tower_job_list.py
@@ -44,7 +44,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -39,7 +39,6 @@ options:
     job_type:
       description:
         - The job type to use for the job template.
-      required: False
       choices: ["run", "check"]
       type: str
     inventory:
@@ -332,12 +331,12 @@ def main():
         playbook=dict(),
         credential=dict(default=''),
         vault_credential=dict(default=''),
-        custom_virtualenv=dict(required=False),
+        custom_virtualenv=dict(),
         credentials=dict(type='list', default=[], elements='str'),
         forks=dict(type='int'),
         limit=dict(default=''),
         verbosity=dict(type='int', choices=[0, 1, 2, 3, 4], default=0),
-        extra_vars=dict(type='dict', required=False),
+        extra_vars=dict(type='dict'),
         job_tags=dict(default=''),
         force_handlers=dict(type='bool', default=False, aliases=['force_handlers_enabled']),
         skip_tags=dict(default=''),
@@ -369,7 +368,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_job_wait.py
+++ b/awx_collection/plugins/modules/tower_job_wait.py
@@ -127,7 +127,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     job_id = module.params.get('job_id')

--- a/awx_collection/plugins/modules/tower_label.py
+++ b/awx_collection/plugins/modules/tower_label.py
@@ -48,7 +48,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -67,14 +66,14 @@ from ..module_utils.tower_api import TowerModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(required=True, type='str'),
-        new_name=dict(required=False, type='str'),
-        organization=dict(required=True, type='str'),
+        name=dict(required=True),
+        new_name=dict(),
+        organization=dict(required=True),
         state=dict(choices=['present'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -37,7 +37,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_notification.py
+++ b/awx_collection/plugins/modules/tower_notification.py
@@ -390,7 +390,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -37,14 +37,12 @@ options:
       description:
         - Local absolute file path containing a custom Python virtualenv to use.
       type: str
-      required: False
       default: ''
     max_hosts:
       description:
         - The max hosts allowed in this organizations
       default: "0"
       type: int
-      required: False
       version_added: "3.7"
     state:
       description:
@@ -55,7 +53,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -85,15 +82,15 @@ from ..module_utils.tower_api import TowerModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(type='str', required=True),
-        description=dict(type='str', required=False),
-        custom_virtualenv=dict(type='str', required=False),
-        max_hosts=dict(type='int', required=False, default="0"),
-        state=dict(type='str', choices=['present', 'absent'], default='present', required=False),
+        name=dict(required=True),
+        description=dict(),
+        custom_virtualenv=dict(),
+        max_hosts=dict(type='int', default="0"),
+        state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -99,7 +99,6 @@ options:
       description:
         - Local absolute file path containing a custom Python virtualenv to use
       type: str
-      required: False
       default: ''
     organization:
       description:
@@ -123,7 +122,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -178,27 +176,27 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        description=dict(required=False),
-        scm_type=dict(required=False, choices=['manual', 'git', 'hg', 'svn', 'insights'], default='manual'),
-        scm_url=dict(required=False),
-        local_path=dict(required=False),
-        scm_branch=dict(required=False, default=''),
-        scm_refspec=dict(required=False, default=''),
-        scm_credential=dict(required=False),
-        scm_clean=dict(required=False, type='bool', default=False),
-        scm_delete_on_update=dict(required=False, type='bool', default=False),
-        scm_update_on_launch=dict(required=False, type='bool', default=False),
-        scm_update_cache_timeout=dict(required=False, type='int', default=0),
-        scm_allow_override=dict(required=False, type='bool'),
-        job_timeout=dict(required=False, type='int', default=0),
-        custom_virtualenv=dict(required=False, type='str'),
+        description=dict(),
+        scm_type=dict(choices=['manual', 'git', 'hg', 'svn', 'insights'], default='manual'),
+        scm_url=dict(),
+        local_path=dict(),
+        scm_branch=dict(default=''),
+        scm_refspec=dict(default=''),
+        scm_credential=dict(),
+        scm_clean=dict(type='bool', default=False),
+        scm_delete_on_update=dict(type='bool', default=False),
+        scm_update_on_launch=dict(type='bool', default=False),
+        scm_update_cache_timeout=dict(type='int', default=0),
+        scm_allow_override=dict(type='bool'),
+        job_timeout=dict(type='int', default=0),
+        custom_virtualenv=dict(),
         organization=dict(required=True),
-        state=dict(required=False, choices=['present', 'absent'], default='present'),
-        wait=dict(required=False, type='bool', default=True),
+        state=dict(choices=['present', 'absent'], default='present'),
+        wait=dict(type='bool', default=True),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -79,7 +79,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 
@@ -119,7 +118,7 @@ def main():
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     role_type = module.params.pop('role')
     role_field = role_type + '_role'

--- a/awx_collection/plugins/modules/tower_send.py
+++ b/awx_collection/plugins/modules/tower_send.py
@@ -27,19 +27,16 @@ options:
       description:
         - The assets to import.
         - This can be the output of tower_receive or loaded from a file
-      required: False
       type: str
     files:
       description:
         - List of files to import.
-      required: False
       default: []
       type: list
       elements: str
     prevent:
       description:
         - A list of asset types to prevent import for
-      required: false
       default: []
       type: list
       elements: str
@@ -47,7 +44,6 @@ options:
       description:
         - The password management option to use.
         - The prompt option is not supported.
-      required: false
       default: 'default'
       choices: ["default", "random"]
       type: str
@@ -98,10 +94,10 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        assets=dict(required=False),
-        files=dict(required=False, default=[], type='list', elements='str'),
-        prevent=dict(required=False, default=[], type='list', elements='str'),
-        password_management=dict(required=False, default='default', choices=['default', 'random']),
+        assets=dict(),
+        files=dict(default=[], type='list', elements='str'),
+        prevent=dict(default=[], type='list', elements='str'),
+        password_management=dict(default='default', choices=['default', 'random']),
     )
 
     module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -26,25 +26,21 @@ options:
     name:
       description:
         - Name of setting to modify
-      required: False
       type: str
     value:
       description:
         - Value to be modified for given setting.
         - If given a non-string type, will make best effort to cast it to type API expects.
         - For better control over types, use the C(settings) param instead.
-      required: False
       type: str
     settings:
       description:
         - A data structure to be sent into the settings endpoint
-      required: False
       type: dict
       version_added: "3.7"
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 requirements:
@@ -112,9 +108,9 @@ def coerce_type(module, value):
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(required=False),
-        value=dict(required=False),
-        settings=dict(required=False, type='dict'),
+        name=dict(),
+        value=dict(),
+        settings=dict(type='dict'),
     )
 
     # Create a module for ourselves

--- a/awx_collection/plugins/modules/tower_team.py
+++ b/awx_collection/plugins/modules/tower_team.py
@@ -31,13 +31,11 @@ options:
     new_name:
       description:
         - To use when changing a team's name.
-      required: False
       type: str
       version_added: "3.7"
     description:
       description:
         - The description to use for the team.
-      required: False
       type: str
     organization:
       description:
@@ -53,7 +51,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -77,14 +74,14 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
-        new_name=dict(required=False),
-        description=dict(required=False),
+        new_name=dict(),
+        description=dict(),
         organization=dict(required=True),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -31,36 +31,30 @@ options:
     first_name:
       description:
         - First name of the user.
-      required: False
       type: str
     last_name:
       description:
         - Last name of the user.
-      required: False
       type: str
     email:
       description:
         - Email address of the user.
-      required: False
       type: str
     is_superuser:
       description:
         - Designates that this user has all permissions without explicitly assigning them.
-      required: False
       type: bool
       default: False
       aliases: ['superuser']
     is_system_auditor:
       description:
         - User is a system wide auditor.
-      required: False
       type: bool
       default: False
       aliases: ['auditor']
     password:
       description:
         - Write-only field used to change the password.
-      required: False
       type: str
     state:
       description:
@@ -71,7 +65,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -121,18 +114,18 @@ from ..module_utils.tower_api import TowerModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        username=dict(required=True, type='str'),
-        first_name=dict(required=False, type='str'),
-        last_name=dict(required=False, type='str'),
-        email=dict(required=False, type='str'),
-        is_superuser=dict(required=False, type='bool', default=False, aliases=['superuser']),
-        is_system_auditor=dict(required=False, type='bool', default=False, aliases=['auditor']),
-        password=dict(required=False, type='str', no_log=True),
+        username=dict(required=True),
+        first_name=dict(),
+        last_name=dict(),
+        email=dict(),
+        is_superuser=dict(type='bool', default=False, aliases=['superuser']),
+        is_system_auditor=dict(type='bool', default=False, aliases=['auditor']),
+        password=dict(no_log=True),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     username = module.params.get('username')

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -32,69 +32,56 @@ options:
     new_name:
       description:
         - Setting this option will change the existing name.
-      required: False
       type: str
     description:
       description:
         - Optional description of this workflow job template.
-      required: False
       type: str
     extra_vars:
       description:
         - Variables which will be made available to jobs ran inside the workflow.
-      required: False
       type: dict
     organization:
       description:
         - Organization the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
-      required: False
       type: str
     allow_simultaneous:
       description:
         - Allow simultaneous runs of the workflow job template.
-      required: False
       type: bool
     ask_variables_on_launch:
       description:
         - Prompt user for C(extra_vars) on launch.
-      required: False
       type: bool
     inventory:
       description:
         - Inventory applied as a prompt, assuming job template prompts for inventory
-      required: False
       type: str
     limit:
       description:
         - Limit applied as a prompt, assuming job template prompts for limit
-      required: False
       type: str
     scm_branch:
       description:
         - SCM branch applied as a prompt, assuming job template prompts for SCM branch
-      required: False
       type: str
     ask_inventory_on_launch:
       description:
         - Prompt user for inventory on launch of this workflow job template
-      required: False
       type: bool
     ask_scm_branch_on_launch:
       description:
         - Prompt user for SCM branch on launch of this workflow job template
-      required: False
       type: bool
     ask_limit_on_launch:
       description:
         - Prompt user for limit on launch of this workflow job template
-      required: False
       type: bool
     webhook_service:
       description:
         - Service that webhook requests will be accepted from
-      required: False
       type: str
       choices:
         - github
@@ -102,7 +89,6 @@ options:
     webhook_credential:
       description:
         - Personal Access Token for posting back the status to the service API
-      required: False
       type: str
     survey_enabled:
       description:
@@ -113,7 +99,6 @@ options:
       description:
         - The definition of the survey associated to the workflow.
       type: dict
-      required: false
     state:
       description:
         - Desired state of the resource.
@@ -125,7 +110,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -153,28 +137,28 @@ def update_survey(module, last_request):
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(required=True, type='str'),
-        new_name=dict(type='str'),
-        description=dict(type='str'),
+        name=dict(required=True),
+        new_name=dict(),
+        description=dict(),
         extra_vars=dict(type='dict'),
-        organization=dict(type='str'),
+        organization=dict(),
         survey=dict(type='dict'),  # special handling
         survey_enabled=dict(type='bool'),
         allow_simultaneous=dict(type='bool'),
         ask_variables_on_launch=dict(type='bool'),
-        inventory=dict(type='str'),
-        limit=dict(type='str'),
-        scm_branch=dict(type='str'),
+        inventory=dict(),
+        limit=dict(),
+        scm_branch=dict(),
         ask_inventory_on_launch=dict(type='bool'),
         ask_scm_branch_on_launch=dict(type='bool'),
         ask_limit_on_launch=dict(type='bool'),
-        webhook_service=dict(type='str', choices=['github', 'gitlab']),
-        webhook_credential=dict(type='str'),
+        webhook_service=dict(choices=['github', 'gitlab']),
+        webhook_credential=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template_node.py
@@ -31,23 +31,19 @@ options:
       description:
         - Variables to apply at launch time.
         - Will only be accepted if job template prompts for vars or has a survey asking for those vars.
-      required: False
       type: dict
       default: {}
     inventory:
       description:
         - Inventory applied as a prompt, if job template prompts for inventory
-      required: False
       type: str
     scm_branch:
       description:
         - SCM branch applied as a prompt, if job template prompts for SCM branch
-      required: False
       type: str
     job_type:
       description:
         - Job type applied as a prompt, if job template prompts for job type
-      required: False
       type: str
       choices:
         - 'run'
@@ -55,27 +51,22 @@ options:
     job_tags:
       description:
         - Job tags applied as a prompt, if job template prompts for job tags
-      required: False
       type: str
     skip_tags:
       description:
         - Tags to skip, applied as a prompt, if job tempalte prompts for job tags
-      required: False
       type: str
     limit:
       description:
         - Limit to act on, applied as a prompt, if job template prompts for limit
-      required: False
       type: str
     diff_mode:
       description:
         - Run diff mode, applied as a prompt, if job template prompts for diff mode
-      required: False
       type: bool
     verbosity:
       description:
         - Verbosity applied as a prompt, if job template prompts for verbosity
-      required: False
       type: str
       choices:
         - '0'
@@ -96,19 +87,16 @@ options:
       description:
         - The organization of the workflow job template the node exists in.
         - Used for looking up the workflow, not a direct model field.
-      required: False
       type: str
     unified_job_template:
       description:
         - Name of unified job template to run in the workflow.
         - Can be a job template, project, inventory source, etc.
         - Omit if creating an approval node (not yet implemented).
-      required: False
       type: str
     all_parents_must_converge:
       description:
         - If enabled then the node will only run if all of the parent nodes have met the criteria to reach this node
-      required: False
       type: bool
     identifier:
       description:
@@ -120,21 +108,18 @@ options:
       description:
         - Nodes that will run after this node completes.
         - List of node identifiers.
-      required: False
       type: list
       elements: str
     success_nodes:
       description:
         - Nodes that will run after this node on success.
         - List of node identifiers.
-      required: False
       type: list
       elements: str
     failure_nodes:
       description:
         - Nodes that will run after this node on failure.
         - List of node identifiers.
-      required: False
       type: list
       elements: str
     credentials:
@@ -142,7 +127,6 @@ options:
         - Credentials to be applied to job as launch-time prompts.
         - List of credential names.
         - Uniqueness is not handled rigorously.
-      required: False
       type: list
       elements: str
     state:
@@ -154,7 +138,6 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
-      required: False
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
@@ -186,19 +169,19 @@ from ..module_utils.tower_api import TowerModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        identifier=dict(required=True, type='str'),
-        workflow_job_template=dict(required=True, type='str', aliases=['workflow']),
-        organization=dict(type='str'),
+        identifier=dict(required=True),
+        workflow_job_template=dict(required=True, aliases=['workflow']),
+        organization=dict(),
         extra_data=dict(type='dict'),
-        inventory=dict(type='str'),
-        scm_branch=dict(type='str'),
-        job_type=dict(type='str', choices=['run', 'check']),
-        job_tags=dict(type='str'),
-        skip_tags=dict(type='str'),
-        limit=dict(type='str'),
+        inventory=dict(),
+        scm_branch=dict(),
+        job_type=dict(choices=['run', 'check']),
+        job_tags=dict(),
+        skip_tags=dict(),
+        limit=dict(),
         diff_mode=dict(type='bool'),
-        verbosity=dict(type='str', choices=['0', '1', '2', '3', '4', '5']),
-        unified_job_template=dict(type='str'),
+        verbosity=dict(choices=['0', '1', '2', '3', '4', '5']),
+        unified_job_template=dict(),
         all_parents_must_converge=dict(type='bool'),
         success_nodes=dict(type='list', elements='str'),
         always_nodes=dict(type='list', elements='str'),
@@ -208,7 +191,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     identifier = module.params.get('identifier')

--- a/awx_collection/plugins/modules/tower_workflow_launch.py
+++ b/awx_collection/plugins/modules/tower_workflow_launch.py
@@ -28,12 +28,10 @@ options:
     extra_vars:
       description:
         - Any extra vars required to launch the job.
-      required: False
       type: str
     wait:
       description:
         - Wait for the workflow to complete.
-      required: False
       default: True
       type: bool
     timeout:
@@ -94,9 +92,9 @@ except ImportError:
 def main():
     argument_spec = dict(
         workflow_template=dict(required=True),
-        extra_vars=dict(required=False),
-        wait=dict(required=False, default=True, type='bool'),
-        timeout=dict(required=False, default=None, type='int'),
+        extra_vars=dict(),
+        wait=dict(default=True, type='bool'),
+        timeout=dict(default=None, type='int'),
     )
 
     module = TowerModule(

--- a/awx_collection/plugins/modules/tower_workflow_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_template.py
@@ -78,7 +78,6 @@ options:
       description:
         - The definition of the survey associated to the workflow.
       type: dict
-      required: false
     state:
       description:
         - Desired state of the resource.
@@ -128,16 +127,16 @@ except ImportError:
 def main():
     argument_spec = dict(
         name=dict(required=True),
-        description=dict(required=False),
-        extra_vars=dict(type='dict', required=False),
-        organization=dict(required=False),
-        allow_simultaneous=dict(type='bool', required=False),
-        schema=dict(type='list', elements='dict', required=False),
+        description=dict(),
+        extra_vars=dict(type='dict'),
+        organization=dict(),
+        allow_simultaneous=dict(type='bool'),
+        schema=dict(type='list', elements='dict'),
         survey=dict(type='dict'),
-        survey_enabled=dict(type='bool', required=False),
-        inventory=dict(required=False),
-        ask_inventory=dict(type='bool', required=False),
-        ask_extra_vars=dict(type='bool', required=False),
+        survey_enabled=dict(type='bool'),
+        inventory=dict(),
+        ask_inventory=dict(type='bool'),
+        ask_extra_vars=dict(type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 


### PR DESCRIPTION
##### SUMMARY
We inconsistently provided in some cases, and did not provide in other cases, these things.

Ansible core uses these as the defaults, so we don't have to put them in. I find it a whole lot more readable with them out. Our modules and API follows this pattern quite well - that the vast majority of parameters are non-required string-types. There's no need to say so each time.

##### ISSUE TYPE
 - Feature Pull Request

##### AWX VERSION
```
9.3.0
```

