### PR TITLE
Create hacking environment for awxkit command line like ansible

### DIFF
--- a/awxkit/hacking/README.md
+++ b/awxkit/hacking/README.md
@@ -1,0 +1,17 @@
+'Hacking' directory tools
+=========================
+
+env-setup
+---------
+
+The 'env-setup' script modifies your environment to allow you to run
+awxkit from a git checkout using python3.
+
+First, Set up your environment to run from the checkout:
+
+    $ source ./hacking/env-setup
+
+Then, you can confirm `awx` and `akit` command as follows:
+
+    $ awx --help
+    $ akit --help

--- a/awxkit/hacking/bin/akit
+++ b/awxkit/hacking/bin/akit
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import re
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(
+        load_entry_point('awxkit', 'console_scripts', 'akit')()
+    )
+
+#
+# [EOF]
+#

--- a/awxkit/hacking/bin/awx
+++ b/awxkit/hacking/bin/awx
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import re
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(
+        load_entry_point('awxkit', 'console_scripts', 'awx')()
+    )
+
+#
+# [EOF]
+#

--- a/awxkit/hacking/env-setup
+++ b/awxkit/hacking/env-setup
@@ -1,0 +1,97 @@
+# usage: source hacking/env-setup [-q]
+#    modifies environment for running awxkit from checkout
+
+prepend_path()
+{
+    variable_name="$1"
+    value="$2"
+
+    old_value=$( eval "echo \$$variable_name" )
+
+    if [ "x$old_value" != "x" ]; then
+        value="$value:"
+    fi
+
+    export "$variable_name=$value$old_value"
+}
+
+# Default values for shell variables we use
+PYTHONPATH=${PYTHONPATH-""}
+PATH=${PATH-""}
+MANPATH=${MANPATH-$(manpath)}
+PYTHON=$(which python 2>/dev/null || which python3 2>/dev/null)
+PYTHON_BIN=${PYTHON_BIN-$PYTHON}
+
+verbosity=${1-info} # Defaults to `info' if unspecified
+
+if [ "$verbosity" = -q ]; then
+    verbosity=silent
+fi
+
+# When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
+if [ -n "$BASH_SOURCE" ] ; then
+    HACKING_DIR=$(dirname "$BASH_SOURCE")
+elif [ $(basename -- "$0") = "env-setup" ]; then
+    HACKING_DIR=$(dirname "$0")
+# Works with ksh93 but not pdksh, have to eval to keep ash happy...
+elif [ -n "$KSH_VERSION" ] && echo $KSH_VERSION | grep -qv '^@(#)PD KSH'; then
+    eval "HACKING_DIR=\$(dirname \"\${.sh.file}\")"
+else
+    HACKING_DIR="$PWD/hacking"
+fi
+
+FULL_PATH=$($PYTHON_BIN -c "import os; print(os.path.realpath('$HACKING_DIR'))")
+export AWXKIT_HOME="$(dirname "$FULL_PATH")"
+PREFIX_PYTHONPATH="$AWXKIT_HOME"
+PREFIX_PATH="$HACKING_DIR/bin"
+
+expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || prepend_path PYTHONPATH "$PREFIX_PYTHONPATH"
+expr "$PATH" : "${PREFIX_PATH}.*" > /dev/null || prepend_path PATH "$PREFIX_PATH"
+
+#
+# Generate egg_info so that pkg_resources works
+#
+gen_egg_info()
+{
+    # check for current and past egg-info directory names
+    if ls "$PREFIX_PYTHONPATH"/awxkit*.egg-info >/dev/null 2>&1; then
+        # bypass shell aliases with leading backslash
+        # see https://github.com/ansible/ansible/pull/11967
+        \rm -rf "$PREFIX_PYTHONPATH"/awxkit*.egg-info
+    fi
+    $PYTHON_BIN setup.py egg_info
+}
+
+if [ "$AWXKIT_HOME" != "$PWD" ] ; then
+    current_dir="$PWD"
+else
+    current_dir="$AWXKIT_HOME"
+fi
+(
+	cd "$AWXKIT_HOME"
+	if [ "$verbosity" = silent ] ; then
+	    gen_egg_info > /dev/null 2>&1 &
+            find . -type f -name "*.pyc" -exec rm -f {} \; > /dev/null 2>&1
+	else
+	    gen_egg_info
+            find . -type f -name "*.pyc" -exec rm -f {} \;
+	fi
+	cd "$current_dir"
+)
+
+if [ "$verbosity" != silent ] ; then
+    cat <<- EOF
+
+	Setting up awxkit to run out of checkout...
+
+	PATH=$PATH
+	PYTHONPATH=$PYTHONPATH
+
+	Done!
+
+	EOF
+fi
+
+#
+# [EOF]
+#


### PR DESCRIPTION
##### SUMMARY
Ansible has the following `hacking` environment to assist testing for developers. I think it would be nice if we have a similar environment for `awxkit`.

Reference: https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#environment-setup

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - awxkit

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
This `hacking/env-setup` is based on the Ansible hacking environment.
