### PR TITLE
Allow setting identifier for approval nodes

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3611,9 +3611,11 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
         elif self.instance:
             ujt = self.instance.unified_job_template
         if ujt is None:
-            if 'workflow_job_template' in attrs:
-                return {'workflow_job_template': attrs['workflow_job_template']}
-            return {}
+            ret = {}
+            for fd in ('workflow_job_template', 'identifier'):
+                if fd in attrs:
+                    ret[fd] = attrs[fd]
+            return ret
 
         # build additional field survey_passwords to track redacted variables
         password_dict = {}

--- a/awx_collection/test/awx/test_workflow_job_template_node.py
+++ b/awx_collection/test/awx/test_workflow_job_template_node.py
@@ -47,8 +47,33 @@ def test_create_workflow_job_template_node(run_module, admin_user, wfjt, job_tem
         "changed": True
     }
 
+    assert node.identifier == this_identifier
     assert node.workflow_job_template_id == wfjt.id
     assert node.unified_job_template_id == job_template.id
+
+
+@pytest.mark.django_db
+def test_create_workflow_job_template_node_no_template(run_module, admin_user, wfjt, job_template):
+    """This is a part of the API contract for creating approval nodes
+    and at some point in the future, tha feature will be supported by the collection
+    """
+    this_identifier = '42🐉'
+    result = run_module('tower_workflow_job_template_node', {
+        'identifier': this_identifier,
+        'workflow_job_template': wfjt.name,
+        'organization': wfjt.organization.name,
+    }, admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed', False), result
+
+    node = WorkflowJobTemplateNode.objects.get(pk=result['id'])
+    # node = WorkflowJobTemplateNode.objects.first()
+
+    assert result['id'] == node.id
+
+    assert node.identifier == this_identifier
+    assert node.workflow_job_template_id == wfjt.id
+    assert node.unified_job_template_id is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible/awx/issues/6563

If you created a WFJT node without a unified job template, then the identifier would be set to a new uuid4, no matter what you gave it. Simple bug, this fixes it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### AWX VERSION
```
10.0.0
```

