### PR TITLE
Move to one container image rather than two mostly-identical ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This is a list of high-level changes for each release of AWX. A full list of commits can be found at `https://github.com/ansible/awx/releases/tag/<version>`.
 
 ## 12.0.0 (TBD)
+- Moved to a single container image build instead of separate awx_web and awx_task images. The container image is just `awx` (https://github.com/ansible/awx/pull/7228)
 - Official AWX container image builds now use a two-stage container build process that notably reduces the size of our published images (https://github.com/ansible/awx/pull/7017)
 - Removed support for HipChat notifications ([EoL announcement](https://www.atlassian.com/partnerships/slack/faq#faq-98b17ca3-247f-423b-9a78-70a91681eff0)); all previously-created HipChat notification templates will be deleted due to this removal.
 - Fixed a bug which broke AWX installations with oc version 4.3 (https://github.com/ansible/awx/pull/6948/files)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,7 +109,7 @@ In the sections below, you'll find deployment details and instructions for each 
 
 ### Official vs Building Images
 
-When installing AWX you have the option of building your own images or using the images provided on DockerHub (see [awx_web](https://hub.docker.com/r/ansible/awx_web/) and [awx_task](https://hub.docker.com/r/ansible/awx_task/))
+When installing AWX you have the option of building your own image or using the image provided on DockerHub (see [awx](https://hub.docker.com/r/ansible/awx/))
 
 This is controlled by the following variables in the `inventory` file
 
@@ -122,7 +122,7 @@ If these variables are present then all deployments will use these hosted images
 
 *dockerhub_base*
 
-> The base location on DockerHub where the images are hosted (by default this pulls container images named `ansible/awx_web:tag` and `ansible/awx_task:tag`)
+> The base location on DockerHub where the images are hosted (by default this pulls a container image named `ansible/awx:tag`)
 
 *dockerhub_version*
 

--- a/installer/inventory
+++ b/installer/inventory
@@ -5,7 +5,7 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 # Remove these lines if you want to run a local image build
 # Otherwise the setup playbook will install the official Ansible images. Versions may
 # be selected based on: latest, 1, 1.0, 1.0.0, 1.0.0.123
-# by default the base will be used to search for ansible/awx_web and ansible/awx_task
+# by default the base will be used to search for ansible/awx
 dockerhub_base=ansible
 
 # Openshift Install

--- a/installer/roles/image_build/files/launch_awx.sh
+++ b/installer/roles/image_build/files/launch_awx.sh
@@ -14,4 +14,4 @@ awx-manage collectstatic --noinput --clear
 
 unset $(cut -d = -f -1 /etc/tower/conf.d/environment.sh)
 
-supervisord -c /supervisor.conf
+supervisord -c /etc/supervisord.conf

--- a/installer/roles/image_build/files/supervisor.conf
+++ b/installer/roles/image_build/files/supervisor.conf
@@ -1,6 +1,9 @@
 [supervisord]
 nodaemon = True
 umask = 022
+logfile = /dev/stdout
+logfile_maxbytes = 0
+pidfile = /var/run/supervisor/supervisor.web.pid
 
 [program:nginx]
 command = nginx -g "daemon off;"

--- a/installer/roles/image_build/files/supervisor_task.conf
+++ b/installer/roles/image_build/files/supervisor_task.conf
@@ -1,12 +1,13 @@
 [supervisord]
 nodaemon = True
 umask = 022
+logfile = /dev/stdout
+logfile_maxbytes = 0
+pidfile = /var/run/supervisor/supervisor.pid
 
 [program:dispatcher]
 command = awx-manage run_dispatcher
 directory = /var/lib/awx
-environment = LANGUAGE="en_US.UTF-8",LANG="en_US.UTF-8",LC_ALL="en_US.UTF-8",LC_CTYPE="en_US.UTF-8"
-#user = {{ aw_user }}
 autostart = true
 autorestart = true
 stopwaitsecs = 5
@@ -42,10 +43,10 @@ events=TICK_60
 priority=0
 
 [unix_http_server]
-file=/tmp/supervisor.sock
+file=/var/run/supervisor/supervisor.sock
 
 [supervisorctl]
-serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -84,13 +84,9 @@
   set_fact:
     docker_base_path: "{{ awx_local_base_config_path|default('/tmp') }}/docker-image"
 
-- name: Set awx_web image name
+- name: Set awx image name
   set_fact:
-    web_image: "{{ web_image|default('awx_web') }}"
-
-- name: Set awx_task image name
-  set_fact:
-    task_image: "{{ task_image|default('awx_task') }}"
+    awx_image: "{{ awx_image|default('awx') }}"
 
 - name: Ensure directory exists
   file:
@@ -108,12 +104,6 @@
   template:
     src: Dockerfile.j2
     dest: "{{ docker_base_path }}/Dockerfile"
-  delegate_to: localhost
-
-- name: Template task Dockerfile
-  template:
-    src: Dockerfile.task.j2
-    dest: "{{ docker_base_path }}/Dockerfile.task"
   delegate_to: localhost
 
 - name: Stage launch_awx
@@ -174,7 +164,7 @@
     dest: "{{ docker_base_path }}/Makefile"
   delegate_to: localhost
 
-- name: Build base web image
+- name: Build base awx image
   docker_image:
     build:
       path: "{{ docker_base_path }}"
@@ -184,34 +174,17 @@
         http_proxy: "{{ http_proxy | default('') }}"
         https_proxy: "{{ https_proxy | default('') }}"
         no_proxy: "{{ no_proxy | default('') }}"
-    name: "{{ web_image }}"
+    name: "{{ awx_image }}"
     tag: "{{ awx_version }}"
     source: 'build'
     force_source: true
   delegate_to: localhost
 
-- name: Build base task image
-  docker_image:
-    build:
-      path: "{{ docker_base_path }}"
-      dockerfile: Dockerfile.task
-      pull: false
-      args:
-        http_proxy: "{{ http_proxy | default('') }}"
-        https_proxy: "{{ https_proxy | default('') }}"
-        no_proxy: "{{ no_proxy | default('') }}"
-    name: "{{ task_image }}"
-    tag: "{{ awx_version }}"
-    source: 'build'
-    force_source: true
-  delegate_to: localhost
-
-- name: Tag task and web images as latest
+- name: Tag awx images as latest
   command: "docker tag {{ item }}:{{ awx_version }} {{ item }}:latest"
   delegate_to: localhost
   with_items:
-    - "{{ task_image }}"
-    - "{{ web_image }}"
+    - "{{ awx_image }}"
 
 - name: Clean docker base directory
   file:

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -185,8 +185,8 @@ ADD tools/scripts/awx-python /usr/bin/awx-python
 ADD launch_awx.sh /usr/bin/launch_awx.sh
 ADD launch_awx_task.sh /usr/bin/launch_awx_task.sh
 ADD settings.py /etc/tower/settings.py
-ADD supervisor.conf /supervisor.conf
-ADD supervisor_task.conf /supervisor_task.conf
+ADD supervisor.conf /etc/supervisord.conf
+ADD supervisor_task.conf /etc/supervisord_task.conf
 ADD config-watcher /usr/bin/config-watcher
 {% endif %}
 
@@ -198,10 +198,10 @@ RUN for dir in \
       /var/run/awx-rsyslog \
       /var/log/tower \
       /var/log/nginx \
+      /var/run/supervisor \
       /var/lib/nginx ; \
     do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp root $dir ; done && \
     for file in \
-      /supervisord.log \
       /etc/passwd ; \
     do touch $file ; chmod g+rw $file ; chgrp root $file ; done
 

--- a/installer/roles/image_build/templates/Dockerfile.task.j2
+++ b/installer/roles/image_build/templates/Dockerfile.task.j2
@@ -1,6 +1,0 @@
-FROM {{ web_image }}:{{ awx_version }}
-USER 0
-RUN sudo dnf -y remove nginx
-USER 1000
-EXPOSE 8052
-CMD /usr/bin/launch_awx_task.sh

--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -26,4 +26,4 @@ awx-manage register_queue --queuename=tower --instance_percent=100
 
 unset $(cut -d = -f -1 /etc/tower/conf.d/environment.sh)
 
-supervisord -c /supervisor_task.conf
+supervisord -c /etc/supervisord_task.conf

--- a/installer/roles/image_push/tasks/main.yml
+++ b/installer/roles/image_push/tasks/main.yml
@@ -10,35 +10,19 @@
 
 - name: Remove local images to ensure proper push behavior
   block:
-    - name: Remove web image
+    - name: Remove awx image
       docker_image:
-        name: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ web_image }}"
-        tag: "{{ awx_version }}"
-        state: absent
-
-    - name: Remove task image
-      docker_image:
-        name: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ task_image }}"
+        name: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}"
         tag: "{{ awx_version }}"
         state: absent
   delegate_to: localhost
 
 - name: Tag and Push Container Images
   block:
-    - name: Tag and push web image to registry
+    - name: Tag and push awx image to registry
       docker_image:
-        name: "{{ web_image }}"
-        repository: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ web_image }}"
-        tag: "{{ item }}"
-        push: true
-      with_items:
-        - "latest"
-        - "{{ awx_version }}"
-
-    - name: Tag and push task image to registry
-      docker_image:
-        name: "{{ task_image }}"
-        repository: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ task_image }}"
+        name: "{{ awx_image }}"
+        repository: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}"
         tag: "{{ item }}"
         push: true
       with_items:
@@ -48,7 +32,5 @@
 
 - name: Set full image path for Registry
   set_fact:
-    awx_web_docker_actual_image: >-
-      {{ docker_registry }}/{{ docker_registry_repository }}/{{ web_image }}:{{ awx_version }}
-    awx_task_docker_actual_image: >-
-      {{ docker_registry }}/{{ docker_registry_repository }}/{{ task_image }}:{{ awx_version }}
+    awx_docker_actual_image: >-
+      {{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}:{{ awx_version }}

--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -9,10 +9,10 @@ admin_password: ''
 kubernetes_base_path: "{{ local_base_config_path|default('/tmp') }}/{{ kubernetes_deployment_name }}-config"
 
 kubernetes_task_version: "{{ tower_package_version | default(dockerhub_version) }}"
-kubernetes_task_image: "{{ tower_package_name | default('ansible/awx_task') }}"
-
 kubernetes_web_version: "{{ tower_package_version | default(dockerhub_version) }}"
-kubernetes_web_image: "{{ tower_package_name | default('ansible/awx_web') }}"
+kubernetes_awx_image: "{{ tower_package_name | default('ansible/awx') }}"
+kubernetes_web_image: "{{ kubernetes_awx_image }}"
+kubernetes_task_image: "{{ kubernetes_awx_image }}"
 
 web_mem_request: 1
 web_cpu_request: 500

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -190,15 +190,10 @@
 
 - name: Set image names if using custom registry
   block:
-    - name: Set task image name
+    - name: Set awx image name
       set_fact:
-        kubernetes_task_image: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ task_image }}"
-      when: kubernetes_task_image is not defined
-
-    - name: Set web image name
-      set_fact:
-        kubernetes_web_image: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ web_image }}"
-      when: kubernetes_web_image is not defined
+        kubernetes_awx_image: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}"
+      when: kubernetes_awx_image is not defined
   when: docker_registry is defined
 
 - name: Determine Deployment api version

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -144,12 +144,12 @@ spec:
               readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-web-config
-              mountPath: "/supervisor.conf"
+              mountPath: "/etc/supervisord.conf"
               subPath: supervisor.conf
               readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-task-config
-              mountPath: "/supervisor_task.conf"
+              mountPath: "/etc/supervisord_task.conf"
               subPath: supervisor_task.conf
               readOnly: true
 
@@ -220,12 +220,12 @@ spec:
               readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-web-config
-              mountPath: "/supervisor.conf"
+              mountPath: "/etc/supervisord.conf"
               subPath: supervisor.conf
               readOnly: true
 
             - name: {{ kubernetes_deployment_name }}-supervisor-task-config
-              mountPath: "/supervisor_task.conf"
+              mountPath: "/etc/supervisord_task.conf"
               subPath: supervisor_task.conf
               readOnly: true
 
@@ -241,7 +241,7 @@ spec:
               mountPath: "/var/run/memcached"
           env:
             - name: SUPERVISOR_WEB_CONFIG_PATH
-              value: "/supervisor.conf"
+              value: "/etc/supervisord.conf"
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
             - name: MY_POD_UID

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -89,7 +89,7 @@ spec:
 {% endif %}
       containers:
         - name: {{ kubernetes_deployment_name }}-web
-          image: "{{ kubernetes_web_image }}:{{ kubernetes_web_version }}"
+          image: "{{ kubernetes_awx_image }}:{{ kubernetes_web_version }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8052

--- a/installer/roles/kubernetes/templates/launch_awx.yml.j2
+++ b/installer/roles/kubernetes/templates/launch_awx.yml.j2
@@ -35,7 +35,7 @@ data:
 
     unset $(cut -d = -f -1 /etc/tower/conf.d/environment.sh)
 
-    supervisord -c /supervisor_task.conf
+    supervisord -c /etc/supervisord_task.conf
 
   launch-awx-web: |
     #!/usr/bin/env bash
@@ -54,5 +54,5 @@ data:
 
     unset $(cut -d = -f -1 /etc/tower/conf.d/environment.sh)
 
-    supervisord -c /supervisor.conf
+    supervisord -c /etc/supervisord.conf
 

--- a/installer/roles/kubernetes/templates/supervisor.yml.j2
+++ b/installer/roles/kubernetes/templates/supervisor.yml.j2
@@ -8,6 +8,9 @@ data:
     [supervisord]
     nodaemon = True
     umask = 022
+    logfile = /dev/stdout
+    logfile_maxbytes = 0
+    pidfile = /var/run/supervisor/supervisor.web.pid
 
     [program:nginx]
     command = nginx -g "daemon off;"
@@ -93,6 +96,9 @@ data:
     [supervisord]
     nodaemon = True
     umask = 022
+    logfile = /dev/stdout
+    logfile_maxbytes = 0
+    pidfile = /var/run/supervisor/supervisor.pid
 
     [program:dispatcher]
     command = awx-manage run_dispatcher
@@ -133,10 +139,10 @@ data:
     priority=0
 
     [unix_http_server]
-    file=/tmp/supervisor.sock
+    file=/var/run/supervisor/supervisor.sock
 
     [supervisorctl]
-    serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+    serverurl=unix:///var/run/supervisor/supervisor.sock ; use a unix:// URL  for a unix socket
 
     [rpcinterface:supervisor]
     supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 dockerhub_version: "{{ lookup('file', playbook_dir + '/../VERSION') }}"
 
+awx_image: "awx"
 redis_image: "redis"
 
 postgresql_version: "10"

--- a/installer/roles/local_docker/tasks/set_image.yml
+++ b/installer/roles/local_docker/tasks/set_image.yml
@@ -1,19 +1,11 @@
 ---
 - name: Manage AWX Container Images
   block:
-    - name: Export Docker web image if it isnt local and there isnt a registry defined
+    - name: Export Docker awx image if it isnt local and there isnt a registry defined
       docker_image:
-        name: "{{ web_image }}"
+        name: "{{ awx_image }}"
         tag: "{{ awx_version }}"
-        archive_path: "{{ awx_local_base_config_path|default('/tmp') }}/{{ web_image }}_{{ awx_version }}.tar"
-      when: inventory_hostname != "localhost" and docker_registry is not defined
-      delegate_to: localhost
-
-    - name: Export Docker task image if it isnt local and there isnt a registry defined
-      docker_image:
-        name: "{{ task_image }}"
-        tag: "{{ awx_version }}"
-        archive_path: "{{ awx_local_base_config_path|default('/tmp') }}/{{ task_image }}_{{ awx_version }}.tar"
+        archive_path: "{{ awx_local_base_config_path|default('/tmp') }}/{{ awx_image }}_{{ awx_version }}.tar"
       when: inventory_hostname != "localhost" and docker_registry is not defined
       delegate_to: localhost
 
@@ -28,43 +20,27 @@
         state: directory
       when: ansible_connection != "local" and docker_registry is not defined
 
