### PR TITLE
Deprecate Send, Receive, and Workflow Template Collections Modules

### DIFF
--- a/awx_collection/meta/routing.yml
+++ b/awx_collection/meta/routing.yml
@@ -1,0 +1,15 @@
+---
+plugin_routing:
+  modules:
+    tower_receive:
+      deprecation:
+        removal_date: TBD
+        warning_text: see plugin documentation for details
+    tower_send:
+      deprecation:
+        removal_date: TBD
+        warning_text: see plugin documentation for details
+    tower_workflow_template:
+      deprecation:
+        removal_date: TBD
+        warning_text: see plugin documentation for details

--- a/awx_collection/plugins/modules/tower_receive.py
+++ b/awx_collection/plugins/modules/tower_receive.py
@@ -9,13 +9,17 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
 DOCUMENTATION = '''
 ---
 module: tower_receive
+deprecated:
+  removed_in: "3.7"
+  why: Deprecated in favor of upcoming C(_export) module.
+  alternative: Once published, use M(tower_export) instead.
 author: "John Westcott IV (@john-westcott-iv)"
 version_added: "2.8"
 short_description: Receive assets from Ansible Tower.

--- a/awx_collection/plugins/modules/tower_send.py
+++ b/awx_collection/plugins/modules/tower_send.py
@@ -9,13 +9,17 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
 DOCUMENTATION = '''
 ---
 module: tower_send
+deprecated:
+  removed_in: "3.7"
+  why: Deprecated in favor of upcoming C(_import) module.
+  alternative: Once published, use M(tower_import) instead.
 author: "John Westcott IV (@john-westcott-iv)"
 version_added: "2.8"
 short_description: Send assets to Ansible Tower.

--- a/awx_collection/plugins/modules/tower_workflow_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_template.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'status': ['preview'],
+ANSIBLE_METADATA = {'status': ['deprecated'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
 
@@ -16,6 +16,10 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: tower_workflow_template
+deprecated:
+  removed_in: "3.7"
+  why: Deprecated in favor of C(_workflow_job_template) and C(_workflow_job_template_node) modules.
+  alternative: Use M(tower_workflow_job_template) and M(_workflow_job_template_node) instead.
 author: "Adrien Fleury (@fleu42)"
 version_added: "2.7"
 short_description: create, update, or destroy Ansible Tower workflow template.

--- a/awx_collection/tests/sanity/ignore-2.10.txt
+++ b/awx_collection/tests/sanity/ignore-2.10.txt
@@ -1,0 +1,6 @@
+plugins/modules/tower_receive.py validate-modules:deprecation-mismatch
+plugins/modules/tower_receive.py validate-modules:invalid-documentation
+plugins/modules/tower_send.py validate-modules:deprecation-mismatch
+plugins/modules/tower_send.py validate-modules:invalid-documentation
+plugins/modules/tower_workflow_template.py validate-modules:deprecation-mismatch
+plugins/modules/tower_workflow_template.py validate-modules:invalid-documentation


### PR DESCRIPTION
##### SUMMARY
The Send, Receive, and Workflow Template modules need to be deprecated; this is related to the "port Collections off of Tower-CLI "work that was recently done for Collections (https://github.com/ansible/awx/issues/5145).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Collections Pull Request 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 10.0.0
```

