### PR TITLE
Force worker processes to have a different signal handler from the parent

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -35,6 +35,7 @@ class WorkerSignalHandler:
 
     def __init__(self):
         self.kill_now = False
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
         signal.signal(signal.SIGINT, self.exit_gracefully)
 
     def exit_gracefully(self, *args, **kwargs):

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -581,3 +581,4 @@ class TaskManager():
                 logger.debug("Starting Scheduler")
                 with task_manager_bulk_reschedule():
                     self._schedule()
+                logger.debug("Finishing Scheduler")


### PR DESCRIPTION
##### SUMMARY

Situations have come up where the 5+ minute kill signal for
run_task_manager is emitted to the worker process running it, but
since the worker improperly inherited the AWXConsumerBase().stop()
handler a deadlock ultimately was triggered on the database
connection.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 11.2.0
