### PR TITLE
Mount bootstrapping scripts in dev

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -170,13 +170,11 @@ ADD {% if build_dev|bool %}installer/roles/image_build/files/{% endif %}rsyslog.
 
 ## File mappings
 {% if build_dev|bool %}
-ADD tools/docker-compose/launch_awx.sh /usr/bin/launch_awx.sh
 ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
 ADD tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
 ADD tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.default.conf
 ADD tools/docker-compose/start_tests.sh /start_tests.sh
-ADD tools/docker-compose/bootstrap_development.sh /usr/bin/bootstrap_development.sh
 ADD tools/docker-compose/entrypoint.sh /entrypoint.sh
 ADD tools/scripts/awx-python /usr/bin/awx-python
 {% else %}

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: ${DEV_DOCKER_TAG_BASE}/awx_devel:${TAG}
     container_name: tools_awx_1
     hostname: awx
-    command: launch_awx.sh
+    command: /awx_devel/tools/docker-compose/launch_awx.sh
     environment:
       CURRENT_UID:
       OS:

--- a/tools/docker-compose/launch_awx.sh
+++ b/tools/docker-compose/launch_awx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set +x
 
-bootstrap_development.sh
+/awx_devel/tools/docker-compose/bootstrap_development.sh
 
 cd /awx_devel
 # Start the services


### PR DESCRIPTION
##### SUMMARY
These scripts are [executed in the container](https://github.com/ansible/awx/blob/devel/tools/docker-compose.yml#L10) every time you run `make docker-compose` (or similar commands). 

Unexpectedly, editing these scripts will not change the behavior of the dev environment because docker-compose is actually running [copies of the scripts that are baked into the container image](https://github.com/ansible/awx/blob/devel/installer/roles/image_build/templates/Dockerfile.j2#L173) at build time.

This PR updates the compose file to ~map the bootstrapping scripts to their respective locations in the container (/usr/bin/)~ so that by default you can freely modify them and test the results without needing to rebuild the entire container image.

edit: new plan is to just remove them from the dockerfile 
