### PR TITLE
rsyslogd is only needed in the web container

### DIFF
--- a/installer/roles/image_build/files/supervisor_task.conf
+++ b/installer/roles/image_build/files/supervisor_task.conf
@@ -26,20 +26,8 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[program:awx-rsyslogd]
-command = rsyslogd -n -i /awx_devel/rsyslog.pid
-autostart = true
-autorestart = true
-stopwaitsecs = 1
-stopsignal=KILL
-stopasgroup=true
-killasgroup=true
-redirect_stderr=true
-stdout_logfile=/dev/stderr
-stdout_logfile_maxbytes=0
-
 [group:tower-processes]
-programs=dispatcher,callback-receiver,awx-rsyslogd
+programs=dispatcher,callback-receiver
 priority=5
 
 # TODO: Exit Handler


### PR DESCRIPTION
##### SUMMARY
Rsyslog is only needed in the awx_web container.  This removes an unnecessary service in the supervisor_task.conf.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
11.0.0
```

