### PR TITLE
Fixes bug where all_parents_must_converge was not being set for new or existing approval nodes

### DIFF
--- a/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
+++ b/awx/ui/client/src/templates/workflows/workflow-maker/workflow-maker.controller.js
@@ -148,11 +148,14 @@ export default ['$scope', 'TemplatesService',
 
                 Object.keys(nodeRef).map((workflowMakerNodeId) => {
                     const node = nodeRef[workflowMakerNodeId];
+                    const all_parents_must_converge = _.get(node, 'all_parents_must_converge', false);
                     if (node.isNew) {
                         if (node.unifiedJobTemplate && node.unifiedJobTemplate.unified_job_type === "workflow_approval") {
                             addPromises.push(TemplatesService.addWorkflowNode({
                                 url: $scope.workflowJobTemplateObj.related.workflow_nodes,
-                                data: {}
+                                data: {
+                                    all_parents_must_converge
+                                }
                             }).then(({data: newNodeData}) => {
                                 Rest.setUrl(newNodeData.related.create_approval_template);
                                 approvalTemplatePromises.push(Rest.post({
@@ -232,6 +235,14 @@ export default ['$scope', 'TemplatesService',
                                     ProcessErrors($scope, data, status, null, {
                                         hdr: $scope.strings.get('error.HEADER')
                                     });
+                                }));
+                            }
+                            if (node.originalNodeObject.all_parents_must_converge !== all_parents_must_converge) {
+                                editPromises.push(TemplatesService.editWorkflowNode({
+                                    id: node.originalNodeObject.id,
+                                    data: {
+                                        all_parents_must_converge
+                                    }
                                 }));
                             }
                         } else {


### PR DESCRIPTION
#### SUMMARY
This PR should address #6998 as it's written.

There's another bug here though and it has to do with create a new approval node.  I've created a corresponding API bug for this one: https://github.com/ansible/awx/issues/7063.

I've provided a fix for this scenario (creating a new approval node with ALL set) in this PR but it won't work until #7063 is fixed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

Here's #6998 in action:

![update_approval_all](https://user-images.githubusercontent.com/9889020/82242258-8d262a00-990b-11ea-8fbf-01f95b8216e9.gif)

Here's #7063:

![new_approval_all](https://user-images.githubusercontent.com/9889020/82242369-b9da4180-990b-11ea-9e98-8f516d66a854.gif)

