### PR TITLE
URL encode '/' to '%2F' for conjur credential plugin

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -50,9 +50,9 @@ conjur_inputs = {
 def conjur_backend(**kwargs):
     url = kwargs['url']
     api_key = kwargs['api_key']
-    account = quote(kwargs['account'])
-    username = quote(kwargs['username'])
-    secret_path = quote(kwargs['secret_path'])
+    account = quote(kwargs['account'], safe='') 
+    username = quote(kwargs['username'], safe='')
+    secret_path = quote(kwargs['secret_path'], safe='')
     version = kwargs.get('secret_version')
     cacert = kwargs.get('cacert', None)
 


### PR DESCRIPTION
##### SUMMARY
All conjur resources that contain a '/' within its ID must be url encoded when making a HTTP request.

Related to this commit: https://github.com/ansible/awx/commit/cfe8a1722c1aeb70c5b26a939672d6975e880de2

Related to this issue:
https://github.com/ansible/awx/issues/7248

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


##### AWX VERSION
all


##### ADDITIONAL INFORMATION

