### PR TITLE
Fix line typo in README.md

### DIFF
--- a/awxkit/awxkit/cli/docs/README.md
+++ b/awxkit/awxkit/cli/docs/README.md
@@ -2,6 +2,7 @@ Building the Documentation
 --------------------------
 To build the docs, spin up a real AWX server, `pip install sphinx sphinxcontrib-autoprogram`, and run:
 
-    ~ TOWER_HOST=https://awx.example.org TOWER_USERNAME=example TOWER_PASSWORD=secret make clean html
+    ~ TOWER_HOST=https://awx.example.org TOWER_USERNAME=example TOWER_PASSWORD=secret
+    ~ make clean html
     ~ cd build/html/ && python -m http.server
     Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ..


### PR DESCRIPTION
##### SUMMARY
In the build instructions line 5 was mashed together with another line causing it to read incorrectly.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
N/A


##### ADDITIONAL INFORMATION
N/A
