### PR TITLE
Activate no_log for Values in input Parameter of tower_credential Module

### DIFF
--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -318,7 +318,7 @@ def main():
         description=dict(),
         organization=dict(),
         credential_type=dict(),
-        inputs=dict(type='dict'),
+        inputs=dict(type='dict', no_log=True),
         user=dict(),
         team=dict(),
         # These are for backwards compatability


### PR DESCRIPTION
##### SUMMARY
When specifying values as a dictionary in the `inputs` parameter, all of it would show up in the task output in verbose mode (`-vvv`).  This change hides _any_ values that are specified in the inputs, in order to keep any sensitive values hidden.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
- Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 10.0.0
```


