### PR TITLE
wsbroadcast better logging and behavior

### DIFF
--- a/awx/main/management/commands/run_wsbroadcast.py
+++ b/awx/main/management/commands/run_wsbroadcast.py
@@ -56,8 +56,8 @@ class Command(BaseCommand):
         host_stats = [('hostname', 'state', 'start time', 'duration (sec)')]
         for h in hostnames:
             connection_color = '91'    # red
-            h = safe_name(h)
-            prefix = f'awx_{h}'
+            h_safe = safe_name(h)
+            prefix = f'awx_{h_safe}'
             connection_state = data.get(f'{prefix}_connection', 'N/A')
             connection_started = 'N/A'
             connection_duration = 'N/A'
@@ -80,8 +80,8 @@ class Command(BaseCommand):
     def get_connection_stats(cls, me, hostnames, data):
         host_stats = [('hostname', 'total', 'per minute')]
         for h in hostnames:
-            h = safe_name(h)
-            prefix = f'awx_{h}'
+            h_safe = safe_name(h)
+            prefix = f'awx_{h_safe}'
             messages_total = data.get(f'{prefix}_messages_received', '0')
             messages_per_minute = data.get(f'{prefix}_messages_received_per_minute', '0')
 

--- a/awx/main/management/commands/run_wsbroadcast.py
+++ b/awx/main/management/commands/run_wsbroadcast.py
@@ -4,6 +4,7 @@ import logging
 import asyncio
 import datetime
 import re
+import redis
 from datetime import datetime as dt
 
 from django.core.management.base import BaseCommand
@@ -91,7 +92,12 @@ class Command(BaseCommand):
 
     def handle(self, *arg, **options):
         if options.get('status'):
-            stats_all = BroadcastWebsocketStatsManager.get_stats_sync()
+            try:
+                stats_all = BroadcastWebsocketStatsManager.get_stats_sync()
+            except redis.exceptions.ConnectionError as e:
+                print(f"Unable to get Broadcast Websocket Status. Failed to connect to redis {e}")
+                return
+
             data = {}
             for family in stats_all:
                 if family.type == 'gauge' and len(family.samples) > 1:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1043,6 +1043,15 @@ LOGGING = {
             'backupCount': 5,
             'formatter':'dispatcher',
         },
+        'wsbroadcast': {
+            # don't define a level here, it's set by settings.LOG_AGGREGATOR_LEVEL
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filters': ['require_debug_false', 'dynamic_level_filter'],
+            'filename': os.path.join(LOG_ROOT, 'wsbroadcast.log'),
+            'maxBytes': 1024 * 1024 * 5, # 5 MB
+            'backupCount': 5,
+            'formatter':'simple',
+        },
         'celery.beat': {
             'class':'logging.StreamHandler',
             'level': 'ERROR'
@@ -1129,6 +1138,9 @@ LOGGING = {
         },
         'awx.main.dispatch': {
             'handlers': ['dispatcher'],
+        },
+        'awx.main.wsbroadcast': {
+            'handlers': ['wsbroadcast'],
         },
         'awx.isolated.manager.playbooks': {
             'handlers': ['management_playbooks'],

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -55,6 +55,7 @@ AWX_ISOLATED_USERNAME = 'awx'
 LOGGING['handlers']['tower_warnings']['filename'] = '/var/log/tower/tower.log'  # noqa
 LOGGING['handlers']['callback_receiver']['filename'] = '/var/log/tower/callback_receiver.log'  # noqa
 LOGGING['handlers']['dispatcher']['filename'] = '/var/log/tower/dispatcher.log'  # noqa
+LOGGING['handlers']['wsbroadcast']['filename'] = '/var/log/tower/wsbroadcast.log'  # noqa
 LOGGING['handlers']['task_system']['filename'] = '/var/log/tower/task_system.log'  # noqa
 LOGGING['handlers']['management_playbooks']['filename'] = '/var/log/tower/management_playbooks.log'  # noqa
 LOGGING['handlers']['system_tracking_migrations']['filename'] = '/var/log/tower/tower_system_tracking_migrations.log'  # noqa


### PR DESCRIPTION
    show user unsafe name

    * We log stats using a safe hostname because of prometheus requirements.
    However, when we display users the hostname we should use the Instance
    hostname. This change outputs the Instance.hostname instead of the safe
    prometheus name.

* do not include iso nodes in wsbroadcast status
* log file for wsbroadcast `/var/log/tower/wsbroadcast.log`
* awx_manage run_wsbroadcast --status nice error message if someone
    failed to start awx services (i.e. redis)

