### PR TITLE
configure cluster with local_docker

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -60,6 +60,9 @@ dockerhub_base=ansible
 # management_mem_limit=2
 
 # Common Docker parameters
+# If clustering with local_docker is used then set the task hostname
+# to the local hostname to distinguish between instances, e.g.
+# awx_task_hostname={{ ansible_hostname }}
 awx_task_hostname=awx
 awx_web_hostname=awxweb
 postgres_data_dir="~/.awx/pgdocker"

--- a/installer/inventory
+++ b/installer/inventory
@@ -62,8 +62,8 @@ dockerhub_base=ansible
 # Common Docker parameters
 # If clustering with local_docker is used then set the task hostname
 # to the local hostname to distinguish between instances, e.g.
-# awx_task_hostname={{ ansible_hostname }}
-awx_task_hostname=awx
+# awx_task_hostname={{ inventory_hostname }}
+awx_task_hostname={% if ansible_play_hosts_all|length > 1 %}{{ inventory_hostname }}{% else %}awx{% endif %}
 awx_web_hostname=awxweb
 postgres_data_dir="~/.awx/pgdocker"
 host_port=80

--- a/installer/roles/image_build/files/settings.py
+++ b/installer/roles/image_build/files/settings.py
@@ -7,6 +7,17 @@ def get_secret():
     if os.path.exists("/etc/tower/SECRET_KEY"):
         return open('/etc/tower/SECRET_KEY', 'rb').read().strip()
 
+def get_uuid():
+    if os.path.exists("/etc/tower/UUID"):
+        return open('/etc/tower/UUID', 'r').read().strip()
+    else:
+        return '00000000-0000-0000-0000-000000000000'
+
+def get_cluster_host_id():
+    if os.path.exists("/etc/tower/CLUSTER_ID"):
+        return open('/etc/tower/CLUSTER_ID', 'r').read().strip()
+    else:
+        return 'awx'
 
 ADMINS = ()
 
@@ -26,8 +37,8 @@ ALLOWED_HOSTS = ['*']
 AWX_PROOT_ENABLED = False
 
 
-CLUSTER_HOST_ID = "awx"
-SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
+CLUSTER_HOST_ID = get_cluster_host_id()
+SYSTEM_UUID = get_uuid()
 
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False

--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -56,6 +56,7 @@
     source: 'build'
     force_source: true
   delegate_to: localhost
+  run_once: true
   when: use_container_for_build|default(true)|bool
 
 - name: Build AWX distribution using container
@@ -71,6 +72,7 @@
     volumes:
       - ../:/awx:Z
   delegate_to: localhost
+  run_once: true
   when: use_container_for_build|default(true)|bool
 
 - name: Build AWX distribution locally

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -43,14 +43,14 @@
 
 - name: Render UUID file
   copy:
-    content: "{{ ansible_hostname | to_uuid }}"
+    content: "{{ inventory_hostname | to_uuid }}"
     dest: "{{ docker_compose_dir }}/UUID"
     mode: '0600'
   when: ansible_play_hosts_all|length > 1
 
 - name: Render CLUSTER_ID file
   copy:
-    content: "{{ ansible_hostname }}"
+    content: "{{ inventory_hostname }}"
     dest: "{{ docker_compose_dir }}/CLUSTER_ID"
     mode: '0600'
   when: ansible_play_hosts_all|length > 1

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -41,6 +41,20 @@
     mode: 0600
   register: awx_secret_key
 
+- name: Render UUID file
+  copy:
+    content: "{{ ansible_hostname | to_uuid }}"
+    dest: "{{ docker_compose_dir }}/UUID"
+    mode: '0600'
+  when: ansible_play_hosts_all|length > 1
+
+- name: Render CLUSTER_ID file
+  copy:
+    content: "{{ ansible_hostname }}"
+    dest: "{{ docker_compose_dir }}/CLUSTER_ID"
+    mode: '0600'
+  when: ansible_play_hosts_all|length > 1
+
 - block:
     - name: Start the containers
       docker_compose:

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -28,6 +28,10 @@ services:
       - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"
