### PR TITLE
Add ability to monitor jobs and workflow_jobs via awx cli, fixes #6165

### DIFF
--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -552,3 +552,41 @@ class SettingsModify(CustomAction):
         except json.decoder.JSONDecodeError:
             return False
         return True
+
+
+class HasMonitor(object):
+
+    action = 'monitor'
+
+    def add_arguments(self, parser, resource_options_parser):
+        from .options import pk_or_name
+        parser.choices[self.action].add_argument(
+            'id',
+            type=functools.partial(
+                pk_or_name, None, self.resource, page=self.page
+            ),
+            help=''
+        )
+
+    def perform(self, **kwargs):
+        response = self.page.get()
+        mon = monitor_workflow if response.type == 'workflow_job' else monitor
+        if not response.failed and response.status != 'successful':
+            status = mon(
+                response,
+                self.page.connection.session,
+            )
+            if status:
+                response.json['status'] = status
+                if status in ('failed', 'error'):
+                    setattr(response, 'rc', 1)
+        else:
+            return 'Unable to monitor finished job'
+
+
+class JobMonitor(HasMonitor, CustomAction):
+    resource = 'jobs'
+
+
+class WorkflowJobMonitor(HasMonitor, CustomAction):
+    resource = 'workflow_jobs'


### PR DESCRIPTION
Signed-off-by: Francois Herbert <francois@herbert.org.nz>

##### SUMMARY
Add monitor action to job and workflow_jobs resources

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
awx: 11.0.0
```

##### ADDITIONAL INFORMATION
Mimics behaviour of original tower-cli tool