### PR TITLE
fix schema check

### DIFF
--- a/awx/main/tests/docs/test_swagger_generation.py
+++ b/awx/main/tests/docs/test_swagger_generation.py
@@ -174,7 +174,7 @@ class TestSwaggerGeneration():
                 data
             )
             data = re.sub(
-                r'"action_node": "awx-[^"]+"',
+                r'"action_node": "[^"]+"',
                 '"action_node": "awx"',
                 data
             )


### PR DESCRIPTION
* Not sure how or when, but ours crawling tests set the cluster node id
to NOT start with `awx-`. That is fine, the schema checker just needs to
account for that.
