### PR TITLE
Cast the start/end times with timezone.

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -248,8 +248,8 @@ def copy_tables(since, full_path):
                               main_jobevent.role, 
                               main_jobevent.job_id, 
                               main_jobevent.host_id, 
-                              main_jobevent.host_name,
-                              CAST(main_jobevent.event_data::json->>'start' AS TIMESTAMP WITH TIME ZONE) AS start,
+                              main_jobevent.host_name
+                              , CAST(main_jobevent.event_data::json->>'start' AS TIMESTAMP WITH TIME ZONE) AS start,
                               CAST(main_jobevent.event_data::json->>'end' AS TIMESTAMP WITH TIME ZONE) AS end,
                               main_jobevent.event_data::json->'duration' AS duration,
                               main_jobevent.event_data::json->'res'->'warnings' AS warnings,

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -249,8 +249,8 @@ def copy_tables(since, full_path):
                               main_jobevent.job_id, 
                               main_jobevent.host_id, 
                               main_jobevent.host_name,
-                              CAST(main_jobevent.event_data::json->>'start' AS TIMESTAMP) AS start,
-                              CAST(main_jobevent.event_data::json->>'end' AS TIMESTAMP) AS end,
+                              CAST(main_jobevent.event_data::json->>'start' AS TIMESTAMP WITH TIME ZONE) AS start,
+                              CAST(main_jobevent.event_data::json->>'end' AS TIMESTAMP WITH TIME ZONE) AS end,
                               main_jobevent.event_data::json->'duration' AS duration,
                               main_jobevent.event_data::json->'res'->'warnings' AS warnings,
                               main_jobevent.event_data::json->'res'->'deprecations' AS deprecations


### PR DESCRIPTION
##### SUMMARY

The runner events currently don't have them specified, but are generated with `utcnow()`, so this cast does the right thing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

