### PR TITLE
Remove 'supports_check_mode' Text from Converted Collection Modules

### DIFF
--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -348,7 +348,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True, required_one_of=[['kind', 'credential_type']])
+    module = TowerModule(argument_spec=argument_spec, required_one_of=[['kind', 'credential_type']])
 
     # Extract our parameters
     name = module.params.get('name')

--- a/awx_collection/plugins/modules/tower_job_cancel.py
+++ b/awx_collection/plugins/modules/tower_job_cancel.py
@@ -68,10 +68,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(
-        argument_spec=argument_spec,
-        supports_check_mode=True,
-    )
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
     job_id = module.params.get('job_id')

--- a/awx_collection/plugins/modules/tower_job_list.py
+++ b/awx_collection/plugins/modules/tower_job_list.py
@@ -102,7 +102,6 @@ def main():
     # Create a module for ourselves
     module = TowerModule(
         argument_spec=argument_spec,
-        supports_check_mode=True,
         mutually_exclusive=[
             ('page', 'all_pages'),
         ]

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -62,7 +62,6 @@ def main():
             data=dict(type='dict', required=True),
             eula_accepted=dict(type='bool', required=True),
         ),
-        supports_check_mode=True
     )
 
     json_output = {'changed': False}

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -117,7 +117,6 @@ def main():
     # Create a module for ourselves
     module = TowerModule(
         argument_spec=argument_spec,
-        supports_check_mode=True,
         required_one_of=[['name', 'settings']],
         mutually_exclusive=[['name', 'settings']],
         required_if=[['name', 'present', ['value']]]

--- a/awx_collection/plugins/modules/tower_workflow_launch.py
+++ b/awx_collection/plugins/modules/tower_workflow_launch.py
@@ -120,7 +120,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     optional_args = {}
     # Extract our parameters

--- a/awx_collection/tools/templates/tower_module.j2
+++ b/awx_collection/tools/templates/tower_module.j2
@@ -143,7 +143,7 @@ def main():
     )
 
     # Create a module for ourselves
-    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = TowerModule(argument_spec=argument_spec)
 
     # Extract our parameters
 {% for option in item['json']['actions']['POST'] %}


### PR DESCRIPTION
##### SUMMARY
`support_check_mode=True` is now the default for converted Collection modules, so let's remove redundant code.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Collections Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

