### PR TITLE
rsyslogd: set some reasonable limits for disk queues

### DIFF
--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -18,6 +18,7 @@ def construct_rsyslog_conf_template(settings=settings):
         '$WorkDirectory /var/lib/awx/rsyslog',
         f'$MaxMessageSize {max_bytes}',
         '$IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf',
+        'main_queue(queue.spoolDirectory="/var/lib/awx" queue.maxdiskspace="1g" queue.type="Disk" queue.filename="awx-external-logger-backlog")',
         'module(load="imuxsock" SysSock.Use="off")',
         'input(type="imuxsock" Socket="' + settings.LOGGING['handlers']['external_logger']['address'] + '" unlink="on")',
         'template(name="awx" type="string" string="%rawmsg-after-pri%")',


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/6746
see: https://rsyslog-doc.readthedocs.io/en/latest/concepts/queues.html#disk-assisted-memory-queues