### PR TITLE
Comply with updated Ansible sanity test rules

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -33,7 +33,6 @@ options:
     - The Tower OAuth token to use.
     - If value not set, will try environment variable C(TOWER_OAUTH_TOKEN) and then config files
     type: str
-    version_added: "3.7"
   validate_certs:
     description:
     - Whether to allow insecure connections to Tower or AWX.

--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -12,7 +12,6 @@ DOCUMENTATION = '''
       - Matthew Jones (@matburt)
       - Yunfan Zhang (@YunfanZhang42)
     short_description: Ansible dynamic inventory plugin for Ansible Tower.
-    version_added: "2.7"
     description:
         - Reads inventories from Ansible Tower.
         - Supports reading configuration from both YAML config file and environment variables.
@@ -68,7 +67,6 @@ DOCUMENTATION = '''
             description: Make extra requests to provide all group vars with metadata about the source Ansible Tower host.
             type: bool
             default: False
-            version_added: "2.8"
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/lookup/tower_schedule_rrule.py
+++ b/awx_collection/plugins/lookup/tower_schedule_rrule.py
@@ -6,7 +6,6 @@ __metaclass__ = type
 DOCUMENTATION = """
     lookup: tower_schedule_rrule
     author: John Westcott IV (@john-westcott-iv)
-    version_added: "3.7"
     short_description: Generate an rrule string which can be used for Tower Schedules
     requirements:
       - pytz

--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_credential
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower credential.
 description:
     - Create, update, or destroy Ansible Tower credentials. See
@@ -45,7 +44,6 @@ options:
       description:
         - Name of credential type.
         - Will be preferred over kind
-      version_added: "2.10"
       type: str
     inputs:
       description:
@@ -53,7 +51,6 @@ options:
           Credential inputs where the keys are var names used in templating.
           Refer to the Ansible Tower documentation for example syntax.
         - Any fields in this dict will take prescedence over any fields mentioned below (i.e. host, username, etc)
-      version_added: "2.9"
       type: dict
     user:
       description:
@@ -124,7 +121,6 @@ options:
       description:
         - STS token for aws type.
         - Deprecated, please use inputs
-      version_added: "2.6"
       type: str
     secret:
       description:
@@ -177,7 +173,6 @@ options:
         - This parameter is only valid if C(kind) is specified as C(vault).
         - Deprecated, please use inputs
       type: str
-      version_added: "2.8"
     state:
       description:
         - Desired state of the resource.
@@ -360,9 +355,9 @@ def main():
     # Deprication warnings
     for legacy_input in OLD_INPUT_NAMES:
         if module.params.get(legacy_input) is not None:
-            module.deprecate(msg='{0} parameter has been deprecated, please use inputs instead'.format(legacy_input), version="3.6")
+            module.deprecate(msg='{0} parameter has been deprecated, please use inputs instead'.format(legacy_input), version="ansible.tower:4.0.0")
     if kind:
-        module.deprecate(msg='The kind parameter has been deprecated, please use credential_type instead', version="3.6")
+        module.deprecate(msg='The kind parameter has been deprecated, please use credential_type instead', version="ansible.tower:4.0.0")
 
     cred_type_id = module.resolve_name_to_id('credential_types', credential_type if credential_type else KIND_CHOICES[kind])
     if organization:

--- a/awx_collection/plugins/modules/tower_credential_type.py
+++ b/awx_collection/plugins/modules/tower_credential_type.py
@@ -18,7 +18,6 @@ DOCUMENTATION = '''
 ---
 module: tower_credential_type
 author: "Adrien Fleury (@fleu42)"
-version_added: "2.7"
 short_description: Create, update, or destroy custom Ansible Tower credential type.
 description:
     - Create, update, or destroy Ansible Tower credential type. See

--- a/awx_collection/plugins/modules/tower_group.py
+++ b/awx_collection/plugins/modules/tower_group.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_group
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower group.
 description:
     - Create, update, or destroy Ansible Tower groups. See
@@ -63,7 +62,6 @@ options:
       description:
         - A new name for this group (for renaming)
       type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_host.py
+++ b/awx_collection/plugins/modules/tower_host.py
@@ -16,7 +16,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_host
-version_added: "2.3"
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: create, update, or destroy Ansible Tower host.
 description:
@@ -32,7 +31,6 @@ options:
       description:
         - To use when changing a hosts's name.
       type: str
-      version_added: "3.7"
     description:
       description:
         - The description to use for the host.

--- a/awx_collection/plugins/modules/tower_inventory.py
+++ b/awx_collection/plugins/modules/tower_inventory.py
@@ -16,7 +16,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_inventory
-version_added: "2.3"
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: create, update, or destroy Ansible Tower inventory.
 description:
@@ -46,12 +45,10 @@ options:
         - The kind field. Cannot be modified after created.
       default: ""
       choices: ["", "smart"]
-      version_added: "2.7"
       type: str
     host_filter:
       description:
         -  The host_filter field. Only useful when C(kind=smart).
-      version_added: "2.7"
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_inventory_source
 author: "Adrien Fleury (@fleu42)"
-version_added: "2.7"
 short_description: create, update, or destroy Ansible Tower inventory source.
 description:
     - Create, update, or destroy Ansible Tower inventory source. See
@@ -32,7 +31,6 @@ options:
       description:
         - A new name for this assets (will rename the asset)
       type: str
-      version_added: "3.7"
     description:
       description:
         - The description to use for the inventory source.
@@ -85,7 +83,6 @@ options:
         - Override vars in child groups and hosts with those from external source.
       type: bool
     custom_virtualenv:
-      version_added: "2.9"
       description:
         - Local absolute file path containing a custom Python virtualenv to use.
       type: str

--- a/awx_collection/plugins/modules/tower_job_cancel.py
+++ b/awx_collection/plugins/modules/tower_job_cancel.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_job_cancel
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: Cancel an Ansible Tower Job.
 description:
     - Cancel Ansible Tower jobs. See

--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_job_launch
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: Launch an Ansible Job.
 description:
     - Launch an Ansible Tower jobs. See
@@ -64,29 +63,24 @@ options:
         - A specific of the SCM project to run the template on.
         - This is only applicable if your project allows for branch override.
       type: str
-      version_added: "3.7"
     skip_tags:
       description:
         - Specific tags to skip from the playbook.
       type: list
       elements: str
-      version_added: "3.7"
     verbosity:
       description:
         - Verbosity level for this job run
       type: int
       choices: [ 0, 1, 2, 3, 4, 5 ]
-      version_added: "3.7"
     diff_mode:
       description:
         - Show the changes made by Ansible tasks where supported
       type: bool
-      version_added: "3.7"
     credential_passwords:
       description:
         - Passwords for credentials which are set to prompt on launch
       type: dict
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_job_list.py
+++ b/awx_collection/plugins/modules/tower_job_list.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_job_list
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: List Ansible Tower jobs.
 description:
     - List Ansible Tower jobs. See

--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_job_template
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower job templates.
 description:
     - Create, update, or destroy Ansible Tower job templates. See
@@ -57,19 +56,16 @@ options:
       description:
         - Name of the credential to use for the job template.
         - Deprecated, use 'credentials'.
-      version_added: 2.7
       type: str
     credentials:
       description:
         - List of credentials to use for the job template.
       type: list
       elements: str
-      version_added: 2.8
     vault_credential:
       description:
         - Name of the vault credential to use for the job template.
         - Deprecated, use 'credentials'.
-      version_added: 2.7
       type: str
     forks:
       description:
@@ -89,7 +85,6 @@ options:
       description:
         - Specify C(extra_vars) for the template.
       type: dict
-      version_added: 3.7
     job_tags:
       description:
         - Comma separated list of the tags to use for the job template.
@@ -97,7 +92,6 @@ options:
     force_handlers:
       description:
         - Enable forcing playbook handlers to run even if a task fails.
-      version_added: 2.7
       type: bool
       default: 'no'
       aliases:
@@ -109,12 +103,10 @@ options:
     start_at_task:
       description:
         - Start the playbook at the task matching this name.
-      version_added: 2.7
       type: str
     diff_mode:
       description:
         - Enable diff mode for the job template.
-      version_added: 2.7
       type: bool
       aliases:
         - diff_mode_enabled
@@ -122,7 +114,6 @@ options:
     use_fact_cache:
       description:
         - Enable use of fact caching for the job template.
-      version_added: 2.7
       type: bool
       default: 'no'
       aliases:
@@ -139,7 +130,6 @@ options:
     ask_diff_mode_on_launch:
       description:
         - Prompt user to enable diff mode (show changes) to files when supported by modules.
-      version_added: 2.7
       type: bool
       default: 'False'
       aliases:
@@ -154,7 +144,6 @@ options:
     ask_limit_on_launch:
       description:
         - Prompt user for a limit on launch.
-      version_added: 2.7
       type: bool
       default: 'False'
       aliases:
@@ -169,7 +158,6 @@ options:
     ask_skip_tags_on_launch:
       description:
         - Prompt user for job tags to skip on launch.
-      version_added: 2.7
       type: bool
       default: 'False'
       aliases:
@@ -184,7 +172,6 @@ options:
     ask_verbosity_on_launch:
       description:
         - Prompt user to choose a verbosity level on launch.
-      version_added: 2.7
       type: bool
       default: 'False'
       aliases:
@@ -206,13 +193,11 @@ options:
     survey_enabled:
       description:
         - Enable a survey on the job template.
-      version_added: 2.7
       type: bool
       default: 'no'
     survey_spec:
       description:
         - JSON/YAML dict formatted survey definition.
-      version_added: 2.8
       type: dict
     become_enabled:
       description:
@@ -222,7 +207,6 @@ options:
     allow_simultaneous:
       description:
         - Allow simultaneous runs of the job template.
-      version_added: 2.7
       type: bool
       default: 'no'
       aliases:
@@ -232,7 +216,6 @@ options:
         - Maximum time in seconds to wait for a job to finish (server-side).
       type: int
     custom_virtualenv:
-      version_added: "2.9"
       description:
         - Local absolute file path containing a custom Python virtualenv to use.
       type: str

--- a/awx_collection/plugins/modules/tower_job_wait.py
+++ b/awx_collection/plugins/modules/tower_job_wait.py
@@ -16,7 +16,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_job_wait
-version_added: "2.3"
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: Wait for Ansible Tower job to finish.
 description:
@@ -141,7 +140,7 @@ def main():
             interval = abs((min_interval + max_interval) / 2)
         module.deprecate(
             msg="Min and max interval have been deprecated, please use interval instead; interval will be set to {0}".format(interval),
-            version="3.7"
+            version="ansible.tower:4.0.0"
         )
 
     # Attempt to look up job based on the provided id

--- a/awx_collection/plugins/modules/tower_label.py
+++ b/awx_collection/plugins/modules/tower_label.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_label
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower labels.
 description:
     - Create, update, or destroy Ansible Tower labels. See

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -16,7 +16,6 @@ DOCUMENTATION = '''
 ---
 module: tower_license
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.9"
 short_description: Set the license for Ansible Tower
 description:
     - Get or Set Ansible Tower license. See
@@ -27,13 +26,11 @@ options:
         - The contents of the license file
       required: True
       type: dict
-      version_added: "3.7"
     eula_accepted:
       description:
         - Whether or not the EULA is accepted.
       required: True
       type: bool
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/tower_notification.py
+++ b/awx_collection/plugins/modules/tower_notification.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_notification
 author: "Samuel Carpentier (@samcarpentier)"
-version_added: "2.8"
 short_description: create, update, or destroy Ansible Tower notification.
 description:
     - Create, update, or destroy Ansible Tower notifications. See
@@ -371,7 +370,9 @@ def main():
     # Deprecation warnings for all other params
     for legacy_input in OLD_INPUT_NAMES:
         if module.params.get(legacy_input) is not None:
-            module.deprecate(msg='{0} parameter has been deprecated, please use notification_configuration instead'.format(legacy_input), version="3.6")
+            module.deprecate(
+                msg='{0} parameter has been deprecated, please use notification_configuration instead'.format(legacy_input),
+                version="ansible.tower:4.0.0")
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
     organization_id = None

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -16,7 +16,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_organization
-version_added: "2.3"
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: create, update, or destroy Ansible Tower organizations
 description:
@@ -33,7 +32,6 @@ options:
         - The description to use for the organization.
       type: str
     custom_virtualenv:
-      version_added: "2.9"
       description:
         - Local absolute file path containing a custom Python virtualenv to use.
       type: str
@@ -43,7 +41,6 @@ options:
         - The max hosts allowed in this organizations
       default: "0"
       type: int
-      version_added: "3.7"
     state:
       description:
         - Desired state of the resource.

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_project
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower projects
 description:
     - Create, update, or destroy Ansible Tower projects. See
@@ -56,7 +55,6 @@ options:
         - The refspec to use for the SCM resource.
       type: str
       default: ''
-      version_added: "3.7"
     scm_credential:
       description:
         - Name of the credential to use with this SCM resource.
@@ -77,7 +75,6 @@ options:
       type: bool
       default: 'no'
     scm_update_cache_timeout:
-      version_added: "2.8"
       description:
         - Cache Timeout to cache prior project syncs for a certain number of seconds.
             Only valid if scm_update_on_launch is to True, otherwise ignored.
@@ -87,17 +84,14 @@ options:
       description:
         - Allow changing the SCM branch or revision in a job template that uses this project.
       type: bool
-      version_added: "3.7"
       aliases:
         - scm_allow_override
     job_timeout:
-      version_added: "2.8"
       description:
         - The amount of time (in seconds) to run before the SCM Update is canceled. A value of 0 means no timeout.
       default: 0
       type: int
     custom_virtualenv:
-      version_added: "2.8"
       description:
         - Local absolute file path containing a custom Python virtualenv to use
       type: str

--- a/awx_collection/plugins/modules/tower_receive.py
+++ b/awx_collection/plugins/modules/tower_receive.py
@@ -17,11 +17,10 @@ DOCUMENTATION = '''
 ---
 module: tower_receive
 deprecated:
-  removed_in: "3.7"
+  removed_in: "14.0.0"
   why: Deprecated in favor of upcoming C(_export) module.
   alternative: Once published, use M(tower_export) instead.
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.8"
 short_description: Receive assets from Ansible Tower.
 description:
     - Receive assets from Ansible Tower. See
@@ -166,7 +165,7 @@ def main():
 
     module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)
 
-    module.deprecate(msg="This module is deprecated and will be replaced by the AWX CLI export command.", version="3.7")
+    module.deprecate(msg="This module is deprecated and will be replaced by the AWX CLI export command.", version="awx.awx:14.0.0")
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -16,7 +16,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_role
-version_added: "2.3"
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: grant or revoke an Ansible Tower role.
 description:

--- a/awx_collection/plugins/modules/tower_schedule.py
+++ b/awx_collection/plugins/modules/tower_schedule.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_schedule
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower schedules.
 description:
     - Create, update, or destroy Ansible Tower schedules. See

--- a/awx_collection/plugins/modules/tower_send.py
+++ b/awx_collection/plugins/modules/tower_send.py
@@ -17,11 +17,10 @@ DOCUMENTATION = '''
 ---
 module: tower_send
 deprecated:
-  removed_in: "3.7"
+  removed_in: "14.0.0"
   why: Deprecated in favor of upcoming C(_import) module.
   alternative: Once published, use M(tower_import) instead.
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.8"
 short_description: Send assets to Ansible Tower.
 description:
     - Send assets to Ansible Tower. See
@@ -106,7 +105,7 @@ def main():
 
     module = TowerModule(argument_spec=argument_spec, supports_check_mode=False)
 
-    module.deprecate(msg="This module is deprecated and will be replaced by the AWX CLI import command", version="3.7")
+    module.deprecate(msg="This module is deprecated and will be replaced by the AWX CLI import command", version="awx.awx:14.0.0")
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_settings
 author: "Nikhil Jain (@jainnikhil30)"
-version_added: "2.7"
 short_description: Modify Ansible Tower settings.
 description:
     - Modify Ansible Tower settings. See
@@ -37,7 +36,6 @@ options:
       description:
         - A data structure to be sent into the settings endpoint
       type: dict
-      version_added: "3.7"
 requirements:
   - pyyaml
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/tower_team.py
+++ b/awx_collection/plugins/modules/tower_team.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_team
 author: "Wayne Witzel III (@wwitzel3)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower team.
 description:
     - Create, update, or destroy Ansible Tower teams. See
@@ -32,7 +31,6 @@ options:
       description:
         - To use when changing a team's name.
       type: str
-      version_added: "3.7"
     description:
       description:
         - The description to use for the team.

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_user
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower users.
 description:
     - Create, update, or destroy Ansible Tower users. See

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_workflow_job_template
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower workflow job templates.
 description:
     - Create, update, or destroy Ansible Tower workflow job templates.

--- a/awx_collection/plugins/modules/tower_workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template_node.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
 ---
 module: tower_workflow_job_template_node
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.3"
 short_description: create, update, or destroy Ansible Tower workflow job template nodes.
 description:
     - Create, update, or destroy Ansible Tower workflow job template nodes.

--- a/awx_collection/plugins/modules/tower_workflow_launch.py
+++ b/awx_collection/plugins/modules/tower_workflow_launch.py
@@ -14,7 +14,6 @@ DOCUMENTATION = '''
 ---
 module: tower_workflow_launch
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.8"
 short_description: Run a workflow in Ansible Tower
 description:
     - Launch an Ansible Tower workflows. See
@@ -32,7 +31,6 @@ options:
         - Organization the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
-      required: False
       type: str
     inventory:
       description:
@@ -47,7 +45,6 @@ options:
         - A specific branch of the SCM project to run the template on.
         - This is only applicable if your project allows for branch override.
       type: str
-      version_added: "3.7"
     extra_vars:
       description:
         - Any extra vars required to launch the job.

--- a/awx_collection/plugins/modules/tower_workflow_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_template.py
@@ -17,11 +17,10 @@ DOCUMENTATION = '''
 ---
 module: tower_workflow_template
 deprecated:
-  removed_in: "3.7"
+  removed_in: "14.0.0"
   why: Deprecated in favor of C(_workflow_job_template) and C(_workflow_job_template_node) modules.
   alternative: Use M(tower_workflow_job_template) and M(_workflow_job_template_node) instead.
 author: "Adrien Fleury (@fleu42)"
-version_added: "2.7"
 short_description: create, update, or destroy Ansible Tower workflow template.
 description:
     - A tower-cli based module for CRUD actions on workflow job templates.
@@ -37,12 +36,10 @@ options:
       description:
         - Prompt user for (extra_vars) on launch.
       type: bool
-      version_added: "2.9"
     ask_inventory:
       description:
         - Prompt user for inventory on launch.
       type: bool
-      version_added: "2.9"
     description:
       description:
         - The description to use for the workflow.
@@ -54,7 +51,6 @@ options:
     inventory:
       description:
         - Name of the inventory to use for the job template.
-      version_added: "2.9"
       type: str
     name:
       description:
@@ -153,7 +149,7 @@ def main():
         "This module is replaced by the combination of tower_workflow_job_template and "
         "tower_workflow_job_template_node. This uses the old tower-cli and wll be "
         "removed in 2022."
-    ), version='4.2.0')
+    ), version='awx.awx:14.0.0')
 
     name = module.params.get('name')
     state = module.params.get('state')

--- a/awx_collection/tests/sanity/ignore-2.10.txt
+++ b/awx_collection/tests/sanity/ignore-2.10.txt
@@ -1,6 +1,6 @@
 plugins/modules/tower_receive.py validate-modules:deprecation-mismatch
-plugins/modules/tower_receive.py validate-modules:invalid-documentation
 plugins/modules/tower_send.py validate-modules:deprecation-mismatch
-plugins/modules/tower_send.py validate-modules:invalid-documentation
 plugins/modules/tower_workflow_template.py validate-modules:deprecation-mismatch
-plugins/modules/tower_workflow_template.py validate-modules:invalid-documentation
+plugins/modules/tower_credential.py pylint:wrong-collection-deprecated-version-tag
+plugins/modules/tower_job_wait.py pylint:wrong-collection-deprecated-version-tag
+plugins/modules/tower_notification.py pylint:wrong-collection-deprecated-version-tag

--- a/awx_collection/tools/roles/generate/templates/tower_module.j2
+++ b/awx_collection/tools/roles/generate/templates/tower_module.j2
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
 ---
 module: tower_{{ singular_item_type }}
 author: "John Westcott IV (@john-westcott-iv)"
-version_added: "2.3"
+version_added: "4.0"
 short_description: create, update, or destroy Ansible Tower {{ human_readable }}.
 description:
     - Create, update, or destroy Ansible Tower {{ human_readable }}. See
@@ -87,7 +87,6 @@ options:
         - The Tower OAuth token to use.
       required: False
       type: str
-      version_added: "3.7"
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -30,6 +30,13 @@
         path: "{{ collection_path }}/plugins/inventory/tower.py"
         regexp: "^    NAME = 'awx.awx.tower'  # REPLACE$"
         replace: "    NAME = '{{ collection_namespace }}.{{ collection_package }}.tower'  # REPLACE"
+
+    - name: Get sanity tests to work with non-default name
+      lineinfile:
+        path: "{{ collection_path }}/tests/sanity/ignore-2.10.txt"
+        state: absent
+        regexp: ' pylint:wrong-collection-deprecated-version-tag$'
+
   when:
     - (collection_package != 'awx') or (collection_namespace != 'awx')
 


### PR DESCRIPTION
##### SUMMARY
See:

https://github.com/ansible/proposals/issues/178#issuecomment-637965720

> In this case, version_added should not be there, because the option was there when the module was introduced to the collection.

That applies for the auto-migrated collections, and other maintainers still _can_ go their own way. But the tests don't allow for pinning versions from ansible-base. So we can't keep the old stuff. That decision has already been made.

There are some other wonky things in here, because we are balancing 2 different namespaces. For the 3 deprecated modules not shipped in the `ansible.tower` collection, we are free to reference `awx.awx` versions.

In the modules where we deprecate things which are in `ansible.tower`, we prefer Tower versions over AWX versions. Thus, we ignore those rules permanently for `awx.awx`. We might have to delete those rules for the `ansible.tower` collection (because it will become correct with the namespace change, and will trigger the unnecessary-ignore rule). Let me ping @felixfontein here, because I'm sure they weren't anticipating this situation of releasing the same content under 2 different namespaces.

##### ISSUE TYPE
 - Bugfix Pull Request

