### PR TITLE
confidence in websocket group logic is high

### DIFF
--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -189,7 +189,6 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
                     group_name,
                     self.channel_name
                 )
-            logger.debug(f"Channel {self.channel_name} left groups {old_groups} and joined {new_groups_exclusive}")
             self.scope['session']['groups'] = new_groups
             await self.send_json({
                 "groups_current": list(new_groups),


### PR DESCRIPTION
* Replying to websocket group membership with the previous state, delta,
    and new state has shown to be quite stable. This debug message is not
    very helpful and is noisy in the dev env. This change removes the debug
    message.
