### PR TITLE
Add cypress black box code cov instrumentation to ui_next 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ awx/ui_next/src/locales/
 awx/ui_next/coverage/
 awx/ui_next/build
 awx/ui_next/.env.local
+awx/ui_next/instrumented
 rsyslog.pid
 tools/prometheus/data
 tools/docker-compose/Dockerfile

--- a/awx/ui_next/.eslintignore
+++ b/awx/ui_next/.eslintignore
@@ -7,3 +7,4 @@ build
 node_modules
 dist
 images
+instrumented

--- a/awx/ui_next/package.json
+++ b/awx/ui_next/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@babel/polyfill": "^7.8.7",
+    "@cypress/instrument-cra": "^1.4.0",
     "@lingui/cli": "^2.9.2",
     "@lingui/macro": "^2.9.1",
     "@nteract/mockument": "^1.0.4",
@@ -53,6 +54,7 @@
   },
   "scripts": {
     "start": "PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
+    "start-instrumented": "DEBUG=instrument-cra PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts -r @cypress/instrument-cra start",
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "TZ='UTC' react-scripts test --coverage --watchAll=false",
     "test-watch": "TZ='UTC' react-scripts test",


### PR DESCRIPTION
##### SUMMARY
This PR adds the capability to run cypress tests and collected code coverage metrics from an instrumented ui_next dev build. This generated report matches the code cov report generated by jest.

This PR does not include documentation on how to run this locally as that will exist alongside the testing codebase for now.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION