### PR TITLE
Updated awx_task_hostname

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -60,7 +60,7 @@ dockerhub_base=ansible
 # management_mem_limit=2
 
 # Common Docker parameters
-awx_task_hostname=awx
+awx_task_hostname=awx_task
 awx_web_hostname=awxweb
 postgres_data_dir="~/.awx/pgdocker"
 host_port=80


### PR DESCRIPTION
Changed awx_task_hostname to awx_task from awx alone. This will correct the error which occurs after install.yml runs. Without this, awx_task fails to find its own instance, and the fresh AWX instance ends up in upgrading loop.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed awx_task_hostname to awx_task from awx alone. 
This will correct the error which occurs after install.yml runs. Without this, awx_task fails to find its own instance, and the fresh AWX instance ends up in upgrading loop.
related #1825
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
See the related ticket comment section. The same solution was posted there and case closed, however, the bug is still there. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
