### PR TITLE
add defaults to qs instead of passing as additional params to api requests

### DIFF
--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -23,17 +23,19 @@ import {
   WorkflowJobsAPI,
 } from '@api';
 
-const QS_CONFIG = getQSConfig(
-  'job',
-  {
-    page: 1,
-    page_size: 20,
-    order_by: '-finished',
-  },
-  ['page', 'page_size']
-);
-
 function JobList({ i18n, defaultParams, showTypeColumn = false }) {
+  const QS_CONFIG = getQSConfig(
+    'job',
+    {
+      page: 1,
+      page_size: 20,
+      order_by: '-finished',
+      not__launch_type: 'sync',
+      ...defaultParams,
+    },
+    ['page', 'page_size']
+  );
+
   const [selected, setSelected] = useState([]);
   const location = useLocation();
 
@@ -48,7 +50,7 @@ function JobList({ i18n, defaultParams, showTypeColumn = false }) {
 
       const {
         data: { count, results },
-      } = await UnifiedJobsAPI.read({ ...params, ...defaultParams });
+      } = await UnifiedJobsAPI.read({ ...params });
 
       return {
         itemCount: count,

--- a/awx/ui_next/src/screens/Job/Jobs.jsx
+++ b/awx/ui_next/src/screens/Job/Jobs.jsx
@@ -53,10 +53,7 @@ function Jobs({ i18n }) {
       <Switch>
         <Route exact path={match.path}>
           <PageSection>
-            <JobList
-              showTypeColumn
-              defaultParams={{ not__launch_type: 'sync' }}
-            />
+            <JobList showTypeColumn />
           </PageSection>
         </Route>
         <Route path={`${match.path}/:id/details`}>


### PR DESCRIPTION
closes #589 

...actually #589 was already fixed, but this moves these additional params to the qs default params (how that was designed to work).

The only real benefit is that filters that need to be across all instances of the list (in this example, `?not__job_type=sync`) can be set once, rather than having to be set every time the list is called.  Otherwise, the two ways of doing things are equivalent, I think, and nothing should change functionally with this pr.

The reason this is no longer an issue is because  new UI hides url parameters when they match both key and value specified by the defaults of the query set for that list.  So for example, the jobs list uses this url:

/api/v2/unified_jobs/?not__launch_type=sync&order_by=-finished&page=1&page_size=20

but because `not__launch_type: sync` is defined in the default params, it is stripped from the URL.