### PR TITLE
(docs): enabled syntax highlighting for http patch

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -5,9 +5,11 @@ AWX supports custom CORS headers via the Django CORS Middleware
 
 To define CORS-specific settings, add them to ``/etc/tower/conf.d/cors.py``:
 
-    CORS_ORIGIN_WHITELIST = (
-        'hostname.example.com',
-        '127.0.0.1:9000'
-    )
+```python
+CORS_ORIGIN_WHITELIST = (
+    'hostname.example.com',
+    '127.0.0.1:9000'
+)
+```
 
 ...and restart all AWX services for changes to take effect.

--- a/docs/custom_virtualenvs.md
+++ b/docs/custom_virtualenvs.md
@@ -140,14 +140,16 @@ Assigning Custom Virtualenvs
 Once you've created a custom virtualenv, you can assign it at the Organization,
 Project, or Job Template level:
 
-    PATCH https://awx-host.example.org/api/v2/organizations/N/
-    PATCH https://awx-host.example.org/api/v2/projects/N/
-    PATCH https://awx-host.example.org/api/v2/job_templates/N/
+```http
+PATCH https://awx-host.example.org/api/v2/organizations/N/
+PATCH https://awx-host.example.org/api/v2/projects/N/
+PATCH https://awx-host.example.org/api/v2/job_templates/N/
 
-    Content-Type: application/json
-    {
-        'custom_virtualenv': '/opt/my-envs/custom-venv/'
-    }
+Content-Type: application/json
+{
+    "custom_virtualenv": "/opt/my-envs/custom-venv/"
+}
+```
 
 An HTTP `GET` request to `/api/v2/config/` will provide a list of
 detected installed virtualenvs:


### PR DESCRIPTION
I only tested the syntax highlighting for http requests feature of Github. 

I think so it is more readable.