### PR TITLE
Stop bouncing k8s deployment post-install

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -293,6 +293,4 @@
 - name: Scale up deployment
   shell: |
     {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
-      scale {{ deployment_object }} {{ kubernetes_deployment_name }} --replicas=0
-    {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
       scale {{ deployment_object }} {{ kubernetes_deployment_name }} --replicas={{ replicas | default(kubernetes_deployment_replica_size) }}


### PR DESCRIPTION
We shouldnt need to do this now that RabbitMQ autoclustering is gone.
