### PR TITLE
Preserve extra_vars when they are not prompted

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.jsx
@@ -44,7 +44,10 @@ function LaunchPrompt({ config, resource, onLaunch, onCancel, i18n }) {
     setValue('limit', values.limit);
     setValue('job_tags', values.job_tags);
     setValue('skip_tags', values.skip_tags);
-    setValue('extra_vars', mergeExtraVars(values.extra_vars, surveyValues));
+    const extraVars = config.ask_variables_on_launch
+      ? values.extra_vars || '---'
+      : resource.extra_vars;
+    setValue('extra_vars', mergeExtraVars(extraVars, surveyValues));
     setValue('scm_branch', values.scm_branch);
     onLaunch(postValues);
   };

--- a/awx/ui_next/src/components/LaunchPrompt/mergeExtraVars.js
+++ b/awx/ui_next/src/components/LaunchPrompt/mergeExtraVars.js
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml';
 
-export default function mergeExtraVars(extraVars, survey = {}) {
+export default function mergeExtraVars(extraVars = '', survey = {}) {
   const vars = yaml.safeLoad(extraVars) || {};
   return {
     ...vars,

--- a/awx/ui_next/src/components/LaunchPrompt/mergeExtraVars.test.js
+++ b/awx/ui_next/src/components/LaunchPrompt/mergeExtraVars.test.js
@@ -32,6 +32,10 @@ describe('mergeExtraVars', () => {
     });
   });
 
+  test('should handle undefined', () => {
+    expect(mergeExtraVars(undefined, undefined)).toEqual({});
+  });
+
   describe('maskPasswords', () => {
     test('should mask password fields', () => {
       const vars = {

--- a/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/PreviewStep.test.jsx
@@ -71,8 +71,30 @@ describe('PreviewStep', () => {
     expect(detail).toHaveLength(1);
     expect(detail.prop('resource')).toEqual(resource);
     expect(detail.prop('overrides')).toEqual({
-      extra_vars: '---',
       limit: '4',
+    });
+  });
+
+  test('should handle extra vars without survey', async () => {
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik initialValues={{ extra_vars: 'one: 1' }}>
+          <PreviewStep
+            resource={resource}
+            config={{
+              ask_variables_on_launch: true,
+            }}
+          />
+        </Formik>
+      );
+    });
+
+    const detail = wrapper.find('PromptDetail');
+    expect(detail).toHaveLength(1);
+    expect(detail.prop('resource')).toEqual(resource);
+    expect(detail.prop('overrides')).toEqual({
+      extra_vars: 'one: 1',
     });
   });
 });


### PR DESCRIPTION
##### SUMMARY
Ensures extra_vars display properly during JT launch when they are not prompted, and ensures they are POSTed properly to the API

addresses #7142

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### TESTING NOTES
There are a number of permutations to consider when testing extra_vars:
* extra_vars are not prompted and no survey is enabled: the default vars should show in the preview and POST to the API
* extra_vars are prompted and no survey is enabled: the values provided to the prompt should show under "Prompted Values" in the preview and POST to the API
* extra_vars are not prompted but survey is enabled: the survey values provided to the prompt should be merged with the default vars and show under "Prompted Values" in the preview and POST to the API
* extra_vars are prompted and survey is enabled: the values provided to the prompt should be merged with the survey values provided. these merged values should show under "Prompted Values" in the preview and POST to the API

