### PR TITLE
Fix Collection README to Display Properly

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -51,8 +51,9 @@ oauth_token = LEdCpKVKc4znzffcpQL5vLG8oyeku6
 ## Release and Upgrade Notes
 
 Notable releases of the `awx.awx` collection:
- - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection
- - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/)
+
+ - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
+ - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
 
 The following notes are changes that may require changes to playbooks:
 

--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -20,11 +20,12 @@ Installing the `tar.gz` involves no special instructions.
 
 ## Running
 
-Non-deprecated modules in this collection have no python requirements, but
+Non-deprecated modules in this collection have no Python requirements, but
 may require the official [AWX CLI](https://docs.ansible.com/ansible-tower/latest/html/towercli/index.html)
 in the future. The `DOCUMENTATION` for each module will report this.
 
 You can specify authentication by a combination of either:
+
  - host, username, password
  - host, OAuth2 token
 
@@ -33,6 +34,7 @@ AWX CLI [login](https://docs.ansible.com/ansible-tower/latest/html/towercli/refe
 command.
 
 These can be specified via:
+
  - environment variables (most useful when running against localhost)
  - direct module parameters
  - a config file path specified by the `tower_config_file` parameter
@@ -60,14 +62,19 @@ The following notes are changes that may require changes to playbooks:
  - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
  - Creating a "scan" type job template is no longer supported.
  - Specifying a custom certificate via the `TOWER_CERTIFICATE` environment variable no longer works.
- - Type changes of variable fields
-   - `extra_vars` in the `tower_job_launch` module worked with a `list` previously, but now only works with a `dict` type.
-   - `extra_vars` in the `tower_workflow_job_template` module worked with a `string` previously but now expects a `dict`.
-   - When the `extra_vars` parameter is used with the `tower_job_launch` module, the launch will fail unless `ask_extra_vars` or `survey_enabled` is explicitly set to `True` on the Job Template.
-   - The `variables` parameter in the `tower_group`, `tower_host` and `tower_inventory` modules now expects a `dict` type and no longer supports the use of `@` syntax for a file.
- - Type changes of other types of fields
-   - `inputs` or `injectors` in the `tower_credential_type` module worked with a string previously but now expects a `dict`.
-   - `schema` in the `tower_workflow_job_template` module worked with a `string` previously but not expects a `list` of `dict`s.
+ - Type changes of variable fields:
+
+   - `extra_vars` in the `tower_job_launch` module worked with a `list` previously, but now only works with a `dict` type
+   - `extra_vars` in the `tower_workflow_job_template` module worked with a `string` previously but now expects a `dict`
+   - When the `extra_vars` parameter is used with the `tower_job_launch` module, the launch will fail unless `ask_extra_vars` or `survey_enabled` is explicitly set to `True` on the Job Template
+   - The `variables` parameter in the `tower_group`, `tower_host` and `tower_inventory` modules now expects a `dict` type and no longer supports the use of `@` syntax for a file
+
+
+ - Type changes of other types of fields:
+
+   - `inputs` or `injectors` in the `tower_credential_type` module worked with a string previously but now expects a `dict`
+   - `schema` in the `tower_workflow_job_template` module worked with a `string` previously but not expects a `list` of `dict`s
+
  - `tower_group` used to also service inventory sources, but this functionality has been removed from this module; use `tower_inventory_source` instead.
  - Specified `tower_config` file used to handle `k=v` pairs on a single line; this is no longer supported. Please use a file formatted as `yaml`, `json` or `ini` only.
  - Some return values (e.g., `credential_type`) have been removed. Use of `id` is recommended.


### PR DESCRIPTION
##### SUMMARY

The Collection README on Galaxy shows up like this:

![Screen Shot 2020-04-16 at 4 09 21 PM](https://user-images.githubusercontent.com/28930622/79502274-5f448180-7ffd-11ea-9c3b-3baa6d0671a0.png)

The portion in the red rectangle should be a bulleted list. 
