### PR TITLE
Add option to find playbooks in symlink directories

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -436,6 +436,16 @@ register(
 )
 
 register(
+    'AWX_SHOW_PLAYBOOK_LINKS',
+    field_class=fields.BooleanField,
+    default=False,
+    label=_('Show linked playbooks'),
+    help_text=_('Show playbooks that are in directories which are symbolic links'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
     'PRIMARY_GALAXY_URL',
     field_class=fields.URLField,
     required=False,

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -199,7 +199,7 @@ class ProjectOptions(models.Model):
         results = []
         project_path = self.get_project_path()
         if project_path:
-            for dirpath, dirnames, filenames in os.walk(smart_str(project_path)):
+            for dirpath, dirnames, filenames in os.walk(smart_str(project_path),followlinks=settings.AWX_SHOW_PLAYBOOK_LINKS):
                 if skip_directory(dirpath):
                     continue
                 for filename in filenames:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -568,6 +568,9 @@ AWX_ROLES_ENABLED = True
 # Note: This setting may be overridden by database settings.
 AWX_COLLECTIONS_ENABLED = True
 
+# show playbooks that are links in the UI
+AWX_SHOW_PLAYBOOK_LINKS = False
+
 # Settings for primary galaxy server, should be set in the UI
 PRIMARY_GALAXY_URL = ''
 PRIMARY_GALAXY_USERNAME = ''

--- a/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
+++ b/awx/ui/client/src/configuration/forms/jobs-form/configuration-jobs.form.js
@@ -71,6 +71,9 @@ export default ['i18n', function(i18n) {
             AWX_COLLECTIONS_ENABLED: {
                 type: 'toggleSwitch',
             },
+            AWX_SHOW_PLAYBOOK_LINKS: {
+                type: 'toggleSwitch',
+            },
             PRIMARY_GALAXY_URL: {
                 type: 'text',
                 reset: 'PRIMARY_GALAXY_URL',


### PR DESCRIPTION
##### SUMMARY
Add a setting in settings -> jobs -> 'Show Linked Playbooks',  which enabled or disables the option to find playbooks that are in a symlinked directory.
 

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
 - UI


##### AWX VERSION
```
awx: 11.0.0
```

##### ADDITIONAL INFORMATION
We have playbooks that are in symlinked folders which don't get discovered by awx. 
This change allows those playbooks to be used.

By default, this feature is disabled so user experience will not change until setting is modified. 

Once the setting is changed you won't see any difference in the list of playbooks until the project is synchronised.
