### PR TITLE
add a setting for enabling high rsyslogd verbosity

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -810,6 +810,16 @@ register(
     category=_('Logging'),
     category_slug='logging',
 )
+register(
+    'LOG_AGGREGATOR_RSYSLOGD_DEBUG',
+    field_class=fields.BooleanField,
+    default=False,
+    label=_('Enable rsyslogd debugging'),
+    help_text=_('Enabled high verbosity debugging for rsyslogd.  '
+                'Useful for debugging connection issues for external log aggregation.'),
+    category=_('Logging'),
+    category_slug='logging',
+)
 
 
 register(

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -22,6 +22,8 @@ def construct_rsyslog_conf_template(settings=settings):
         spool_directory = '/var/lib/awx'
 
     max_bytes = settings.MAX_EVENT_RES_DATA
+    if settings.LOG_AGGREGATOR_RSYSLOGD_DEBUG:
+        parts.append('$DebugLevel 2')
     parts.extend([
         '$WorkDirectory /var/lib/awx/rsyslog',
         f'$MaxMessageSize {max_bytes}',

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -942,6 +942,7 @@ LOG_AGGREGATOR_VERIFY_CERT = True
 LOG_AGGREGATOR_LEVEL = 'INFO'
 LOG_AGGREGATOR_MAX_DISK_USAGE_GB = 1
 LOG_AGGREGATOR_MAX_DISK_USAGE_PATH = '/var/lib/awx'
+LOG_AGGREGATOR_RSYSLOGD_DEBUG = False
 
 # The number of retry attempts for websocket session establishment
 # If you're encountering issues establishing websockets in clustered Tower,


### PR DESCRIPTION
as we worked on this and were troubleshooting issues, I found that we were regularly changing the `rsyslogd` process invocation to include `-d` when we wanted to debug; I expect users will periodically want to do this sort of thing, and shouldn't have to edit `supervisor.conf` to do so

cc @gamuniz note that this debug level is *extremely* verbose and should only be used as a mechanism for temporary troubleshooting