### PR TITLE
Add subnet configuration to Docker Compose to avoid conflicts.

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -154,3 +154,6 @@ secret_key=awxsecret
 # which makes include "optional" - i.e. not fail
 # if file is absent
 #extra_nginx_include="/etc/nginx/awx_extra[.]conf"
+
+# Docker compose explicit subnet. Set to avoid overlapping your existing LAN networks.
+#docker_compose_subnet="172.17.0.1/16"

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -171,6 +171,17 @@ services:
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
   {% endif %}
+
+{% if docker_compose_subnet is defined %}
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet:  {{ docker_compose_subnet }}
+{% endif %}
+
 volumes:
   supervisor-socket:
   rsyslog-socket:


### PR DESCRIPTION
##### SUMMARY
H/T to @amedeos and #5556 which is waiting on a conflict resolution. I split out just the Docker Compose subnet configuration part.

The out of the box subnet that Docker Compose selects may conflict with your existing LAN subnets. This makes it configurable.

This resolves issues like #750

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
awx: 11.2.0