### PR TITLE
ensure last comma removed in select

### DIFF
--- a/awx/main/tests/functional/analytics/test_collectors.py
+++ b/awx/main/tests/functional/analytics/test_collectors.py
@@ -36,6 +36,8 @@ def sqlite_copy_expert(request):
         for line in sql.split('\n'):
             if line.find('main_jobevent.event_data::') == -1:
                 sql_new.append(line)
+            elif not line.endswith(','):
+                sql_new[-1] = sql_new[-1].rstrip(',')
         sql = '\n'.join(sql_new)
 
         self.execute(sql)


### PR DESCRIPTION
* We strip out the json select fields in our tests since it is an sql
    lite database underneath. Ideally, we would do something fancier, but we
    aren't. In doing this stipping, we could strip the last element in the
    projection list. This would result in an extra dangling comma. This
    commit removes the danging comma in the projection list after the
    removal of JSON projections.

This fixes problems introduced in https://github.com/ansible/awx/pull/6671 with the unit tests