### PR TITLE
Remove dev env futzing of supervisord.conf permissions

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -220,7 +220,6 @@ RUN for dir in \
       /vendor ; \
     do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp root $dir ; done && \
     for file in \
-      /etc/supervisord.conf \
       /var/run/nginx.pid \
       /venv/awx/lib/python3.6/site-packages/awx.egg-link ; \
     do touch $file ; chmod g+rw $file ; done

--- a/tools/docker-compose-cluster.yml
+++ b/tools/docker-compose-cluster.yml
@@ -31,6 +31,7 @@ services:
       - "../:/awx_devel"
       - "./redis/redis_socket_ha_1:/var/run/redis/"
       - "./memcached/:/var/run/memcached"
+      - "./docker-compose/supervisor.conf:/etc/supervisord.conf"
     ports:
       - "5899-5999:5899-5999"
   awx-2:
@@ -50,6 +51,7 @@ services:
       - "../:/awx_devel"
       - "./redis/redis_socket_ha_2:/var/run/redis/"
       - "./memcached/:/var/run/memcached"
+      - "./docker-compose/supervisor.conf:/etc/supervisord.conf"
     ports:
       - "7899-7999:7899-7999"
   awx-3:
@@ -69,6 +71,7 @@ services:
       - "../:/awx_devel"
       - "./redis/redis_socket_ha_3:/var/run/redis/"
       - "./memcached/:/var/run/memcached"
+      - "./docker-compose/supervisor.conf:/etc/supervisord.conf"
     ports:
       - "8899-8999:8899-8999"
   redis_1:

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - "./redis/redis_socket_standalone:/var/run/redis/"
       - "./memcached/:/var/run/memcached"
       - "./rsyslog/:/var/lib/awx/rsyslog"
+      - "./docker-compose/supervisor.conf:/etc/supervisord.conf"
     privileged: true
     tty: true
   # A useful container that simply passes through log messages to the console

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -20,7 +20,6 @@ else
 fi
 
 make awx-link
-yes | cp -rf /awx_devel/tools/docker-compose/supervisor.conf /etc/supervisord.conf
 
 # AWX bootstrapping
 make version_file


### PR DESCRIPTION
If we just link to where it will be in the dev env, we don't need to copy it at startup, and we don't need write permissions on it.

(variation on the theme of https://github.com/ansible/awx/pull/7055)
