### PR TITLE
make rsyslog service restarts a bit less noisy

### DIFF
--- a/awx/main/utils/reload.py
+++ b/awx/main/utils/reload.py
@@ -29,11 +29,12 @@ def supervisor_service_command(command, service='*', communicate=True):
         restart_stdout, restart_err = supervisor_process.communicate()
         restart_code = supervisor_process.returncode
         if restart_code or restart_err:
-            logger.error('supervisorctl {} errored with exit code `{}`, stdout:\n{}stderr:\n{}'.format(
-                command, restart_code, restart_stdout.strip(), restart_err.strip()))
+            logger.error('supervisorctl {} {} errored with exit code `{}`, stdout:\n{}stderr:\n{}'.format(
+                command, service, restart_code, restart_stdout.strip(), restart_err.strip()))
         else:
-            logger.info('supervisorctl {} finished, stdout:\n{}'.format(
-                command, restart_stdout.strip()))
+            logger.debug(
+                'supervisorctl {} {} succeeded'.format(command, service)
+            )
     else:
         logger.info('Submitted supervisorctl {} command, not waiting for result'.format(command))
 


### PR DESCRIPTION
this is a little too noisy; it logs on *every* logging config change, and it's probably not necessary to report in such high verbosity if things are working as designed

cc @gamuniz 

before (always)

<img width="839" alt="image" src="https://user-images.githubusercontent.com/214912/79259696-1f459900-7e5b-11ea-8562-ff3de1287c99.png">

after (only when log level is set to `DEBUG`):

<img width="835" alt="image" src="https://user-images.githubusercontent.com/214912/79259584-f45b4500-7e5a-11ea-840e-1d3778b3b04e.png">
