### PR TITLE
Updates credential details to support plugin and prompt fields

### DIFF
--- a/awx/ui_next/src/api/models/Credentials.js
+++ b/awx/ui_next/src/api/models/Credentials.js
@@ -35,7 +35,7 @@ class Credentials extends Base {
             },
           }
         );
-        if (data.next && requestCounter <= maxRequests) {
+        if (data?.next && requestCounter <= maxRequests) {
           return fetchInputSources(
             pageNo + 1,
             inputSources.concat(data.results)

--- a/awx/ui_next/src/api/models/Credentials.js
+++ b/awx/ui_next/src/api/models/Credentials.js
@@ -21,8 +21,11 @@ class Credentials extends Base {
   }
 
   readInputSources(id) {
+    const maxRequests = 5;
+    let requestCounter = 0;
     const fetchInputSources = async (pageNo = 1, inputSources = []) => {
       try {
+        requestCounter++;
         const { data } = await this.http.get(
           `${this.baseUrl}${id}/input_sources/`,
           {
@@ -32,7 +35,7 @@ class Credentials extends Base {
             },
           }
         );
-        if (data.next) {
+        if (data.next && requestCounter <= maxRequests) {
           return fetchInputSources(
             pageNo + 1,
             inputSources.concat(data.results)

--- a/awx/ui_next/src/api/models/Credentials.js
+++ b/awx/ui_next/src/api/models/Credentials.js
@@ -20,10 +20,31 @@ class Credentials extends Base {
     return this.http.options(`${this.baseUrl}${id}/access_list/`);
   }
 
-  readInputSources(id, params) {
-    return this.http.get(`${this.baseUrl}${id}/input_sources/`, {
-      params,
-    });
+  readInputSources(id) {
+    const fetchInputSources = async (pageNo = 1, inputSources = []) => {
+      try {
+        const { data } = await this.http.get(
+          `${this.baseUrl}${id}/input_sources/`,
+          {
+            params: {
+              page: pageNo,
+              page_size: 200,
+            },
+          }
+        );
+        if (data.next) {
+          return fetchInputSources(
+            pageNo + 1,
+            inputSources.concat(data.results)
+          );
+        }
+        return Promise.resolve(inputSources.concat(data.results));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    };
+
+    return fetchInputSources();
   }
 
   test(id, data) {

--- a/awx/ui_next/src/api/models/Credentials.js
+++ b/awx/ui_next/src/api/models/Credentials.js
@@ -41,7 +41,11 @@ class Credentials extends Base {
             inputSources.concat(data.results)
           );
         }
-        return Promise.resolve(inputSources.concat(data.results));
+        return Promise.resolve({
+          data: {
+            results: inputSources.concat(data.results),
+          },
+        });
       } catch (error) {
         return Promise.reject(error);
       }

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -238,7 +238,9 @@ function CredentialDetail({ i18n, credential }) {
       </DetailList>
       {Object.keys(inputSources).length > 0 && (
         <PluginFieldText>
-          {i18n._(t`* This field will be retrieved from an external secret management system using the specified credential.`)}
+          {i18n._(
+            t`* This field will be retrieved from an external secret management system using the specified credential.`
+          )}
         </PluginFieldText>
       )}
       <CardActionsRow>

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -60,7 +60,9 @@ function CredentialDetail({ i18n, credential }) {
         {
           data: { inputs: credentialTypeInputs, managed_by_tower },
         },
-        loadedInputSources,
+        {
+          data: { results: loadedInputSources },
+        },
       ] = await Promise.all([
         CredentialTypesAPI.readDetail(credential_type.id),
         CredentialsAPI.readInputSources(credentialId),

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -64,12 +64,10 @@ function CredentialDetail({ i18n, credential }) {
           {
             data: { inputs: credentialTypeInputs, managed_by_tower },
           },
-          {
-            data: { results: loadedInputSources },
-          },
+          loadedInputSources,
         ] = await Promise.all([
           CredentialTypesAPI.readDetail(credential_type.id),
-          CredentialsAPI.readInputSources(credentialId, { page_size: 200 }),
+          CredentialsAPI.readInputSources(credentialId),
         ]);
 
         setFields(credentialTypeInputs.fields || []);

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useCallback } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
-import { t, Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 import { shape } from 'prop-types';
 import styled from 'styled-components';
 import { Button, List, ListItem } from '@patternfly/react-core';
@@ -238,10 +238,7 @@ function CredentialDetail({ i18n, credential }) {
       </DetailList>
       {Object.keys(inputSources).length > 0 && (
         <PluginFieldText>
-          <Trans>
-            * This field will be retrieved from an external secret management
-            system using the specified credential.
-          </Trans>
+          {i18n._(t`* This field will be retrieved from an external secret management system using the specified credential.`)}
         </PluginFieldText>
       )}
       <CardActionsRow>

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.jsx
@@ -75,7 +75,7 @@ function CredentialDetail({ i18n, credential }) {
 
   const { error, dismissError } = useDismissableError(deleteError);
 
-  const renderDetail = ({ id, label, type }) => {
+  const renderDetail = ({ id, label, type, ask_at_runtime }) => {
     let detail;
 
     if (type === 'boolean') {
@@ -95,6 +95,10 @@ function CredentialDetail({ i18n, credential }) {
           value={i18n._(t`Encrypted`)}
           isEncrypted={isEncrypted}
         />
+      );
+    } else if (ask_at_runtime && inputs[id] === 'ASK') {
+      detail = (
+        <Detail key={id} label={label} value={i18n._(t`Prompt on launch`)} />
       );
     } else {
       detail = <Detail key={id} label={label} value={inputs[id]} />;

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
@@ -12,8 +12,35 @@ jest.mock('../../../api');
 
 const mockCredential = mockCredentials.results[0];
 
+const mockInputSource = {
+  id: 33,
+  type: 'credential_input_source',
+  url: '/api/v2/credential_input_sources/33/',
+  summary_fields: {
+    source_credential: {
+      id: 424,
+      name: 'External Credential',
+      description: '',
+      kind: 'conjur',
+      cloud: false,
+      credential_type_id: 20,
+    },
+  },
+  input_field_name: 'ssh_key_unlock',
+  metadata: {
+    secret_path: '/foo/bar/baz',
+    secret_version: '17',
+  },
+};
+
 CredentialTypesAPI.readDetail.mockResolvedValue({
   data: mockCredentialType,
+});
+
+CredentialsAPI.readInputSources.mockResolvedValue({
+  data: {
+    results: [mockInputSource],
+  },
 });
 
 function expectDetailToMatch(wrapper, label, value) {
@@ -52,6 +79,18 @@ describe('<CredentialDetail />', () => {
       mockCredential.summary_fields.credential_type.name
     );
     expectDetailToMatch(wrapper, 'Username', mockCredential.inputs.username);
+    expectDetailToMatch(wrapper, 'Password', 'Encrypted');
+    expectDetailToMatch(wrapper, 'SSH Private Key', 'Encrypted');
+    expectDetailToMatch(wrapper, 'Signed SSH Certificate', 'Encrypted');
+    const sshKeyUnlockDetail = wrapper.find(
+      'Detail#credential-ssh_key_unlock-detail'
+    );
+    expect(sshKeyUnlockDetail.length).toBe(1);
+    expect(sshKeyUnlockDetail.find('CredentialChip').length).toBe(1);
+    expect(
+      wrapper.find('CodeMirrorInput#credential-ssh_key_unlock-metadata').props()
+        .value
+    ).toBe(JSON.stringify(mockInputSource.metadata, null, 2));
     expectDetailToMatch(
       wrapper,
       'Privilege Escalation Method',
@@ -61,6 +100,11 @@ describe('<CredentialDetail />', () => {
       wrapper,
       'Privilege Escalation Username',
       mockCredential.inputs.become_username
+    );
+    expectDetailToMatch(
+      wrapper,
+      'Privilege Escalation Password',
+      'Prompt on launch'
     );
     expect(wrapper.find(`Detail[label="Options"] ListItem`).text()).toEqual(
       'Authorize'

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
@@ -37,11 +37,7 @@ CredentialTypesAPI.readDetail.mockResolvedValue({
   data: mockCredentialType,
 });
 
-CredentialsAPI.readInputSources.mockResolvedValue({
-  data: {
-    results: [mockInputSource],
-  },
-});
+CredentialsAPI.readInputSources.mockResolvedValue([mockInputSource]);
 
 function expectDetailToMatch(wrapper, label, value) {
   const detail = wrapper.find(`Detail[label="${label}"]`);

--- a/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialDetail/CredentialDetail.test.jsx
@@ -37,7 +37,11 @@ CredentialTypesAPI.readDetail.mockResolvedValue({
   data: mockCredentialType,
 });
 
-CredentialsAPI.readInputSources.mockResolvedValue([mockInputSource]);
+CredentialsAPI.readInputSources.mockResolvedValue({
+  data: {
+    results: [mockInputSource],
+  },
+});
 
 function expectDetailToMatch(wrapper, label, value) {
   const detail = wrapper.find(`Detail[label="${label}"]`);

--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.jsx
@@ -151,7 +151,7 @@ function CredentialEdit({ credential, me }) {
   };
 
   if (error) {
-    return <ContentError />;
+    return <ContentError error={error} />;
   }
 
   if (isLoading) {

--- a/awx/ui_next/src/screens/Credential/shared/data.credentials.json
+++ b/awx/ui_next/src/screens/Credential/shared/data.credentials.json
@@ -3,394 +3,394 @@
   "next": "/api/v2/credentials/",
   "previous": null,
   "results": [
-      {
+    {
+      "id": 1,
+      "type": "credential",
+      "url": "/api/v2/credentials/1/",
+      "related": {
+        "created_by": "/api/v2/users/1/",
+        "modified_by": "/api/v2/users/1/",
+        "activity_stream": "/api/v2/credentials/1/activity_stream/",
+        "access_list": "/api/v2/credentials/1/access_list/",
+        "object_roles": "/api/v2/credentials/1/object_roles/",
+        "owner_users": "/api/v2/credentials/1/owner_users/",
+        "owner_teams": "/api/v2/credentials/1/owner_teams/",
+        "copy": "/api/v2/credentials/1/copy/",
+        "input_sources": "/api/v2/credentials/1/input_sources/",
+        "credential_type": "/api/v2/credential_types/23/",
+        "user": "/api/v2/users/7/"
+      },
+      "summary_fields": {
+        "organization": {
           "id": 1,
-          "type": "credential",
-          "url": "/api/v2/credentials/1/",
-          "related": {
-              "created_by": "/api/v2/users/1/",
-              "modified_by": "/api/v2/users/1/",
-              "activity_stream": "/api/v2/credentials/1/activity_stream/",
-              "access_list": "/api/v2/credentials/1/access_list/",
-              "object_roles": "/api/v2/credentials/1/object_roles/",
-              "owner_users": "/api/v2/credentials/1/owner_users/",
-              "owner_teams": "/api/v2/credentials/1/owner_teams/",
-              "copy": "/api/v2/credentials/1/copy/",
-              "input_sources": "/api/v2/credentials/1/input_sources/",
-              "credential_type": "/api/v2/credential_types/23/",
-              "user": "/api/v2/users/7/"
-          },
-          "summary_fields": {
-              "organization": {
-                "id": 1,
-                "name": "Org",
-                "description": ""
-              },
-              "credential_type": {
-                "id": 1,
-                "name": "Machine",
-                "description": ""
-              },
-              "created_by": {
-                  "id": 1,
-                  "username": "admin",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "modified_by": {
-                  "id": 1,
-                  "username": "admin",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "object_roles": {
-                  "admin_role": {
-                      "description": "Can manage all aspects of the credential",
-                      "name": "Admin",
-                      "id": 284
-                  },
-                  "use_role": {
-                      "description": "Can use the credential in a job template",
-                      "name": "Use",
-                      "id": 285
-                  },
-                  "read_role": {
-                      "description": "May view settings for the credential",
-                      "name": "Read",
-                      "id": 286
-                  }
-              },
-              "user_capabilities": {
-                  "edit": true,
-                  "delete": true,
-                  "copy": true,
-                  "use": true
-              }
-          },
-          "created": "2019-12-17T16:12:25.258897Z",
-          "modified": "2019-12-17T16:12:25.258920Z",
-          "name": "Foo",
-          "description": "Foo Description",
-          "organization": 1,
-          "credential_type": 1,
-          "inputs": {
-            "password": "$encrypted$",
-            "username": "foo",
-            "ssh_key_data": "$encrypted$",
-            "become_method": "sudo",
-            "become_password": "$encrypted$",
-            "become_username": "bar",
-            "ssh_public_key_data": "$encrypted$",
-            "authorize": true
+          "name": "Org",
+          "description": ""
         },
-          "kind": null,
-          "cloud": true,
-          "kubernetes": false
+        "credential_type": {
+          "id": 1,
+          "name": "Machine",
+          "description": ""
+        },
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
+        },
+        "object_roles": {
+          "admin_role": {
+            "description": "Can manage all aspects of the credential",
+            "name": "Admin",
+            "id": 284
+          },
+          "use_role": {
+            "description": "Can use the credential in a job template",
+            "name": "Use",
+            "id": 285
+          },
+          "read_role": {
+            "description": "May view settings for the credential",
+            "name": "Read",
+            "id": 286
+          }
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true,
+          "use": true
+        }
       },
-      {
+      "created": "2019-12-17T16:12:25.258897Z",
+      "modified": "2019-12-17T16:12:25.258920Z",
+      "name": "Foo",
+      "description": "Foo Description",
+      "organization": 1,
+      "credential_type": 1,
+      "inputs": {
+        "password": "$encrypted$",
+        "username": "foo",
+        "ssh_key_data": "$encrypted$",
+        "become_method": "sudo",
+        "become_password": "ASK",
+        "become_username": "bar",
+        "ssh_public_key_data": "$encrypted$",
+        "authorize": true
+      },
+      "kind": null,
+      "cloud": true,
+      "kubernetes": false
+    },
+    {
+      "id": 2,
+      "type": "credential",
+      "url": "/api/v2/credentials/2/",
+      "related": {
+        "created_by": "/api/v2/users/8/",
+        "modified_by": "/api/v2/users/12/",
+        "activity_stream": "/api/v2/credentials/2/activity_stream/",
+        "access_list": "/api/v2/credentials/2/access_list/",
+        "object_roles": "/api/v2/credentials/2/object_roles/",
+        "owner_users": "/api/v2/credentials/2/owner_users/",
+        "owner_teams": "/api/v2/credentials/2/owner_teams/",
+        "copy": "/api/v2/credentials/2/copy/",
+        "input_sources": "/api/v2/credentials/2/input_sources/",
+        "credential_type": "/api/v2/credential_types/1/",
+        "user": "/api/v2/users/7/"
+      },
+      "summary_fields": {
+        "credential_type": {
+          "id": 1,
+          "name": "Machine",
+          "description": ""
+        },
+        "created_by": {
+          "id": 8,
+          "username": "user-2",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 12,
+          "username": "user-6",
+          "first_name": "",
+          "last_name": ""
+        },
+        "object_roles": {
+          "admin_role": {
+            "description": "Can manage all aspects of the credential",
+            "name": "Admin",
+            "id": 81
+          },
+          "use_role": {
+            "description": "Can use the credential in a job template",
+            "name": "Use",
+            "id": 82
+          },
+          "read_role": {
+            "description": "May view settings for the credential",
+            "name": "Read",
+            "id": 83
+          }
+        },
+        "user_capabilities": {
+          "edit": false,
+          "delete": false,
+          "copy": false,
+          "use": false
+        },
+        "owners": [
+          {
+            "id": 7,
+            "type": "user",
+            "name": "user-1",
+            "description": " ",
+            "url": "/api/v2/users/7/"
+          }
+        ]
+      },
+      "created": "2019-12-16T21:04:40.896097Z",
+      "modified": "2019-12-16T21:04:40.896121Z",
+      "name": "Bar",
+      "description": "",
+      "organization": null,
+      "credential_type": 1,
+      "inputs": {},
+      "kind": "ssh",
+      "cloud": false,
+      "kubernetes": false
+    },
+    {
+      "id": 3,
+      "type": "credential",
+      "url": "/api/v2/credentials/3/",
+      "related": {
+        "created_by": "/api/v2/users/9/",
+        "modified_by": "/api/v2/users/13/",
+        "activity_stream": "/api/v2/credentials/3/activity_stream/",
+        "access_list": "/api/v2/credentials/3/access_list/",
+        "object_roles": "/api/v2/credentials/3/object_roles/",
+        "owner_users": "/api/v2/credentials/3/owner_users/",
+        "owner_teams": "/api/v2/credentials/3/owner_teams/",
+        "copy": "/api/v2/credentials/3/copy/",
+        "input_sources": "/api/v2/credentials/3/input_sources/",
+        "credential_type": "/api/v2/credential_types/1/",
+        "user": "/api/v2/users/8/"
+      },
+      "summary_fields": {
+        "credential_type": {
+          "id": 1,
+          "name": "Machine",
+          "description": ""
+        },
+        "created_by": {
+          "id": 9,
+          "username": "user-3",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 13,
+          "username": "user-7",
+          "first_name": "",
+          "last_name": ""
+        },
+        "object_roles": {
+          "admin_role": {
+            "description": "Can manage all aspects of the credential",
+            "name": "Admin",
+            "id": 84
+          },
+          "use_role": {
+            "description": "Can use the credential in a job template",
+            "name": "Use",
+            "id": 85
+          },
+          "read_role": {
+            "description": "May view settings for the credential",
+            "name": "Read",
+            "id": 86
+          }
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true,
+          "use": true
+        },
+        "owners": [
+          {
+            "id": 8,
+            "type": "user",
+            "name": "user-2",
+            "description": " ",
+            "url": "/api/v2/users/8/"
+          }
+        ]
+      },
+      "created": "2019-12-16T21:04:40.955954Z",
+      "modified": "2019-12-16T21:04:40.955976Z",
+      "name": "Baz",
+      "description": "",
+      "organization": null,
+      "credential_type": 1,
+      "inputs": {},
+      "kind": "ssh",
+      "cloud": false,
+      "kubernetes": false
+    },
+    {
+      "id": 4,
+      "type": "credential",
+      "url": "/api/v2/credentials/4/",
+      "related": {
+        "created_by": "/api/v2/users/1/",
+        "modified_by": "/api/v2/users/1/",
+        "activity_stream": "/api/v2/credentials/4/activity_stream/",
+        "access_list": "/api/v2/credentials/4/access_list/",
+        "object_roles": "/api/v2/credentials/4/object_roles/",
+        "owner_users": "/api/v2/credentials/4/owner_users/",
+        "owner_teams": "/api/v2/credentials/4/owner_teams/",
+        "copy": "/api/v2/credentials/4/copy/",
+        "input_sources": "/api/v2/credentials/4/input_sources/",
+        "credential_type": "/api/v2/credential_types/25/",
+        "user": "/api/v2/users/1/"
+      },
+      "summary_fields": {
+        "credential_type": {
           "id": 2,
-          "type": "credential",
-          "url": "/api/v2/credentials/2/",
-          "related": {
-              "created_by": "/api/v2/users/8/",
-              "modified_by": "/api/v2/users/12/",
-              "activity_stream": "/api/v2/credentials/2/activity_stream/",
-              "access_list": "/api/v2/credentials/2/access_list/",
-              "object_roles": "/api/v2/credentials/2/object_roles/",
-              "owner_users": "/api/v2/credentials/2/owner_users/",
-              "owner_teams": "/api/v2/credentials/2/owner_teams/",
-              "copy": "/api/v2/credentials/2/copy/",
-              "input_sources": "/api/v2/credentials/2/input_sources/",
-              "credential_type": "/api/v2/credential_types/1/",
-              "user": "/api/v2/users/7/"
-          },
-          "summary_fields": {
-              "credential_type": {
-                "id": 1,
-                "name": "Machine",
-                "description": ""
-              },
-              "created_by": {
-                  "id": 8,
-                  "username": "user-2",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "modified_by": {
-                  "id": 12,
-                  "username": "user-6",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "object_roles": {
-                  "admin_role": {
-                      "description": "Can manage all aspects of the credential",
-                      "name": "Admin",
-                      "id": 81
-                  },
-                  "use_role": {
-                      "description": "Can use the credential in a job template",
-                      "name": "Use",
-                      "id": 82
-                  },
-                  "read_role": {
-                      "description": "May view settings for the credential",
-                      "name": "Read",
-                      "id": 83
-                  }
-              },
-              "user_capabilities": {
-                  "edit": false,
-                  "delete": false,
-                  "copy": false,
-                  "use": false
-              },
-              "owners": [
-                  {
-                      "id": 7,
-                      "type": "user",
-                      "name": "user-1",
-                      "description": " ",
-                      "url": "/api/v2/users/7/"
-                  }
-              ]
-          },
-          "created": "2019-12-16T21:04:40.896097Z",
-          "modified": "2019-12-16T21:04:40.896121Z",
-          "name": "Bar",
-          "description": "",
-          "organization": null,
-          "credential_type": 1,
-          "inputs": {},
-          "kind": "ssh",
-          "cloud": false,
-          "kubernetes": false
-      },
-      {
-          "id": 3,
-          "type": "credential",
-          "url": "/api/v2/credentials/3/",
-          "related": {
-              "created_by": "/api/v2/users/9/",
-              "modified_by": "/api/v2/users/13/",
-              "activity_stream": "/api/v2/credentials/3/activity_stream/",
-              "access_list": "/api/v2/credentials/3/access_list/",
-              "object_roles": "/api/v2/credentials/3/object_roles/",
-              "owner_users": "/api/v2/credentials/3/owner_users/",
-              "owner_teams": "/api/v2/credentials/3/owner_teams/",
-              "copy": "/api/v2/credentials/3/copy/",
-              "input_sources": "/api/v2/credentials/3/input_sources/",
-              "credential_type": "/api/v2/credential_types/1/",
-              "user": "/api/v2/users/8/"
-          },
-          "summary_fields": {
-              "credential_type": {
-                "id": 1,
-                "name": "Machine",
-                "description": ""
-              },
-              "created_by": {
-                  "id": 9,
-                  "username": "user-3",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "modified_by": {
-                  "id": 13,
-                  "username": "user-7",
-                  "first_name": "",
-                  "last_name": ""
-              },
-              "object_roles": {
-                  "admin_role": {
-                      "description": "Can manage all aspects of the credential",
-                      "name": "Admin",
-                      "id": 84
-                  },
-                  "use_role": {
-                      "description": "Can use the credential in a job template",
-                      "name": "Use",
-                      "id": 85
-                  },
-                  "read_role": {
-                      "description": "May view settings for the credential",
-                      "name": "Read",
-                      "id": 86
-                  }
-              },
-              "user_capabilities": {
-                  "edit": true,
-                  "delete": true,
-                  "copy": true,
-                  "use": true
-              },
-              "owners": [
-                  {
-                      "id": 8,
-                      "type": "user",
-                      "name": "user-2",
-                      "description": " ",
-                      "url": "/api/v2/users/8/"
-                  }
-              ]
-          },
-          "created": "2019-12-16T21:04:40.955954Z",
-          "modified": "2019-12-16T21:04:40.955976Z",
-          "name": "Baz",
-          "description": "",
-          "organization": null,
-          "credential_type": 1,
-          "inputs": {},
-          "kind": "ssh",
-          "cloud": false,
-          "kubernetes": false
-      },
-      {
-        "id": 4,
-        "type": "credential",
-        "url": "/api/v2/credentials/4/",
-        "related": {
-            "created_by": "/api/v2/users/1/",
-            "modified_by": "/api/v2/users/1/",
-            "activity_stream": "/api/v2/credentials/4/activity_stream/",
-            "access_list": "/api/v2/credentials/4/access_list/",
-            "object_roles": "/api/v2/credentials/4/object_roles/",
-            "owner_users": "/api/v2/credentials/4/owner_users/",
-            "owner_teams": "/api/v2/credentials/4/owner_teams/",
-            "copy": "/api/v2/credentials/4/copy/",
-            "input_sources": "/api/v2/credentials/4/input_sources/",
-            "credential_type": "/api/v2/credential_types/25/",
-            "user": "/api/v2/users/1/"
+          "name": "Vault",
+          "description": ""
         },
-        "summary_fields": {
-            "credential_type": {
-              "id": 2,
-              "name": "Vault",
-              "description": ""
-            },
-            "created_by": {
-                "id": 1,
-                "username": "admin",
-                "first_name": "",
-                "last_name": ""
-            },
-            "modified_by": {
-                "id": 1,
-                "username": "admin",
-                "first_name": "",
-                "last_name": ""
-            },
-            "object_roles": {
-                "admin_role": {
-                    "description": "Can manage all aspects of the credential",
-                    "name": "Admin",
-                    "id": 318
-                },
-                "use_role": {
-                    "description": "Can use the credential in a job template",
-                    "name": "Use",
-                    "id": 319
-                },
-                "read_role": {
-                    "description": "May view settings for the credential",
-                    "name": "Read",
-                    "id": 320
-                }
-            },
-            "user_capabilities": {
-                "edit": true,
-                "delete": true,
-                "copy": true,
-                "use": true
-            },
-            "owners": [
-                {
-                    "id": 1,
-                    "type": "user",
-                    "name": "admin",
-                    "description": " ",
-                    "url": "/api/v2/users/1/"
-                }
-            ]
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
         },
-        "created": "2019-12-18T16:31:09.772005Z",
-        "modified": "2019-12-18T16:31:09.832666Z",
-        "name": "FooBar",
-        "description": "",
-        "organization": null,
-        "credential_type": 2,
-        "inputs": {},
-        "kind": null,
-        "cloud": true,
-        "kubernetes": false
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
+        },
+        "object_roles": {
+          "admin_role": {
+            "description": "Can manage all aspects of the credential",
+            "name": "Admin",
+            "id": 318
+          },
+          "use_role": {
+            "description": "Can use the credential in a job template",
+            "name": "Use",
+            "id": 319
+          },
+          "read_role": {
+            "description": "May view settings for the credential",
+            "name": "Read",
+            "id": 320
+          }
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true,
+          "use": true
+        },
+        "owners": [
+          {
+            "id": 1,
+            "type": "user",
+            "name": "admin",
+            "description": " ",
+            "url": "/api/v2/users/1/"
+          }
+        ]
+      },
+      "created": "2019-12-18T16:31:09.772005Z",
+      "modified": "2019-12-18T16:31:09.832666Z",
+      "name": "FooBar",
+      "description": "",
+      "organization": null,
+      "credential_type": 2,
+      "inputs": {},
+      "kind": null,
+      "cloud": true,
+      "kubernetes": false
     },
     {
       "id": 5,
       "type": "credential",
       "url": "/api/v2/credentials/5/",
       "related": {
-          "created_by": "/api/v2/users/1/",
-          "modified_by": "/api/v2/users/1/",
-          "activity_stream": "/api/v2/credentials/5/activity_stream/",
-          "access_list": "/api/v2/credentials/5/access_list/",
-          "object_roles": "/api/v2/credentials/5/object_roles/",
-          "owner_users": "/api/v2/credentials/5/owner_users/",
-          "owner_teams": "/api/v2/credentials/5/owner_teams/",
-          "copy": "/api/v2/credentials/5/copy/",
-          "input_sources": "/api/v2/credentials/5/input_sources/",
-          "credential_type": "/api/v2/credential_types/25/",
-          "user": "/api/v2/users/1/"
+        "created_by": "/api/v2/users/1/",
+        "modified_by": "/api/v2/users/1/",
+        "activity_stream": "/api/v2/credentials/5/activity_stream/",
+        "access_list": "/api/v2/credentials/5/access_list/",
+        "object_roles": "/api/v2/credentials/5/object_roles/",
+        "owner_users": "/api/v2/credentials/5/owner_users/",
+        "owner_teams": "/api/v2/credentials/5/owner_teams/",
+        "copy": "/api/v2/credentials/5/copy/",
+        "input_sources": "/api/v2/credentials/5/input_sources/",
+        "credential_type": "/api/v2/credential_types/25/",
+        "user": "/api/v2/users/1/"
       },
       "summary_fields": {
-          "credential_type": {
-            "id": 3,
-            "name": "Source Control",
-            "description": ""
+        "credential_type": {
+          "id": 3,
+          "name": "Source Control",
+          "description": ""
+        },
+        "created_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 1,
+          "username": "admin",
+          "first_name": "",
+          "last_name": ""
+        },
+        "object_roles": {
+          "admin_role": {
+            "description": "Can manage all aspects of the credential",
+            "name": "Admin",
+            "id": 290
           },
-          "created_by": {
-              "id": 1,
-              "username": "admin",
-              "first_name": "",
-              "last_name": ""
+          "use_role": {
+            "description": "Can use the credential in a job template",
+            "name": "Use",
+            "id": 291
           },
-          "modified_by": {
-              "id": 1,
-              "username": "admin",
-              "first_name": "",
-              "last_name": ""
-          },
-          "object_roles": {
-              "admin_role": {
-                  "description": "Can manage all aspects of the credential",
-                  "name": "Admin",
-                  "id": 290
-              },
-              "use_role": {
-                  "description": "Can use the credential in a job template",
-                  "name": "Use",
-                  "id": 291
-              },
-              "read_role": {
-                  "description": "May view settings for the credential",
-                  "name": "Read",
-                  "id": 292
-              }
-          },
-          "user_capabilities": {
-              "edit": true,
-              "delete": true,
-              "copy": true,
-              "use": true
-          },
-          "owners": [
-              {
-                  "id": 1,
-                  "type": "user",
-                  "name": "admin",
-                  "description": " ",
-                  "url": "/api/v2/users/1/"
-              }
-          ]
+          "read_role": {
+            "description": "May view settings for the credential",
+            "name": "Read",
+            "id": 292
+          }
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true,
+          "use": true
+        },
+        "owners": [
+          {
+            "id": 1,
+            "type": "user",
+            "name": "admin",
+            "description": " ",
+            "url": "/api/v2/users/1/"
+          }
+        ]
       },
       "created": "2019-12-17T16:12:44.923123Z",
       "modified": "2019-12-17T16:12:44.923151Z",


### PR DESCRIPTION
##### SUMMARY
Link #7127 

This PR accomplishes two things:

1) Support display of prompt on launch password fields in the Details view:
<img width="334" alt="Screen Shot 2020-06-08 at 11 00 58 AM" src="https://user-images.githubusercontent.com/9889020/84046145-b456a100-a977-11ea-818c-84d8fe46fccf.png">

- Previously we were showing the `ASK` text that the API returns.  I think this is a little bit more informative and it matches the pattern that we have on the JT details view.

2) Support display of plugin configured fields in the Details view:
<img width="1382" alt="Screen Shot 2020-06-08 at 11 01 29 AM" src="https://user-images.githubusercontent.com/9889020/84046258-d819e700-a977-11ea-99d1-23050d1eaf75.png">

- Since we added support for credential plugins with https://github.com/ansible/awx/pull/7125 we needed to update the details view to display that plugin configuration.  Configuration consists of two things: a credential and some metadata.  After talking with @trahman73 we decided that the path of least resistance was to display the metadata as JSON in a codemirror underneath the field.  This way, a user can see both the credential and the metadata used when pulling this field from an external source.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI