### PR TITLE
Changed column label for plain jobs to "Playbook Run" to align with search

### DIFF
--- a/awx/ui_next/src/components/JobList/JobListItem.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.jsx
@@ -15,7 +15,6 @@ import DataListCell from '@components/DataListCell';
 import { RocketIcon } from '@patternfly/react-icons';
 import LaunchButton from '@components/LaunchButton';
 import StatusIcon from '@components/StatusIcon';
-import { toTitleCase } from '@util/strings';
 import { formatDateString } from '@util/dates';
 import { JOB_TYPE_URL_SEGMENTS } from '@constants';
 import styled from 'styled-components';
@@ -35,6 +34,15 @@ function JobListItem({
   showTypeColumn = false,
 }) {
   const labelId = `check-action-${job.id}`;
+
+  const jobTypes = {
+    project_update: i18n._(t`SCM Update`),
+    inventory_update: i18n._(t`Inventory Sync`),
+    job: i18n._(t`Playbook Run`),
+    command: i18n._(t`Command`),
+    management_job: i18n._(t`Management Job`),
+    workflow_job: i18n._(t`Workflow Job`),
+  };
 
   return (
     <DataListItem aria-labelledby={labelId} id={`${job.id}`}>
@@ -62,7 +70,7 @@ function JobListItem({
             ...(showTypeColumn
               ? [
                   <DataListCell key="type" aria-label="type">
-                    {toTitleCase(job.type)}
+                    {jobTypes[job.type]}
                   </DataListCell>,
                 ]
               : []),


### PR DESCRIPTION
##### SUMMARY
From https://github.com/ansible/awx/issues/5033:

> @jlmitch5 and I conferred on inconsistencies with the name of "plain" job runs:
> 
> ![Screenshot from 2020-04-03 10-51-55](https://user-images.githubusercontent.com/19942822/78375257-8bdab100-759a-11ea-8e41-1edd26258a07.png)

This changes the column name, seen here:
![Screenshot from 2020-04-03 11-28-19](https://user-images.githubusercontent.com/19942822/78378444-f392fb00-759e-11ea-9b4c-39a318eb4c9a.png)

The search tag will be done in another PR that @jlmitch5 is working on.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
 - UI
