### PR TITLE
Fix launch prompt errors when no survey present

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.jsx
@@ -14,9 +14,11 @@ function PreviewStep({ resource, config, survey, formErrors }) {
       .filter(q => q.type === 'password')
       .map(q => q.variable);
     const masked = maskPasswords(surveyValues, passwordFields);
-    extraVars = yaml.safeDump(mergeExtraVars(values.extra_vars, masked));
+    extraVars = yaml.safeDump(
+      mergeExtraVars(values.extra_vars || '---', masked)
+    );
   } else {
-    extraVars = values.extra_vars;
+    extraVars = values.extra_vars || '---';
   }
   return (
     <>

--- a/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.jsx
@@ -8,10 +8,16 @@ import getSurveyValues from '../getSurveyValues';
 function PreviewStep({ resource, config, survey, formErrors }) {
   const { values } = useFormikContext();
   const surveyValues = getSurveyValues(values);
-  const passwordFields = survey.spec
-    .filter(q => q.type === 'password')
-    .map(q => q.variable);
-  const masked = maskPasswords(surveyValues, passwordFields);
+  let extraVars;
+  if (survey && survey.spec) {
+    const passwordFields = survey.spec
+      .filter(q => q.type === 'password')
+      .map(q => q.variable);
+    const masked = maskPasswords(surveyValues, passwordFields);
+    extraVars = yaml.safeDump(mergeExtraVars(values.extra_vars, masked));
+  } else {
+    extraVars = values.extra_vars;
+  }
   return (
     <>
       <PromptDetail
@@ -19,7 +25,7 @@ function PreviewStep({ resource, config, survey, formErrors }) {
         launchConfig={config}
         overrides={{
           ...values,
-          extra_vars: yaml.safeDump(mergeExtraVars(values.extra_vars, masked)),
+          extra_vars: extraVars,
         }}
       />
       {formErrors && (

--- a/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Formik } from 'formik';
+import { mountWithContexts } from '@testUtils/enzymeHelpers';
+import PreviewStep from './PreviewStep';
+
+const resource = {
+  id: 1,
+  type: 'job_template',
+  summary_fields: {
+    inventory: { id: 12 },
+    recent_jobs: [],
+  },
+  related: {},
+};
+
+const survey = {
+  name: '',
+  spec: [
+    {
+      variable: 'foo',
+      type: 'text',
+    },
+  ],
+};
+
+describe('PreviewStep', () => {
+  test('should render PromptDetail', async () => {
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik initialValues={{ limit: '4', survey_foo: 'abc' }}>
+          <PreviewStep
+            resource={resource}
+            config={{
+              ask_limit_on_launch: true,
+              survey_enabled: true,
+            }}
+            survey={survey}
+          />
+        </Formik>
+      );
+    });
+
+    const detail = wrapper.find('PromptDetail');
+    expect(detail).toHaveLength(1);
+    expect(detail.prop('resource')).toEqual(resource);
+    expect(detail.prop('overrides')).toEqual({
+      extra_vars: 'foo: abc\n',
+      limit: '4',
+      survey_foo: 'abc',
+    });
+  });
+
+  test('should render PromptDetail without survey', async () => {
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik initialValues={{ limit: '4' }}>
+          <PreviewStep
+            resource={resource}
+            config={{
+              ask_limit_on_launch: true,
+            }}
+          />
+        </Formik>
+      );
+    });
+
+    const detail = wrapper.find('PromptDetail');
+    expect(detail).toHaveLength(1);
+    expect(detail.prop('resource')).toEqual(resource);
+    expect(detail.prop('overrides')).toEqual({
+      extra_vars: '---',
+      limit: '4',
+    });
+  });
+});

--- a/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Formik } from 'formik';
-import { mountWithContexts } from '@testUtils/enzymeHelpers';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import PreviewStep from './PreviewStep';
 
 const resource = {

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
@@ -9,6 +9,9 @@ export default function useInventoryStep(config, resource, visitedSteps, i18n) {
   const [stepErrors, setStepErrors] = useState({});
 
   const validate = values => {
+    if (!config.ask_inventory_on_launch) {
+      return {};
+    }
     const errors = {};
     if (!values.inventory) {
       errors.inventory = i18n._(t`An inventory must be selected`);

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useSurveyStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useSurveyStep.jsx
@@ -56,7 +56,7 @@ export default function useSurveyStep(config, resource, visitedSteps, i18n) {
     isReady: !isLoading && !!survey,
     error,
     setTouched: setFieldsTouched => {
-      if (!survey) {
+      if (!survey || !survey.spec) {
         return;
       }
       const fields = {};


### PR DESCRIPTION
##### SUMMARY
This is a follow up to two bugs introduced in #6955 

* JT Prompts threw an error if the job had no survey attached
* JT Prompts Inventory field was being required even when that step was not prompted on launch

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
