### PR TITLE
Collect task timing, warnings, and deprecations from job events

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -222,7 +222,7 @@ def query_info(since, collection_type):
 
 
 # Copies Job Events from db to a .csv to be shipped
-@table_version('events_table.csv', '1.0')
+@table_version('events_table.csv', '1.1')
 @table_version('unified_jobs_table.csv', '1.0')
 @table_version('unified_job_template_table.csv', '1.0')
 def copy_tables(since, full_path):
@@ -248,7 +248,12 @@ def copy_tables(since, full_path):
                               main_jobevent.role, 
                               main_jobevent.job_id, 
                               main_jobevent.host_id, 
-                              main_jobevent.host_name
+                              main_jobevent.host_name,
+                              CAST(main_jobevent.event_data::json->>'start' AS TIMESTAMP) AS start,
+                              CAST(main_jobevent.event_data::json->>'end' AS TIMESTAMP) AS end,
+                              main_jobevent.event_data::json->'duration' AS duration,
+                              main_jobevent.event_data::json->'res'->'warnings' AS warnings,
+                              main_jobevent.event_data::json->'res'->'deprecations' AS deprecations
                               FROM main_jobevent 
                               WHERE main_jobevent.created > {}
                               ORDER BY main_jobevent.id ASC) TO STDOUT WITH CSV HEADER'''.format(since.strftime("'%Y-%m-%d %H:%M:%S'"))


### PR DESCRIPTION
Timing information requires ansible-runner >= 1.4.6. (https://github.com/ansible/ansible-runner/pull/405)

warnings and deprecations are arrays of strings.

Example data for a job event:
```
44850,2020-04-09 20:45:15.41272+00,3ed1304c-e218-46fd-b87e-e46f76d5bee5,52540010-16de-635d-79ff-000000000008,runner_on_ok,"""command""",f,t,hello_world.yml,all,oofda,"",7659,946,3.12.146.51,2020-04-09 20:45:13.3168,2020-04-09 20:45:15.412123,2.095323,"[""Consider using the yum module rather than running 'yum'.  If you need to use command because yum is insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in ansible.cfg to get rid of this message.""]",
```
