### PR TITLE
Allow running project updates with Ansible 2.10

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2071,6 +2071,7 @@ class RunProjectUpdate(BaseTask):
         env['TMP'] = settings.AWX_PROOT_BASE_PATH
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         env['ANSIBLE_CALLBACK_PLUGINS'] = self.get_path_to('..', 'plugins', 'callback')
+        env['ANSIBLE_COLLECTIONS_PATHS'] = settings.PROJECT_COLLECTIONS_ROOT
         if settings.GALAXY_IGNORE_CERTS:
             env['ANSIBLE_GALAXY_IGNORE'] = True
         # Set up the public Galaxy server, if enabled

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -123,6 +123,10 @@ PROJECTS_ROOT = os.path.join(BASE_DIR, 'projects')
 # Absolute filesystem path to the directory to host collections for
 # running inventory imports
 INVENTORY_COLLECTIONS_ROOT = os.path.join(BASE_DIR, 'vendor', 'inventory_collections')
+# running project updates
+PROJECT_COLLECTIONS_ROOT = os.path.join(BASE_DIR, 'vendor', 'project_collections')
+# running isolated projects
+ISOLATED_COLLECTIONS_ROOT = os.path.join(BASE_DIR, 'vendor', 'isolated_collections')
 
 # Absolute filesystem path to the directory for job status stdout (default for
 # development and tests, default for production defined in production.py). This

--- a/tools/collections/clone_vendor.sh
+++ b/tools/collections/clone_vendor.sh
@@ -62,9 +62,24 @@ if [ ! -d "$base_dir/awx/awx" ]
 then
 	mkdir -p $base_dir/awx
   ln -s $(shell pwd)/awx_collection $base_dir/awx/awx
-	git clone  $base_dir/awx/awx
 else
   echo "awx collection already exists"
+fi
+
+if [ ! -d "$base_dir/community/general" ]
+then
+	mkdir -p $base_dir/community
+	git clone https://github.com/ansible-collections/community.general.git $base_dir/community/general
+else
+  echo "community general collection already exists"
+fi
+
+if [ ! -d "$base_dir/ansible/posix" ]
+then
+	mkdir -p $base_dir/ansible
+	git clone https://github.com/ansible-collections/ansible.posix.git $base_dir/ansible/posix
+else
+  echo "posix collection already exists"
 fi
 
 echo "-- confirmation of what is installed --"


### PR DESCRIPTION
Right now this only works with:

 - development environment
 - https://github.com/ansible/ansible/pull/67684

I feel that we should be able to provide this compatibility in the current development cycle, but the fact that the Ansible tombstoning PR has not been merged is substantially hampering options for that, and shuts down most of the ideas I've had to genuinely test this.