### PR TITLE
Enable management job notications for admins

### DIFF
--- a/awx/ui/client/src/management-jobs/notifications/notification.controller.js
+++ b/awx/ui/client/src/management-jobs/notifications/notification.controller.js
@@ -6,10 +6,10 @@
 
 export default
     [   'NotificationsList', 'GetBasePath', 'ToggleNotification', 'NotificationsListInit',
-        '$stateParams', 'Dataset', '$scope',
+        '$stateParams', 'Dataset', '$scope', 'isAdmin',
         function(
             NotificationsList, GetBasePath, ToggleNotification, NotificationsListInit,
-            $stateParams, Dataset, $scope) {
+            $stateParams, Dataset, $scope, isAdmin) {
             var defaultUrl = GetBasePath('system_job_templates'),
                 list = NotificationsList,
                 id = $stateParams.management_id;
@@ -18,6 +18,8 @@ export default
                 $scope.list = list;
                 $scope[`${list.iterator}_dataset`] = Dataset.data;
                 $scope[list.name] = $scope[`${list.iterator}_dataset`].results;
+
+                $scope.sufficientRoleForNotifToggle = isAdmin;
 
                 NotificationsListInit({
                     scope: $scope,

--- a/awx/ui/client/src/management-jobs/notifications/notification.route.js
+++ b/awx/ui/client/src/management-jobs/notifications/notification.route.js
@@ -39,6 +39,19 @@ export default {
             let path = `${GetBasePath('system_job_templates')}${$stateParams.management_id}`;
             Rest.setUrl(path);
             return Rest.get(path).then((res) => res.data);
+        }],
+        isAdmin: ['Rest', 'GetBasePath', function(Rest, GetBasePath) {
+            Rest.setUrl(GetBasePath('me'));
+            return Rest.get()
+                .then((res) => {
+                    if (res.data && res.data.results && res.data.count && res.data.results[0] && res.data.results[0].is_superuser) {
+                        return true;
+                    }
+                    return false;
+                })
+                .catch(() => {
+                    return false;
+                });
         }]
     },
     ncyBreadcrumb: {


### PR DESCRIPTION
##### SUMMARY
Make the management job notification toggles enabled for admins. Relates to a bug in an external repo.

