### PR TITLE
Fix new flake8 from pyflakes 2.2.0 release

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3668,7 +3668,7 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
                         attrs.get('survey_passwords', {}).pop(key, None)
                     else:
                         errors.setdefault('extra_vars', []).append(
-                            _('"$encrypted$ is a reserved keyword, may not be used for {var_name}."'.format(key))
+                            _('"$encrypted$ is a reserved keyword, may not be used for {}."'.format(key))
                         )
 
         # Launch configs call extra_vars extra_data for historical reasons

--- a/awx/conf/fields.py
+++ b/awx/conf/fields.py
@@ -172,9 +172,9 @@ class URLField(CharField):
                         netloc = '{}:{}'.format(netloc, url_parts.port)
                     if url_parts.username:
                         if url_parts.password:
-                            netloc = '{}:{}@{}' % (url_parts.username, url_parts.password, netloc)
+                            netloc = '{}:{}@{}'.format(url_parts.username, url_parts.password, netloc)
                         else:
-                            netloc = '{}@{}' % (url_parts.username, netloc)
+                            netloc = '{}@{}'.format(url_parts.username, netloc)
                     value = urlparse.urlunsplit([url_parts.scheme, netloc, url_parts.path, url_parts.query, url_parts.fragment])
             except Exception:
                 raise  # If something fails here, just fall through and let the validators check it.

--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -410,7 +410,7 @@ class SettingsWrapper(UserSettingsHolder):
         field = self.registry.get_setting_field(name)
         if field.read_only:
             logger.warning('Attempt to set read only setting "%s".', name)
-            raise ImproperlyConfigured('Setting "%s" is read only.'.format(name))
+            raise ImproperlyConfigured('Setting "{}" is read only.'.format(name))
 
         try:
             data = field.to_representation(value)
@@ -441,7 +441,7 @@ class SettingsWrapper(UserSettingsHolder):
         field = self.registry.get_setting_field(name)
         if field.read_only:
             logger.warning('Attempt to delete read only setting "%s".', name)
-            raise ImproperlyConfigured('Setting "%s" is read only.'.format(name))
+            raise ImproperlyConfigured('Setting "{}" is read only.'.format(name))
         for setting in Setting.objects.filter(key=name, user__isnull=True):
             setting.delete()
             # pre_delete handler will delete from cache.

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -309,6 +309,6 @@ def copy_tables(since, full_path):
                                  main_unifiedjobtemplate.status 
                                  FROM main_unifiedjobtemplate, django_content_type
                                  WHERE main_unifiedjobtemplate.polymorphic_ctype_id = django_content_type.id
-                                 ORDER BY main_unifiedjobtemplate.id ASC) TO STDOUT WITH CSV HEADER'''.format(since.strftime("'%Y-%m-%d %H:%M:%S'"))    
+                                 ORDER BY main_unifiedjobtemplate.id ASC) TO STDOUT WITH CSV HEADER'''
     _copy_table(table='unified_job_template', query=unified_job_template_query, path=full_path)
     return

--- a/awx/main/dispatch/periodic.py
+++ b/awx/main/dispatch/periodic.py
@@ -22,7 +22,7 @@ class Scheduler(Scheduler):
 
         def run():
             ppid = os.getppid()
-            logger.warn(f'periodic beat started')
+            logger.warn('periodic beat started')
             while True:
                 if os.getppid() != ppid:
                     # if the parent PID changes, this process has been orphaned

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -123,9 +123,9 @@ class AWXConsumerRedis(AWXConsumerBase):
                 res = json.loads(res[1])
                 self.process_task(res)
             except redis.exceptions.RedisError:
-                logger.exception(f"encountered an error communicating with redis")
+                logger.exception("encountered an error communicating with redis")
             except (json.JSONDecodeError, KeyError):
-                logger.exception(f"failed to decode JSON message from redis")
+                logger.exception("failed to decode JSON message from redis")
             if self.should_stop:
                 return
 

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -91,7 +91,7 @@ class CallbackBrokerWorker(BaseWorker):
                     for e in events:
                         try:
                             if (
-                                isinstance(exc, IntegrityError),
+                                isinstance(exc, IntegrityError) and
                                 getattr(e, 'host_id', '')
                             ):
                                 # this is one potential IntegrityError we can

