### PR TITLE
Fixes ca_trust_dir mapping for k8s and openshift

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -145,6 +145,8 @@ secret_key=awxsecret
 # CA Trust directory. If you need to provide custom CA certificates, supplying
 # this variable causes this directory on the host to be bind mounted over
 # /etc/pki/ca-trust in the awx_task and awx_web containers.
+# If you are deploying on openshift or kubernetes, set the variable to /etc/pki/ca-trust instead,
+# as the awx_web and awx_task containers will not run the `update-ca-trust` command.
 #ca_trust_dir=/etc/pki/ca-trust/source/anchors
 
 # Include /etc/nginx/awx_extra.conf

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -93,6 +93,11 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8052
+{% if ca_trust_dir is defined %}
+          env:
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+{% endif %}
           volumeMounts:
             - name: supervisor-socket
               mountPath: "/var/run/supervisor"
@@ -102,7 +107,7 @@ spec:
               mountPath: "/var/lib/awx/rsyslog"
 {% if ca_trust_dir is defined %}
             - name: {{ kubernetes_deployment_name }}-ca-trust-dir
-              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              mountPath: "{{ ca_trust_dir }}"
               readOnly: true
 {% endif %}
 {% if project_data_dir is defined %}
@@ -188,7 +193,7 @@ spec:
               mountPath: "/var/lib/awx/rsyslog"
 {% if ca_trust_dir is defined %}
             - name: {{ kubernetes_deployment_name }}-ca-trust-dir
-              mountPath: "/etc/pki/ca-trust/source/anchors/"
+              mountPath: "{{ ca_trust_dir }}"
               readOnly: true
 {% endif %}
 {% if custom_venvs is defined %}
@@ -247,6 +252,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+{% if ca_trust_dir is defined %}
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+{% endif %}
           resources:
             requests:
               memory: "{{ task_mem_request }}Gi"


### PR DESCRIPTION
##### SUMMARY

Basically, when we mount the certificate using the official images (kubernetes role), it does not work, the containers don't run the `update-ca-trust`.

This patch allows the deployments to correctly map the certificates for `local_docker` and `kubernetes` role. 


related: #3010 #5704

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0

```


##### ADDITIONAL INFORMATION
* The directory gets mounted on all 3 containers
```
$ kubectl get deployment awx -o yaml | grep awx-ca-trust-dir | grep -v apiVe
          name: awx-ca-trust-dir
          name: awx-ca-trust-dir
          name: awx-ca-trust-dir
```

* The if we look at the `awx_web` and the `awx_task` we can reproduce the problem:

```
kubectl iexec awx  
Found matching pod (awx-67f8d54b9d-z4fbp) with filter: awx
Container: ✔ awx-web
sh-4.4$ ls -la /etc/pki/ca-trust/source/anchors/Toca-Bundle-CA.crt 
-rw-r--r--. 1 root root 4086 May  8 14:33 /etc/pki/ca-trust/source/anchors/Toca-Bundle-CA.crt

sh-4.4$ git clone https://git.tatu.home/mmello/toca_ansible_playbooks.git 
Cloning into 'toca_ansible_playbooks'...
fatal: unable to access 'https://git.tatu.home/mmello/toca_ansible_playbooks.git/': SSL certificate problem: unable to get local issuer certificate

sh-4.4$ openssl s_client --connect git.tatu.home:443 
CONNECTED(00000003)
depth=0 CN = *.tatu.home, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN = *.tatu.home, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
verify error:num=21:unable to verify the first certificate
verify return:1

sh-4.4$ /var/lib/awx/venv/ansible/bin/python -c 'import requests; requests.get("https://git.tatu.home")'
Traceback (most recent call last):
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 485, in wrap_socket
    cnx.do_handshake()
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/OpenSSL/SSL.py", line 1934, in do_handshake
    self._raise_ssl_error(self._ssl, result)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/OpenSSL/SSL.py", line 1671, in _raise_ssl_error
    _raise_current_error()
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/OpenSSL/_util.py", line 54, in exception_from_error_queue
    raise exception_type(errors)
