### PR TITLE
Fix JT form playbook select error message and more 

### DIFF
--- a/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
@@ -108,10 +108,7 @@ class JobTemplateEdit extends Component {
     try {
       await JobTemplatesAPI.update(template.id, remainingValues);
       await Promise.all([
-        this.submitLabels(
-          labels,
-          values.project.summary_fields.organization.id
-        ),
+        this.submitLabels(labels, template?.organization),
         this.submitInstanceGroups(instanceGroups, initialInstanceGroups),
         this.submitCredentials(credentials),
       ]);

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -52,7 +52,7 @@ function JobTemplateForm({
   i18n,
 }) {
   const [contentError, setContentError] = useState(false);
-  const [project, setProject] = useState(null);
+  const [project, setProject] = useState(template?.summary_fields?.project);
   const [inventory, setInventory] = useState(
     template?.summary_fields?.inventory
   );
@@ -282,6 +282,7 @@ function JobTemplateForm({
         <FormGroup
           fieldId="template-playbook"
           helperTextInvalid={playbookMeta.error}
+          isValid={!playbookMeta.touched || !playbookMeta.error}
           isRequired
           label={i18n._(t`Playbook`)}
         >

--- a/awx/ui_next/src/types.js
+++ b/awx/ui_next/src/types.js
@@ -70,7 +70,7 @@ export const JobTemplate = shape({
   inventory: number,
   job_type: oneOf(['run', 'check']),
   playbook: string,
-  project: shape({}),
+  project: number,
 });
 
 export const Inventory = shape({


### PR DESCRIPTION
##### SUMMARY

* Show error message when playbook select is dirty and has no value
<img width="250" alt="Screen Shot 2020-04-06 at 5 48 48 PM" src="https://user-images.githubusercontent.com/15881645/78609220-446d5280-7830-11ea-9d47-c39f42719999.png">

* When job template form renders, set the summary_fields project object as the project's initial state

* When job template edit form saves, pull `template.organization` value out and send it when submitting labels. This addresses a bug where you can't save a job template edit form that has zero changes

* Job Template `project` type should be a number

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
