### PR TITLE
[#6957] Include an "update-ca-trust extract" when ca_trust_dir is defined

### DIFF
--- a/installer/roles/kubernetes/templates/launch_awx.yml.j2
+++ b/installer/roles/kubernetes/templates/launch_awx.yml.j2
@@ -17,6 +17,9 @@ data:
     ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
     ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "path=/var/run/redis/redis.sock" all
 
+{% if ca_trust_dir is defined %}
+    update-ca-trust extract
+{% endif %}
 
     if [ -z "$AWX_SKIP_MIGRATIONS" ]; then
         awx-manage migrate --noinput


### PR DESCRIPTION
##### SUMMARY
As described in the Issue [#6957], even if the variable `ca_trust_dir` is defined it's not enough to get a custom certificate imported in the awx_task POD in Openshift.
This Pull Request will include the command `update-ca-trust extract` in the launch_awx.yml.j2 template if the variable `ca_trust_dir` is defined.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0
```


##### ADDITIONAL INFORMATION
