### PR TITLE
Improve UI tooltip for Logger Test button

### DIFF
--- a/awx/ui/client/src/configuration/forms/system-form/configuration-system.controller.js
+++ b/awx/ui/client/src/configuration/forms/system-form/configuration-system.controller.js
@@ -199,7 +199,7 @@ export default [
                 $scope.$parent.vm.testTooltip = i18n._('Save and enable log aggregation before testing the log aggregator.');
             } else {
                 $scope.$parent.vm.disableTestButton = false;
-                $scope.$parent.vm.testTooltip = i18n._('Send a test log message to the configured log aggregator.');
+                $scope.$parent.vm.testTooltip = i18n._('Send a test log message to the configured external log service.  Note: The awx logger must be enabled.');
             }
         });
 


### PR DESCRIPTION
##### SUMMARY

When you his "TEST" in the UI, it will not send a log to the external logging service if the "awx" logger is not enabled in the `LOG_AGGREGATOR_LOGGERS`.  This hover-over 
tooltip should make that a little more clear.  

![tooltip_logger](https://user-images.githubusercontent.com/11698892/80137038-9e7c5080-8570-11ea-8d4f-9be7dc6bc7c0.png)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI


