### PR TITLE
added change so that groups and host names cannot share the same name

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1719,6 +1719,8 @@ class HostSerializer(BaseSerializerWithVariables):
         name = force_text(value or '')
         # Validate here only, update in main validate method.
         host, port = self._get_host_port_from_name(name)
+        if Group.objects.filter(name=value).exists():
+            raise serializers.ValidationError(_('Invalid group name. Name already exists as a Group.'))
         return value
 
     def validate_inventory(self, value):
@@ -1808,6 +1810,8 @@ class GroupSerializer(BaseSerializerWithVariables):
     def validate_name(self, value):
         if value in ('all', '_meta'):
             raise serializers.ValidationError(_('Invalid group name.'))
+        elif Host.objects.filter(name=value).exists():
+            raise serializers.ValidationError(_('Invalid group name. Name already exists as a Host.'))
         return value
 
     def validate_inventory(self, value):

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -59,6 +59,21 @@ def test_inventory_source_unique_together_with_inv(inventory_factory):
     is2 = InventorySource(name='foo', source='file', inventory=inv2)
     is2.validate_unique()
 
+@pytest.mark.django_db
+def test_inventory_host_name_unique(scm_inventory, post, admin_user):
+    inv_src = scm_inventory.inventory_sources.first()
+    group = inv_src.groups.create(name='barfoo', inventory=scm_inventory)
+    group.save()
+    host1 = inv_src.hosts.create(name='barfoo', inventory=scm_inventory)
+    post(reverse('api:inventory_hosts_list', kwargs={'pk': host1.id}), admin_user, expect=400)
+    
+@pytest.mark.django_db   
+def test_inventory_group_name_unique(scm_inventory, post, admin_user):
+    inv_src = scm_inventory.inventory_sources.first()
+    host = inv_src.hosts.create(name='barfoo', inventory=scm_inventory)
+    host.save()
+    group = inv_src.groups.create(name='barfoo', inventory=scm_inventory)
+    post(reverse('api:inventory_groups_list', kwargs={'pk': group.id}), admin_user, expect=400)
 
 @pytest.mark.parametrize("role_field,expected_status_code", [
     (None, 403),


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change added so that a host name foo cannot be created in the same inventory that has a group named foo and vice versa. related #4680 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before: you were allowed to create a host and group with the same name.
After: Will error and return a 400

