### PR TITLE
make job id search use number field

### DIFF
--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -33,7 +33,7 @@ function JobList({ i18n, defaultParams, showTypeColumn = false }) {
       not__launch_type: 'sync',
       ...defaultParams,
     },
-    ['page', 'page_size']
+    ['id', 'page', 'page_size']
   );
 
   const [selected, setSelected] = useState([]);


### PR DESCRIPTION
link https://github.com/ansible/awx/issues/6288 ended up being a super easy fix...just needed to add id as an integer field in the qs config and it automatically updated to the number picker