### PR TITLE
[fix] Don't rsync directories created by rsync itself

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -156,6 +156,8 @@ class IsolatedManager(object):
             '- /env/ssh_key',
             # don't rsync kube config files
             '- .kubeconfig*'
+            # don't rsync files created by rsync itself
+            '- .~tmp~'
         ]
 
         for filename, data in (


### PR DESCRIPTION
Don't rsync `.~tmp~` directories, created by rsync itself. These derail assumptions in the code that e.g. some directories contain only files.

Fixes #6675
related #6675

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Isolated manager
 
##### AWX VERSION
```
awx: 10.0.0
```

