### PR TITLE
Remove state checks from user list test

### DIFF
--- a/awx/ui_next/src/screens/User/UserList/UserList.test.jsx
+++ b/awx/ui_next/src/screens/User/UserList/UserList.test.jsx
@@ -121,17 +121,8 @@ describe('UsersList with full permissions', () => {
   });
 
   test('Users are retrieved from the api and the components finishes loading', async () => {
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === true
-    );
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(loadUsers).toHaveBeenCalled();
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === false
-    );
   });
 
   test('Selects one team when row is checked', async () => {
@@ -255,17 +246,7 @@ describe('UsersList with full permissions', () => {
   });
 
   test('Add button shown for users with ability to POST', async () => {
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === true
-    );
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === false
-    );
-    expect(wrapper.find('ToolbarAddButton').length).toBe(1);
+    await waitForElement(wrapper, 'ToolbarAddButton', el => el.length === 1);
   });
 });
 
@@ -280,16 +261,8 @@ describe('UsersList without full permissions', () => {
     });
 
     wrapper = mountWithContexts(<UsersList />);
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === true
-    );
-    await waitForElement(
-      wrapper,
-      'UsersList',
-      el => el.state('hasContentLoading') === false
-    );
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 1);
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('ToolbarAddButton').length).toBe(0);
   });
 });


### PR DESCRIPTION
##### SUMMARY
Removes state checks from user list test 

This updates the UserList test to check observable things (what's been rendered, etc.) instead of internal state. I'd probably do this refactoring eventually anyway but the reason I'm doing it now is that @nixocio and I found that it resolved an unexpected test failure that he was seeing locally.

In the api retrieval test, I'm also removing any check for an initial `loading` state. This is because the paginated data list component only shows the loading component if the `items` list is empty, which it isn't for that test.