+    {% if ansible_play_hosts_all|length > 1 %}
+      - "{{ docker_compose_dir }}/CLUSTER_ID:/etc/tower/CLUSTER_ID"
+      - "{{ docker_compose_dir }}/UUID:/etc/tower/UUID"
+    {% endif %}
       - "{{ docker_compose_dir }}/environment.sh:/etc/tower/conf.d/environment.sh"
       - "{{ docker_compose_dir }}/credentials.py:/etc/tower/conf.d/credentials.py"
       - "{{ docker_compose_dir }}/nginx.conf:/etc/nginx/nginx.conf:ro"
@@ -66,6 +70,12 @@ services:
     {% elif awx_alternate_dns_servers is defined %}
     dns: "{{ awx_alternate_dns_servers }}"
     {% endif %}
+    {% if ansible_play_hosts_all|length > 1 %}
+    extra_hosts:
+    {% for host in ansible_play_hosts_all %}
+      - "{{ host }}:{{ hostvars[host].ansible_default_ipv4.address }}"
+    {% endfor %}
+    {% endif %}
     environment:
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
@@ -90,6 +100,10 @@ services:
       - rsyslog-socket:/var/run/awx-rsyslog/
       - rsyslog-config:/var/lib/awx/rsyslog/
       - "{{ docker_compose_dir }}/SECRET_KEY:/etc/tower/SECRET_KEY"
+    {% if ansible_play_hosts_all|length > 1 %}
+      - "{{ docker_compose_dir }}/CLUSTER_ID:/etc/tower/CLUSTER_ID"
+      - "{{ docker_compose_dir }}/UUID:/etc/tower/UUID"
+    {% endif %}
       - "{{ docker_compose_dir }}/environment.sh:/etc/tower/conf.d/environment.sh"
       - "{{ docker_compose_dir }}/credentials.py:/etc/tower/conf.d/credentials.py"
       - "{{ docker_compose_dir }}/redis_socket:/var/run/redis/:rw"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR makes the CLUSTER_HOST_ID and SYSTEM_UUID configurable. This should allow a clustered setup with local_docker.

If the inventory has more then one host, then the installer will create two additional files, CLUSTER_ID and UUID (both based on the hostname), in the compose directory and mount these files into the docker container.

The task container will register itself as instance with the provided UUID and CLUSTER_ID.

All instances must reach each other via their hostnames (CLUSTER_ID) with https on port 443. To allow name resolution each node is listed in extra_hosts.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx_web      | 334 static files copied to '/var/lib/awx/public/static'.
awx_web      | 2020-06-05 10:27:32,052 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in
 the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
awx_web      | 2020-06-05 10:27:32,052 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in
 the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
