### PR TITLE
Make all_parents_must_converge settable when creating node

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3600,7 +3600,7 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
             ujt = self.instance.unified_job_template
         if ujt is None:
             ret = {}
-            for fd in ('workflow_job_template', 'identifier'):
+            for fd in ('workflow_job_template', 'identifier', 'all_parents_must_converge'):
                 if fd in attrs:
                     ret[fd] = attrs[fd]
             return ret

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -72,6 +72,18 @@ def test_node_accepts_prompted_fields(inventory, project, workflow_job_template,
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("field_name, field_value", [
+    ('all_parents_must_converge', True),
+    ('all_parents_must_converge', False),
+])
+def test_create_node_with_field(field_name, field_value, workflow_job_template, post, admin_user):
+    url = reverse('api:workflow_job_template_workflow_nodes_list',
+                  kwargs={'pk': workflow_job_template.pk})
+    res = post(url, {field_name: field_value}, user=admin_user, expect=201)
+    assert res.data[field_name] == field_value
+
+
+@pytest.mark.django_db
 class TestApprovalNodes():
     def test_approval_node_creation(self, post, approval_node, admin_user):
         url = reverse('api:workflow_job_template_node_create_approval',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
#7063 

When targeting the `api/v2/workflow_job_templates/id#/workflow_nodes/` endpoint, user could not set `all_parents_must_converge` to true.

this change fixes that.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 11.2.0
```