### PR TITLE
revert back to the old way of calling flake8 linter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ exclude=.tox,venv,awx/lib/site-packages,awx/plugins/inventory,awx/ui,awx/api/url
 
 [testenv:linters]
 deps =
+  make
   flake8
   yamllint
 commands =


### PR DESCRIPTION
##### SUMMARY
In this [PR](https://github.com/ansible/awx/pull/6730) I changed how zuul calls the flake8 linter.  This PR fixes a warning caused by that.  



This will address the following warning:
```
2020-04-20 21:02:02.071915 | static | linters run-test: commands[0] | make flake8
2020-04-20 21:02:02.072469 | static | WARNING: test command found but not installed in testenv
2020-04-20 21:02:02.072524 | static |   cmd: /usr/bin/make
2020-04-20 21:02:02.072566 | static |   env: /awx_devel/.tox/linters
2020-04-20 21:02:02.072699 | static | Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
2020-04-20 21:02:02.072731 | static |
2020-04-20 21:02:02.072791 | static | DEPRECATION WARNING: this will be an error in tox 4 and above!
```