### PR TITLE
Adds SAML Attribute Mapping to Teams and Orgs

### DIFF
--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -740,7 +740,9 @@ class SAMLOrgAttrField(HybridDictField):
 class SAMLTeamAttrTeamOrgMapField(HybridDictField):
 
     team = fields.CharField(required=True, allow_null=False)
+    team_alias = fields.CharField(required=False, allow_null=True)
     organization = fields.CharField(required=True, allow_null=False)
+    organization_alias = fields.CharField(required=False, allow_null=True)
 
     child = _Forbidden()
 

--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -187,13 +187,22 @@ def update_user_teams_by_saml_attr(backend, details, user=None, *args, **kwargs)
 
     team_ids = []
     for team_name_map in team_map.get('team_org_map', []):
-        team_name = team_name_map.get('team', '')
+        team_name = team_name_map.get('team', None)
+        team_alias = team_name_map.get('team_alias', None)
+        organization_name = team_name_map.get('organization', None)
+        organization_alias = team_name_map.get('organization_alias', None)
         if team_name in saml_team_names:
-            if not team_name_map.get('organization', ''):
+            if not organization_name:
                 # Settings field validation should prevent this.
                 logger.error("organization name invalid for team {}".format(team_name))
                 continue
-            org = Organization.objects.get_or_create(name=team_name_map['organization'])[0]
+
+            if organization_alias:
+                organization_name = organization_alias
+            org = Organization.objects.get_or_create(name=organization_name)[0]
+
+            if team_alias:
+                team_name = team_alias
             team = Team.objects.get_or_create(name=team_name, organization=org)[0]
 
             team_ids.append(team.id)

--- a/awx/sso/tests/functional/test_pipeline.py
+++ b/awx/sso/tests/functional/test_pipeline.py
@@ -193,6 +193,10 @@ class TestSAMLAttr():
                     {'team': 'Red', 'organization': 'Default1'},
                     {'team': 'Green', 'organization': 'Default1'},
                     {'team': 'Green', 'organization': 'Default3'},
+                    {
+                        'team': 'Yellow', 'team_alias': 'Yellow_Alias',
+                        'organization': 'Default4', 'organization_alias': 'Default4_Alias'
+                    },
                 ]
             }
         return MockSettings()
@@ -284,4 +288,19 @@ class TestSAMLAttr():
 
             assert Team.objects.get(name='Green', organization__name='Default1').member_role.members.count() == 3
             assert Team.objects.get(name='Green', organization__name='Default3').member_role.members.count() == 3
+
+    def test_update_user_teams_alias_by_saml_attr(self, orgs, users, kwargs, mock_settings):
+        with mock.patch('django.conf.settings', mock_settings):
+            u1 = users[0]
+
+            # Test getting teams from attribute with team->org mapping
+            kwargs['response']['attributes']['groups'] = ['Yellow']
+
+            # Ensure team and org will be created
+            update_user_teams_by_saml_attr(None, None, u1, **kwargs)
+
+            assert Team.objects.filter(name='Yellow', organization__name='Default4').count() == 0
+            assert Team.objects.filter(name='Yellow_Alias', organization__name='Default4_Alias').count() == 1
+            assert Team.objects.get(
+                name='Yellow_Alias', organization__name='Default4_Alias').member_role.members.count() == 1
 

--- a/awx/sso/tests/unit/test_fields.py
+++ b/awx/sso/tests/unit/test_fields.py
@@ -71,6 +71,14 @@ class TestSAMLTeamAttrField():
             {'team': 'Engineering', 'organization': 'Ansible2'},
             {'team': 'Engineering2', 'organization': 'Ansible'},
         ]},
+        {'remove': True, 'saml_attr': 'foobar', 'team_org_map': [
+            {
+                'team': 'Engineering', 'team_alias': 'Engineering Team',
+                'organization': 'Ansible', 'organization_alias': 'Awesome Org'
+            },
+            {'team': 'Engineering', 'organization': 'Ansible2'},
+            {'team': 'Engineering2', 'organization': 'Ansible'},
+        ]},
     ])
     def test_internal_value_valid(self, data):
         field = SAMLTeamAttrField()


### PR DESCRIPTION
##### SUMMARY
Adds SAML Attribute Mapping to Teams and Orgs

related #2688

This change allows users to map SAML attributes for specifying teams and organizations.  This way, the attribute statement received doesn't need to match with the team or organization name.  

If no `team_alias` or `organization_alias` is not passed, it will be ignored.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.0.0
```

##### ADDITIONAL INFORMATION

* Decoded SAML response snippet
```
    <AttributeStatement>
   ....SNIP....
      <Attribute Name="member-of">
        <AttributeValue>Domain Admins</AttributeValue>
        <AttributeValue>Domain Users</AttributeValue>
      </Attribute>
   ....SNIP....
    </AttributeStatement>
```
* SAML Team Attribute Mapping
```
{
 "remove": false,
 "team_org_map": [
  {
   "team": "Domain Admins",
   "organization": "Default",
   "team_alias": "Administrators"
  },
  {
   "team": "Domain Users",
   "organization_alias": "OrgAlias",
   "organization": "Default"
  }
 ],
 "saml_attr": "member-of"
}
```

* Once the use authenticates, organization and team alias are created as expected

_Team Administrators on Default org_

```
[root@rh-tower ~]# curl -k -L -u admin https://rh-tower.tatu.home/api/v2/teams/56/ | jq
{
  "id": 56,
  "type": "team",
  "url": "/api/v2/teams/56/",
},
  "summary_fields": {
    "organization": {
      "id": 1,
      "name": "Default",
      "description": ""
    },
  "created": "2020-04-21T16:29:27.116775Z",
  "modified": "2020-04-21T16:29:27.116790Z",
  "name": "Administrators",
  "description": "",
  "organization": 1
}
``` 
_Team Administrators on Default org_

```
[root@rh-tower ~]# curl -k -L -u admin https://rh-tower.tatu.home/api/v2/teams/57/ | jq
{
  "id": 57,
  "type": "team",
  "url": "/api/v2/teams/57/",
},
  "summary_fields": {
    "organization": {
      "id": 52,
      "name": "OrgAlias",
      "description": ""
    },
},
  "created": "2020-04-21T16:29:27.371498Z",
  "modified": "2020-04-21T16:29:27.371544Z",
  "name": "Domain Users",
  "description": "",
  "organization": 52
}
```
