### PR TITLE
Remove query_parameters from page loop causing 414

### DIFF
--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -276,7 +276,7 @@ class Page(object):
         if all_pages and page.next:
             paged_results = [r.json()['results']]
             while page.next:
-                r = self.connection.get(self.next, query_parameters)
+                r = self.connection.get(self.next)
                 page = self.page_identity(r)
                 paged_results.append(r.json()['results'])
             json = r.json()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Additional pages with results from awx-cli duplicate URI parameters which eventually lead to 414 error.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx-cli 3.7.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
`awx -v job_events list --job #### --task 'Task name' --failed false --all`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
DEBUG:awxkit.api.pages.page:Unable to parse JSON response (414): No JSON object could be decoded - '<html>
<head><title>414 Request-URI Too Large</title></head>
<body>
<center><h1>414 Request-URI Too Large</h1></center>
<hr><center>nginx</center>
</body>
</html>
```
