### PR TITLE
Revert "follow symlinks while discovering valid playbooks"

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -199,7 +199,7 @@ class ProjectOptions(models.Model):
         results = []
         project_path = self.get_project_path()
         if project_path:
-            for dirpath, dirnames, filenames in os.walk(smart_str(project_path), followlinks=True):
+            for dirpath, dirnames, filenames in os.walk(smart_str(project_path)):
                 if skip_directory(dirpath):
                     continue
                 for filename in filenames:

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -64,7 +64,6 @@ def could_be_playbook(project_path, dir_path, filename):
                 matched = True
                 break
     except IOError:
-        logger.exception(f'failed to open {playbook_path}')
         return None
     if not matched:
         return None


### PR DESCRIPTION
This reverts commit 3dd21d720eb5351e63f9f31c4e601a67965dac56.

This is causing endless recursion in `os.walk` in certain scenarios.