### PR TITLE
Remove pexpect_timeout setting for ansible-runner

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -109,7 +109,6 @@ class IsolatedManager(object):
             'cancel_callback': self.canceled_callback,
             'settings': {
                 'job_timeout': settings.AWX_ISOLATED_LAUNCH_TIMEOUT,
-                'pexpect_timeout': getattr(settings, 'PEXPECT_TIMEOUT', 5),
                 'suppress_ansible_output': True,
             },
         }

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1423,7 +1423,6 @@ class BaseTask(object):
                 'status_handler': self.status_handler,
                 'settings': {
                     'job_timeout': self.get_instance_timeout(self.instance),
-                    'pexpect_timeout': getattr(settings, 'PEXPECT_TIMEOUT', 5),
                     'suppress_ansible_output': True,
                     **process_isolation_params,
                     **resource_profiling_params,


### PR DESCRIPTION
PEXPECT_TIMEOUT has never(?) been an actual AWX setting, and 5 is the
runner default anyway.

##### SUMMARY
Did a drive-by grep to see what we still used pexpect for, saw this.
