### PR TITLE
JT form loading UX

### DIFF
--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -19,22 +19,20 @@ const QS_CONFIG = getQSConfig('inventory', {
 
 function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
   const {
-    result: { count, inventories },
-    error,
+    result: { inventories, count },
     request: fetchInventories,
+    error,
+    isLoading,
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, history.location.search);
       const { data } = await InventoriesAPI.read(params);
       return {
-        count: data.count,
         inventories: data.results,
+        count: data.count,
       };
-    }, [history.location.search]),
-    {
-      count: 0,
-      inventories: [],
-    }
+    }, [history.location]),
+    { inventories: [], count: 0 }
   );
 
   useEffect(() => {
@@ -50,6 +48,7 @@ function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
         onChange={onChange}
         onBlur={onBlur}
         required={required}
+        isLoading={isLoading}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -56,6 +56,7 @@ function Lookup(props) {
     header,
     onChange,
     onBlur,
+    isLoading,
     value,
     multiple,
     required,
@@ -124,6 +125,7 @@ function Lookup(props) {
           id={id}
           onClick={() => dispatch({ type: 'TOGGLE_MODAL' })}
           variant={ButtonVariant.tertiary}
+          isDisabled={isLoading}
         >
           <SearchIcon />
         </SearchButton>

--- a/awx/ui_next/src/components/Lookup/Lookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.test.jsx
@@ -159,4 +159,30 @@ describe('<Lookup />', () => {
     const list = wrapper.find('TestList');
     expect(list.prop('canDelete')).toEqual(false);
   });
+
+  test('should be disabled while isLoading is true', async () => {
+    const mockSelected = [{ name: 'foo', id: 1, url: '/api/v2/item/1' }];
+    wrapper = mountWithContexts(
+      <Lookup
+        id="test"
+        multiple
+        header="Foo Bar"
+        value={mockSelected}
+        onChange={onChange}
+        qsConfig={QS_CONFIG}
+        isLoading
+        renderOptionsList={({ state, dispatch, canDelete }) => (
+          <TestList
+            id="options-list"
+            state={state}
+            dispatch={dispatch}
+            canDelete={canDelete}
+          />
+        )}
+      />
+    );
+    checkRootElementNotPresent('body div[role="dialog"]');
+    const button = wrapper.find('button[aria-label="Search"]');
+    expect(button.prop('disabled')).toEqual(true);
+  });
 });

--- a/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
@@ -156,7 +156,7 @@ describe('<MultiCredentialsLookup />', () => {
       });
     });
     wrapper.update();
-    act(() => {
+    await act(async () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
@@ -201,7 +201,7 @@ describe('<MultiCredentialsLookup />', () => {
       });
     });
     wrapper.update();
-    act(() => {
+    await act(async () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
@@ -248,7 +248,7 @@ describe('<MultiCredentialsLookup />', () => {
       });
     });
     wrapper.update();
-    act(() => {
+    await act(async () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
@@ -301,7 +301,7 @@ describe('<MultiCredentialsLookup />', () => {
       });
     });
     wrapper.update();
-    act(() => {
+    await act(async () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([

--- a/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
@@ -32,9 +32,10 @@ function ProjectLookup({
   history,
 }) {
   const {
-    result: { count, projects },
-    error,
+    result: { projects, count },
     request: fetchProjects,
+    error,
+    isLoading,
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, history.location.search);
@@ -74,6 +75,7 @@ function ProjectLookup({
         onBlur={onBlur}
         onChange={onChange}
         required={required}
+        isLoading={isLoading}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList

--- a/awx/ui_next/src/screens/Template/shared/LabelSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/LabelSelect.jsx
@@ -30,6 +30,7 @@ async function loadLabelOptions(setLabels, onError) {
 }
 
 function LabelSelect({ value, placeholder, onChange, onError, createText }) {
+  const [isLoading, setIsLoading] = useState(true);
   const { selections, onSelect, options, setOptions } = useSyncedSelectValue(
     value,
     onChange
@@ -41,7 +42,10 @@ function LabelSelect({ value, placeholder, onChange, onError, createText }) {
   };
 
   useEffect(() => {
-    loadLabelOptions(setOptions, onError);
+    (async () => {
+      await loadLabelOptions(setOptions, onError);
+      setIsLoading(false);
+    })();
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
@@ -77,6 +81,7 @@ function LabelSelect({ value, placeholder, onChange, onError, createText }) {
         }
         return label;
       }}
+      isDisabled={isLoading}
       selections={selections}
       isExpanded={isExpanded}
       ariaLabelledBy="label-select"

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
@@ -14,6 +14,9 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
     error,
   } = useRequest(
     useCallback(async () => {
+      if (!projectId) {
+        return [];
+      }
       const { data } = await ProjectsAPI.readPlaybooks(projectId);
       const opts = (data || []).map(playbook => ({
         value: playbook,

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
@@ -1,39 +1,48 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { number, string, oneOfType } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import AnsibleSelect from '../../../components/AnsibleSelect';
 import { ProjectsAPI } from '../../../api';
+import useRequest from '../../../util/useRequest';
 
 function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
-  const [options, setOptions] = useState([]);
+  const {
+    result: options,
+    request: fetchOptions,
+    isLoading,
+    error,
+  } = useRequest(
+    useCallback(async () => {
+      const { data } = await ProjectsAPI.readPlaybooks(projectId);
+      const opts = (data || []).map(playbook => ({
+        value: playbook,
+        key: playbook,
+        label: playbook,
+        isDisabled: false,
+      }));
+
+      opts.unshift({
+        value: '',
+        key: '',
+        label: i18n._(t`Choose a playbook`),
+        isDisabled: false,
+      });
+      return opts;
+    }, [projectId, i18n]),
+    []
+  );
 
   useEffect(() => {
-    if (!projectId) {
-      return;
-    }
-    (async () => {
-      try {
-        const { data } = await ProjectsAPI.readPlaybooks(projectId);
-        const opts = (data || []).map(playbook => ({
-          value: playbook,
-          key: playbook,
-          label: playbook,
-          isDisabled: false,
-        }));
+    fetchOptions();
+  }, [fetchOptions]);
 
-        opts.unshift({
-          value: '',
-          key: '',
-          label: i18n._(t`Choose a playbook`),
-          isDisabled: false,
-        });
-        setOptions(opts);
-      } catch (contentError) {
-        onError(contentError);
-      }
-    })();
-  }, [projectId, i18n, onError]);
+  useEffect(() => {
+    if (error) {
+      onError(error);
+    }
+  }, [error, onError]);
+
   return (
     <AnsibleSelect
       id="template-playbook"
@@ -41,6 +50,7 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
       isValid={isValid}
       {...field}
       onBlur={onBlur}
+      isDisabled={isLoading}
     />
   );
 }


### PR DESCRIPTION
##### SUMMARY
Prevents the user from interacting with inputs/lookups in JT form while they are still loading.

Addresses #6640

![jt-form-loading](https://user-images.githubusercontent.com/410794/82351638-b00b1980-99b1-11ea-8b6e-793710a48ea1.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION
This is a “good enough for now” fix. After discussion with @jakemcdermott and @trahman73, we decided we would do this initial fix in a way that’s quick and helps us get to 4.0. Later we can circle back and add some better "skeleton" representations of the form fields while they load, so they experience can be a little less distracting for the user.