### PR TITLE
Collection: Ignore some sanity errors in ansible 2.9

### DIFF
--- a/awx_collection/tests/sanity/ignore-2.9.txt
+++ b/awx_collection/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,6 @@
+plugins/modules/tower_receive.py validate-modules:deprecation-mismatch
+plugins/modules/tower_receive.py validate-modules:invalid-documentation
+plugins/modules/tower_send.py validate-modules:deprecation-mismatch
+plugins/modules/tower_send.py validate-modules:invalid-documentation
+plugins/modules/tower_workflow_template.py validate-modules:deprecation-mismatch
+plugins/modules/tower_workflow_template.py validate-modules:invalid-documentation


### PR DESCRIPTION
##### SUMMARY
Ignore the same sanity errors for ansible 2.9 and 2.10. I confirmed that `ansible-test sanity` now works with ansible 2.9 locally

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Collection
