### PR TITLE
add support token use for tower_inventory

### DIFF
--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -155,7 +155,8 @@ class InventoryModule(BaseInventoryPlugin):
         if not token_auth:
             request_handler = Request(url_username=self.get_option('username'),
                                       url_password=self.get_option('password'),
-                                      force_basic_auth=True,                                                                                                                      validate_certs=self.get_option('validate_certs'))
+                                      force_basic_auth=True,
+                                      validate_certs=self.get_option('validate_certs'))
         else:
             token = self.get_option('password')
             token_header = 'Bearer ' + token


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It's possible to user token for auth in tower when user awx.awx.tower plugin
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
awx.awx colletion tower.py

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 Dynamic inventory with oauth token #69348 #69367 
 ```
