### PR TITLE
Rename awx rsyslog socket and PID dir

### DIFF
--- a/awx/main/tests/unit/api/test_logger.py
+++ b/awx/main/tests/unit/api/test_logger.py
@@ -144,7 +144,7 @@ def test_rsyslog_conf_template(enabled, type, host, port, protocol, expected_con
     # Set test settings
     logging_defaults = getattr(settings, 'LOGGING')
     setattr(mock_settings, 'LOGGING', logging_defaults)
-    setattr(mock_settings, 'LOGGING["handlers"]["external_logger"]["address"]', '/var/run/rsyslog/rsyslog.sock')
+    setattr(mock_settings, 'LOGGING["handlers"]["external_logger"]["address"]', '/var/run/awx-rsyslog/rsyslog.sock')
     setattr(mock_settings, 'LOG_AGGREGATOR_ENABLED', enabled)
     setattr(mock_settings, 'LOG_AGGREGATOR_TYPE', type)
     setattr(mock_settings, 'LOG_AGGREGATOR_HOST', host)

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -8,10 +8,25 @@ from awx.main.utils.reload import supervisor_service_command
 def construct_rsyslog_conf_template(settings=settings):
     tmpl = ''
     parts = []
+    enabled = getattr(settings, 'LOG_AGGREGATOR_ENABLED')
     host = getattr(settings, 'LOG_AGGREGATOR_HOST', '')
     port = getattr(settings, 'LOG_AGGREGATOR_PORT', '')
     protocol = getattr(settings, 'LOG_AGGREGATOR_PROTOCOL', '')
     timeout = getattr(settings, 'LOG_AGGREGATOR_TCP_TIMEOUT', 5)
+    max_bytes = settings.MAX_EVENT_RES_DATA
+    parts.extend([
+        '$WorkDirectory /var/lib/awx/rsyslog',
+        f'$MaxMessageSize {max_bytes}',
+        '$IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf',
+        'module(load="imuxsock" SysSock.Use="off")',
+        'input(type="imuxsock" Socket="' + settings.LOGGING['handlers']['external_logger']['address'] + '" unlink="on")',
+        'template(name="awx" type="string" string="%rawmsg-after-pri%")',
+    ])
+    if not enabled:
+        parts.append('action(type="omfile" file="/dev/null")')  # rsyslog needs *at least* one valid action to start
+        tmpl = '\n'.join(parts)
+        return tmpl
+        
     if protocol.startswith('http'):
         scheme = 'https'
         # urlparse requires '//' to be provided if scheme is not specified
@@ -26,19 +41,10 @@ def construct_rsyslog_conf_template(settings=settings):
                 port = parsed.port
         except ValueError:
             port = settings.LOG_AGGREGATOR_PORT
-    max_bytes = settings.MAX_EVENT_RES_DATA
-    parts.extend([
-        '$WorkDirectory /var/lib/awx/rsyslog',
-        f'$MaxMessageSize {max_bytes}',
-        '$IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf',
-        'module(load="imuxsock" SysSock.Use="off")',
-        'input(type="imuxsock" Socket="' + settings.LOGGING['handlers']['external_logger']['address'] + '" unlink="on")',
-        'template(name="awx" type="string" string="%rawmsg-after-pri%")',
-    ])
-    if protocol.startswith('http'):
+
         # https://github.com/rsyslog/rsyslog-doc/blob/master/source/configuration/modules/omhttp.rst
-        ssl = "on" if parsed.scheme == 'https' else "off"
-        skip_verify = "off" if settings.LOG_AGGREGATOR_VERIFY_CERT else "on"
+        ssl = 'on' if parsed.scheme == 'https' else 'off'
+        skip_verify = 'off' if settings.LOG_AGGREGATOR_VERIFY_CERT else 'on'
         if not port:
             port = 443 if parsed.scheme == 'https' else 80
 
@@ -82,7 +88,7 @@ def construct_rsyslog_conf_template(settings=settings):
             f'action(type="omfwd" target="{host}" port="{port}" protocol="{protocol}" action.resumeRetryCount="-1" action.resumeInterval="{timeout}" template="awx")'  # noqa
         )
     else:
