### PR TITLE
Rename SCM to Source Control

### DIFF
--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -147,7 +147,7 @@ function JobList({ i18n, defaultParams, showTypeColumn = false }) {
               name: i18n._(t`Job Type`),
               key: `type`,
               options: [
-                [`project_update`, i18n._(t`SCM Update`)],
+                [`project_update`, i18n._(t`Source Control Update`)],
                 [`inventory_update`, i18n._(t`Inventory Sync`)],
                 [`job`, i18n._(t`Playbook Run`)],
                 [`ad_hoc_command`, i18n._(t`Command`)],

--- a/awx/ui_next/src/components/JobList/JobListItem.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.jsx
@@ -36,7 +36,7 @@ function JobListItem({
   const labelId = `check-action-${job.id}`;
 
   const jobTypes = {
-    project_update: i18n._(t`SCM Update`),
+    project_update: i18n._(t`Source Control Update`),
     inventory_update: i18n._(t`Inventory Sync`),
     job: i18n._(t`Playbook Run`),
     command: i18n._(t`Command`),

--- a/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
@@ -88,7 +88,7 @@ function ProjectLookup({
                 ],
               },
               {
-                name: i18n._(t`SCM URL`),
+                name: i18n._(t`Source Control URL`),
                 key: 'scm_url',
               },
               {

--- a/awx/ui_next/src/components/PromptDetail/PromptDetail.jsx
+++ b/awx/ui_next/src/components/PromptDetail/PromptDetail.jsx
@@ -140,7 +140,7 @@ function PromptDetail({ i18n, resource, launchConfig = {} }) {
             )}
             {launchConfig.ask_scm_branch_on_launch && (
               <Detail
-                label={i18n._(t`SCM Branch`)}
+                label={i18n._(t`Source Control Branch`)}
                 value={defaults?.scm_branch}
               />
             )}

--- a/awx/ui_next/src/components/PromptDetail/PromptDetail.test.jsx
+++ b/awx/ui_next/src/components/PromptDetail/PromptDetail.test.jsx
@@ -77,7 +77,7 @@ describe('PromptDetail', () => {
       assertDetail('Job Type', 'run');
       assertDetail('Credential', 'Demo Credential');
       assertDetail('Inventory', 'Demo Inventory');
-      assertDetail('SCM Branch', '123');
+      assertDetail('Source Control Branch', '123');
       assertDetail('Limit', '3');
       assertDetail('Verbosity', '1 (Verbose)');
       assertDetail('Job Tags', 'onetwothree');
@@ -113,7 +113,7 @@ describe('PromptDetail', () => {
         'Job Type',
         'Credential',
         'Inventory',
-        'SCM Branch',
+        'Source Control Branch',
         'Limit',
         'Verbosity',
         'Job Tags',

--- a/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.jsx
+++ b/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.jsx
@@ -50,15 +50,15 @@ function PromptProjectDetail({ i18n, resource }) {
   return (
     <>
       <Detail
-        label={i18n._(t`SCM Type`)}
+        label={i18n._(t`Source Control Type`)}
         value={scm_type === '' ? i18n._(t`Manual`) : toTitleCase(scm_type)}
       />
-      <Detail label={i18n._(t`SCM URL`)} value={scm_url} />
-      <Detail label={i18n._(t`SCM Branch`)} value={scm_branch} />
-      <Detail label={i18n._(t`SCM Refspec`)} value={scm_refspec} />
+      <Detail label={i18n._(t`Source Control URL`)} value={scm_url} />
+      <Detail label={i18n._(t`Source Control Branch`)} value={scm_branch} />
+      <Detail label={i18n._(t`Source Control Refspec`)} value={scm_refspec} />
       {summary_fields?.credential?.id && (
         <Detail
-          label={i18n._(t`SCM Credential`)}
+          label={i18n._(t`Source Control Credential`)}
           value={
             <CredentialChip
               key={resource.summary_fields.credential.id}

--- a/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.test.jsx
+++ b/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.test.jsx
@@ -32,15 +32,18 @@ describe('PromptProjectDetail', () => {
       expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
     }
 
-    assertDetail('SCM Type', 'Git');
-    assertDetail('SCM URL', 'https://github.com/ansible/ansible-tower-samples');
-    assertDetail('SCM Branch', 'foo');
-    assertDetail('SCM Refspec', 'refs/');
+    assertDetail('Source Control Type', 'Git');
+    assertDetail(
+      'Source Control URL',
+      'https://github.com/ansible/ansible-tower-samples'
+    );
+    assertDetail('Source Control Branch', 'foo');
+    assertDetail('Source Control Refspec', 'refs/');
     assertDetail('Cache Timeout', '3 Seconds');
     assertDetail('Ansible Environment', 'mock virtual env');
     assertDetail('Project Base Path', 'dir/foo/bar');
     assertDetail('Playbook Directory', '_6__demo_project');
-    assertDetail('SCM Credential', 'Scm: mock scm');
+    assertDetail('Source Control Credential', 'Scm: mock scm');
     expect(
       wrapper
         .find('Detail[label="Options"]')

--- a/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.jsx
@@ -137,7 +137,10 @@ function ScheduleDetail({ schedule, i18n }) {
                 }
               />
             )}
-            <Detail label={i18n._(t`SCM Branch`)} value={scm_branch} />
+            <Detail
+              label={i18n._(t`Source Control Branch`)}
+              value={scm_branch}
+            />
             <Detail label={i18n._(t`Limit`)} value={limit} />
             {typeof diff_mode === 'boolean' && (
               <Detail

--- a/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.jsx
@@ -121,7 +121,9 @@ describe('<ScheduleDetail />', () => {
     expect(wrapper.find('Title[children="Prompted Fields"]').length).toBe(0);
     expect(wrapper.find('Detail[label="Job Type"]').length).toBe(0);
     expect(wrapper.find('Detail[label="Inventory"]').length).toBe(0);
-    expect(wrapper.find('Detail[label="SCM Branch"]').length).toBe(0);
+    expect(wrapper.find('Detail[label="Source Control Branch"]').length).toBe(
+      0
+    );
     expect(wrapper.find('Detail[label="Limit"]').length).toBe(0);
     expect(wrapper.find('Detail[label="Show Changes"]').length).toBe(0);
     expect(wrapper.find('Detail[label="Credentials"]').length).toBe(0);
@@ -209,7 +211,7 @@ describe('<ScheduleDetail />', () => {
     expect(wrapper.find('Detail[label="Inventory"]').length).toBe(1);
     expect(
       wrapper
-        .find('Detail[label="SCM Branch"]')
+        .find('Detail[label="Source Control Branch"]')
         .find('dd')
         .text()
     ).toBe('foo/branch');

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.jsx
@@ -33,7 +33,7 @@ function ScheduleListItem({ i18n, isSelected, onSelect, schedule }) {
   const jobTypeLabels = {
     inventory_update: i18n._(t`Inventory Sync`),
     job: i18n._(t`Playbook Run`),
-    project_update: i18n._(t`SCM Update`),
+    project_update: i18n._(t`Source Control Update`),
     system_job: i18n._(t`Management Job`),
     workflow_job: i18n._(t`Workflow Job`),
   };

--- a/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.test.jsx
@@ -48,7 +48,7 @@ CredentialTypesAPI.read.mockResolvedValue({
             },
             {
               id: 'ssh_key_data',
-              label: 'SCM Private Key',
+              label: 'Source Control Private Key',
               type: 'string',
               format: 'ssh_private_key',
               secret: true,

--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
@@ -141,7 +141,7 @@ CredentialTypesAPI.read.mockResolvedValue({
             },
             {
               id: 'ssh_key_data',
-              label: 'SCM Private Key',
+              label: 'Source Control Private Key',
               type: 'string',
               format: 'ssh_private_key',
               secret: true,

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
@@ -217,7 +217,7 @@ const credentialTypes = [
         },
         {
           id: 'ssh_key_data',
-          label: 'SCM Private Key',
+          label: 'Source Control Private Key',
           type: 'string',
           format: 'ssh_private_key',
           secret: true,

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
@@ -100,17 +100,17 @@ function ProjectDetail({ project, i18n }) {
           />
         )}
         <Detail
-          label={i18n._(t`SCM Type`)}
+          label={i18n._(t`Source Control Type`)}
           value={
             scm_type === '' ? i18n._(t`Manual`) : toTitleCase(project.scm_type)
           }
         />
-        <Detail label={i18n._(t`SCM URL`)} value={scm_url} />
-        <Detail label={i18n._(t`SCM Branch`)} value={scm_branch} />
-        <Detail label={i18n._(t`SCM Refspec`)} value={scm_refspec} />
+        <Detail label={i18n._(t`Source Control URL`)} value={scm_url} />
+        <Detail label={i18n._(t`Source Control Branch`)} value={scm_branch} />
+        <Detail label={i18n._(t`Source Control Refspec`)} value={scm_refspec} />
         {summary_fields.credential && (
           <Detail
-            label={i18n._(t`SCM Credential`)}
+            label={i18n._(t`Source Control Credential`)}
             value={
               <CredentialChip
                 key={summary_fields.credential.id}

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.test.jsx
@@ -74,12 +74,12 @@ describe('<ProjectDetail />', () => {
     assertDetail('Name', mockProject.name);
     assertDetail('Description', mockProject.description);
     assertDetail('Organization', mockProject.summary_fields.organization.name);
-    assertDetail('SCM Type', 'Git');
-    assertDetail('SCM URL', mockProject.scm_url);
-    assertDetail('SCM Branch', mockProject.scm_branch);
-    assertDetail('SCM Refspec', mockProject.scm_refspec);
+    assertDetail('Source Control Type', 'Git');
+    assertDetail('Source Control URL', mockProject.scm_url);
+    assertDetail('Source Control Branch', mockProject.scm_branch);
+    assertDetail('Source Control Refspec', mockProject.scm_refspec);
     assertDetail(
-      'SCM Credential',
+      'Source Control Credential',
       `Scm: ${mockProject.summary_fields.credential.name}`
     );
     assertDetail(

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectList.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectList.jsx
@@ -125,7 +125,7 @@ function ProjectList({ i18n }) {
                 ],
               },
               {
-                name: i18n._(t`SCM URL`),
+                name: i18n._(t`Source Control URL`),
                 key: 'scm_url',
               },
               {

--- a/awx/ui_next/src/screens/Project/shared/ProjectForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectForm.jsx
@@ -170,7 +170,7 @@ function ProjectFormFields({
         helperTextInvalid={scmTypeMeta.error}
         isRequired
         isValid={!scmTypeMeta.touched || !scmTypeMeta.error}
-        label={i18n._(t`SCM Type`)}
+        label={i18n._(t`Source Control Credential Type`)}
       >
         <AnsibleSelect
           {...scmTypeField}
@@ -179,7 +179,7 @@ function ProjectFormFields({
             {
               value: '',
               key: '',
-              label: i18n._(t`Choose an SCM Type`),
+              label: i18n._(t`Choose a Source Control Type`),
               isDisabled: true,
             },
             ...scmTypeOptions.map(([value, label]) => {

--- a/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
@@ -119,7 +119,9 @@ describe('<ProjectForm />', () => {
     expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
     expect(wrapper.find('FormGroup[label="Description"]').length).toBe(1);
     expect(wrapper.find('FormGroup[label="Organization"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="SCM Type"]').length).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="Source Control Credential Type"]').length
+    ).toBe(1);
     expect(wrapper.find('FormGroup[label="Ansible Environment"]').length).toBe(
       1
     );
@@ -140,12 +142,18 @@ describe('<ProjectForm />', () => {
       );
     });
     wrapper.update();
-    expect(wrapper.find('FormGroup[label="SCM URL"]').length).toBe(1);
+    expect(wrapper.find('FormGroup[label="Source Control URL"]').length).toBe(
+      1
+    );
     expect(
-      wrapper.find('FormGroup[label="SCM Branch/Tag/Commit"]').length
+      wrapper.find('FormGroup[label="Source Control Branch/Tag/Commit"]').length
     ).toBe(1);
-    expect(wrapper.find('FormGroup[label="SCM Refspec"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="SCM Credential"]').length).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="Source Control Refspec"]').length
+    ).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="Source Control Credential"]').length
+    ).toBe(1);
     expect(wrapper.find('FormGroup[label="Options"]').length).toBe(1);
   });
 
@@ -184,7 +192,7 @@ describe('<ProjectForm />', () => {
     });
   });
 
-  test('should display insights credential lookup when scm type is "insights"', async () => {
+  test('should display insights credential lookup when source control type is "insights"', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <ProjectForm handleSubmit={jest.fn()} handleCancel={jest.fn()} />
@@ -268,7 +276,7 @@ describe('<ProjectForm />', () => {
     expect(wrapper.find('ManualSubForm Alert').length).toBe(1);
   });
 
-  test('should reset scm subform values when scm type changes', async () => {
+  test('should reset source control subform values when source control type changes', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <ProjectForm
@@ -280,17 +288,21 @@ describe('<ProjectForm />', () => {
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
 
+    console.log(wrapper.debug());
+
     const scmTypeSelect = wrapper.find(
-      'FormGroup[label="SCM Type"] FormSelect'
+      'FormGroup[label="Source Control Credential Type"] FormSelect'
     );
     await act(async () => {
       scmTypeSelect.invoke('onChange')('hg', { target: { name: 'Mercurial' } });
     });
     wrapper.update();
     await act(async () => {
-      wrapper.find('FormGroup[label="SCM URL"] input').simulate('change', {
-        target: { value: 'baz', name: 'scm_url' },
-      });
+      wrapper
+        .find('FormGroup[label="Source Control URL"] input')
+        .simulate('change', {
+          target: { value: 'baz', name: 'scm_url' },
+        });
     });
     wrapper.update();
     expect(wrapper.find('input#project-scm-url').prop('value')).toEqual('baz');

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/GitSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/GitSubForm.jsx
@@ -20,7 +20,7 @@ const GitSubForm = ({
       i18n={i18n}
       tooltip={
         <span>
-          {i18n._(t`Example URLs for GIT SCM include:`)}
+          {i18n._(t`Example URLs for GIT Source Control include:`)}
           <ul css="margin: 10px 0 10px 20px">
             <li>https://github.com/ansible/ansible.git</li>
             <li>git@github.com:ansible/ansible.git</li>
@@ -35,10 +35,13 @@ const GitSubForm = ({
         </span>
       }
     />
-    <BranchFormField i18n={i18n} label={i18n._(t`SCM Branch/Tag/Commit`)} />
+    <BranchFormField
+      i18n={i18n}
+      label={i18n._(t`Source Control Branch/Tag/Commit`)}
+    />
     <FormField
       id="project-scm-refspec"
-      label={i18n._(t`SCM Refspec`)}
+      label={i18n._(t`Source Control Refspec`)}
       name="scm_refspec"
       type="text"
       tooltipMaxWidth="400px"

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/HgSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/HgSubForm.jsx
@@ -19,7 +19,7 @@ const HgSubForm = ({
       i18n={i18n}
       tooltip={
         <span>
-          {i18n._(t`Example URLs for Mercurial SCM include:`)}
+          {i18n._(t`Example URLs for Mercurial Source Control include:`)}
           <ul css={{ margin: '10px 0 10px 20px' }}>
             <li>https://bitbucket.org/username/project</li>
             <li>ssh://hg@bitbucket.org/username/project</li>
@@ -32,7 +32,10 @@ const HgSubForm = ({
         </span>
       }
     />
-    <BranchFormField i18n={i18n} label={i18n._(t`SCM Branch/Tag/Revision`)} />
+    <BranchFormField
+      i18n={i18n}
+      label={i18n._(t`Source Control Branch/Tag/Revision`)}
+    />
     <ScmCredentialFormField
       credential={credential}
       onCredentialSelection={onCredentialSelection}

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx
@@ -54,7 +54,7 @@ const ManualSubForm = ({
             assigned to other projects. Create a new directory there and make
             sure the playbook files can be read by the "awx" system user,
             or have ${brandName} directly retrieve your playbooks from
-            source control using the SCM Type option above.`)}
+            source control using the Source Control Type option above.`)}
         </Alert>
       )}
       <FormField

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SharedFields.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SharedFields.jsx
@@ -15,7 +15,7 @@ export const UrlFormField = withI18n()(({ i18n, tooltip }) => (
   <FormField
     id="project-scm-url"
     isRequired
-    label={i18n._(t`SCM URL`)}
+    label={i18n._(t`Source Control URL`)}
     name="scm_url"
     tooltip={tooltip}
     tooltipMaxWidth="350px"
@@ -32,7 +32,7 @@ export const BranchFormField = withI18n()(({ i18n, label }) => (
     label={label}
     tooltip={i18n._(t`Branch to checkout. In addition to branches,
         you can input tags, commit hashes, and arbitrary refs. Some
-        commit hashes and refs may not be availble unless you also
+        commit hashes and refs may not be available unless you also
         provide a custom refspec.`)}
   />
 ));
@@ -44,7 +44,7 @@ export const ScmCredentialFormField = withI18n()(
     return (
       <CredentialLookup
         credentialTypeId={credential.typeId}
-        label={i18n._(t`SCM Credential`)}
+        label={i18n._(t`Source Control Credential`)}
         value={credential.value}
         onChange={value => {
           onCredentialSelection('scm', value);
@@ -94,7 +94,7 @@ export const ScmTypeOptions = withI18n()(
               name="allow_override"
               label={i18n._(t`Allow Branch Override`)}
               tooltip={i18n._(
-                t`Allow changing the SCM branch or revision in a job
+                t`Allow changing the Source Control branch or revision in a job
                     template that uses this project.`
               )}
             />

--- a/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SvnSubForm.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectSubForms/SvnSubForm.jsx
@@ -19,7 +19,7 @@ const SvnSubForm = ({
       i18n={i18n}
       tooltip={
         <span>
-          {i18n._(t`Example URLs for Subversion SCM include:`)}
+          {i18n._(t`Example URLs for Subversion Source Control include:`)}
           <ul css={{ margin: '10px 0 10px 20px' }}>
             <li>https://github.com/ansible/ansible</li>
             <li>svn://servername.example.com/path</li>

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
@@ -206,7 +206,10 @@ function JobTemplateDetail({ i18n, template }) {
         ) : (
           renderMissingDataDetail(i18n._(t`Project`))
         )}
-        <Detail label={i18n._(t`SCM Branch`)} value={template.scm_branch} />
+        <Detail
+          label={i18n._(t`Source Control Branch`)}
+          value={template.scm_branch}
+        />
         <Detail label={i18n._(t`Playbook`)} value={playbook} />
         <Detail label={i18n._(t`Forks`)} value={forks || '0'} />
         <Detail label={i18n._(t`Limit`)} value={limit} />

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
@@ -82,8 +82,8 @@ describe('<JobTemplateDetail />', () => {
     });
   });
 
-  test('should render SCM_Branch', async () => {
-    const SCMBranch = wrapper.find('Detail[label="SCM Branch"]');
+  test('should render Source Control Branch', async () => {
+    const SCMBranch = wrapper.find('Detail[label="Source Control Branch"]');
     expect(SCMBranch.prop('value')).toBe('Foo branch');
   });
 

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx
@@ -78,7 +78,7 @@ function ProjectsList({ history, i18n, nodeResource, onUpdateNodeResource }) {
           ],
         },
         {
-          name: i18n._(t`SCM URL`),
+          name: i18n._(t`Source Control URL`),
           key: 'scm_url',
         },
         {

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -266,7 +266,7 @@ function JobTemplateForm({
         {project?.allow_override && (
           <FieldWithPrompt
             fieldId="template-scm-branch"
-            label={i18n._(t`SCM Branch`)}
+            label={i18n._(t`Source Control Branch`)}
             promptId="template-ask-scm-branch-on-launch"
             promptName="ask_scm_branch_on_launch"
           >

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
@@ -288,7 +288,7 @@ function WorkflowJobTemplateForm({
             />
             <FormField
               type="text"
-              label={i18n._(t`SCM Branch`)}
+              label={i18n._(t`Source Control Branch`)}
               tooltip={i18n._(
                 t`Select a branch for the workflow. This branch is applied to all job template nodes that prompt for a branch.`
               )}


### PR DESCRIPTION
Rename `SCM` references to `Source Control`.
Also update tests to reflect this change.

closes: https://github.com/ansible/awx/issues/5820
