### PR TITLE
Installer - local_docker - fixed the ability to rerun the playbook

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -117,6 +117,11 @@ create_preload_data=True
 # your credentials
 secret_key=awxsecret
 
+# By default a broadcast websocket secret will be generated.
+# If you would like to *rerun the playbook*, you need to set a unique password.
+# Otherwise it would generate a new one every playbook run.
+# broadcast_websocket_secret=
+
 # Build AWX with official logos
 # Requires cloning awx-logos repo as a sibling of this project.
 # Review the trademark guidelines at https://github.com/ansible/awx-logos/blob/master/TRADEMARKS.md

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -4,6 +4,7 @@
     broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
   run_once: true
   no_log: true
+  when: broadcast_websocket_secret is not defined
 
 - fail:
     msg: "Only set one of kubernetes_context or openshift_host"

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -12,21 +12,21 @@
 
 - name: Create Docker Compose Configuration
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ docker_compose_dir }}/{{ item }}"
-    mode: 0600
-  with_items:
-    - environment.sh
-    - credentials.py
-    - docker-compose.yml
-    - nginx.conf
-    - redis.conf
+    src: "{{ item.file }}.j2"
+    dest: "{{ docker_compose_dir }}/{{ item.file }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - file: environment.sh
+      mode: "0600"
+    - file: credentials.py
+      mode: "0600"
+    - file: docker-compose.yml
+      mode: "0600"
+    - file: nginx.conf
+      mode: "0600"
+    - file: redis.conf
+      mode: "0664"
   register: awx_compose_config
-
-- name: Set redis config to other group readable to satisfy redis-server
-  file:
-    path: "{{ docker_compose_dir }}/redis.conf"
-    mode: 0666
 
 - name: Render SECRET_KEY file
   copy:

--- a/installer/roles/local_docker/tasks/main.yml
+++ b/installer/roles/local_docker/tasks/main.yml
@@ -4,6 +4,7 @@
     broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
   run_once: true
   no_log: true
+  when: broadcast_websocket_secret is not defined
 
 - import_tasks: upgrade_postgres.yml
   when:


### PR DESCRIPTION
##### SUMMARY
There where two _bugs_ which prevent me to rerun the playbook with the docker-compose installation **without** changes.

1. Added the ability, to set the `broadcast_websocket_secret` variable.
Otherwise the following code would generate a new random password every run.
`broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"`

2. Fixed a bug, where the `redis.conf` first would be stored with mod 0600 and in the next task changed to 0666.
```
TASK [local_docker : Create Docker Compose Configuration] ********************************************************************************************************************************
ok: [xxx] => (item=environment.sh)
ok: [xxx] => (item=credentials.py)
ok: [xxx] => (item=docker-compose.yml)
ok: [xxx] => (item=nginx.conf)
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0666",
+    "mode": "0600",
     "path": "/root/.awx/awxcompose/redis.conf"
 }

changed: [xxx] => (item=redis.conf)

TASK [local_docker : Set redis config to other group readable to satisfy redis-server] ***************************************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0600",
+    "mode": "0666",
     "path": "/root/.awx/awxcompose/redis.conf"
 }

changed: [xxx]
```
Now the `redis.conf` will be right away created with the correct mode 0666.

##### ISSUE TYPE
 - Bugfix Pull Request

I couldn't find an open issue.

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
11.2.0
```