### PR TITLE
Absent not working for tower_workflow_job_template_node Fix

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -464,6 +464,8 @@ class TowerModule(AnsibleModule):
                 item_name = existing_item['name']
             elif 'username' in existing_item:
                 item_name = existing_item['username']
+            elif 'identifier' in existing_item:
+                item_name = existing_item['identifier']
             else:
                 self.fail_json(msg="Unable to process delete of {0} due to missing name".format(item_type))
 


### PR DESCRIPTION
##### SUMMARY
tower_workflow_job_template_node was unable to delete nodes, due to lack of name in the data returned from the api existing data. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
awx: 11.2.0
```

##### ADDITIONAL INFORMATION
This should fix the problem with limited changes. item.name is used for error messages and checks only. 


Current:
```
failed: [localhost] (item={'identifier': 'Node202', 'unified_job_template': 'Demo Job Template', 'state': 'absent'}) => {"ansible_loop_var": "item", "changed": false, "item": {"identifier": "Node202", "state": "absent", "unified_job_template": "Demo Job Template"}, "msg": "Unable to process delete of workflow_job_template_node due to missing name"}
```
With Change:
```
changed: [localhost] => (item={'identifier': 'Node202', 'unified_job_template': 'Demo Job Template', 'state': 'absent'})
```