### PR TITLE
Document and align the env var for OAuth token

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -15,20 +15,25 @@ options:
   tower_host:
     description:
     - URL to your Tower or AWX instance.
+    - If value not set, will try environment variable C(TOWER_HOST) and then config files
+    default: '127.0.0.1'
     type: str
   tower_username:
     description:
     - Username for your Tower or AWX instance.
+    - If value not set, will try environment variable C(TOWER_USERNAME) and then config files
     type: str
   tower_password:
     description:
     - Password for your Tower or AWX instance.
+    - If value not set, will try environment variable C(TOWER_PASSWORD) and then config files
     type: str
   validate_certs:
     description:
     - Whether to allow insecure connections to Tower or AWX.
     - If C(no), SSL certificates will not be validated.
     - This should only be used on personally controlled sites using self-signed certificates.
+    - If value not set, will try environment variable C(TOWER_VERIFY_SSL) and then config files
     type: bool
     aliases: [ tower_verify_ssl ]
   tower_config_file:

--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -16,7 +16,7 @@ options:
     description:
     - URL to your Tower or AWX instance.
     - If value not set, will try environment variable C(TOWER_HOST) and then config files
-    default: '127.0.0.1'
+    - If value not specified by any means, the value of C(127.0.0.1) will be used
     type: str
   tower_username:
     description:

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -124,7 +124,7 @@ def tower_check_mode(module):
 class TowerModule(AnsibleModule):
     def __init__(self, argument_spec, **kwargs):
         args = dict(
-            tower_host=dict(default='127.0.0.1'),
+            tower_host=dict(),
             tower_username=dict(),
             tower_password=dict(no_log=True),
             validate_certs=dict(type='bool', aliases=['tower_verify_ssl']),

--- a/awx_collection/plugins/module_utils/ansible_tower.py
+++ b/awx_collection/plugins/module_utils/ansible_tower.py
@@ -124,7 +124,7 @@ def tower_check_mode(module):
 class TowerModule(AnsibleModule):
     def __init__(self, argument_spec, **kwargs):
         args = dict(
-            tower_host=dict(),
+            tower_host=dict(default='127.0.0.1'),
             tower_username=dict(),
             tower_password=dict(no_log=True),
             validate_certs=dict(type='bool', aliases=['tower_verify_ssl']),

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -47,7 +47,7 @@ class TowerModule(AnsibleModule):
 
     def __init__(self, argument_spec, **kwargs):
         args = dict(
-            tower_host=dict(required=False, default='127.0.0.1', fallback=(env_fallback, ['TOWER_HOST'])),
+            tower_host=dict(required=False, fallback=(env_fallback, ['TOWER_HOST'])),
             tower_username=dict(required=False, fallback=(env_fallback, ['TOWER_USERNAME'])),
             tower_password=dict(no_log=True, required=False, fallback=(env_fallback, ['TOWER_PASSWORD'])),
             validate_certs=dict(type='bool', aliases=['tower_verify_ssl'], required=False, fallback=(env_fallback, ['TOWER_VERIFY_SSL'])),

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -47,7 +47,7 @@ class TowerModule(AnsibleModule):
 
     def __init__(self, argument_spec, **kwargs):
         args = dict(
-            tower_host=dict(required=False, fallback=(env_fallback, ['TOWER_HOST'])),
+            tower_host=dict(required=False, default='127.0.0.1', fallback=(env_fallback, ['TOWER_HOST'])),
             tower_username=dict(required=False, fallback=(env_fallback, ['TOWER_USERNAME'])),
             tower_password=dict(no_log=True, required=False, fallback=(env_fallback, ['TOWER_PASSWORD'])),
             validate_certs=dict(type='bool', aliases=['tower_verify_ssl'], required=False, fallback=(env_fallback, ['TOWER_VERIFY_SSL'])),

--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -187,6 +187,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       required: False
       type: str
       version_added: "3.7"

--- a/awx_collection/plugins/modules/tower_credential_type.py
+++ b/awx_collection/plugins/modules/tower_credential_type.py
@@ -62,6 +62,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -67,6 +67,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_host.py
+++ b/awx_collection/plugins/modules/tower_host.py
@@ -60,6 +60,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_inventory.py
+++ b/awx_collection/plugins/modules/tower_inventory.py
@@ -62,6 +62,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -122,6 +122,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_cancel.py
+++ b/awx_collection/plugins/modules/tower_job_cancel.py
@@ -36,6 +36,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -90,6 +90,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_list.py
+++ b/awx_collection/plugins/modules/tower_job_list.py
@@ -44,6 +44,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -272,6 +272,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 

--- a/awx_collection/plugins/modules/tower_job_wait.py
+++ b/awx_collection/plugins/modules/tower_job_wait.py
@@ -52,6 +52,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       required: False
       type: str
       version_added: "3.7"

--- a/awx_collection/plugins/modules/tower_label.py
+++ b/awx_collection/plugins/modules/tower_label.py
@@ -48,6 +48,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -37,6 +37,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_notification.py
+++ b/awx_collection/plugins/modules/tower_notification.py
@@ -213,6 +213,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       version_added: "3.7"
       type: str
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -53,6 +53,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -122,6 +122,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -79,6 +79,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -41,6 +41,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 requirements:

--- a/awx_collection/plugins/modules/tower_team.py
+++ b/awx_collection/plugins/modules/tower_team.py
@@ -51,6 +51,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -65,6 +65,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -110,6 +110,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template_node.py
@@ -138,6 +138,7 @@ options:
     tower_oauthtoken:
       description:
         - The Tower OAuth token to use.
+        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth

--- a/awxkit/awxkit/cli/docs/source/authentication.rst
+++ b/awxkit/awxkit/cli/docs/source/authentication.rst
@@ -22,7 +22,7 @@ value:
 
 .. code:: bash
 
-    export TOWER_TOKEN=6E5SXhld7AMOhpRveZsLJQsfs9VS8U
+    export TOWER_OAUTH_TOKEN=6E5SXhld7AMOhpRveZsLJQsfs9VS8U
 
 By ingesting this token, you can run subsequent CLI commands without having to
 specify your username and password each time:

--- a/awxkit/awxkit/cli/docs/source/usage.rst
+++ b/awxkit/awxkit/cli/docs/source/usage.rst
@@ -89,5 +89,5 @@ A few of the most important ones are:
 ``--conf.password, TOWER_PASSWORD``
     the AWX password to use for authentication
 
-``--conf.token, TOWER_TOKEN``
+``--conf.token, TOWER_OAUTH_TOKEN``
     an OAuth2.0 token to use for authentication

--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -16,7 +16,7 @@ def add_authentication_arguments(parser, env):
     )
     auth.add_argument(
         '--conf.token',
-        default=env.get('TOWER_TOKEN', ''),
+        default=env.get('TOWER_OAUTH_TOKEN', env.get('TOWER_TOKEN', '')),
         help='an OAuth2.0 token (get one by using `awx login`)',
         metavar='TEXT',
     )

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -102,7 +102,7 @@ class Login(CustomCommand):
         else:
             fmt = client.get_config('format')
             if fmt == 'human':
-                print('export TOWER_TOKEN={}'.format(token))
+                print('export TOWER_OAUTH_TOKEN={}'.format(token))
             else:
                 print(to_str(FORMATTERS[fmt]({'token': token}, '.')).strip())
 


### PR DESCRIPTION
##### SUMMARY
From the experience of trying to setup awxkit authentication, the environment variable for the token didn't align.

Thought I should see about getting this in before anyone dives back into hooking up import/export to the modules.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request


##### AWX VERSION
```
10.0.0
```


##### ADDITIONAL INFORMATION
Took pattern from other module:

https://github.com/ansible-collections/community.general/blob/f6a76d91d5ab19fcc528284f9bbb4bbffc7134ca/plugins/doc_fragments/alicloud.py#L13

There is [a nice pattern](https://github.com/ansible/awx/blob/d40143a63de3b0cf4cb5c76c429e281cc9a54239/awx_collection/plugins/inventory/tower.py#L34-L35) for non-module plugins, but that doesn't apply to modules. I understand that this is because env vars on the _control machine_ are not read for this purpose. That is a complete incoherent mess, and no one is on the same page about forcing these to always be ran on localhost.

Question: does this align with the inventory plugin?

Answer: the inventory plugin does not accept token, period. See multiple other open PRs related to sharing auth & config processing between the modules and inventory plugin.
