### PR TITLE
[WIP]List redirect broken

### DIFF
--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -65,7 +65,7 @@ function JobList({ i18n, defaultParams, showTypeColumn = false }) {
     fetchJobs();
   }, [fetchJobs]);
 
-  const isAllSelected = selected.length === jobs.length && selected.length > 0;
+  const isAllSelected = selected.length === itemCount && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteJobs,

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.jsx
@@ -62,8 +62,7 @@ function ScheduleList({
     fetchSchedules();
   }, [fetchSchedules]);
 
-  const isAllSelected =
-    selected.length === schedules.length && selected.length > 0;
+  const isAllSelected = selected.length === itemCount && selected.length > 0;
 
   const {
     isLoading: isDeleteLoading,

--- a/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.jsx
@@ -55,7 +55,8 @@ function CredentialList({ i18n }) {
   }, [fetchCredentials]);
 
   const isAllSelected =
-    selected.length > 0 && selected.length === credentials.length;
+    selected.length > 0 && selected.length === credentialCount;
+
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteCredentials,

--- a/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.jsx
+++ b/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.jsx
@@ -68,7 +68,7 @@ function HostGroupsList({ i18n, host }) {
   }, [fetchGroups]);
 
   const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
-    groups
+    itemCount
   );
 
   const {
@@ -189,8 +189,8 @@ function HostGroupsList({ i18n, host }) {
                 modalTitle={i18n._(t`Disassociate group from host?`)}
                 modalNote={i18n._(t`
                   Note that you may still see the group in the list after
-                  disassociating if the host is also a member of that group’s 
-                  children.  This list shows all groups the host is associated 
+                  disassociating if the host is also a member of that group’s
+                  children.  This list shows all groups the host is associated
                   with directly and indirectly.
                 `)}
               />,

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -57,7 +57,7 @@ function HostList({ i18n }) {
     fetchHosts();
   }, [fetchHosts]);
 
-  const isAllSelected = selected.length === hosts.length && selected.length > 0;
+  const isAllSelected = selected.length === count && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteHosts,

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -57,7 +57,7 @@ function InventoryGroupHostList({ i18n }) {
   );
 
   const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
-    hosts
+    hostCount
   );
 
   useEffect(() => {

--- a/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.jsx
@@ -151,8 +151,7 @@ function InventoryGroupsList({ i18n }) {
 
   const canAdd =
     actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
-  const isAllSelected =
-    selected.length > 0 && selected.length === groups.length;
+  const isAllSelected = selected.length > 0 && selected.length === groupCount;
 
   return (
     <>

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
@@ -66,7 +66,7 @@ function InventoryHostGroupsList({ i18n }) {
   }, [fetchGroups]);
 
   const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
-    groups
+    itemCount
   );
 
   const {
@@ -186,8 +186,8 @@ function InventoryHostGroupsList({ i18n }) {
                 modalTitle={i18n._(t`Disassociate group from host?`)}
                 modalNote={i18n._(t`
                   Note that you may still see the group in the list after
-                  disassociating if the host is also a member of that group’s 
-                  children.  This list shows all groups the host is associated 
+                  disassociating if the host is also a member of that group’s
+                  children.  This list shows all groups the host is associated
                   with directly and indirectly.
                 `)}
               />,

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
@@ -102,7 +102,7 @@ function InventoryHostList({ i18n }) {
 
   const canAdd =
     actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
-  const isAllSelected = selected.length > 0 && selected.length === hosts.length;
+  const isAllSelected = selected.length > 0 && selected.length === hostCount;
 
   return (
     <>

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -58,8 +58,7 @@ function InventoryList({ i18n }) {
     fetchInventories();
   }, [fetchInventories]);
 
-  const isAllSelected =
-    selected.length === inventories.length && selected.length > 0;
+  const isAllSelected = selected.length === itemCount && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteTeams,

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -60,7 +60,7 @@ function OrganizationsList({ i18n }) {
   }, [fetchOrganizations]);
 
   const isAllSelected =
-    selected.length === organizations.length && selected.length > 0;
+    selected.length === organizationCount && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteOrganizations,

--- a/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
@@ -143,8 +143,7 @@ function ProjectJobTemplatesList({ i18n }) {
     <ToolbarAddButton key="add" linkTo="/templates/job_template/add/" />
   );
 
-  const isAllSelected =
-    selected.length === templates.length && selected.length > 0;
+  const isAllSelected = selected.length === count && selected.length > 0;
 
   return (
     <>

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectList.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectList.jsx
@@ -57,8 +57,7 @@ function ProjectList({ i18n }) {
     fetchProjects();
   }, [fetchProjects]);
 
-  const isAllSelected =
-    selected.length === projects.length && selected.length > 0;
+  const isAllSelected = selected.length === itemCount && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteProjects,

--- a/awx/ui_next/src/screens/Team/TeamList/TeamList.jsx
+++ b/awx/ui_next/src/screens/Team/TeamList/TeamList.jsx
@@ -57,7 +57,7 @@ function TeamList({ i18n }) {
     fetchTeams();
   }, [fetchTeams]);
 
-  const isAllSelected = selected.length === teams.length && selected.length > 0;
+  const isAllSelected = selected.length === itemCount && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteTeams,

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -67,8 +67,7 @@ function TemplateList({ i18n }) {
     fetchTemplates();
   }, [fetchTemplates]);
 
-  const isAllSelected =
-    selected.length === templates.length && selected.length > 0;
+  const isAllSelected = selected.length === count && selected.length > 0;
   const {
     isLoading: isDeleteLoading,
     deleteItems: deleteTemplates,

--- a/awx/ui_next/src/screens/User/UserList/UserList.jsx
+++ b/awx/ui_next/src/screens/User/UserList/UserList.jsx
@@ -139,8 +139,7 @@ class UsersList extends Component {
 
     const canAdd =
       actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
-    const isAllSelected =
-      selected.length === users.length && selected.length > 0;
+    const isAllSelected = selected.length === itemCount && selected.length > 0;
 
     return (
       <Fragment>

--- a/awx/ui_next/src/util/useSelected.jsx
+++ b/awx/ui_next/src/util/useSelected.jsx
@@ -11,9 +11,9 @@ import { useState } from 'react';
  * }
  */
 
-export default function useSelected(list = []) {
+export default function useSelected(itemCount) {
   const [selected, setSelected] = useState([]);
-  const isAllSelected = selected.length > 0 && selected.length === list.length;
+  const isAllSelected = selected.length > 0 && selected.length === itemCount;
 
   const handleSelect = row => {
     if (selected.some(s => s.id === row.id)) {

--- a/awx/ui_next/src/util/useSelected.test.jsx
+++ b/awx/ui_next/src/util/useSelected.test.jsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import useSelected from './useSelected';
 
 const array = [{ id: '1' }, { id: '2' }, { id: '3' }];
+const itemCount = 3;
 
 const TestHook = ({ callback }) => {
   callback();
@@ -49,7 +50,7 @@ describe('useSelected hook', () => {
   test('should return expected isAllSelected value', () => {
     testHook(() => {
       ({ selected, isAllSelected, handleSelect, setSelected } = useSelected(
-        array
+        itemCount
       ));
     });
 


### PR DESCRIPTION
##### SUMMARY
This addresses #6734 
Many lists have an `isAllSelected` variable that compared the selected list length to the length of all the items.  The problem with this is that when you follow the steps described in the issue, the number of items is not an accurate list of all of the items because the pagination  causes the api to send only a portion of the items.  Thus, we are now using the item count, which doesn't change to know `isAllSelected`.  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```

```


##### ADDITIONAL INFORMATION

![Redirect Broken](https://user-images.githubusercontent.com/39280967/79901513-ef0f7480-83dd-11ea-96ee-7e6f2108a116.gif)
