### PR TITLE
Fix adding orphaned user to org

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -11,7 +11,6 @@ from functools import reduce
 from django.conf import settings
 from django.db.models import Q, Prefetch
 from django.contrib.auth.models import User
-from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -650,8 +649,8 @@ class UserAccess(BaseAccess):
                 # in these cases only superusers can modify orphan users
                 return False
             return not obj.roles.all().exclude(
-                content_type=ContentType.objects.get_for_model(User)
-            ).filter(ancestors__in=self.user.roles.all()).exists()
+                ancestors__in=self.user.roles.all()
+            ).exists()
         else:
             return self.is_all_org_admin(obj)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Take all the roles of orphan User A, find all ancestors to these roles. The org admin must have 1 or more of these ancestor roles. If not, the admin cannot add User A to the org.

The conditional was incorrectly checking that scenario -- it wouldn't add the User A, if that User A had a role with an ancestor that the org admin also had.

This change fixes that.

I modified the functional test for adding an orphan. Now the `rando` user has membership to an organization credential, but `rando` is not a member of the org. Now when org admin tries to add `rando`, it will pass, where before this assertion would have failed. The test passed previously because rando had no roles at all, so the `not  .. .exists()` conditional was always met. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 10.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
