### PR TITLE
Fixed get_ssh_version() to work with 8.0p1-4 + FIPS

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -199,6 +199,7 @@ def get_ssh_version():
         proc = subprocess.Popen(['ssh', '-V'],
                                 stderr=subprocess.PIPE)
         result = smart_str(proc.communicate()[1])
+        result = [_ for _ in result.split('\n') if _.startswith('OpenSSH')][0]
         return result.split(" ")[0].split("_")[1]
     except Exception:
         return 'unknown'


### PR DESCRIPTION
##### SUMMARY
Whenever running RHEL8.1 with  openssh-clients-8.0p1-4.el8_1.x86_64 + FIPS, the method `get_ssh_version()` returns `unknown`. 


related: https://bugzilla.redhat.com/show_bug.cgi?id=1778224

Thanks to @gamuniz

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
11.2.0
```

##### ADDITIONAL INFORMATION
```
 [root@tower-fips ~]# ssh -V
 FIPS mode initialized
 OpenSSH_8.0p1, OpenSSL 1.1.1c FIPS  28 May 2019
```

* Before patch
```
>>> from awx.main.utils import get_ssh_version
>>> get_ssh_version()
'unknown'
>>> exit()
```

* After patch

```
# awx-manage  shell_plus
>>> from awx.main.utils import get_ssh_version
>>> get_ssh_version()
'8.0p1,'
```