### PR TITLE
Send content-type with mattermost notifications, fixes #7264

### DIFF
--- a/awx/main/notifications/mattermost_backend.py
+++ b/awx/main/notifications/mattermost_backend.py
@@ -3,7 +3,6 @@
 
 import logging
 import requests
-import json
 
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
@@ -45,7 +44,7 @@ class MattermostBackend(AWXBaseEmailBackend, CustomNotificationBase):
             payload['text'] = m.subject
 
             r = requests.post("{}".format(m.recipients()[0]),
-                              data=json.dumps(payload), verify=(not self.mattermost_no_verify_ssl))
+                              json=payload, verify=(not self.mattermost_no_verify_ssl))
             if r.status_code >= 400:
                 logger.error(smart_text(_("Error sending notification mattermost: {}").format(r.text)))
                 if not self.fail_silently:


### PR DESCRIPTION
By letting `requests` know that it sends JSON it will automatically attach the correct content type. Tested this on my local instance and now mattermost notifications works again.