### PR TITLE
Support adding/removing notifications to multiple awx modules

### DIFF
--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -125,6 +125,21 @@ options:
         - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
+    notification_templates_started:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str
+    notification_templates_success:
+      description:
+        - list of notifications to send on success
+      type: list
+      elements: str
+    notification_templates_error:
+      description:
+        - list of notifications to send on error
+      type: list
+      elements: str            
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -174,6 +189,9 @@ def main():
         update_cache_timeout=dict(type='int'),
         source_project=dict(),
         update_on_project_update=dict(type='bool'),
+        notification_templates_started=dict(type="list", elements='str'),
+        notification_templates_success=dict(type="list", elements='str'),
+        notification_templates_error=dict(type="list", elements='str'),        
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -201,6 +219,27 @@ def main():
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(inventory_source)
+
+    # Attempt to look up associated field items the user specified.
+    association_fields = {}
+
+    notifications_start = module.params.get('notification_templates_started')
+    if notifications_start is not None:
+        association_fields['notification_templates_started'] = []
+        for item in notifications_start:
+            association_fields['notification_templates_started'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_success = module.params.get('notification_templates_success')
+    if notifications_success is not None:
+        association_fields['notification_templates_success'] = []
+        for item in notifications_success:
+            association_fields['notification_templates_success'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_error = module.params.get('notification_templates_error')
+    if notifications_error is not None:
+        association_fields['notification_templates_error'] = []
+        for item in notifications_error:
+            association_fields['notification_templates_error'].append(module.resolve_name_to_id('notification_templates', item))
 
     # Create the data that gets sent for create and update
     inventory_source_fields = {
@@ -239,7 +278,11 @@ def main():
         module.fail_json(msg="If creating a new inventory source, the source param must be present")
 
     # If the state was present we can let the module build or update the existing inventory_source, this will return on its own
-    module.create_or_update_if_needed(inventory_source, inventory_source_fields, endpoint='inventory_sources', item_type='inventory source')
+    module.create_or_update_if_needed(
+        inventory_source, inventory_source_fields, 
+        endpoint='inventory_sources', item_type='inventory source',
+        associations=association_fields
+    )
 
 
 if __name__ == '__main__':

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -139,7 +139,7 @@ options:
       description:
         - list of notifications to send on error
       type: list
-      elements: str            
+      elements: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -191,7 +191,7 @@ def main():
         update_on_project_update=dict(type='bool'),
         notification_templates_started=dict(type="list", elements='str'),
         notification_templates_success=dict(type="list", elements='str'),
-        notification_templates_error=dict(type="list", elements='str'),        
+        notification_templates_error=dict(type="list", elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -279,7 +279,7 @@ def main():
 
     # If the state was present we can let the module build or update the existing inventory_source, this will return on its own
     module.create_or_update_if_needed(
-        inventory_source, inventory_source_fields, 
+        inventory_source, inventory_source_fields,
         endpoint='inventory_sources', item_type='inventory source',
         associations=association_fields
     )

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -173,7 +173,7 @@ def main():
 
     # If the state was present and we can let the module build or update the existing organization, this will return on its own
     module.create_or_update_if_needed(
-        organization, org_fields, 
+        organization, org_fields,
         endpoint='organizations', item_type='organization',
         associations=association_fields,
     )

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -56,11 +56,6 @@ options:
         - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
-    notification_templates_approvals:
-      description:
-        - list of notifications to send on start
-      type: list
-      elements: str
     notification_templates_started:
       description:
         - list of notifications to send on start
@@ -75,12 +70,12 @@ options:
       description:
         - list of notifications to send on error
       type: list
-      elements: str  
+      elements: str
     notification_templates_approvals:
       description:
         - list of notifications to send on start
       type: list
-      elements: str                
+      elements: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -179,7 +174,7 @@ def main():
     # If the state was present and we can let the module build or update the existing organization, this will return on its own
     module.create_or_update_if_needed(
         organization, org_fields, 
-        endpoint='organizations', item_type='organization'
+        endpoint='organizations', item_type='organization',
         associations=association_fields,
     )
 

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -56,6 +56,31 @@ options:
         - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
+    notification_templates_approvals:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str
+    notification_templates_started:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str
+    notification_templates_success:
+      description:
+        - list of notifications to send on success
+      type: list
+      elements: str
+    notification_templates_error:
+      description:
+        - list of notifications to send on error
+      type: list
+      elements: str  
+    notification_templates_approvals:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str                
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -87,6 +112,10 @@ def main():
         description=dict(),
         custom_virtualenv=dict(),
         max_hosts=dict(type='int', default="0"),
+        notification_templates_started=dict(type="list", elements='str'),
+        notification_templates_success=dict(type="list", elements='str'),
+        notification_templates_error=dict(type="list", elements='str'),
+        notification_templates_approvals=dict(type="list", elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -111,6 +140,32 @@ def main():
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(organization)
+    # Attempt to look up associated field items the user specified.
+    association_fields = {}
+
+    notifications_start = module.params.get('notification_templates_started')
+    if notifications_start is not None:
+        association_fields['notification_templates_started'] = []
+        for item in notifications_start:
+            association_fields['notification_templates_started'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_success = module.params.get('notification_templates_success')
+    if notifications_success is not None:
+        association_fields['notification_templates_success'] = []
+        for item in notifications_success:
+            association_fields['notification_templates_success'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_error = module.params.get('notification_templates_error')
+    if notifications_error is not None:
+        association_fields['notification_templates_error'] = []
+        for item in notifications_error:
+            association_fields['notification_templates_error'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_approval = module.params.get('notification_templates_approvals')
+    if notifications_approval is not None:
+        association_fields['notification_templates_approvals'] = []
+        for item in notifications_approval:
+            association_fields['notification_templates_approvals'].append(module.resolve_name_to_id('notification_templates', item))
 
     # Create the data that gets sent for create and update
     org_fields = {'name': name}
@@ -122,7 +177,11 @@ def main():
         org_fields['max_hosts'] = max_hosts
 
     # If the state was present and we can let the module build or update the existing organization, this will return on its own
-    module.create_or_update_if_needed(organization, org_fields, endpoint='organizations', item_type='organization')
+    module.create_or_update_if_needed(
+        organization, org_fields, 
+        endpoint='organizations', item_type='organization'
+        associations=association_fields,
+    )
 
 
 if __name__ == '__main__':

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -127,6 +127,21 @@ options:
         - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
       type: str
       version_added: "3.7"
+    notification_templates_started:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str
+    notification_templates_success:
+      description:
+        - list of notifications to send on success
+      type: list
+      elements: str
+    notification_templates_error:
+      description:
+        - list of notifications to send on error
+      type: list
+      elements: str      
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -194,6 +209,9 @@ def main():
         job_timeout=dict(type='int', default=0),
         custom_virtualenv=dict(),
         organization=dict(required=True),
+        notification_templates_started=dict(type="list", elements='str'),
+        notification_templates_success=dict(type="list", elements='str'),
+        notification_templates_error=dict(type="list", elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
         wait=dict(type='bool', default=True),
     )
@@ -240,6 +258,27 @@ def main():
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(project)
 
+    # Attempt to look up associated field items the user specified.
+    association_fields = {}
+
+    notifications_start = module.params.get('notification_templates_started')
+    if notifications_start is not None:
+        association_fields['notification_templates_started'] = []
+        for item in notifications_start:
+            association_fields['notification_templates_started'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_success = module.params.get('notification_templates_success')
+    if notifications_success is not None:
+        association_fields['notification_templates_success'] = []
+        for item in notifications_success:
+            association_fields['notification_templates_success'].append(module.resolve_name_to_id('notification_templates', item))
+
+    notifications_error = module.params.get('notification_templates_error')
+    if notifications_error is not None:
+        association_fields['notification_templates_error'] = []
+        for item in notifications_error:
+            association_fields['notification_templates_error'].append(module.resolve_name_to_id('notification_templates', item))
+
     # Create the data that gets sent for create and update
     project_fields = {
         'name': name,
@@ -274,7 +313,12 @@ def main():
         on_change = wait_for_project_update
 
     # If the state was present and we can let the module build or update the existing project, this will return on its own
-    module.create_or_update_if_needed(project, project_fields, endpoint='projects', item_type='project', on_create=on_change, on_update=on_change)
+    module.create_or_update_if_needed(
+        project, project_fields, 
+        endpoint='projects', item_type='project', 
+        associations=association_fields,
+        on_create=on_change, on_update=on_change
+    )
 
 
 if __name__ == '__main__':

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -141,7 +141,7 @@ options:
       description:
         - list of notifications to send on error
       type: list
-      elements: str      
+      elements: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -314,8 +314,8 @@ def main():
 
     # If the state was present and we can let the module build or update the existing project, this will return on its own
     module.create_or_update_if_needed(
-        project, project_fields, 
-        endpoint='projects', item_type='project', 
+        project, project_fields,
+        endpoint='projects', item_type='project',
         associations=association_fields,
         on_create=on_change, on_update=on_change
     )

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -132,7 +132,7 @@ options:
       description:
         - list of notifications to send on start
       type: list
-      elements: str          
+      elements: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -253,7 +253,7 @@ def main():
         association_fields['notification_templates_approvals'] = []
         for item in notifications_approval:
             association_fields['notification_templates_approvals'].append(module.resolve_name_to_id('notification_templates', item))
-            
+
     on_change = None
     new_spec = module.params.get('survey')
     if new_spec:

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -128,6 +128,11 @@ options:
         - list of notifications to send on error
       type: list
       elements: str
+    notification_templates_approvals:
+      description:
+        - list of notifications to send on start
+      type: list
+      elements: str          
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -173,6 +178,7 @@ def main():
         notification_templates_started=dict(type="list", elements='str'),
         notification_templates_success=dict(type="list", elements='str'),
         notification_templates_error=dict(type="list", elements='str'),
+        notification_templates_approvals=dict(type="list", elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -242,6 +248,12 @@ def main():
         for item in notifications_error:
             association_fields['notification_templates_error'].append(module.resolve_name_to_id('notification_templates', item))
 
+    notifications_approval = module.params.get('notification_templates_approvals')
+    if notifications_approval is not None:
+        association_fields['notification_templates_approvals'] = []
+        for item in notifications_approval:
+            association_fields['notification_templates_approvals'].append(module.resolve_name_to_id('notification_templates', item))
+            
     on_change = None
     new_spec = module.params.get('survey')
     if new_spec:


### PR DESCRIPTION
##### SUMMARY
Notification templates added for Projects, organizations, and Inventory sources
Approval notifications added for workflow templates and organizations
This should complete the work of all api objects that have notification endpoints.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Collection  modules:
    tower_inventory_source
    tower_organization
    tower_project
    tower_workflow_job_template

##### AWX VERSION
awx: 11.0.0