### PR TITLE
adds description-based search to templates list

### DIFF
--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -154,6 +154,10 @@ function TemplateList({ i18n }) {
               isDefault: true,
             },
             {
+              name: i18n._(t`Description`),
+              key: 'description',
+            },
+            {
               name: i18n._(t`Type`),
               key: 'type',
               options: [


### PR DESCRIPTION
link #6442  is a bit weird because description isn't shown on the list view, but, nonetheless, you can now search by description.  (Will note that description is not something people were interested in searching by, it wasn't mentioned once, during our ansiblefest ux feedback survey).