### PR TITLE
make search keys show labels instead of api values

### DIFF
--- a/awx/ui_next/src/components/ListHeader/ListHeader.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.jsx
@@ -53,15 +53,35 @@ class ListHeader extends React.Component {
     this.pushHistoryState(replaceParams(oldParams, { [key]: value }));
   }
 
-  handleRemove(key, value) {
+  handleRemove(key, chipValue) {
+    const { searchColumns } = this.props;
+
+    // converts chip's value to the value as understood by the API
+    const getValFromChip = chipVal => {
+      for (let i = 0; i < searchColumns.length; i++) {
+        const col = searchColumns[i];
+        if (col?.options?.length) {
+          for (let j = 0; j < col.options.length; j++) {
+            const opt = col.options[j];
+            const [optVal, optLabel] = opt;
+            if (chipVal === optLabel) {
+              return optVal;
+            }
+          }
+        }
+      }
+
+      if (parseInt(chipVal, 10)) {
+        return parseInt(chipVal, 10);
+      }
+      return chipVal;
+    };
+
     const { location, qsConfig } = this.props;
-    let oldParams = parseQueryString(qsConfig, location.search);
-    if (parseInt(value, 10)) {
-      oldParams = removeParams(qsConfig, oldParams, {
-        [key]: parseInt(value, 10),
-      });
-    }
-    this.pushHistoryState(removeParams(qsConfig, oldParams, { [key]: value }));
+    const oldParams = parseQueryString(qsConfig, location.search);
+    this.pushHistoryState(
+      removeParams(qsConfig, oldParams, { [key]: getValFromChip(chipValue) })
+    );
   }
 
   handleRemoveAll() {

--- a/awx/ui_next/src/components/ListHeader/ListHeader.test.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.test.jsx
@@ -111,4 +111,36 @@ describe('ListHeader', () => {
     toolbar.prop('onRemove')('name__icontains', 'foo');
     expect(history.location.search).toEqual('?item.page_size=10');
   });
+
+  test('should test handle remove of option-based key', () => {
+    const qsConfigNew = {
+      namespace: 'item',
+      defaultParams: { page: 1, page_size: 5, order_by: '-type' },
+      integerFields: [],
+    };
+    const query = '?item.or__type=foo&item.page_size=10';
+    const history = createMemoryHistory({
+      initialEntries: [`/organizations/1/teams${query}`],
+    });
+    const wrapper = mountWithContexts(
+      <ListHeader
+        itemCount={7}
+        qsConfig={qsConfigNew}
+        searchColumns={[
+          {
+            name: 'type',
+            key: 'type',
+            options: [['foo', 'Foo Bar!']],
+            isDefault: true,
+          },
+        ]}
+        sortColumns={[{ name: 'type', key: 'type' }]}
+      />,
+      { context: { router: { history } } }
+    );
+    expect(history.location.search).toEqual(query);
+    const toolbar = wrapper.find('DataListToolbar');
+    toolbar.prop('onRemove')('or__type', 'Foo Bar!');
+    expect(history.location.search).toEqual('?item.page_size=10');
+  });
 });

--- a/awx/ui_next/src/components/Search/Search.jsx
+++ b/awx/ui_next/src/components/Search/Search.jsx
@@ -148,6 +148,16 @@ class Search extends React.Component {
       return paramsArr.filter(key => defaultParamsKeys.indexOf(key) === -1);
     };
 
+    const getChipLabel = (value, colKey) => {
+      const currentSearchColumn = columns.find(({ key }) => key === colKey);
+      if (currentSearchColumn?.options?.length) {
+        return currentSearchColumn.options.find(
+          ([optVal]) => optVal === value
+        )[1];
+      }
+      return value.toString();
+    };
+
     const getChipsByKey = () => {
       const queryParams = parseQueryString(qsConfig, location.search);
 
@@ -173,10 +183,12 @@ class Search extends React.Component {
 
         if (Array.isArray(queryParams[key])) {
           queryParams[key].forEach(val =>
-            queryParamsByKey[columnKey].chips.push(val.toString())
+            queryParamsByKey[columnKey].chips.push(getChipLabel(val, columnKey))
           );
         } else {
-          queryParamsByKey[columnKey].chips.push(queryParams[key].toString());
+          queryParamsByKey[columnKey].chips.push(
+            getChipLabel(queryParams[key], columnKey)
+          );
         }
       });
 

--- a/awx/ui_next/src/components/Search/Search.test.jsx
+++ b/awx/ui_next/src/components/Search/Search.test.jsx
@@ -3,6 +3,7 @@ import {
   DataToolbar,
   DataToolbarContent,
 } from '@patternfly/react-core/dist/umd/experimental';
+import { createMemoryHistory } from 'history';
 import { mountWithContexts } from '@testUtils/enzymeHelpers';
 import Search from './Search';
 
@@ -91,5 +92,38 @@ describe('<Search />', () => {
       .instance()
       .handleDropdownSelect({ target: { innerText: 'Description' } });
     expect(wrapper.state('searchKey')).toEqual('description');
+  });
+
+  test('filter keys are properly labeled', () => {
+    const columns = [
+      { name: 'Name', key: 'name', isDefault: true },
+      { name: 'Type', key: 'type', options: [['foo', 'Foo Bar!']] },
+      { name: 'Description', key: 'description' },
+    ];
+    const query =
+      '?organization.or__type=foo&organization.name=bar&item.page_size=10';
+    const history = createMemoryHistory({
+      initialEntries: [`/organizations/${query}`],
+    });
+    const wrapper = mountWithContexts(
+      <DataToolbar
+        id={`${QS_CONFIG.namespace}-list-toolbar`}
+        clearAllFilters={() => {}}
+        collapseListedFiltersBreakpoint="md"
+      >
+        <DataToolbarContent>
+          <Search qsConfig={QS_CONFIG} columns={columns} />
+        </DataToolbarContent>
+      </DataToolbar>,
+      { context: { router: { history } } }
+    );
+    const typeFilterWrapper = wrapper.find(
+      'DataToolbarFilter[categoryName="Type"]'
+    );
+    expect(typeFilterWrapper.prop('chips')).toContain('Foo Bar!');
+    const nameFilterWrapper = wrapper.find(
+      'DataToolbarFilter[categoryName="Name"]'
+    );
+    expect(nameFilterWrapper.prop('chips')).toContain('bar');
   });
 });


### PR DESCRIPTION
Link #6111

This PR makes it so the UI shows the i18n'd label for the tag value.

![Screen Shot 2020-04-17 at 2 20 59 PM](https://user-images.githubusercontent.com/1342624/79601371-b195a900-80b6-11ea-9d3a-4fc1a5858ee3.png)

Since these chips are generated by patternfly, I need to convert back to the api value from this prettified string when remove is attempted as well.

Tests are included for both sides of the conversion.