### PR TITLE
Fix List Navigation Pagination

### DIFF
--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
@@ -43,11 +43,13 @@ class PaginatedDataList extends React.Component {
     this.pushHistoryState(replaceParams(oldParams, { page: pageNumber }));
   }
 
-  handleSetPageSize(event, pageSize) {
+  handleSetPageSize(event, pageSize, page) {
     const { history, qsConfig } = this.props;
     const { search } = history.location;
     const oldParams = parseQueryString(qsConfig, search);
-    this.pushHistoryState(replaceParams(oldParams, { page_size: pageSize }));
+    this.pushHistoryState(
+      replaceParams(oldParams, { page_size: pageSize, page })
+    );
   }
 
   pushHistoryState(params) {

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
@@ -22,7 +22,7 @@ describe('<PaginatedDataList />', () => {
     jest.restoreAllMocks();
   });
 
-  test('initially renders succesfully', () => {
+  test('initially renders successfully', () => {
     mountWithContexts(
       <PaginatedDataList
         items={mockData}
@@ -83,11 +83,11 @@ describe('<PaginatedDataList />', () => {
     );
 
     const pagination = wrapper.find('Pagination');
-    pagination.prop('onPerPageSelect')(null, 25);
-    expect(history.location.search).toEqual('?item.page_size=25');
+    pagination.prop('onPerPageSelect')(null, 25, 2);
+    expect(history.location.search).toEqual('?item.page=2&item.page_size=25');
     wrapper.update();
     // since page_size = 5 is the default, that should be strip out of the search
-    pagination.prop('onPerPageSelect')(null, 5);
-    expect(history.location.search).toEqual('');
+    pagination.prop('onPerPageSelect')(null, 5, 2);
+    expect(history.location.search).toEqual('?item.page=2');
   });
 });


### PR DESCRIPTION
Fix List Navigation Pagination. Add missing variable `page` to
`handleSetPageSize`. Also update unit-tests impacted by this change.

closes: https://github.com/ansible/awx/issues/5983

