### PR TITLE
Fix vmware inventory sync to not delete/re-add hosts

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -717,7 +717,7 @@ VMWARE_ENABLED_VAR = 'guest.gueststate'
 VMWARE_ENABLED_VALUE = 'running'
 
 # Inventory variable name containing the unique instance ID.
-VMWARE_INSTANCE_ID_VAR = 'config.instanceuuid'
+VMWARE_INSTANCE_ID_VAR = 'config.instanceUuid'
 
 # Filter for allowed group and host names when importing inventory
 # from VMware.


### PR DESCRIPTION
##### SUMMARY
This fixes the vmware inventory sync issue, where it deletes/re-adds the host even if nothing has changed for the host.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Checking the API from vmware the property was always instanceUuid

Vmware Esxi 6.0
https://code.vmware.com/apis/42/vsphere/doc/vim.vm.ConfigInfo.html

Vmware Esxi 5.5
https://code.vmware.com/apis/197/vsphere/doc/vim.vm.ConfigInfo.html

Earlier script used to lowercase every hostvar but the new inventory plugin doesn't do that and hence the instanceUuid doesnt match with instanceuuid.

Thanks to @Akasurde for lending his ESXI server for testing