### PR TITLE
Fix inventory group host list error modal dismissal

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -67,7 +67,7 @@ function InventoryGroupHostList({ i18n }) {
   const {
     isLoading: isDisassociateLoading,
     deleteItems: disassociateHosts,
-    deletionError: disassociateError,
+    deletionError: disassociateErr,
   } = useDeleteItems(
     useCallback(async () => {
       return Promise.all(
@@ -96,7 +96,7 @@ function InventoryGroupHostList({ i18n }) {
     [groupId, inventoryId]
   );
 
-  const { request: handleAssociate, error: associateError } = useRequest(
+  const { request: handleAssociate, error: associateErr } = useRequest(
     useCallback(
       async hostsToAssociate => {
         await Promise.all(
@@ -110,9 +110,14 @@ function InventoryGroupHostList({ i18n }) {
     )
   );
 
-  const { error, dismissError } = useDismissableError(
-    associateError || disassociateError
-  );
+  const {
+    error: associateError,
+    dismissError: dismissAssociateError,
+  } = useDismissableError(associateErr);
+  const {
+    error: disassociateError,
+    dismissError: dismissDisassociateError,
+  } = useDismissableError(disassociateErr);
 
   const canAdd =
     actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
@@ -211,17 +216,26 @@ function InventoryGroupHostList({ i18n }) {
           title={i18n._(t`Select Hosts`)}
         />
       )}
-      {error && (
+      {associateError && (
         <AlertModal
-          isOpen={error}
-          onClose={dismissError}
+          isOpen={associateError}
+          onClose={dismissAssociateError}
           title={i18n._(t`Error!`)}
           variant="error"
         >
-          {associateError
-            ? i18n._(t`Failed to associate.`)
-            : i18n._(t`Failed to disassociate one or more hosts.`)}
-          <ErrorDetail error={error} />
+          {i18n._(t`Failed to associate.`)}
+          <ErrorDetail error={associateError} />
+        </AlertModal>
+      )}
+      {disassociateError && (
+        <AlertModal
+          isOpen={disassociateError}
+          onClose={dismissDisassociateError}
+          title={i18n._(t`Error!`)}
+          variant="error"
+        >
+          {i18n._(t`Failed to disassociate one or more hosts.`)}
+          <ErrorDetail error={disassociateError} />
         </AlertModal>
       )}
     </>

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
@@ -148,6 +148,9 @@ describe('<InventoryGroupHostList />', () => {
     });
     wrapper.update();
     expect(wrapper.find('AlertModal ErrorDetail').length).toBe(1);
+    expect(wrapper.find('AlertModal ModalBoxBody').text()).toEqual(
+      expect.stringContaining('Failed to disassociate one or more hosts.')
+    );
   });
 
   test('should show associate host modal when adding an existing host', () => {
@@ -193,6 +196,39 @@ describe('<InventoryGroupHostList />', () => {
     await waitForElement(wrapper, 'AssociateModal', el => el.length === 0);
     expect(InventoriesAPI.readHosts).toHaveBeenCalledTimes(1);
     expect(GroupsAPI.associateHost).toHaveBeenCalledTimes(1);
+  });
+
+  test('should show error modal for failed host association', async () => {
+    GroupsAPI.associateHost.mockRejectedValue(new Error());
+    InventoriesAPI.readHosts.mockResolvedValue({
+      data: {
+        count: 1,
+        results: [{ id: 123, name: 'foo', url: '/api/v2/hosts/123/' }],
+      },
+    });
+    wrapper
+      .find('DropdownToggle button[aria-label="add host"]')
+      .simulate('click');
+    await act(async () => {
+      wrapper
+        .find('DropdownItem[aria-label="add existing host"]')
+        .simulate('click');
+    });
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
+    await act(async () => {
+      wrapper
+        .find('CheckboxListItem')
+        .first()
+        .invoke('onSelect')();
+    });
+    await act(async () => {
+      wrapper.find('button[aria-label="Save"]').simulate('click');
+    });
+    wrapper.update();
+    expect(wrapper.find('AlertModal ErrorDetail').length).toBe(1);
+    expect(wrapper.find('AlertModal ModalBoxBody').text()).toEqual(
+      expect.stringContaining('Failed to associate.')
+    );
   });
 
   test('should navigate to host add form when adding a new host', async () => {


### PR DESCRIPTION
##### SUMMARY
Issue: #7024 

* Handle clearing associate and disassociate errors in separate dismissal hooks 
* Add unit test to check associate and disassociate error modals render the correct error message

![host modal](https://user-images.githubusercontent.com/15881645/82577155-9526d980-9b58-11ea-9f6e-d2743b50fc79.gif)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
