### PR TITLE
[fix] Use rsync --blocking-io to work around EAGAIN hazard

### DIFF
--- a/awx/playbooks/check_isolated.yml
+++ b/awx/playbooks/check_isolated.yml
@@ -38,6 +38,7 @@
         recursive: true
         set_remote_user: false
         rsync_opts:
+          - "--blocking-io"
           - "--rsh=$RSH"
       environment:
         RSH: "oc rsh --config={{ ansible_kubectl_config }}"
@@ -51,6 +52,7 @@
         mode: pull
         set_remote_user: false
         rsync_opts:
+          - "--blocking-io"
           - "--rsh=$RSH"
       environment:
         RSH: "oc rsh --config={{ ansible_kubectl_config }}"

--- a/awx/playbooks/run_isolated.yml
+++ b/awx/playbooks/run_isolated.yml
@@ -25,6 +25,7 @@
         dest: "{{ dest }}"
         set_remote_user: false
         rsync_opts:
+          - "--blocking-io"
           - "--rsh=$RSH"
       environment:
         RSH: "oc rsh --config={{ ansible_kubectl_config }}"


### PR DESCRIPTION
related #6692

Work around the fact that `rsync` and `oc rsh` have different ideas about whether stdin / stdout should be set to non-blocking, and AWX uses some pipework that combines both.

- Whenever `rsync` is in use (as part of a `synchronize:` task in one of the `*_isolated.yml` playbooks), ensure that `--blocking-io` is part of `rsync_opts`.