### PR TITLE
Ability to specify temp dir to gather_analytics()

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -97,8 +97,11 @@ def gather(dest=None, module=None, collection_type='scheduled'):
         from awx.main.analytics import collectors
         module = collectors
 
+    tgz_tempdir = settings.ANALYTICS_GATHER_DIR
+    if tgz_tempdir and not os.path.isdir(tgz_tempdir):
+        os.makedirs(tgz_tempdir, 755)
 
-    dest = dest or tempfile.mkdtemp(prefix='awx_analytics')
+    dest = dest or tempfile.mkdtemp(prefix='awx_analytics', dir=tgz_tempdir)
     for name, func in inspect.getmembers(module):
         if inspect.isfunction(func) and hasattr(func, '__awx_analytics_key__'):
             key = func.__awx_analytics_key__

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -646,6 +646,9 @@ INSIGHTS_TRACKING_STATE = False
 AUTOMATION_ANALYTICS_LAST_GATHER = None
 AUTOMATION_ANALYTICS_INTERVAL = 14400
 
+# Define a staging directory to be used for gather_analytics
+ANALYTICS_GATHER_DIR = None
+
 # Default list of modules allowed for ad hoc commands.
 # Note: This setting may be overridden by database settings.
 AD_HOC_COMMANDS = [


### PR DESCRIPTION
##### SUMMARY
For large environments configured with a small /tmp partition,
gather_analytics() tends to fail due to space constraints.
This patch allows the ability to configure a temporary staging
directory to be used.

Thanks to Gabe Muniz @gamuniz (:1st_place_medal:) for the collaboration on this patch.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 11.2.0
```

##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[root@awx ~]# ls -lad /gather2
ls: cannot access /gather2: No such file or directory

[root@awx ~]# grep ^ANALYT /etc/tower/conf.d/insights.py 
ANALYTICS_GATHER_DIR = '/gather2/testing/this/does/not/exist'

[root@awx ~]# awx-manage  gather_analytics
Last analytics run was: 2020-05-14 04:21:14.542282+00:00
/gather2/testing/this/does/not/exist/0885970a-3653-4d39-9d1e-501701c1ee41_2020-05-14-160833+0000.tar.gz

[root@awx ~]# tree /gather2
/gather2
└── testing
    └── this
        └── does
            └── not
                └── exist
                    └── 0885970a-3653-4d39-9d1e-501701c1ee41_2020-05-14-160833+0000.tar.gz
5 directories, 1 file
```
