### PR TITLE
Prevent exception for Non value

### DIFF
--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -82,6 +82,10 @@ except ImportError:
 
 
 def coerce_type(module, value):
+    # If our value is already None we can just return directly
+    if value == None:
+        return value
+
     yaml_ish = bool((
         value.startswith('{') and value.endswith('}')
     ) or (

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -83,7 +83,7 @@ except ImportError:
 
 def coerce_type(module, value):
     # If our value is already None we can just return directly
-    if value == None:
+    if value is None:
         return value
 
     yaml_ish = bool((

--- a/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
@@ -79,3 +79,9 @@
   tower_settings:
     name: AWX_PROOT_BASE_PATH
     value: '{{ junk_var | default(omit) }}'
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "'Unable to update settings' in result.msg"

--- a/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
@@ -74,3 +74,9 @@
 - assert:
     that:
       - "result is changed"
+
+- name: Handle an omit value
+  tower_settings:
+    name: AWX_PROOT_BASE_PATH
+    value: '{{ junk_var | default(omit) }}'
+

--- a/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_settings/tasks/main.yml
@@ -79,4 +79,3 @@
   tower_settings:
     name: AWX_PROOT_BASE_PATH
     value: '{{ junk_var | default(omit) }}'
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #7267
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
This can be tested with the following task:
- name: Handle an omit value
  tower_settings:
    name: AWX_PROOT_BASE_PATH
    value: '{{ junk_var | default(omit) }}'

Without the change you get the stack.
With the new change it now long stacks but will return something like:

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to update settings, see response", "response": {"json": {"AWX_PROOT_BASE_PATH": ["This field may not be null."]}, "status_code": 400}}
```

