### PR TITLE
Adds ux for unsynced projects

### DIFF
--- a/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.jsx
+++ b/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.jsx
@@ -41,10 +41,10 @@ class ClipboardCopyButton extends React.Component {
 
   render() {
     const {
-      clickTip,
+      copyTip,
       entryDelay,
       exitDelay,
-      hoverTip,
+      copiedSuccessTip,
       isDisabled,
     } = this.props;
     const { copied } = this.state;
@@ -54,13 +54,13 @@ class ClipboardCopyButton extends React.Component {
         entryDelay={entryDelay}
         exitDelay={exitDelay}
         trigger="mouseenter focus click"
-        content={copied ? clickTip : hoverTip}
+        content={copied ? copiedSuccessTip : copyTip}
       >
         <Button
           isDisabled={isDisabled}
           variant="plain"
           onClick={this.handleCopyClick}
-          aria-label={hoverTip}
+          aria-label={copyTip}
         >
           <CopyIcon />
         </Button>
@@ -70,10 +70,10 @@ class ClipboardCopyButton extends React.Component {
 }
 
 ClipboardCopyButton.propTypes = {
-  clickTip: PropTypes.string.isRequired,
+  copyTip: PropTypes.string.isRequired,
   entryDelay: PropTypes.number,
   exitDelay: PropTypes.number,
-  hoverTip: PropTypes.string.isRequired,
+  copiedSuccessTip: PropTypes.string.isRequired,
   stringToCopy: PropTypes.string.isRequired,
   switchDelay: PropTypes.number,
   isDisabled: PropTypes.bool.isRequired,

--- a/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.jsx
+++ b/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.jsx
@@ -40,7 +40,13 @@ class ClipboardCopyButton extends React.Component {
   };
 
   render() {
-    const { clickTip, entryDelay, exitDelay, hoverTip } = this.props;
+    const {
+      clickTip,
+      entryDelay,
+      exitDelay,
+      hoverTip,
+      isDisabled,
+    } = this.props;
     const { copied } = this.state;
 
     return (
@@ -51,6 +57,7 @@ class ClipboardCopyButton extends React.Component {
         content={copied ? clickTip : hoverTip}
       >
         <Button
+          isDisabled={isDisabled}
           variant="plain"
           onClick={this.handleCopyClick}
           aria-label={hoverTip}
@@ -69,6 +76,7 @@ ClipboardCopyButton.propTypes = {
   hoverTip: PropTypes.string.isRequired,
   stringToCopy: PropTypes.string.isRequired,
   switchDelay: PropTypes.number,
+  isDisabled: PropTypes.bool.isRequired,
 };
 
 ClipboardCopyButton.defaultProps = {

--- a/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.test.jsx
+++ b/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.test.jsx
@@ -13,6 +13,7 @@ describe('ClipboardCopyButton', () => {
         clickTip="foo"
         hoverTip="bar"
         stringToCopy="foobar!"
+        isDisabled={false}
       />
     );
     expect(wrapper).toHaveLength(1);
@@ -23,6 +24,7 @@ describe('ClipboardCopyButton', () => {
         clickTip="foo"
         hoverTip="bar"
         stringToCopy="foobar!"
+        isDisabled={false}
       />
     ).find('ClipboardCopyButton');
     expect(wrapper.state('copied')).toBe(false);
@@ -32,5 +34,16 @@ describe('ClipboardCopyButton', () => {
     jest.runAllTimers();
     wrapper.update();
     expect(wrapper.state('copied')).toBe(false);
+  });
+  test('should render disabled button', () => {
+    const wrapper = mountWithContexts(
+      <ClipboardCopyButton
+        clickTip="foo"
+        hoverTip="bar"
+        stringToCopy="foobar!"
+        isDisabled
+      />
+    );
+    expect(wrapper.find('Button').prop('isDisabled')).toBe(true);
   });
 });

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -128,14 +128,14 @@ function ProjectListItem({
               {project.scm_revision.substring(0, 7)}
               {!project.scm_revision && (
                 <Label aria-label={i18n._(t`copy to clipboard disabled`)}>
-                  {i18n._(t`Sync to activate`)}
+                  {i18n._(t`Sync for revision`)}
                 </Label>
               )}
               <ClipboardCopyButton
                 isDisabled={!project.scm_revision}
                 stringToCopy={project.scm_revision}
-                hoverTip={i18n._(t`Copy full revision to clipboard.`)}
-                clickTip={i18n._(t`Successfully copied to clipboard!`)}
+                copyTip={i18n._(t`Copy full revision to clipboard.`)}
+                copiedSuccessTip={i18n._(t`Successfully copied to clipboard!`)}
               />
             </DataListCell>,
           ]}

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -32,6 +32,11 @@ const DataListAction = styled(_DataListAction)`
   grid-gap: 16px;
   grid-template-columns: repeat(3, 40px);
 `;
+
+const Label = styled.span`
+  color: var(--pf-global--disabled-color--100);
+`;
+
 function ProjectListItem({
   project,
   isSelected,
@@ -121,13 +126,17 @@ function ProjectListItem({
             </DataListCell>,
             <DataListCell key="revision">
               {project.scm_revision.substring(0, 7)}
-              {project.scm_revision ? (
-                <ClipboardCopyButton
-                  stringToCopy={project.scm_revision}
-                  hoverTip={i18n._(t`Copy full revision to clipboard.`)}
-                  clickTip={i18n._(t`Successfully copied to clipboard!`)}
-                />
-              ) : null}
+              {!project.scm_revision && (
+                <Label aria-label={i18n._(t`copy to clipboard disabled`)}>
+                  {i18n._(t`Sync to activate`)}
+                </Label>
+              )}
+              <ClipboardCopyButton
+                isDisabled={!project.scm_revision}
+                stringToCopy={project.scm_revision}
+                hoverTip={i18n._(t`Copy full revision to clipboard.`)}
+                clickTip={i18n._(t`Successfully copied to clipboard!`)}
+              />
             </DataListCell>,
           ]}
         />

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
@@ -245,7 +245,7 @@ describe('<ProjectsListItem />', () => {
     );
     expect(
       wrapper.find('span[aria-label="copy to clipboard disabled"]').text()
-    ).toBe('Sync to activate');
+    ).toBe('Sync for revision');
     expect(wrapper.find('ClipboardCopyButton').prop('isDisabled')).toBe(true);
   });
 });

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.test.jsx
@@ -218,4 +218,34 @@ describe('<ProjectsListItem />', () => {
     );
     expect(wrapper.find('CopyButton').length).toBe(0);
   });
+  test('should render disabled copy to clipboard button', () => {
+    const wrapper = mountWithContexts(
+      <ProjectsListItem
+        isSelected={false}
+        detailUrl="/project/1"
+        onSelect={() => {}}
+        project={{
+          id: 1,
+          name: 'Project 1',
+          url: '/api/v2/projects/1',
+          type: 'project',
+          scm_type: 'git',
+          scm_revision: '',
+          summary_fields: {
+            last_job: {
+              id: 9000,
+              status: 'successful',
+            },
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
+    );
+    expect(
+      wrapper.find('span[aria-label="copy to clipboard disabled"]').text()
+    ).toBe('Sync to activate');
+    expect(wrapper.find('ClipboardCopyButton').prop('isDisabled')).toBe(true);
+  });
 });


### PR DESCRIPTION
##### SUMMARY
After discussions with @dsesami and @trahman73 we decided that there needed to be a bit more help for users on newly copied/unsynced projects.  https://github.com/ansible/awx/issues/6863#issuecomment-636073900 

This PR disables the copy to clipboard button, and adds a message for the user to all unsynced projects.  
##### ISSUE TYPE
-enhancement

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![Screen Shot 2020-06-03 at 2 59 55 PM](https://user-images.githubusercontent.com/39280967/83677941-e8fadf00-a5aa-11ea-8e02-4d58355a2ed0.png)
