### PR TITLE
fix for CSRF issue in traefik configuration 

### DIFF
--- a/installer/roles/image_build/files/settings.py
+++ b/installer/roles/image_build/files/settings.py
@@ -85,4 +85,5 @@ DATABASES = {
 if os.getenv("DATABASE_SSLMODE", False):
     DATABASES['default']['OPTIONS'] = {'sslmode': os.getenv("DATABASE_SSLMODE")}
 
+USE_X_FORWARDED_HOST = True
 USE_X_FORWARDED_PORT = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

have traefik setup where container apps have domain "apps.test.int" and the awx web container SSL termination is resolved at the endpoint awx.apps.test.int:443 by traefik proxy.

In this configuration, when attempting to log into the AWX instance at the endpoint "https://awx.apps.test.int/" we are observing a 403 error on the /api/login call preventing successful login.

In observing the nginx web container log, it is resulting in:
```
django.security.csrf Forbidden (Referer checking failed - https://awx.apps.test.int/ does not match any trusted origins.): /api/login/ 
```

We were able to resolve by adding the following directive to the settings.py:
```
USE_X_FORWARDED_HOST=True 
```
in order to successfully pass the traefik hostname to the nginx container instance.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
