### PR TITLE
Ignore the rsyslog.conf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ rsyslog.pid
 /tower-license/**
 tools/prometheus/data
 tools/docker-compose/Dockerfile
+tools/rsyslog/rsyslog.conf
 
 # Tower setup playbook testing
 setup/test/roles/postgresql


### PR DESCRIPTION
##### SUMMARY
Ignore the rsyslog.conf file since it is a file generated during the build process.

Recently when running the dev environment, you would notice this when you run `git status`:

    Untracked files:
      (use "git add <file>..." to include in what will be committed)
	    tools/rsyslog/rsyslog.conf


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - Installer

##### AWX VERSION
```
awx: 11.2.0
```