### PR TITLE
This allows for using different docker logging drivers

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -155,3 +155,10 @@ secret_key=awxsecret
 
 # Docker compose explicit subnet. Set to avoid overlapping your existing LAN networks.
 #docker_compose_subnet="172.17.0.1/16"
+#
+# Allow for different docker logging drivers
+# By Default; the logger will be json-file, however you can override
+# that by uncommenting the docker_logger below.
+# Be aware that journald may rate limit your log messages if you choose it.
+# See: https://docs.docker.com/config/containers/logging/configure/
+# docker_logger=journald

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -68,6 +68,10 @@ services:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
+    {% if docker_logger is defined %}
+    logging:
+      driver: {{ docker_logger }}
+    {% endif %}
 
   task:
     image: {{ awx_docker_actual_image }}
@@ -138,6 +142,10 @@ services:
     volumes:
       - "{{ docker_compose_dir }}/redis.conf:/usr/local/etc/redis/redis.conf:ro"
       - "{{ docker_compose_dir }}/redis_socket:/var/run/redis/:rw"
+    {% if docker_logger is defined %}
+    logging:
+      driver: {{ docker_logger }}
+    {% endif %}
 
   {% if pg_hostname is not defined %}
   postgres:
@@ -154,6 +162,10 @@ services:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
+    {% if docker_logger is defined %}
+    logging:
+      driver: {{ docker_logger }}
+    {% endif %}
   {% endif %}
 
 {% if docker_compose_subnet is defined %}


### PR DESCRIPTION
##### SUMMARY
I wanted to be able to make us of docker's other logging providers.  This merge allows for that.


##### COMPONENT NAME
local_installer


##### AWX VERSION
```
ben@kepler:~/dev/personal/awx (journald_logging_option)*$ make VERSION
awx: 11.2.0

```

##### ADDITIONAL INFORMATION
N/A
