### PR TITLE
Drop requirements.txt for awxkit

### DIFF
--- a/awxkit/requirements.txt
+++ b/awxkit/requirements.txt
@@ -1,2 +1,0 @@
-PyYAML
-requests

--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -2,12 +2,6 @@ import os
 import glob
 import shutil
 from setuptools import setup, find_packages, Command
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-requirements = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
 
 
 def get_version():
@@ -66,7 +60,10 @@ setup(
         'clean': CleanCommand,
     },
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=[
+        'PyYAML',
+        'requests',
+    ],
     python_requires=">=3.6",
     extras_require={
         'formatting': ['jq'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

awxkit's setup.py was making use of pip internal structures which is not
a good thing as they may change. Actually that just happened.

To avoid that, drop requirements.txt and move the items there to the
install_requires param.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awxkit

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Not applicable
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Recent released pip changed internal structures and has broken the awxkit setup.py.

```console
$ pip --version
pip 20.1 from /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages/pip (python 3.7)
```

Before the changes

```console
$ pip install .
Processing /home/elyezer/code/ansible/awx/awxkit
    ERROR: Command errored out with exit status 1:
     command: /home/elyezer/.virtualenvs/test/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/elyezer/code/ansible/awx/awxkit/setup.py'"'"'; __file__='"'"'/home/elyezer/code/ansible/awx/awxkit/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-2_meafv0
         cwd: /home/elyezer/code/ansible/awx/awxkit/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/elyezer/code/ansible/awx/awxkit/setup.py", line 10, in <module>
        requirements = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
      File "/home/elyezer/code/ansible/awx/awxkit/setup.py", line 10, in <listcomp>
        requirements = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
    AttributeError: 'ParsedRequirement' object has no attribute 'req'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

After the changes:

```console
$ pip install .
Processing /home/elyezer/code/ansible/awx/awxkit
Requirement already satisfied: PyYAML in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from awxkit==11.2.0) (5.3.1)
Requirement already satisfied: requests in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from awxkit==11.2.0) (2.23.0)
Requirement already satisfied: idna<3,>=2.5 in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from requests->awxkit==11.2.0) (2.9)
Requirement already satisfied: chardet<4,>=3.0.2 in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from requests->awxkit==11.2.0) (3.0.4)
Requirement already satisfied: certifi>=2017.4.17 in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from requests->awxkit==11.2.0) (2020.4.5.1)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /home/elyezer/.virtualenvs/test/lib/python3.7/site-packages (from requests->awxkit==11.2.0) (1.25.9)
Building wheels for collected packages: awxkit
  Building wheel for awxkit (setup.py) ... done
  Created wheel for awxkit: filename=awxkit-11.2.0-py3-none-any.whl size=104456 sha256=288b96ebe5f8c4d6a7bc53f4fcc1f9b4e63d78ca5d12bfc69a6c1fd984aa8101
  Stored in directory: /tmp/pip-ephem-wheel-cache-_tftt_ke/wheels/ef/bb/6f/4e20bffee211d023a9781f6c70106dd765283b800e7a965204
Successfully built awxkit
Installing collected packages: awxkit
Successfully installed awxkit-11.2.0
```