### PR TITLE
AWX installer docker-compose params `host_port` and `host_port_ssl` can also be undefined to prevent exposing a port.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -481,11 +481,11 @@ Before starting the install process, review the [inventory](./installer/inventor
 
 *host_port*
 
-> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. Defaults to *80*.
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. If undefined no port will be exposed. Defaults to *80*.
 
 *host_port_ssl*
 
-> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container for SSL support. Defaults to *443*, only works if you also set `ssl_certificate` (see below).
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container for SSL support. If undefined no port will be exposed. Defaults to *443*, only works if you also set `ssl_certificate` (see below).
 
 *ssl_certificate*
 

--- a/installer/inventory
+++ b/installer/inventory
@@ -119,6 +119,11 @@ create_preload_data=True
 # your credentials
 secret_key=awxsecret
 
+# By default a broadcast websocket secret will be generated.
+# If you would like to *rerun the playbook*, you need to set a unique password.
+# Otherwise it would generate a new one every playbook run.
+# broadcast_websocket_secret=
+
 # Build AWX with official logos
 # Requires cloning awx-logos repo as a sibling of this project.
 # Review the trademark guidelines at https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md

--- a/installer/roles/check_vars/tasks/check_docker.yml
+++ b/installer/roles/check_vars/tasks/check_docker.yml
@@ -6,9 +6,3 @@
       - postgres_data_dir is defined and postgres_data_dir != ''
     msg: "Set the value of 'postgres_data_dir' in the inventory file."
   when: pg_hostname is not defined or pg_hostname == ''
-
-- name: host_port should be defined
-  assert:
-    that:
-      - host_port is defined and host_port != ''
-    msg: "Set the value of 'host_port' in the inventory file."

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -4,6 +4,7 @@
     broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
   run_once: true
   no_log: true
+  when: broadcast_websocket_secret is not defined
 
 - fail:
     msg: "Only set one of kubernetes_context or openshift_host"

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -18,21 +18,21 @@
 
 - name: Create Docker Compose Configuration
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ docker_compose_dir }}/{{ item }}"
-    mode: 0600
-  with_items:
-    - environment.sh
-    - credentials.py
-    - docker-compose.yml
-    - nginx.conf
-    - redis.conf
+    src: "{{ item.file }}.j2"
+    dest: "{{ docker_compose_dir }}/{{ item.file }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - file: environment.sh
+      mode: "0600"
+    - file: credentials.py
+      mode: "0600"
+    - file: docker-compose.yml
+      mode: "0600"
+    - file: nginx.conf
+      mode: "0600"
+    - file: redis.conf
+      mode: "0666"
   register: awx_compose_config
-
-- name: Set redis config to other group readable to satisfy redis-server
-  file:
-    path: "{{ docker_compose_dir }}/redis.conf"
-    mode: 0666
 
 - name: Render SECRET_KEY file
   copy:

--- a/installer/roles/local_docker/tasks/main.yml
+++ b/installer/roles/local_docker/tasks/main.yml
@@ -4,6 +4,7 @@
     broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
   run_once: true
   no_log: true
+  when: broadcast_websocket_secret is not defined
 
 - import_tasks: upgrade_postgres.yml
   when:

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -11,11 +11,15 @@ services:
       {% if pg_hostname is not defined %}
       - postgres
       {% endif %}
+    {% if (host_port is defined) or (host_port_ssl is defined) %}
     ports:
-      {% if ssl_certificate is defined %}
+      {% if (host_port_ssl is defined) and (ssl_certificate is defined) %}
       - "{{ host_port_ssl }}:8053"
       {% endif %}
+      {% if host_port is defined %}
       - "{{ host_port }}:8052"
+      {% endif %}
+    {% endif %}
     hostname: {{ awx_web_hostname }}
     user: root
     restart: unless-stopped


### PR DESCRIPTION
##### SUMMARY
AWX installer docker-compose params `host_port` and `host_port_ssl` can also be undefined to prevent exposing a port.
E.g. this is necessary if you would like to use a dedicated reverse proxy in front of the awx_web container and NOT directly expose the ports.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
11.2.0
```