### PR TITLE
AWX installer docker-compose params `host_port` and `host_port_ssl` can also be undefined to prevent exposing a port.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -481,11 +481,11 @@ Before starting the install process, review the [inventory](./installer/inventor
 
 *host_port*
 
-> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. Defaults to *80*.
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container. If undefined no port will be exposed. Defaults to *80*.
 
 *host_port_ssl*
 
-> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container for SSL support. Defaults to *443*, only works if you also set `ssl_certificate` (see below).
+> Provide a port number that can be mapped from the Docker daemon host to the web server running inside the AWX container for SSL support. If undefined no port will be exposed. Defaults to *443*, only works if you also set `ssl_certificate` (see below).
 
 *ssl_certificate*
 

--- a/installer/roles/check_vars/tasks/check_docker.yml
+++ b/installer/roles/check_vars/tasks/check_docker.yml
@@ -6,9 +6,3 @@
       - postgres_data_dir is defined and postgres_data_dir != ''
     msg: "Set the value of 'postgres_data_dir' in the inventory file."
   when: pg_hostname is not defined or pg_hostname == ''
-
-- name: host_port should be defined
-  assert:
-    that:
-      - host_port is defined and host_port != ''
-    msg: "Set the value of 'host_port' in the inventory file."

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -11,11 +11,15 @@ services:
       {% if pg_hostname is not defined %}
       - postgres
       {% endif %}
+    {% if (host_port is defined) or (host_port_ssl is defined) %}
     ports:
-      {% if ssl_certificate is defined %}
+      {% if (host_port_ssl is defined) and (ssl_certificate is defined) %}
       - "{{ host_port_ssl }}:8053"
       {% endif %}
+      {% if host_port is defined %}
       - "{{ host_port }}:8052"
+      {% endif %}
+    {% endif %}
     hostname: {{ awx_web_hostname }}
     user: root
     restart: unless-stopped


### PR DESCRIPTION
##### SUMMARY
AWX installer docker-compose params `host_port` and `host_port_ssl` can also be undefined to prevent exposing a port.
E.g. this is necessary if you would like to use a dedicated reverse proxy in front of the awx_web container and NOT directly expose the ports.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
11.2.0
```