### PR TITLE
fix secret path url encoding. related #7191

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -1,7 +1,7 @@
 from .plugin import CredentialPlugin, CertFiles
 
 import base64
-from urllib.parse import urljoin, quote_plus
+from urllib.parse import urljoin, quote_plus, quote
 
 from django.utils.translation import ugettext_lazy as _
 import requests
@@ -52,7 +52,7 @@ def conjur_backend(**kwargs):
     api_key = kwargs['api_key']
     account = quote_plus(kwargs['account'])
     username = quote_plus(kwargs['username'])
-    secret_path = quote_plus(kwargs['secret_path'])
+    secret_path = quote(kwargs['secret_path'])
     version = kwargs.get('secret_version')
     cacert = kwargs.get('cacert', None)
 


### PR DESCRIPTION
##### SUMMARY
Decided to use `urllib.parse.quote` rather than `urllib.parse.quote_plus` on the `secret_path` because conjur expects spaces to be `%20` rather than `+`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
And version
