### PR TITLE
record redis config in the sosreport

### DIFF
--- a/tools/sosreport/tower.py
+++ b/tools/sosreport/tower.py
@@ -28,6 +28,8 @@ SOSREPORT_TOWER_DIRS = [
     "/var/log/tower",
     "/var/log/nginx",
     "/var/log/supervisor",
+    "/etc/opt/rh/rh-redis5/redis.conf",
+    "/etc/redis.conf",
     "/var/log/dist-upgrade",
     "/var/log/installer",
     "/var/log/unattended-upgrades",


### PR DESCRIPTION
see: https://github.com/ansible/tower/issues/4153

@gamuniz @wenottingham 

This config file is platform-dependent, and I'm being lazy - either of you know off-hand how sos behaves if one of these files is _missing_ (does it just ignore it hopefully?)