### PR TITLE
Updated ingress template for kubernetes to support HTTP and HTTPS when annotations not set

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -64,7 +64,7 @@
       template:
         src: postgresql-persistent.yml.j2
         dest: "{{ kubernetes_base_path }}/postgresql-persistent.yml"
-        mode: "0600"
+        mode: '0600'
 
     - name: Deploy and Activate Postgres (OpenShift)
       shell: |
@@ -209,11 +209,11 @@
   set_fact:
     "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"
   with_items:
-    - "configmap"
-    - "secret"
-    - "deployment"
-    - "supervisor"
-    - "launch_awx"
+    - 'configmap'
+    - 'secret'
+    - 'deployment'
+    - 'supervisor'
+    - 'launch_awx'
   no_log: true
 
 - name: Apply Deployment

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -64,7 +64,7 @@
       template:
         src: postgresql-persistent.yml.j2
         dest: "{{ kubernetes_base_path }}/postgresql-persistent.yml"
-        mode: '0600'
+        mode: "0600"
 
     - name: Deploy and Activate Postgres (OpenShift)
       shell: |
@@ -209,11 +209,11 @@
   set_fact:
     "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"
   with_items:
-    - 'configmap'
-    - 'secret'
-    - 'deployment'
-    - 'supervisor'
-    - 'launch_awx'
+    - "configmap"
+    - "secret"
+    - "deployment"
+    - "supervisor"
+    - "launch_awx"
   no_log: true
 
 - name: Apply Deployment

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -136,7 +136,7 @@ spec:
             - name: {{ kubernetes_deployment_name }}-launch-awx-task
               mountPath: "/usr/bin/launch_awx_task.sh"
               subPath: "launch_awx_task.sh"
-              readOnly: true  
+              readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-web-config
               mountPath: "/supervisor.conf"
@@ -212,7 +212,7 @@ spec:
             - name: {{ kubernetes_deployment_name }}-launch-awx-task
               mountPath: "/usr/bin/launch_awx_task.sh"
               subPath: "launch_awx_task.sh"
-              readOnly: true  
+              readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-web-config
               mountPath: "/supervisor.conf"
@@ -447,8 +447,10 @@ metadata:
 {% for key, value in kubernetes_ingress_annotations.items() %}
     {{ key }}: {{ value }}
 {% endfor %}
+{% endif %}
 
 spec:
+{% if kubernetes_ingress_hostname is defined %}
 {% if kubernetes_ingress_tls_secret is defined %}
   tls:
   - hosts:


### PR DESCRIPTION
##### SUMMARY
Updated ingress template to support ingress hostname and ingress TLS even when ingress annotations not set. 
Currently `kubernetes_ingress_hostname` and `kubernetes_ingress_tls_secret` ignored when `kubernetes_ingress_annotations` not set. 

related #6847 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 11.1.0
```

##### ADDITIONAL INFORMATION
When you deploy AWX into Kubernetes without `kubernetes_ingress_annotations` and with `kubernetes_ingress_hostname` (and with or without `kubernetes_ingress_tls_secret`) template ignores `kubernetes_ingress_hostname` and uses `default` backend. 

Before
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{},"name":"awx-demo-web-svc","namespace":"default"},"spec":{"backend":{"serviceName":"awx-demo-web-svc","servicePort":80}}}
  creationTimestamp: "2020-04-27T20:24:26Z"
  generation: 1
  name: awx-demo-web-svc
  namespace: default
  resourceVersion: "10485699"
  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/awx-demo-web-svc
  uid: 74d409ca-8897-4682-80bd-4fc77a7dccb0
spec:
  backend:
    serviceName: awx-demo-web-svc
    servicePort: 80
status:
  loadBalancer:
    ingress:
    - ip: 10.148.65.11
    - ip: 10.148.65.12
    - ip: 10.148.65.13
```
After
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    field.cattle.io/ingressState: '{"YXd4LWRlbW8td2ViLXN2Yy9oYWFzL2F3eC1kZW1vLmhwY2RjZS5pbnRlbC5jb20vLzgw":"","aHBjZGNl":"p-786v4:example"}'
    field.cattle.io/publicEndpoints: '[{"addresses":["10.148.65.11"],"port":443,"protocol":"HTTPS","serviceName":"haas:awx-demo-web-svc","ingressName":"default:awx-demo-web-svc","hostname":"awx-demo.example.com","allNodes":true}]'
    kubectl.kubernetes.io/last-applied-configuration: '{"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{},"name":"awx-demo-web-svc","namespace":"default"},"spec":{"backend":{"serviceName":"awx-demo-web-svc","servicePort":80}}}'
  creationTimestamp: "2020-04-27T20:24:26Z"
  generation: 2
  name: awx-demo-web-svc
  namespace: default
  resourceVersion: "10488881"
  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/awx-demo-web-svc
  uid: 74d409ca-8897-4682-80bd-4fc77a7dccb0
spec:
  rules:
  - host: awx-demo.example.com
    http:
      paths:
      - backend:
          serviceName: awx-demo-web-svc
          servicePort: 80
  tls:
  - hosts:
    - awx-demo.example.com
    secretName: example-cert
status:
  loadBalancer:
    ingress:
    - ip: 10.148.65.11
    - ip: 10.148.65.12
    - ip: 10.148.65.13
```