### PR TITLE
Pass empty params to launch endpoint rather than null

### DIFF
--- a/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
+++ b/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
@@ -71,7 +71,7 @@ class LaunchButton extends React.Component {
       const { data: launchConfig } = await readLaunch;
 
       if (canLaunchWithoutPrompt(launchConfig)) {
-        this.launchWithParams(null);
+        this.launchWithParams({});
       } else {
         this.setState({
           showLaunchPrompt: true,

--- a/awx/ui_next/src/components/LaunchButton/LaunchButton.test.jsx
+++ b/awx/ui_next/src/components/LaunchButton/LaunchButton.test.jsx
@@ -62,7 +62,7 @@ describe('LaunchButton', () => {
     button.prop('onClick')();
     expect(JobTemplatesAPI.readLaunch).toHaveBeenCalledWith(1);
     await sleep(0);
-    expect(JobTemplatesAPI.launch).toHaveBeenCalledWith(1, null);
+    expect(JobTemplatesAPI.launch).toHaveBeenCalledWith(1, {});
     expect(history.location.pathname).toEqual('/jobs/9000/output');
   });
 
@@ -99,7 +99,7 @@ describe('LaunchButton', () => {
     button.prop('onClick')();
     expect(WorkflowJobTemplatesAPI.readLaunch).toHaveBeenCalledWith(1);
     await sleep(0);
-    expect(WorkflowJobTemplatesAPI.launch).toHaveBeenCalledWith(1, null);
+    expect(WorkflowJobTemplatesAPI.launch).toHaveBeenCalledWith(1, {});
     expect(history.location.pathname).toEqual('/jobs/workflow/9000/output');
   });
 


### PR DESCRIPTION
##### SUMMARY
link #6606 

API will respond with a 400 if we don't send a payload along with the POST to the launch endpoint and the JT has default credential(s).  There may be other JT configurations where this is impacted as well.  Instead, we should send an empty object when no prompting is necessary.  This will alleviate the issue and result in a successful launch.

![launch](https://user-images.githubusercontent.com/9889020/78805010-e30fc580-798e-11ea-81b6-1d6140a559e7.gif)

Now, an error will be seen on the job details view after launching - this is a documented error with an open pr: https://github.com/ansible/awx/pull/6658

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI