### PR TITLE
Manually bumps websocket-extensions to 0.1.14 (awx/ui_next)

### DIFF
--- a/awx/ui_next/package-lock.json
+++ b/awx/ui_next/package-lock.json
@@ -16320,9 +16320,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",


### PR DESCRIPTION
##### SUMMARY
See https://github.com/advisories/GHSA-g78m-2chm-r7qv