### PR TITLE
Add lookup plugin, share auth with inventory plugin

### DIFF
--- a/awx_collection/plugins/lookup/tower_api.py
+++ b/awx_collection/plugins/lookup/tower_api.py
@@ -1,0 +1,66 @@
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: tower_api
+    author: AWX contributors
+    version_added: "3.7"
+    short_description: Lookup API data from Ansible Tower or AWX API
+    description:
+      - Retrieves API data from the Ansible Tower or AWX server about an object.
+      - You can use this to lookup items based on non-identity properties.
+    options:
+      _terms:
+        description:
+          - The API endpoint to query
+        required: True
+      data:
+        description:
+            - The data to be put in the query string for the request
+        type: dict
+    extends_documentation_fragment: awx.awx.auth
+"""
+
+EXAMPLES = """
+    - name: Create inventory in organization with certain description
+      tower_inventory:
+        name: new inventory
+        organization: "{{ query('awx.awx.tower_api', 'organizations', data={'description': 'foo'})[0] }}"
+"""
+
+RETURN = """
+_raw:
+  description:
+    - return data from the API
+  type: list
+  elements: integer
+"""
+
+from ..module_utils.tower_api import TowerModule
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs_orig):
+        kwargs = kwargs_orig.copy()
+
+        obj_ids = []
+
+        for endpoint_raw in terms:
+            endpoint = endpoint_raw.lower()
+            data = kwargs.pop('data', {})
+
+            module = TowerModule(argument_spec={}, mock_params=kwargs)
+
+            response = module.get_endpoint(endpoint, data=data)
+
+            resp_json = response['json']
+            if 'id' in resp_json:
+                obj_ids.append(resp_json['id'])
+            elif 'results' in resp_json:
+                obj_ids.extend([obj['id'] for obj in resp_json['results']])
+
+        return obj_ids

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -29,13 +29,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 import os
 import traceback
-
-from ansible.module_utils._text import to_native
-from ansible.module_utils.urls import urllib_error, ConnectionError, socket, httplib
-from ansible.module_utils.urls import Request  # noqa
 
 TOWER_CLI_IMP_ERR = None
 try:
@@ -49,31 +44,6 @@ except ImportError:
     HAS_TOWER_CLI = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-
-
-class CollectionsParserError(Exception):
-    pass
-
-
-def make_request(request_handler, tower_url):
-    '''
-    Makes the request to given URL, handles errors, returns JSON
-    '''
-    try:
-        response = request_handler.get(tower_url)
-    except (ConnectionError, urllib_error.URLError, socket.error, httplib.HTTPException) as e:
-        n_error_msg = 'Connection to remote host failed: {err}'.format(err=to_native(e))
-        # If Tower gives a readable error message, display that message to the user.
-        if callable(getattr(e, 'read', None)):
-            n_error_msg += ' with message: {err_msg}'.format(err_msg=to_native(e.read()))
-        raise CollectionsParserError(n_error_msg)
-
-    # Attempt to parse JSON.
-    try:
-        return json.loads(response.read())
-    except (ValueError, TypeError) as e:
-        # If the JSON parse fails, print the ValueError
-        raise CollectionsParserError('Failed to parse json from host: {err}'.format(err=to_native(e)))
 
 
 def tower_auth_config(module):

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -45,7 +45,7 @@ class TowerModule(AnsibleModule):
     authenticated = False
     config_name = 'tower_cli.cfg'
 
-    def __init__(self, argument_spec, **kwargs):
+    def __init__(self, argument_spec, mock_params=None, **kwargs):
         args = dict(
             tower_host=dict(required=False, fallback=(env_fallback, ['TOWER_HOST'])),
             tower_username=dict(required=False, fallback=(env_fallback, ['TOWER_USERNAME'])),
@@ -59,7 +59,10 @@ class TowerModule(AnsibleModule):
 
         self.json_output = {'changed': False}
 
-        super(TowerModule, self).__init__(argument_spec=args, **kwargs)
+        if mock_params is not None:
+            self.params = mock_params
+        else:
+            super(TowerModule, self).__init__(argument_spec=args, **kwargs)
 
         self.load_config_files()
 


### PR DESCRIPTION
##### SUMMARY
Everything in the AWX collection should use the same logic for authentication.

The same should go for the AWX CLI, but that's for another day.

This adds a lookup plugin for non-standard lookups of related objects. The example will only take the 1st object, even if there are more. There's a whole bunch to unpack there.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
9.3.0
```


##### ADDITIONAL INFORMATION
The lookup problem faced the same problem that the inventory plugin does - how to configure the client and perform requests.

There is some weirdness doing this in the non-module plugins as opposed to the modules. We should further refactor the main class into a client object and a module object. The parameter `mock_params` makes it clear on the surface that this is a band-aid pending a refactor to do it the correct way.

```
$ cat sanity/tower.yml 
plugin: awx.awx.tower
inventory_id: 1
```

running:

```
$ ansible-inventory -i sanity/tower.yml --list
{
    "_meta": {
        "hostvars": {
            "steve": {
                "remote_tower_enabled": "true",
                "remote_tower_id": 1
            }
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "steve"
        ]
    }
}
```

This doesn't rely on either the TOWER_HOST environment variable or direct inputs in the inventory file. Instead, it relies on the config file.

----

I think this still needs error handling, so making this as draft for now.