-        parts.append(f'action(type="omfile" file="/dev/null")')  # rsyslog needs *at least* one valid action to start
+        parts.append('action(type="omfile" file="/dev/null")')  # rsyslog needs *at least* one valid action to start
     tmpl = '\n'.join(parts)
     return tmpl
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1013,7 +1013,7 @@ LOGGING = {
         'external_logger': {
             'class': 'awx.main.utils.handlers.RSysLogHandler',
             'formatter': 'json',
-            'address': '/var/run/rsyslog/rsyslog.sock',
+            'address': '/var/run/awx-rsyslog/rsyslog.sock',
             'filters': ['external_log_enabled', 'dynamic_level_filter'],
         },
         'tower_warnings': {

--- a/installer/roles/image_build/files/rsyslog.conf
+++ b/installer/roles/image_build/files/rsyslog.conf
@@ -2,6 +2,6 @@ $WorkDirectory /var/lib/awx/rsyslog
 $MaxMessageSize 700000
 $IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf
 module(load="imuxsock" SysSock.Use="off")
-input(type="imuxsock" Socket="/var/run/rsyslog/rsyslog.sock" unlink="on")
+input(type="imuxsock" Socket="/var/run/awx-rsyslog/rsyslog.sock" unlink="on")
 template(name="awx" type="string" string="%msg%")
 action(type="omfile" file="/dev/null")

--- a/installer/roles/image_build/files/supervisor.conf
+++ b/installer/roles/image_build/files/supervisor.conf
@@ -47,7 +47,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:awx-rsyslogd]
-command = rsyslogd -n -i /var/run/rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
 autostart = true
 autorestart = true
 stopwaitsecs = 1

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -101,7 +101,7 @@ ADD rsyslog.repo /etc/yum.repos.d/rsyslog.repo
 RUN yum install -y rsyslog-omhttp
 
 # Pre-create things that we need to write to
-RUN for dir in /home/awx /var/run/supervisor /var/lib/awx /var/lib/awx/rsyslog /var/lib/awx/rsyslog/conf.d /var/run/rsyslog /var/log/tower /var/log/nginx /var/lib/nginx; \
+RUN for dir in /home/awx /var/run/supervisor /var/lib/awx /var/lib/awx/rsyslog /var/lib/awx/rsyslog/conf.d /var/run/awx-rsyslog /var/log/tower /var/log/nginx /var/lib/nginx; \
     do mkdir -p $dir; chmod -R g+rwx $dir; chgrp -R root $dir; done && \
     \
     for file in /etc/passwd /var/run/nginx.pid; \

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -97,7 +97,7 @@ spec:
             - name: supervisor-socket
               mountPath: "/var/run/supervisor"
             - name: rsyslog-socket
-              mountPath: "/var/run/rsyslog"
+              mountPath: "/var/run/awx-rsyslog"
             - name: rsyslog-dir
               mountPath: "/var/lib/awx/rsyslog"
 {% if ca_trust_dir is defined %}
@@ -183,7 +183,7 @@ spec:
             - name: supervisor-socket
               mountPath: "/var/run/supervisor"
             - name: rsyslog-socket
-              mountPath: "/var/run/rsyslog"
+              mountPath: "/var/run/awx-rsyslog"
             - name: rsyslog-dir
               mountPath: "/var/lib/awx/rsyslog"
 {% if ca_trust_dir is defined %}

--- a/installer/roles/kubernetes/templates/supervisor.yml.j2
+++ b/installer/roles/kubernetes/templates/supervisor.yml.j2
@@ -54,7 +54,7 @@ data:
     stderr_logfile_maxbytes=0
 
     [program:awx-rsyslogd]
-    command = rsyslogd -n -i /var/run/rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+    command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
     autostart = true
     autorestart = true
     stopwaitsecs = 1

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -20,6 +20,7 @@ services:
     user: root
     restart: unless-stopped
     volumes:
+      - supervisor-socket:/var/run/supervisor
       - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"
@@ -77,6 +78,7 @@ services:
     user: root
     restart: unless-stopped
     volumes:
+      - supervisor-socket:/var/run/supervisor
       - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -20,7 +20,7 @@ services:
     user: root
     restart: unless-stopped
     volumes:
-      - rsyslog-socket:/var/run/rsyslog/
+      - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"
       - "{{ docker_compose_dir }}/environment.sh:/etc/tower/conf.d/environment.sh"
@@ -77,7 +77,7 @@ services:
     user: root
     restart: unless-stopped
     volumes:
-      - rsyslog-socket:/var/run/rsyslog/
+      - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"
       - "{{ docker_compose_dir }}/environment.sh:/etc/tower/conf.d/environment.sh"

--- a/tools/docker-compose/Dockerfile
+++ b/tools/docker-compose/Dockerfile
@@ -123,7 +123,7 @@ ADD tools/docker-compose/entrypoint.sh /
 ADD tools/scripts/awx-python /usr/bin/awx-python
 
 # Pre-create things that we need to write to
-RUN for dir in /var/lib/awx /var/lib/awx/rsyslog /var/lib/awx/rsyslog/conf.d /var/run/rsyslog /var/log/tower/ /var/lib/awx/projects /.ansible /var/log/nginx /var/lib/nginx /.local; \
+RUN for dir in /var/lib/awx /var/lib/awx/rsyslog /var/lib/awx/rsyslog/conf.d /var/run/awx-rsyslog /var/log/tower/ /var/lib/awx/projects /.ansible /var/log/nginx /var/lib/nginx /.local; \
     do mkdir -p $dir; chmod -R g+rwx $dir; chgrp -R root $dir; done && \
     \
     for file in /etc/passwd /etc/supervisord.conf /venv/awx/lib/python3.6/site-packages/awx.egg-link /var/run/nginx.pid; \

--- a/tools/docker-compose/rsyslog.conf
+++ b/tools/docker-compose/rsyslog.conf
@@ -2,6 +2,6 @@ $WorkDirectory /var/lib/awx/rsyslog
 $MaxMessageSize 700000
 $IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf
 module(load="imuxsock" SysSock.Use="off")
-input(type="imuxsock" Socket="/var/run/rsyslog/rsyslog.sock" unlink="on")
+input(type="imuxsock" Socket="/var/run/awx-rsyslog/rsyslog.sock" unlink="on")
 template(name="awx" type="string" string="%msg%")
 action(type="omfile" file="/dev/null")

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -72,7 +72,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
 [program:awx-rsyslogd]
-command = rsyslogd -n -i /var/run/rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
 autostart = true
 autorestart = true
 stopwaitsecs = 1


### PR DESCRIPTION
##### SUMMARY

Rename Rsyslog socket directory for consistency and also to further differentiate AWX's usage of rsyslog from any rsyslog processes that the user may be running.  


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
10.0.0
```

