### PR TITLE
Moving tower_oauthtoken into a doc fragement

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_legacy.py
+++ b/awx_collection/plugins/doc_fragments/auth_legacy.py
@@ -28,12 +28,6 @@ options:
     - Password for your Tower or AWX instance.
     - If value not set, will try environment variable C(TOWER_PASSWORD) and then config files
     type: str
-  tower_oauthtoken:
-    description:
-    - The Tower OAuth token to use.
-    - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-    type: str
-    version_added: "3.7"
   validate_certs:
     description:
     - Whether to allow insecure connections to Tower or AWX.

--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -184,13 +184,6 @@ options:
       choices: ["present", "absent"]
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      required: False
-      type: str
-      version_added: "3.7"
 
 extends_documentation_fragment: awx.awx.auth
 

--- a/awx_collection/plugins/modules/tower_credential_type.py
+++ b/awx_collection/plugins/modules/tower_credential_type.py
@@ -59,12 +59,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -64,12 +64,6 @@ options:
         - A new name for this group (for renaming)
       type: str
       version_added: "3.7"
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_host.py
+++ b/awx_collection/plugins/modules/tower_host.py
@@ -57,12 +57,6 @@ options:
       choices: ["present", "absent"]
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_inventory.py
+++ b/awx_collection/plugins/modules/tower_inventory.py
@@ -59,12 +59,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -119,12 +119,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
     notification_templates_started:
       description:
         - list of notifications to send on start

--- a/awx_collection/plugins/modules/tower_job_cancel.py
+++ b/awx_collection/plugins/modules/tower_job_cancel.py
@@ -33,12 +33,6 @@ options:
         - Fail loudly if the I(job_id) can not be canceled
       default: False
       type: bool
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -87,12 +87,6 @@ options:
         - Passwords for credentials which are set to prompt on launch
       type: dict
       version_added: "3.7"
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_job_list.py
+++ b/awx_collection/plugins/modules/tower_job_list.py
@@ -41,12 +41,6 @@ options:
       description:
         - Query used to further filter the list of jobs. C({"foo":"bar"}) will be passed at C(?foo=bar)
       type: dict
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -268,12 +268,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
     notification_templates_started:
       description:
         - list of notifications to send on start

--- a/awx_collection/plugins/modules/tower_job_wait.py
+++ b/awx_collection/plugins/modules/tower_job_wait.py
@@ -49,13 +49,6 @@ options:
       description:
         - Maximum time in seconds to wait for a job to finish.
       type: int
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      required: False
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_label.py
+++ b/awx_collection/plugins/modules/tower_label.py
@@ -45,12 +45,6 @@ options:
       default: "present"
       choices: ["present"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -34,12 +34,6 @@ options:
       required: True
       type: bool
       version_added: "3.7"
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_notification.py
+++ b/awx_collection/plugins/modules/tower_notification.py
@@ -210,12 +210,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      version_added: "3.7"
-      type: str
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -50,12 +50,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
     notification_templates_started:
       description:
         - list of notifications to send on start

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -121,12 +121,6 @@ options:
           on the project may be successfully created
       type: bool
       default: True
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
     notification_templates_started:
       description:
         - list of notifications to send on start

--- a/awx_collection/plugins/modules/tower_receive.py
+++ b/awx_collection/plugins/modules/tower_receive.py
@@ -105,7 +105,7 @@ requirements:
 notes:
   - Specifying a name of "all" for any asset type will export all items of that asset type.
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_legacy
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -76,15 +76,6 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
-
-requirements:
-- ansible-tower-cli >= 3.0.2
 
 extends_documentation_fragment: awx.awx.auth
 '''

--- a/awx_collection/plugins/modules/tower_send.py
+++ b/awx_collection/plugins/modules/tower_send.py
@@ -60,7 +60,7 @@ requirements:
   - six.moves.StringIO
   - sys
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_legacy
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -38,12 +38,6 @@ options:
         - A data structure to be sent into the settings endpoint
       type: dict
       version_added: "3.7"
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 requirements:
   - pyyaml
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_team.py
+++ b/awx_collection/plugins/modules/tower_team.py
@@ -48,12 +48,6 @@ options:
       choices: ["present", "absent"]
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -62,12 +62,6 @@ options:
       choices: ["present", "absent"]
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -107,12 +107,6 @@ options:
         - absent
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
     notification_templates_started:
       description:
         - list of notifications to send on start

--- a/awx_collection/plugins/modules/tower_workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template_node.py
@@ -135,12 +135,6 @@ options:
       choices: ["present", "absent"]
       default: "present"
       type: str
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-        - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_workflow_launch.py
+++ b/awx_collection/plugins/modules/tower_workflow_launch.py
@@ -68,12 +68,6 @@ options:
         - If waiting for the workflow to complete this will abort after this
           amount of seconds
       type: int
-    tower_oauthtoken:
-      description:
-        - The Tower OAuth token to use.
-      required: False
-      type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_workflow_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_template.py
@@ -92,7 +92,7 @@ options:
 requirements:
 - ansible-tower-cli >= 3.0.2
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_legacy
 '''
 
 

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -19,7 +19,7 @@
     - name: Change module doc_fragments to support desired namespace and package names
       replace:
         path: "{{ item }}"
-        regexp: '^extends_documentation_fragment: awx.awx.auth$'
+        regexp: '^extends_documentation_fragment: awx.awx.auth'
         replace: 'extends_documentation_fragment: {{ collection_namespace }}.{{ collection_package }}.auth'
       with_fileglob: "{{ collection_path }}/plugins/modules/tower_*.py"
       loop_control:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Move the tower_oauthtoken doc param out of the individual modules and into a doc fragment.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
