### PR TITLE
Keep awxkit's requirements on the setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a list of high-level changes for each release of AWX. A full list of com
 - Added Project (Domain Name) support for the OpenStack Keystone v3 API (https://github.com/ansible/awx/issues/6831)
 - Added a new setting for raising log verbosity for rsyslogd (https://github.com/ansible/awx/pull/6818)
 - Added the ability to monitor stdout in the CLI for running jobs and workflow jobs (https://github.com/ansible/awx/issues/6165)
+- Fixed a bug which prevented the AWX CLI from properly installing with newer versions of pip (https://github.com/ansible/awx/issues/6870)
 - Fixed a bug which broke AWX's external logging support when configured with HTTPS endpoints that utilize self-signed certificates (https://github.com/ansible/awx/issues/6851)
 - Fixed a local docker installer bug that mistakenly attempted to upgrade PostgreSQL when an external pg_hostname is specified (https://github.com/ansible/awx/pull/5398)
 - Fixed a race condition that caused task container crashes when pods are quickly brought down and back up (https://github.com/ansible/awx/issues/6750)

--- a/awxkit/requirements.txt
+++ b/awxkit/requirements.txt
@@ -1,2 +1,1 @@
-PyYAML
-requests
+.

--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -2,12 +2,6 @@ import os
 import glob
 import shutil
 from setuptools import setup, find_packages, Command
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-requirements = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
 
 
 def get_version():
@@ -66,7 +60,10 @@ setup(
         'clean': CleanCommand,
     },
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=[
+        'PyYAML',
+        'requests',
+    ],
     python_requires=">=3.6",
     extras_require={
         'formatting': ['jq'],


### PR DESCRIPTION
awxkit's setup.py was making use of pip internal structures to parse the
requirements.txt file. This is not a good thing as they may change,
actually that just happened.

To avoid this in the future, move the list of requirements to setup.py
and make requirements.txt list `.` as the only item. This way we keep a
single place to update requirements in the future and avoid accessing
pip's internals.

see: https://github.com/ansible/awx/issues/6870