--- a/awx/main/scheduler/dag_simple.py
+++ b/awx/main/scheduler/dag_simple.py
@@ -123,7 +123,7 @@ class SimpleDAG(object):
         self.root_nodes.discard(to_obj_ord)
 
         if from_obj_ord is None and to_obj_ord is None:
-            raise LookupError("From object {} and to object not found".format(from_obj, to_obj))
+            raise LookupError("From object {} and to object {} not found".format(from_obj, to_obj))
         elif from_obj_ord is None:
             raise LookupError("From object not found {}".format(from_obj))
         elif to_obj_ord is None:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -226,7 +226,7 @@ class TaskManager():
                 # non-Ansible jobs on isolated instances run on controller
                 task.instance_group = rampart_group.controller
                 task.execution_node = random.choice(list(rampart_group.controller.instances.all().values_list('hostname', flat=True)))
-                logger.debug('Submitting isolated {} to queue {}.'.format(
+                logger.debug('Submitting isolated {} to queue {} on node {}.'.format(
                              task.log_format, task.instance_group.name, task.execution_node))
             elif controller_node:
                 task.instance_group = rampart_group

--- a/awx/main/tests/factories/tower.py
+++ b/awx/main/tests/factories/tower.py
@@ -220,7 +220,7 @@ def create_job_template(name, roles=None, persisted=True, webhook_service='', **
     if 'organization' in kwargs:
         org = kwargs['organization']
         if type(org) is not Organization:
-            org = mk_organization(org, '%s-desc'.format(org), persisted=persisted)
+            org = mk_organization(org, org, persisted=persisted)
 
     if 'credential' in kwargs:
         cred = kwargs['credential']
@@ -298,7 +298,7 @@ def create_organization(name, roles=None, persisted=True, **kwargs):
     labels = {}
     notification_templates = {}
 
-    org = mk_organization(name, '%s-desc'.format(name), persisted=persisted)
+    org = mk_organization(name, name, persisted=persisted)
 
     if 'inventories' in kwargs:
         for i in kwargs['inventories']:

--- a/awxkit/awxkit/api/pages/workflow_job_templates.py
+++ b/awxkit/awxkit/api/pages/workflow_job_templates.py
@@ -25,8 +25,9 @@ class WorkflowJobTemplate(HasCopy, HasCreate, HasNotifications, HasSurvey, Unifi
         # return job
         jobs_pg = self.related.workflow_jobs.get(id=result.workflow_job)
         if jobs_pg.count != 1:
-            msg = "workflow_job_template launched (id:{}) but job not found in response at {}/workflow_jobs/" % \
-                  (result.json['workflow_job'], self.url)
+            msg = "workflow_job_template launched (id:{}) but job not found in response at {}/workflow_jobs/".format(
+                result.json['workflow_job'], self.url
+            )
             raise exc.UnexpectedAWXState(msg)
         return jobs_pg.results[0]
 

--- a/awxkit/awxkit/api/registry.py
+++ b/awxkit/awxkit/api/registry.py
@@ -79,7 +79,7 @@ class URLRegistry(object):
         for url_pattern, method_pattern in url_iterable:
             if url_pattern in self.store and method_pattern in self.store[url_pattern]:
                 if method_pattern.pattern == not_provided:
-                    exc_msg = '"{0.pattern}" already has methodless registration.'.format(url_pattern, method_pattern)
+                    exc_msg = '"{0.pattern}" already has methodless registration.'.format(url_pattern)
                 else:
                     exc_msg = ('"{0.pattern}" already has registered method "{1.pattern}"'
                                .format(url_pattern, method_pattern))

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,5 @@ deps =
   flake8
   yamllint
 commands =
-  flake8
+  make flake8
   yamllint -s .


### PR DESCRIPTION
##### SUMMARY
Zuul uses flake8, which passes (locally as well), but people still use make flake8 , which has a different pyflakes version (inside the awx venv).

```
3.7.9 (mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.6.8 on Linux
bash-4.4$ which flake8
/usr/local/bin/flake8
bash-4.4$ source /venv/awx/bin/activate
(awx) bash-4.4$ flake8 --version
3.7.9 (mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.2.0) CPython 3.6.8 on Linux
(awx) bash-4.4$ which flake8
/venv/awx/bin/flake8
```

`pyflakes` released a new version (2.2.0) on April 9th - https://pypi.org/project/pyflakes/
So currently, if you run make flake8 it will give you a bunch of new failures which zuul doesn't get

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
11.0.0
```

