### PR TITLE
Allow performing git project updates when Ansible 2.10 (ansible-base) is installed

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -48,22 +48,8 @@
         - update_git
 
     - block:
-        - name: update project using hg
-          hg:
-            dest: "{{project_path|quote}}"
-            repo: "{{scm_url|quote}}"
-            revision: "{{scm_branch|quote}}"
-            force: "{{scm_clean}}"
-          register: hg_result
-
-        - name: Set the hg repository version
-          set_fact:
-            scm_version: "{{ hg_result['after'] }}"
-          when: "'after' in hg_result"
-
-        - name: parse hg version string properly
-          set_fact:
-            scm_version: "{{scm_version|regex_replace('^([A-Za-z0-9]+).*$', '\\1')}}"
+        - name: include hg tasks
+          include_tasks: project_update_hg_tasks.yml
       tags:
         - update_hg
 

--- a/awx/playbooks/project_update_hg_tasks.yml
+++ b/awx/playbooks/project_update_hg_tasks.yml
@@ -1,3 +1,4 @@
+---
 - name: update project using hg
   hg:
     dest: "{{project_path|quote}}"

--- a/awx/playbooks/project_update_hg_tasks.yml
+++ b/awx/playbooks/project_update_hg_tasks.yml
@@ -1,0 +1,16 @@
+- name: update project using hg
+  hg:
+    dest: "{{project_path|quote}}"
+    repo: "{{scm_url|quote}}"
+    revision: "{{scm_branch|quote}}"
+    force: "{{scm_clean}}"
+  register: hg_result
+
+- name: Set the hg repository version
+  set_fact:
+    scm_version: "{{ hg_result['after'] }}"
+  when: "'after' in hg_result"
+
+- name: parse hg version string properly
+  set_fact:
+    scm_version: "{{scm_version|regex_replace('^([A-Za-z0-9]+).*$', '\\1')}}"


### PR DESCRIPTION
##### SUMMARY
The goal here is to _partially_ allow using Ansible 2.10, without full support, so we can start testing it and unblock testing _everything else_.

With this, git projects will work, but hg projects will not.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

