### PR TITLE
Fix rsyslog in the dev env by using a local dir volume

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - "../awx/projects/:/var/lib/awx/projects/"
       - "./redis/redis_socket_standalone:/var/run/redis/"
       - "./memcached/:/var/run/memcached"
+      - "./rsyslog/:/var/lib/awx/rsyslog"
     privileged: true
     tty: true
   # A useful container that simply passes through log messages to the console

--- a/tools/rsyslog/.dir_placeholder
+++ b/tools/rsyslog/.dir_placeholder
@@ -1,0 +1,1 @@
+This dir must pre-exist and be owned by the user you are launching awx dev env as. If the dir does not exist before launching the awx dev environment then docker will create the dir and it will be owned by root. Since we start our awx dev environment with user: ${CURRENT_UID} the rsyslog process will be unable to create a config file in a directory owned by root.


### PR DESCRIPTION
We broke this in the image refactor.