awx_web      | 2020-06-05 10:27:32,357 INFO RPC interface 'supervisor' initialized
awx_web      | 2020-06-05 10:27:32,357 INFO RPC interface 'supervisor' initialized
awx_web      | 2020-06-05 10:27:32,357 CRIT Server 'unix_http_server' running without any HTTP authentication checking
awx_web      | 2020-06-05 10:27:32,357 CRIT Server 'unix_http_server' running without any HTTP authentication checking
awx_web      | 2020-06-05 10:27:32,357 INFO supervisord started with pid 67
awx_web      | 2020-06-05 10:27:32,357 INFO supervisord started with pid 67
awx_task     | Operations to perform:
awx_task     |   Apply all migrations: auth, conf, contenttypes, main, oauth2_provider, sessions, sites, social_django, sso, taggit
awx_task     | Running migrations:
awx_task     |   No migrations to apply.
awx_web      | 2020-06-05 10:27:33,359 INFO spawned: 'awx-config-watcher' with pid 70
awx_web      | 2020-06-05 10:27:33,359 INFO spawned: 'awx-config-watcher' with pid 70
awx_web      | 2020-06-05 10:27:33,362 INFO spawned: 'nginx' with pid 71
awx_web      | 2020-06-05 10:27:33,362 INFO spawned: 'nginx' with pid 71
awx_web      | 2020-06-05 10:27:33,364 INFO spawned: 'uwsgi' with pid 72
awx_web      | 2020-06-05 10:27:33,364 INFO spawned: 'uwsgi' with pid 72
awx_web      | 2020-06-05 10:27:33,367 INFO spawned: 'daphne' with pid 73
awx_web      | 2020-06-05 10:27:33,367 INFO spawned: 'daphne' with pid 73
awx_web      | 2020-06-05 10:27:33,369 INFO spawned: 'wsbroadcast' with pid 74
awx_web      | 2020-06-05 10:27:33,369 INFO spawned: 'wsbroadcast' with pid 74
awx_web      | 2020-06-05 10:27:33,373 INFO spawned: 'awx-rsyslogd' with pid 76
awx_web      | 2020-06-05 10:27:33,373 INFO spawned: 'awx-rsyslogd' with pid 76
awx_web      | *** Starting uWSGI 2.0.18 (64bit) on [Fri Jun  5 10:27:33 2020] ***
awx_web      | compiled with version: 8.3.1 20190507 (Red Hat 8.3.1-4) on 05 June 2020 09:59:08
awx_web      | os: Linux-5.6.14-300.fc32.x86_64 #1 SMP Wed May 20 20:47:32 UTC 2020
awx_web      | nodename: awxweb
awx_web      | machine: x86_64
awx_web      | clock source: unix
awx_web      | detected number of CPU cores: 8
awx_web      | current working directory: /var/lib/awx
awx_web      | detected binary path: /var/lib/awx/venv/awx/bin/uwsgi
awx_web      | !!! no internal routing support, rebuild with pcre support !!!
awx_web      | uWSGI running as root, you can use --uid/--gid/--chroot options
awx_web      | *** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
awx_web      | your memory page size is 4096 bytes
awx_web      |  *** WARNING: you have enabled harakiri without post buffering. Slow upload could be rejected on post-unbuffered webservers ***
awx_web      | detected max file descriptor number: 1024
awx_web      | lock engine: pthread robust mutexes
awx_web      | thunder lock: disabled (you can enable it with --thunder-lock)
awx_web      | uwsgi socket 0 bound to TCP address 127.0.0.1:8050 fd 3
awx_web      | uWSGI running as root, you can use --uid/--gid/--chroot options
awx_web      | *** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
awx_web      | Python version: 3.6.8 (default, Nov 21 2019, 19:31:34)  [GCC 8.3.1 20190507 (Red Hat 8.3.1-4)]
awx_web      | *** Python threads support is disabled. You can enable it with --enable-threads ***
awx_web      | Python main interpreter initialized at 0x2487500
awx_web      | uWSGI running as root, you can use --uid/--gid/--chroot options
awx_web      | *** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
awx_web      | your server socket listen backlog is limited to 100 connections
awx_web      | your mercy for graceful operations on workers is 60 seconds
awx_web      | mapped 609552 bytes (595 KB) for 5 cores
awx_web      | *** Operational MODE: preforking ***
awx_web      | uWSGI running as root, you can use --uid/--gid/--chroot options
awx_web      | *** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
awx_web      | *** uWSGI is running in multiple interpreter mode ***
awx_web      | spawned uWSGI master process (pid: 72)
awx_web      | spawned uWSGI worker 1 (pid: 77, cores: 1)
awx_web      | spawned uWSGI worker 2 (pid: 78, cores: 1)
awx_web      | spawned uWSGI worker 3 (pid: 79, cores: 1)
awx_web      | spawned uWSGI worker 4 (pid: 80, cores: 1)
awx_web      | spawned uWSGI worker 5 (pid: 81, cores: 1)
awx_web      | rsyslogd: pidfile '/var/run/awx-rsyslog/rsyslog.pid' and pid 76 already exist.
awx_web      | If you want to run multiple instances of rsyslog, you need to specify
awx_web      | different pid files for them (-i option).
awx_web      | rsyslogd: run failed with error -3000 (see rsyslog.h or try https://www.rsyslog.com/e/3000 to learn what that number means)
awx_web      | READY
awx_web      | 2020-06-05 10:27:33,591 INFO exited: awx-rsyslogd (exit status 1; not expected)
awx_web      | 2020-06-05 10:27:33,591 INFO exited: awx-rsyslogd (exit status 1; not expected)
awx_web      | 2020-06-05 10:27:34,593 INFO success: awx-config-watcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,593 INFO success: awx-config-watcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,594 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,594 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,594 INFO success: uwsgi entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,594 INFO success: uwsgi entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,595 INFO success: daphne entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,595 INFO success: daphne entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,595 INFO success: wsbroadcast entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,595 INFO success: wsbroadcast entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:34,597 INFO spawned: 'awx-rsyslogd' with pid 101
awx_web      | 2020-06-05 10:27:34,597 INFO spawned: 'awx-rsyslogd' with pid 101
awx_web      | 2020-06-05 10:27:35,599 INFO success: awx-rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:35,599 INFO success: awx-rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (st
artsecs)
awx_postgres | 2020-06-05 10:27:37.066 UTC [38] ERROR:  duplicate key value violates unique constraint "auth_user_username_key"
awx_postgres | 2020-06-05 10:27:37.066 UTC [38] DETAIL:  Key (username)=(admin) already exists.
awx_postgres | 2020-06-05 10:27:37.066 UTC [38] STATEMENT:  INSERT INTO "auth_user" ("password", "last_login", "is_superuser", "username", "first_name", "last_name", "email", "is_staff", "is_active", "date_joined") VALUES ('pbkdf2_sha256$150000$XSJ5xFsOJNgB$5yD5l5THI9vKQ9Q72XSYgYqqVialYR0q62EMcvBjzos=', NULL, true, 'admin', '', '', 'root@localhost', true, true, '2020-06-05T10:27:36.874372+00:00'::timestamptz) RETURNING "auth_user"."id"
awx_task     | Traceback (most recent call last):
awx_task     |   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/django/db/backends/utils.py", line 84, in _execute
awx_task     |     return self.cursor.execute(sql, params)
awx_task     | psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "auth_user_username_key"
awx_task     | DETAIL:  Key (username)=(admin) already exists.
...
awx_task     | django.db.utils.IntegrityError: duplicate key value violates unique constraint "auth_user_username_key"
awx_task     | DETAIL:  Key (username)=(admin) already exists.
awx_task     |
awx_web      | WSGI app 0 (mountpoint='') ready in 4 seconds on interpreter 0x2487500 pid: 78 (default app)
awx_web      | WSGI app 0 (mountpoint='') ready in 4 seconds on interpreter 0x2487500 pid: 81 (default app)
awx_web      | 2020-06-05 10:27:37,327 INFO     daphne.cli Starting server at tcp:port=8051:interface=127.0.0.1
awx_web      | 2020-06-05 10:27:37,327 INFO     Starting server at tcp:port=8051:interface=127.0.0.1
awx_web      | 2020-06-05 10:27:37,328 INFO     daphne.server HTTP/2 support not enabled (install the http2 and tls Twisted extras)
awx_web      | 2020-06-05 10:27:37,328 INFO     HTTP/2 support not enabled (install the http2 and tls Twisted extras)
awx_web      | 2020-06-05 10:27:37,329 INFO     daphne.server Configuring endpoint tcp:port=8051:interface=127.0.0.1
awx_web      | 2020-06-05 10:27:37,329 INFO     Configuring endpoint tcp:port=8051:interface=127.0.0.1
awx_web      | 2020-06-05 10:27:37,331 INFO     daphne.server Listening on TCP address 127.0.0.1:8051
awx_web      | 2020-06-05 10:27:37,331 INFO     Listening on TCP address 127.0.0.1:8051
awx_web      | WSGI app 0 (mountpoint='') ready in 4 seconds on interpreter 0x2487500 pid: 80 (default app)
awx_web      | WSGI app 0 (mountpoint='') ready in 4 seconds on interpreter 0x2487500 pid: 79 (default app)
awx_web      | WSGI app 0 (mountpoint='') ready in 4 seconds on interpreter 0x2487500 pid: 77 (default app)
awx_web      | 2020-06-05 10:27:38,187 ERROR    awx.main.wsbroadcast AWX is currently installing/upgrading.  Trying again in 5s...
awx_task     | An organization is already in the system, exiting.
awx_task     | (changed: False)
awx_web      | 2020-06-05 10:27:43,544 INFO exited: wsbroadcast (exit status 0; expected)
awx_web      | 2020-06-05 10:27:43,544 INFO exited: wsbroadcast (exit status 0; expected)
awx_task     | Successfully registered instance as15097
awx_task     | (changed: True)
awx_web      | 2020-06-05 10:27:44,546 INFO spawned: 'wsbroadcast' with pid 119
awx_web      | 2020-06-05 10:27:44,546 INFO spawned: 'wsbroadcast' with pid 119
awx_web      | 2020-06-05 10:27:45,547 INFO success: wsbroadcast entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:45,547 INFO success: wsbroadcast entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | Instance Group already registered tower
awx_web      | 2020-06-05 10:27:47,061 WARNING  awx.main.wsbroadcast Adding {'awx'} to websocket broadcast list
awx_web      | 2020-06-05 10:27:47,062 DEBUG    awx.main.wsbroadcast Connection from as15097 to awx attempt number 0.
awx_task     | 2020-06-05 10:27:47,111 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
awx_task     | 2020-06-05 10:27:47,111 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
awx_task     | 2020-06-05 10:27:47,415 INFO RPC interface 'supervisor' initialized
awx_task     | 2020-06-05 10:27:47,415 INFO RPC interface 'supervisor' initialized
awx_task     | 2020-06-05 10:27:47,415 CRIT Server 'unix_http_server' running without any HTTP authentication checking
awx_task     | 2020-06-05 10:27:47,415 CRIT Server 'unix_http_server' running without any HTTP authentication checking
awx_task     | 2020-06-05 10:27:47,416 INFO supervisord started with pid 101
awx_task     | 2020-06-05 10:27:47,416 INFO supervisord started with pid 101
awx_web      | 2020-06-05 10:27:47,843 WARNING  awx.main.wsbroadcast Connection from as15097 to awx failed: 'Cannot connect to host awx:443 ssl:False [Name or service not known]'.
awx_web      | 2020-06-05 10:27:47,845 DEBUG    awx.main.wsbroadcast Connection from as15097 to awx attempt number 1.
awx_task     | 2020-06-05 10:27:48,418 INFO spawned: 'awx-config-watcher' with pid 104
awx_task     | 2020-06-05 10:27:48,418 INFO spawned: 'awx-config-watcher' with pid 104
awx_task     | 2020-06-05 10:27:48,419 INFO spawned: 'dispatcher' with pid 105
awx_task     | 2020-06-05 10:27:48,419 INFO spawned: 'dispatcher' with pid 105
awx_task     | 2020-06-05 10:27:48,420 INFO spawned: 'callback-receiver' with pid 106
awx_task     | 2020-06-05 10:27:48,420 INFO spawned: 'callback-receiver' with pid 106
awx_task     | READY
awx_task     | 2020-06-05 10:27:49,513 INFO success: awx-config-watcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:49,513 INFO success: awx-config-watcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:49,513 INFO success: dispatcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:49,513 INFO success: dispatcher entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:49,513 INFO success: callback-receiver entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:50,690 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:117
awx_task     | 2020-06-05 10:27:50,690 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:117
awx_task     | 2020-06-05 10:27:50,694 WARNING  awx.main.dispatch.periodic periodic beat started
awx_task     | 2020-06-05 10:27:50,698 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:119
awx_task     | 2020-06-05 10:27:50,698 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:119
awx_task     | 2020-06-05 10:27:50,703 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:120
awx_task     | 2020-06-05 10:27:50,703 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:120
awx_task     | 2020-06-05 10:27:50,711 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:121
awx_task     | 2020-06-05 10:27:50,711 WARNING  awx.main.commands.run_callback_receiver scaling up worker pid:121
awx_task     | 2020-06-05 10:27:50,744 WARNING  awx.main.dispatch scaling up worker pid:122
awx_task     | 2020-06-05 10:27:50,750 WARNING  awx.main.dispatch scaling up worker pid:123
awx_task     | 2020-06-05 10:27:50,760 WARNING  awx.main.dispatch scaling up worker pid:124
awx_task     | 2020-06-05 10:27:50,770 WARNING  awx.main.dispatch scaling up worker pid:125
awx_task     | 2020-06-05 10:27:50,782 WARNING  awx.main.dispatch Running worker dispatcher listening to queues ['tower_broadcast_all', 'as15097']
awx_task     | 2020-06-05 10:27:50,800 DEBUG    awx.main.tasks Syncing Schedules
awx_task     | 2020-06-05 10:27:50,846 DEBUG    awx.main.tasks Waited 0.0005469322204589844 seconds to obtain lock name: cluster_policy_lock
awx_task     | 2020-06-05 10:27:50,855 INFO     awx.main.tasks Unknown instance awx2-task-a8n in tower policy list
awx_task     | 2020-06-05 10:27:50,856 INFO     awx.main.tasks Unknown instance awx-task-a8n in tower policy list
awx_task     | 2020-06-05 10:27:50,857 DEBUG    awx.main.tasks Policy List, adding Instances [21] to Group tower
awx_task     | 2020-06-05 10:27:50,858 DEBUG    awx.main.tasks Total non-isolated instances:2 available for policy: 2
awx_task     | 2020-06-05 10:27:50,859 DEBUG    awx.main.tasks Policy percentage, adding Instances [22] to Group tower
awx_task     | 2020-06-05 10:27:50,860 DEBUG    awx.main.tasks Adding instances [21, 22] to group tower
awx_task     | 2020-06-05 10:27:50,880 DEBUG    awx.main.tasks Cluster policy computation finished in 0.03359103202819824 seconds
awx_task     | 2020-06-05 10:27:50,881 DEBUG    awx.main.tasks Cluster node heartbeat task.
awx_task     | 2020-06-05 10:27:50,919 DEBUG    awx.main.utils.reload Issuing command to restart services, args=['supervisorctl', '-c', '/etc/supervisord.conf', 'restart', 'tower-processes:awx-rsyslogd']
awx_web      | 2020-06-05 10:27:51,146 INFO waiting for awx-rsyslogd to stop
awx_web      | 2020-06-05 10:27:51,146 INFO waiting for awx-rsyslogd to stop
awx_web      | 2020-06-05 10:27:51,147 INFO stopped: awx-rsyslogd (exit status 0)
awx_web      | 2020-06-05 10:27:51,147 INFO stopped: awx-rsyslogd (exit status 0)
awx_web      | 2020-06-05 10:27:51,153 INFO spawned: 'awx-rsyslogd' with pid 126
awx_web      | 2020-06-05 10:27:51,153 INFO spawned: 'awx-rsyslogd' with pid 126
awx_web      | 2020-06-05 10:27:52,155 INFO success: awx-rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_web      | 2020-06-05 10:27:52,155 INFO success: awx-rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
awx_task     | 2020-06-05 10:27:52,172 DEBUG    awx.main.utils.reload supervisorctl restart awx-rsyslogd succeeded
awx_task     | RESULT 2
awx_task     | OKREADY
awx_web      | RESULT 2
awx_web      | OKREADY
```

The newly created instance as15097:
```
bash-4.4# awx-manage list_instances
[tower capacity=56 policy=100%]
        as15097 capacity=56 version=11.2.0 heartbeat="2020-06-05 10:33:06"
        as15098 capacity=56 version=11.2.0 heartbeat="2020-06-05 10:31:36"
```
