### PR TITLE
Added variable to inventory to add a separate SSL key file

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -66,6 +66,8 @@ postgres_data_dir="~/.awx/pgdocker"
 host_port=80
 host_port_ssl=443
 #ssl_certificate=
+# Optional key file
+#ssl_certificate_key=
 docker_compose_dir="~/.awx/awxcompose"
 
 # Required for Openshift when building the image on your own

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -38,7 +38,10 @@ services:
     {% if ca_trust_dir is defined %}
       - "{{ ca_trust_dir +':/etc/pki/ca-trust/source/anchors:ro' }}"
     {% endif %}
-    {% if ssl_certificate is defined %}
+    {% if (ssl_certificate is defined) and (ssl_certificate_key is defined) %}
+      - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
+      - "{{ ssl_certificate_key +':/etc/nginx/awxweb_key.pem:ro' }}"
+    {% elif (ssl_certificate is defined) and (ssl_certificate_key is not defined) %}
       - "{{ ssl_certificate +':/etc/nginx/awxweb.pem:ro' }}"
     {% endif %}
     {% if (awx_container_search_domains is defined) and (',' in awx_container_search_domains) %}

--- a/installer/roles/local_docker/templates/nginx.conf.j2
+++ b/installer/roles/local_docker/templates/nginx.conf.j2
@@ -47,7 +47,12 @@ http {
     {%endif %}
 
     server {
-        {% if ssl_certificate is defined %}
+        {% if (ssl_certificate is defined) and (ssl_certificate_key is defined) %}
+        listen 8053 ssl;
+
+        ssl_certificate /etc/nginx/awxweb.pem;
+        ssl_certificate_key /etc/nginx/awxweb_key.pem;
+        {% elif if (ssl_certificate is defined) and (ssl_certificate_key is not defined) %}
         listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;

--- a/installer/roles/local_docker/templates/nginx.conf.j2
+++ b/installer/roles/local_docker/templates/nginx.conf.j2
@@ -52,7 +52,7 @@ http {
 
         ssl_certificate /etc/nginx/awxweb.pem;
         ssl_certificate_key /etc/nginx/awxweb_key.pem;
-        {% elif if (ssl_certificate is defined) and (ssl_certificate_key is not defined) %}
+        {% elif (ssl_certificate is defined) and (ssl_certificate_key is not defined) %}
         listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change should make it possible for people to have a custom SSL key file in there setup.

I see this more as a bug since it is not possible to so already without changing files.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
11.1.0
```


##### ADDITIONAL INFORMATION
When people are using letsencrypt with AWX you will not get a a pem file with the private key in it. This is separate from the cert and chain.

