### PR TITLE
Set SDB_NOTIFY_HOST on non-docker OS X

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -10,7 +10,6 @@ import copy
 import sys
 import traceback
 import uuid
-import platform
 
 # Centos-7 doesn't include the svg mime type
 # /usr/lib64/python/mimetypes.py
@@ -177,10 +176,10 @@ CLUSTER_HOST_ID = socket.gethostname()
 if 'Docker Desktop' in os.getenv('OS', ''):
     os.environ['SDB_NOTIFY_HOST'] = 'docker.for.mac.host.internal'
 else:
-    if platform.system() == 'Darwin':
-        os.environ['SDB_NOTIFY_HOST'] = os.popen('ipconfig getifaddr en0').read().strip()
-    else:
+    try:
         os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
+    except Exception:
+        pass
 
 WEBSOCKET_ORIGIN_WHITELIST = ['https://localhost:8043', 'https://localhost:3000']
 AWX_CALLBACK_PROFILE = True

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -10,6 +10,7 @@ import copy
 import sys
 import traceback
 import uuid
+import platform
 
 # Centos-7 doesn't include the svg mime type
 # /usr/lib64/python/mimetypes.py
@@ -176,7 +177,10 @@ CLUSTER_HOST_ID = socket.gethostname()
 if 'Docker Desktop' in os.getenv('OS', ''):
     os.environ['SDB_NOTIFY_HOST'] = 'docker.for.mac.host.internal'
 else:
-    os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
+    if platform.system() == 'Darwin':
+        os.environ['SDB_NOTIFY_HOST'] = os.popen('ipconfig getifaddr en0').read().strip()
+    else:
+        os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
 
 WEBSOCKET_ORIGIN_WHITELIST = ['https://localhost:8043', 'https://localhost:3000']
 AWX_CALLBACK_PROFILE = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When trying to run `make test_collection` on OS X, you get a failure because SDB_NOTIFY_HOST is not set properly from the current command.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without fix:
```
(awx_py2) Johns-MacBook-Pro-3:awx jowestco$ make test_collection
/bin/sh: ip: command not found
Traceback (most recent call last):
  File "/Users/jowestco/virtualenvs/awx/bin/py.test", line 8, in <module>
...
  File "<frozen importlib._bootstrap>", line 668, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 638, in _load_backward_compatible
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/_pytest/assertion/rewrite.py", line 215, in load_module
    py.builtin.exec_(co, mod.__dict__)
  File "/Users/jowestco/GIT/github/john-westcott-iv/awx/awx/settings/development.py", line 179, in <module>
    os.environ['SDB_NOTIFY_HOST'] = os.popen('ip route').read().split(' ')[2]
IndexError: list index out of range
make: *** [test_collection] Error 1
```

With fix:
```
(awx_py2) Johns-MacBook-Pro-3:awx jowestco$ make test_collection
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.7.0, pytest-3.6.0, py-1.8.1, pluggy-0.6.0
django: settings: awx.settings.development (from ini)
rootdir: /Users/jowestco/GIT/github/john-westcott-iv/awx, inifile: pytest.ini
plugins: xdist-1.27.0, timeout-1.3.4, pythonpath-0.7.3, mock-1.11.1, forked-1.1.3, django-3.9.0, cov-2.8.1
collected 70 items                                                                                                                                                                    
...
```