### PR TITLE
Keystone v3 support for OpenStack Credential

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -800,6 +800,10 @@ ManagedCredentialType(
             'label': ugettext_noop('Project (Tenant Name)'),
             'type': 'string',
         }, {
+            'id': 'project_domain_name',
+            'label': ugettext_noop('Project (Domain Name)'),
+            'type': 'string',
+        }, {
             'id': 'domain',
             'label': ugettext_noop('Domain Name'),
             'type': 'string',

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -77,7 +77,7 @@ def _openstack_data(cred):
                           username=cred.get_input('username', default=''),
                           password=cred.get_input('password', default=''),
                           project_name=cred.get_input('project', default=''),
-                          project_domain_name=cred.get_input('project_domain_name'))
+                          project_domain_name=cred.get_input('project_domain_name', default=''))
     if cred.has_input('domain'):
         openstack_auth['domain_name'] = cred.get_input('domain', default='')
     verify_state = cred.get_input('verify_ssl', default=True)

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -76,7 +76,8 @@ def _openstack_data(cred):
     openstack_auth = dict(auth_url=cred.get_input('host', default=''),
                           username=cred.get_input('username', default=''),
                           password=cred.get_input('password', default=''),
-                          project_name=cred.get_input('project', default=''))
+                          project_name=cred.get_input('project', default=''),
+                          project_domain_name=cred.get_input('project_domain_name'))
     if cred.has_input('domain'):
         openstack_auth['domain_name'] = cred.get_input('domain', default='')
     verify_state = cred.get_input('verify_ssl', default=True)

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -76,8 +76,9 @@ def _openstack_data(cred):
     openstack_auth = dict(auth_url=cred.get_input('host', default=''),
                           username=cred.get_input('username', default=''),
                           password=cred.get_input('password', default=''),
-                          project_name=cred.get_input('project', default=''),
-                          project_domain_name=cred.get_input('project_domain_name', default=''))
+                          project_name=cred.get_input('project', default=''))
+    if cred.has_input('project_domain_name'):
+        openstack_auth['project_domain_name'] = cred.get_input('project_domain_name', default='')
     if cred.has_input('domain'):
         openstack_auth['domain_name'] = cred.get_input('domain', default='')
     verify_state = cred.get_input('verify_ssl', default=True)

--- a/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
+++ b/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
@@ -8,6 +8,7 @@ clouds:
       auth_url: https://foo.invalid
       domain_name: fooo
       password: fooo
+      project_domain_name: fooo
       project_name: fooo
       username: fooo
     private: false

--- a/awx/main/tests/data/inventory/scripts/openstack/files/file_reference
+++ b/awx/main/tests/data/inventory/scripts/openstack/files/file_reference
@@ -10,6 +10,7 @@ clouds:
       auth_url: https://foo.invalid
       domain_name: fooo
       password: fooo
+      project_domain_name: fooo
       project_name: fooo
       username: fooo
     private: false


### PR DESCRIPTION
##### SUMMARY

Keystone v3 support for OpenStack Credential

This relates to the enhancement I raise #6831 

##### ISSUE TYPE
- Enhancement Pull Request

##### ADDITIONAL INFORMATION
As detailed in the issue, the pull request will add Project (Domain Name) to the OpenStack Credential and enable successful authentication with Keystone v3 
