### PR TITLE
vmware_vm_inventory: Replace guest.guestId with config.guestId

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -2275,7 +2275,7 @@ class vmware(PluginFileInjector):
             "customValue",  # optional
             "datastore",
             "effectiveRole",
-            "guestHeartbeatStatus",  # optonal
+            "guestHeartbeatStatus",  # optional
             "layout",  # optional
             "layoutEx",  # optional
             "name",
@@ -2287,7 +2287,6 @@ class vmware(PluginFileInjector):
             "resourcePool",
             "rootSnapshot",
             "snapshot",  # optional
-            "tag",
             "triggeredAlarmState",
             "value"
         ]
@@ -2356,7 +2355,7 @@ class vmware(PluginFileInjector):
                 })
         else:
             # default groups from script
-            for entry in ('guest.guestId', '"templates" if config.template else "guests"'):
+            for entry in ('config.guestId', '"templates" if config.template else "guests"'):
                 ret['keyed_groups'].append({
                     'prefix': '', 'separator': '',
                     'key': entry

--- a/awx/main/tests/data/inventory/plugins/vmware/files/vmware_vm_inventory.yml
+++ b/awx/main/tests/data/inventory/plugins/vmware/files/vmware_vm_inventory.yml
@@ -43,7 +43,6 @@ properties:
 - resourcePool
 - rootSnapshot
 - snapshot
-- tag
 - triggeredAlarmState
 - value
 - capability


### PR DESCRIPTION
##### SUMMARY

guest.guestId is optional value and may not be populated everytime.
Use config.guestId instead which is mandatory.
Removed 'tag' property from properties since this property is never
populated.

Partially fixes https://github.com/ansible/awx/issues/7052

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
awx/main/models/inventory.py