OpenSSL.SSL.Error: [('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/connectionpool.py", line 672, in urlopen
    chunked=chunked,
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/connectionpool.py", line 376, in _make_request
    self._validate_conn(conn)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/connectionpool.py", line 994, in _validate_conn
    conn.connect()
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/connection.py", line 394, in connect
    ssl_context=context,
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/util/ssl_.py", line 370, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py", line 491, in wrap_socket
    raise ssl.SSLError("bad handshake: %r" % e)
ssl.SSLError: ("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/connectionpool.py", line 720, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/urllib3/util/retry.py", line 436, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='git.tatu.home', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",),))
```

* when we pass the right certificate
```
sh-4.4$ openssl s_client --connect git.tatu.home:443  -CAfile /etc/pki/ca-trust/source/anchors/Toca-Bundle-CA.crt 
CONNECTED(00000003)
depth=2 CN = TOCA ROOT CA, C = US, ST = North Carolina, L = Holly Springs, O = Toca Home
verify return:1
depth=1 CN = Toca Intermediate Certificate Authority, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
verify return:1
depth=0 CN = *.tatu.home, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
verify return:1
---
Certificate chain
 0 s:CN = *.tatu.home, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
   i:CN = Toca Intermediate Certificate Authority, C = US, ST = North Carolina, L = Holly Springs, O = Toca, OU = Tatu Home
---
```

So looking a little closer, for the `kubernetes role`, since the `update-ca-trust` does not get executed, a good way to address this problem is to mount the top-level directory `/etc/pki/ca-trust` instead of the `/etc/pki/ca-trust/source/anchors` (which makes more sense when using the `local_docker` role). 

`update-ca-trust` merges the certificates at `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`. 

Now, looking at the deployment:

```
kubectl iexec awx  
Found matching pod (awx-59cfbc64f9-jg7cg) with filter: awx
Container: ✔ awx-web
sh-4.4$ ls -la /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-r--r--r--. 1 root root 227394 Apr  3 03:12 /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

** custom CA **
sh-4.4$ git clone https://git.tatu.home/mmello/toca_ansible_playbooks.git
Cloning into 'toca_ansible_playbooks'...
remote: Enumerating objects: 75, done.
remote: Counting objects: 100% (75/75), done.
remote: Compressing objects: 100% (65/65), done.
remote: Total 469 (delta 22), reused 0 (delta 0)
Receiving objects: 100% (469/469), 191.45 KiB | 12.76 MiB/s, done.
Resolving deltas: 100% (229/229), done.

** public CA **
sh-4.4$ git clone https://github.com/ansible/test-playbooks.git
Cloning into 'test-playbooks'...
remote: Enumerating objects: 13, done.
remote: Counting objects: 100% (13/13), done.
remote: Compressing objects: 100% (13/13), done.
remote: Total 5359 (delta 12), reused 0 (delta 0), pack-reused 5346
Receiving objects: 100% (5359/5359), 575.35 KiB | 5.43 MiB/s, done.
Resolving deltas: 100% (4324/4324), done.

** certifi store **
sh-4.4$ env | grep REQUE
REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

sh-4.4$ /var/lib/awx/venv/ansible/bin/python -c 'import requests; print(requests.get("https://git.tatu.home"))'
<Response [200]>
```

And the variable is also exported to the AWX jobs too

```
curl  -u admin  https://tower.tatu.home/api/v2/project_updates/319/ | jq
[...SNIP..]
    "job_env": {
        "AWX_RMQ_MGMT_SERVICE_PORT_RMQMGMT": "15672",
        "PROMETHEUS_NODE_EXPORTER_SERVICE_PORT": "9100",
        "LC_ALL": "en_US.UTF-8",
        "REQUESTS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
```


I tested on my k8s environment and worked great!