### PR TITLE
Fixing fail_json error

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -138,7 +138,7 @@ class TowerModule(AnsibleModule):
                     try:
                         self.load_config(config_file)
                     except ConfigFileException:
-                        self.fail_json('The config file {0} is not properly formatted'.format(config_file))
+                        self.fail_json(msg='The config file {0} is not properly formatted'.format(config_file))
 
     def load_config(self, config_path):
         # Validate the config file is an actual file


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As mentioned in #7002 there was an exception stack being raised in a specific part of the code. This was due to the fail_json format being incorrect. This fixes that issue.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Colletion
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
#7002
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
To replicate the issue, start by creating a tower_cli.cfg file that can not be read:
touch tower_cli.cfg && chmod 000 tower_cli.cfg

Next create a simple playbook that uses the collection
---
- name: Quick test of loading tower config
  hosts: localhost
  connection: local
  gather_facts: False
  collections:
    - awx.awx
  tasks:
    - tower_organization:
        name: 'junk'

When you run this ansible will dump an exception stack.  With the fix you will get an error message.
```