-    - name: Copy web image to docker execution
+    - name: Copy awx image to docker execution
       copy:
-        src: "{{ awx_local_base_config_path|default('/tmp') }}/{{ web_image }}_{{ awx_version }}.tar"
-        dest: "{{ docker_deploy_base_path }}/{{ web_image }}_{{ awx_version }}.tar"
+        src: "{{ awx_local_base_config_path|default('/tmp') }}/{{ awx_image }}_{{ awx_version }}.tar"
+        dest: "{{ docker_deploy_base_path }}/{{ awx_image }}_{{ awx_version }}.tar"
       when: ansible_connection != "local" and docker_registry is not defined
 
-    - name: Copy task image to docker execution
-      copy:
-        src: "{{ awx_local_base_config_path|default('/tmp') }}/{{ task_image }}_{{ awx_version }}.tar"
-        dest: "{{ docker_deploy_base_path }}"
-      when: ansible_connection != "local" and docker_registry is not defined
-
-    - name: Load web image
+    - name: Load awx image
       docker_image:
-        name: "{{ web_image }}"
+        name: "{{ awx_image }}"
         tag: "{{ awx_version }}"
-        load_path: "{{ docker_deploy_base_path }}/{{ web_image }}_{{ awx_version }}.tar"
-        timeout: 300
-      when: ansible_connection != "local" and docker_registry is not defined
-
-    - name: Load task image
-      docker_image:
-        name: "{{ task_image }}"
-        tag: "{{ awx_version }}"
-        load_path: "{{ docker_deploy_base_path }}/{{ task_image }}_{{ awx_version }}.tar"
+        load_path: "{{ docker_deploy_base_path }}/{{ awx_image }}_{{ awx_version }}.tar"
         timeout: 300
       when: ansible_connection != "local" and docker_registry is not defined
 
     - name: Set full image path for local install
       set_fact:
-        awx_web_docker_actual_image: "{{ web_image }}:{{ awx_version }}"
-        awx_task_docker_actual_image: "{{ task_image }}:{{ awx_version }}"
+        awx_docker_actual_image: "{{ awx_image }}:{{ awx_version }}"
       when: docker_registry is not defined
   when: dockerhub_base is not defined
 
 - name: Set DockerHub Image Paths
   set_fact:
-    awx_web_docker_actual_image: "{{ dockerhub_base }}/awx_web:{{ dockerhub_version }}"
-    awx_task_docker_actual_image: "{{ dockerhub_base }}/awx_task:{{ dockerhub_version }}"
+    awx_docker_actual_image: "{{ dockerhub_base }}/awx:{{ dockerhub_version }}"
   when: dockerhub_base is defined

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -127,7 +127,7 @@ services:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}
-      SUPERVISOR_WEB_CONFIG_PATH: '/supervisor.conf'
+      SUPERVISOR_WEB_CONFIG_PATH: '/etc/supervisord.conf'
 
   redis:
     image: {{ redis_image }}

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   web:
-    image: {{ awx_web_docker_actual_image }}
+    image: {{ awx_docker_actual_image }}
     container_name: awx_web
     depends_on:
       - redis
@@ -72,7 +72,7 @@ services:
       no_proxy: {{ no_proxy | default('') }}
 
   task:
-    image: {{ awx_task_docker_actual_image }}
+    image: {{ awx_docker_actual_image }}
     container_name: awx_task
     depends_on:
       - redis
@@ -81,6 +81,7 @@ services:
       {% if pg_hostname is not defined %}
       - postgres
       {% endif %}
+    command: /usr/bin/launch_awx_task.sh
     hostname: {{ awx_task_hostname }}
     user: root
     restart: unless-stopped

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -88,10 +88,10 @@ programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsbroadc
 priority=5
 
 [unix_http_server]
-file=/tmp/supervisor.sock
+file=/var/run/supervisor/supervisor.sock
 
 [supervisorctl]
-serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
##### SUMMARY
This creates one 'awx' container image used by both awx_web and awx_task.

This also tweaks the supervisor configuration to use /var/run/supervisor for
all sockets, and /etc/ for all config files.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

