### PR TITLE
Prevent project lookup from firing requests on every render

### DIFF
--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -103,6 +103,7 @@ function JobTemplateForm({
       }
     }, [template, validateField])
   );
+
   const {
     request: loadRelatedInstanceGroups,
     error: instanceGroupError,
@@ -143,7 +144,7 @@ function JobTemplateForm({
       playbookHelpers.setValue(0);
       scmHelpers.setValue('');
     },
-    [setProject, projectHelpers, playbookHelpers, scmHelpers]
+    [] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const jobTypeOptions = [
@@ -289,7 +290,7 @@ function JobTemplateForm({
           />
           <PlaybookSelect
             projectId={project?.id || projectField.value?.id}
-            isValid={!(playbookMeta.touched || playbookMeta.error)}
+            isValid={!playbookMeta.touched || !playbookMeta.error}
             field={playbookField}
             onBlur={() => playbookHelpers.setTouched()}
             onError={setContentError}


### PR DESCRIPTION
##### SUMMARY
#6608 

Removed the formik field helpers from `handleProjectUpdate` dependency array. 

The `helpers` object gets a different reference on every form update. This causes `handleProjectUpdate` to create a new reference, and because handleProjectUpdate is in the ProjectLookup's `useEffect` dependency array, this triggers the ProjectLookup to fetch a list of projects from the API.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

