### PR TITLE
Allow for SCM installs of the AWX collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,6 @@ use_dev_supervisor.txt
 # Ansible module tests
 /awx_collection_test_venv/
 /awx_collection/*.tar.gz
-/awx_collection/galaxy.yml
 /sanity/
 
 .idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ use_dev_supervisor.txt
 /awx_collection_test_venv/
 /awx_collection/*.tar.gz
 /sanity/
+/awx_collection_build/
 
 .idea/*
 *.unison.tmp

--- a/Makefile
+++ b/Makefile
@@ -401,11 +401,11 @@ symlink_collection:
 
 build_collection:
 	ansible-playbook -i localhost, awx_collection/tools/template_galaxy.yml -e collection_package=$(COLLECTION_PACKAGE) -e collection_namespace=$(COLLECTION_NAMESPACE) -e collection_version=$(VERSION) -e '{"awx_template_version":false}'
-	ansible-galaxy collection build awx_collection --force --output-path=awx_collection
+	ansible-galaxy collection build awx_collection_build --force --output-path=awx_collection_build
 
 install_collection: build_collection
 	rm -rf $(COLLECTION_INSTALL)
-	ansible-galaxy collection install awx_collection/$(COLLECTION_NAMESPACE)-$(COLLECTION_PACKAGE)-$(VERSION).tar.gz
+	ansible-galaxy collection install awx_collection_build/$(COLLECTION_NAMESPACE)-$(COLLECTION_PACKAGE)-$(VERSION).tar.gz
 
 test_collection_sanity: install_collection
 	cd $(COLLECTION_INSTALL) && ansible-test sanity

--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -4,12 +4,12 @@
 [comment]: # (*                                                     *)
 [comment]: # (*             WARNING                                 *)
 [comment]: # (*                                                     *)
-[comment]: # (*  This file is manageed by Ansible and not to be     *)
+[comment]: # (*  This file is templated and not to be               *)
 [comment]: # (*  edited directly! Instead modify:                   *)
 [comment]: # (*  tools/roles/template_galaxy/templates/README.md.j2 *)
 [comment]: # (*                                                     *)
-[comment]: # (*  Changed to the base README.md file are lost upon   *)
-[comment]: # (*  the build of the collection                        *)
+[comment]: # (*  Changes to the base README.md file are refreshed   *)
+[comment]: # (*  upon build of the collection                       *)
 [comment]: # (*******************************************************)
 
 This Ansible collection allows for easy interaction with an AWX server via Ansible playbooks.
@@ -67,6 +67,7 @@ Notable releases of the `awx.awx` collection:
 
  - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
  - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
+ - 0.0.1-devel is the version you should see if installing from source, which is intended for development and expected to be unstable.
 
 The following notes are changes that may require changes to playbooks:
 

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -1,0 +1,26 @@
+authors:
+- AWX Project Contributors <awx-project@googlegroups.com>
+dependencies: {}
+description: Ansible content that interacts with the AWX or Ansible Tower API.
+documentation: https://github.com/ansible/awx/blob/devel/awx_collection/README.md
+homepage: https://www.ansible.com/
+issues: https://github.com/ansible/awx/issues?q=is%3Aissue+label%3Acomponent%3Aawx_collection
+license:
+- GPL-3.0-only
+name: awx
+namespace: awx
+readme: README.md
+repository: https://github.com/ansible/awx
+tags:
+- cloud
+- infrastructure
+- awx
+- ansible
+- automation
+version: 11.2.0
+build_ignore:
+- tools
+- setup.cfg
+- galaxy.yml.j2
+- template_galaxy.yml
+- '*.tar.gz'

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -1,3 +1,14 @@
+# (********************************************************)
+# (*                                                      *)
+# (*             WARNING                                  *)
+# (*                                                      *)
+# (*  This file is managed by Ansible and not to be       *)
+# (*  edited directly! Instead modify:                    *)
+# (*  tools/roles/template_galaxy/templates/galaxy.yml.j2 *)
+# (*                                                      *)
+# (*  Changed to the base README.md file are lost upon    *)
+# (*  the build of the collection                         *)
+# (********************************************************)
 authors:
 - AWX Project Contributors <awx-project@googlegroups.com>
 dependencies: {}

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -9,29 +9,30 @@
 # (*  Changed to the base README.md file are lost upon    *)
 # (*  the build of the collection                         *)
 # (********************************************************)
+---
 authors:
-- AWX Project Contributors <awx-project@googlegroups.com>
+  - AWX Project Contributors <awx-project@googlegroups.com>
 dependencies: {}
 description: Ansible content that interacts with the AWX or Ansible Tower API.
 documentation: https://github.com/ansible/awx/blob/devel/awx_collection/README.md
 homepage: https://www.ansible.com/
 issues: https://github.com/ansible/awx/issues?q=is%3Aissue+label%3Acomponent%3Aawx_collection
 license:
-- GPL-3.0-only
+  - GPL-3.0-only
 name: awx
 namespace: awx
 readme: README.md
 repository: https://github.com/ansible/awx
 tags:
-- cloud
-- infrastructure
-- awx
-- ansible
-- automation
+  - cloud
+  - infrastructure
+  - awx
+  - ansible
+  - automation
 version: 0.0.1-devel
 build_ignore:
-- tools
-- setup.cfg
-- galaxy.yml.j2
-- template_galaxy.yml
-- '*.tar.gz'
+  - tools
+  - setup.cfg
+  - galaxy.yml.j2
+  - template_galaxy.yml
+  - '*.tar.gz'

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -6,8 +6,8 @@
 # (*  edited directly! Instead modify:                    *)
 # (*  tools/roles/template_galaxy/templates/galaxy.yml.j2 *)
 # (*                                                      *)
-# (*  Changed to the base README.md file are lost upon    *)
-# (*  the build of the collection                         *)
+# (*  Changes to the base galaxy.yml file are refreshed   *)
+# (*  upon build of the collection                        *)
 # (********************************************************)
 ---
 authors:

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -28,7 +28,7 @@ tags:
 - awx
 - ansible
 - automation
-version: devel
+version: 0.0.1-devel
 build_ignore:
 - tools
 - setup.cfg

--- a/awx_collection/galaxy.yml
+++ b/awx_collection/galaxy.yml
@@ -17,7 +17,7 @@ tags:
 - awx
 - ansible
 - automation
-version: 11.2.0
+version: devel
 build_ignore:
 - tools
 - setup.cfg

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -33,7 +33,7 @@ class ItemNotDefined(Exception):
 
 class TowerModule(AnsibleModule):
     # This gets set by the make process so whatever is in here is irrelevant
-    _COLLECTION_VERSION = "devel"
+    _COLLECTION_VERSION = "0.0.1-devel"
     _COLLECTION_TYPE = "awx"
     # This maps the collections type (awx/tower) to the values returned by the API
     # Those values can be found in awx/api/generics.py line 204

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -108,7 +108,7 @@ def run_module(request, collection_import):
             sanitize_dict(py_data)
             resp._content = bytes(json.dumps(django_response.data), encoding='utf8')
             resp.status_code = django_response.status_code
-            resp.headers = {'X-API-Product-Name': 'AWX', 'X-API-Product-Version': 'devel'}
+            resp.headers = {'X-API-Product-Name': 'AWX', 'X-API-Product-Version': '0.0.1-devel'}
 
             if request.config.getoption('verbose') > 0:
                 logger.info(

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -93,9 +93,9 @@ def test_no_templated_values(collection_import):
     checked into source.
     """
     TowerModule = collection_import('plugins.module_utils.tower_api').TowerModule
-    assert TowerModule._COLLECTION_VERSION == "devel", (
+    assert TowerModule._COLLECTION_VERSION == "0.0.1-devel", (
         'The collection version is templated when the collection is built '
-        'and the code should retain the placeholder of "devel".'
+        'and the code should retain the placeholder of "0.0.1-devel".'
     )
     InventoryModule = collection_import('plugins.inventory.tower').InventoryModule
     assert InventoryModule.NAME == 'awx.awx.tower', (

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -46,7 +46,7 @@
     dest: "{{ collection_path }}/galaxy.yml"
     force: true
 
-- name: Tempalte the README.md file
+- name: Template the README.md file
   template:
     src: "{{ collection_path }}/tools/roles/template_galaxy/templates/README.md.j2"
     dest: "{{ collection_path }}/README.md"

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -45,3 +45,9 @@
     src: "{{ collection_path }}/tools/roles/template_galaxy/templates/galaxy.yml.j2"
     dest: "{{ collection_path }}/galaxy.yml"
     force: true
+
+- name: Tempalte the README.md file
+  template:
+    src: "{{ collection_path }}/tools/roles/template_galaxy/templates/README.md.j2"
+    dest: "{{ collection_path }}/README.md"
+    force: true

--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -4,12 +4,12 @@
 [comment]: # (*                                                     *)
 [comment]: # (*             WARNING                                 *)
 [comment]: # (*                                                     *)
-[comment]: # (*  This file is manageed by Ansible and not to be     *)
+[comment]: # (*  This file is templated and not to be               *)
 [comment]: # (*  edited directly! Instead modify:                   *)
 [comment]: # (*  tools/roles/template_galaxy/templates/README.md.j2 *)
 [comment]: # (*                                                     *)
-[comment]: # (*  Changed to the base README.md file are lost upon   *)
-[comment]: # (*  the build of the collection                        *)
+[comment]: # (*  Changes to the base README.md file are refreshed   *)
+[comment]: # (*  upon build of the collection                       *)
 [comment]: # (*******************************************************)
 
 This Ansible collection allows for easy interaction with an {% if collection_package | lower() == 'awx' %}AWX{% else %}Ansible Tower{% endif %} server via Ansible playbooks.
@@ -49,13 +49,13 @@ The OAuth2 token is the preferred method. You can obtain a token via the
 AWX CLI [login](https://docs.ansible.com/ansible-tower/latest/html/towercli/reference.html#awx-login)
 command.
 
-These can be specified via:
+These can be specified via (from highest to lowest precedence):
 
- - environment variables (most useful when running against localhost)
  - direct module parameters
+ - environment variables (most useful when running against localhost)
  - a config file path specified by the `tower_config_file` parameter
- - a config file at `/etc/tower/tower_cli.cfg`
  - a config file at `~/.tower_cli.cfg`
+ - a config file at `/etc/tower/tower_cli.cfg`
 
 Config file syntax looks like this:
 
@@ -73,6 +73,7 @@ Notable releases of the `{{ collection_namespace }}.{{ collection_package }}` co
 {% if collection_package | lower() == "awx" %}
  - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
  - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
+ - 0.0.1-devel is the version you should see if installing from source, which is intended for development and expected to be unstable.
 {% else %}
  - 3.7.0 initial release
 {% endif %}

--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -1,4 +1,4 @@
-# AWX Ansible Collection
+# {% if collection_package | lower() == 'awx' %}AWX{% else %}Tower{% endif %} Ansible Collection
 
 [comment]: # (*******************************************************)
 [comment]: # (*                                                     *)
@@ -12,7 +12,7 @@
 [comment]: # (*  the build of the collection                        *)
 [comment]: # (*******************************************************)
 
-This Ansible collection allows for easy interaction with an AWX server via Ansible playbooks.
+This Ansible collection allows for easy interaction with an {% if collection_package | lower() == 'awx' %}AWX{% else %}Ansible Tower{% endif %} server via Ansible playbooks.
 
 This source for this collection lives in the `awx_collection` folder inside of the
 AWX source.
@@ -22,6 +22,7 @@ doc fragment.
 
 ## Building and Installing
 
+{% if collection_package | lower() == 'awx' %}
 This collection templates the `galaxy.yml` file it uses.
 Run `make build_collection` from the root folder of the AWX source tree.
 This will create the `tar.gz` file inside the `awx_collection` folder
@@ -29,6 +30,10 @@ with the current AWX version, for example: `awx_collection/awx-awx-9.2.0.tar.gz`
 
 Installing the `tar.gz` involves no special instructions.
 
+{% else %}
+This collection should be installed from [Content Hub][https://cloud.redhat.com/ansible/automation-hub/ansible/tower/]
+
+{% endif %}
 ## Running
 
 Non-deprecated modules in this collection have no Python requirements, but
@@ -44,13 +49,13 @@ The OAuth2 token is the preferred method. You can obtain a token via the
 AWX CLI [login](https://docs.ansible.com/ansible-tower/latest/html/towercli/reference.html#awx-login)
 command.
 
-These can be specified via (from highest to lowest precedence):
+These can be specified via:
 
- - direct module parameters
  - environment variables (most useful when running against localhost)
+ - direct module parameters
  - a config file path specified by the `tower_config_file` parameter
- - a config file at `~/.tower_cli.cfg`
  - a config file at `/etc/tower/tower_cli.cfg`
+ - a config file at `~/.tower_cli.cfg`
 
 Config file syntax looks like this:
 
@@ -63,10 +68,14 @@ oauth_token = LEdCpKVKc4znzffcpQL5vLG8oyeku6
 
 ## Release and Upgrade Notes
 
-Notable releases of the `awx.awx` collection:
+Notable releases of the `{{ collection_namespace }}.{{ collection_package }}` collection:
 
+{% if collection_package | lower() == "awx" %}
  - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
  - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
+{% else %}
+ - 3.7.0 initial release
+{% endif %}
 
 The following notes are changes that may require changes to playbooks:
 
@@ -94,6 +103,7 @@ The following notes are changes that may require changes to playbooks:
  - `tower_credential` no longer supports passing a file name to ssh_key_data.
  - The HipChat `notification_type` has been removed and can no longer be created using the `tower_notification` module.
 
+{% if collection_package | lower() == "awx" %}
 ## Running Unit Tests
 
 Tests to verify compatibility with the most recent AWX code are in `awx_collection/test/awx`.
@@ -126,6 +136,7 @@ Run the tests:
 cd ~/.ansible/collections/ansible_collections/awx/awx/
 ansible-test integration
 ```
+{% endif %}
 
 ## Licensing
 

--- a/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
@@ -1,3 +1,14 @@
+# (********************************************************)
+# (*                                                      *)
+# (*             WARNING                                  *)
+# (*                                                      *)
+# (*  This file is managed by Ansible and not to be       *)
+# (*  edited directly! Instead modify:                    *)
+# (*  tools/roles/template_galaxy/templates/galaxy.yml.j2 *)
+# (*                                                      *)
+# (*  Changed to the base README.md file are lost upon    *)
+# (*  the build of the collection                         *)
+# (********************************************************)
 authors:
 - AWX Project Contributors <awx-project@googlegroups.com>
 dependencies: {}

--- a/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
@@ -6,8 +6,8 @@
 # (*  edited directly! Instead modify:                    *)
 # (*  tools/roles/template_galaxy/templates/galaxy.yml.j2 *)
 # (*                                                      *)
-# (*  Changed to the base README.md file are lost upon    *)
-# (*  the build of the collection                         *)
+# (*  Changes to the base galaxy.yml file are refreshed   *)
+# (*  upon build of the collection                        *)
 # (********************************************************)
 ---
 authors:

--- a/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
@@ -9,29 +9,30 @@
 # (*  Changed to the base README.md file are lost upon    *)
 # (*  the build of the collection                         *)
 # (********************************************************)
+---
 authors:
-- AWX Project Contributors <awx-project@googlegroups.com>
+  - AWX Project Contributors <awx-project@googlegroups.com>
 dependencies: {}
 description: Ansible content that interacts with the AWX or Ansible Tower API.
 documentation: https://github.com/ansible/awx/blob/devel/awx_collection/README.md
 homepage: https://www.ansible.com/
 issues: https://github.com/ansible/awx/issues?q=is%3Aissue+label%3Acomponent%3Aawx_collection
 license:
-- GPL-3.0-only
+  - GPL-3.0-only
 name: {{ collection_package }}
 namespace: {{ collection_namespace }}
 readme: README.md
 repository: https://github.com/ansible/awx
 tags:
-- cloud
-- infrastructure
-- awx
-- ansible
-- automation
+  - cloud
+  - infrastructure
+  - awx
+  - ansible
+  - automation
 version: {{ collection_version_override | default(collection_version) }}
 build_ignore:
-- tools
-- setup.cfg
-- galaxy.yml.j2
-- template_galaxy.yml
-- '*.tar.gz'
+  - tools
+  - setup.cfg
+  - galaxy.yml.j2
+  - template_galaxy.yml
+  - '*.tar.gz'

--- a/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/galaxy.yml.j2
@@ -17,7 +17,7 @@ tags:
 - awx
 - ansible
 - automation
-version: {{ collection_version }}
+version: {{ collection_version_override | default(collection_version) }}
 build_ignore:
 - tools
 - setup.cfg

--- a/awx_collection/tools/template_galaxy.yml
+++ b/awx_collection/tools/template_galaxy.yml
@@ -27,13 +27,13 @@
       set_fact:
         collection_version_override: 0.0.1-devel
 
-    - name: Template the galaxy.yml source file
+    - name: Template the galaxy.yml source file (should be commited with your changes)
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/galaxy.yml.j2"
         dest: "{{ collection_source }}/galaxy.yml"
         force: true
 
-    - name: Template the README.md source file
+    - name: Template the README.md source file (should be commited with your changes)
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/README.md.j2"
         dest: "{{ collection_source }}/README.md"

--- a/awx_collection/tools/template_galaxy.yml
+++ b/awx_collection/tools/template_galaxy.yml
@@ -27,13 +27,13 @@
       set_fact:
         collection_version_override: 0.0.1-devel
 
-    - name: Template the galaxy.yml file
+    - name: Template the galaxy.yml source file
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/galaxy.yml.j2"
         dest: "{{ collection_source }}/galaxy.yml"
         force: true
 
-    - name: Template the README.md file
+    - name: Template the README.md source file
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/README.md.j2"
         dest: "{{ collection_source }}/README.md"

--- a/awx_collection/tools/template_galaxy.yml
+++ b/awx_collection/tools/template_galaxy.yml
@@ -25,7 +25,7 @@
   tasks:
     - name: Make substitutions in source to sync with templates
       set_fact:
-        collection_version_override: devel
+        collection_version_override: 0.0.1-devel
 
     - name: Template the galaxy.yml file
       template:

--- a/awx_collection/tools/template_galaxy.yml
+++ b/awx_collection/tools/template_galaxy.yml
@@ -7,6 +7,34 @@
     collection_package: awx
     collection_namespace: awx
     collection_version: 0.0.1  # not for updating, pass in extra_vars
-    collection_path: "{{ playbook_dir }}/../"
+    collection_source: "{{ playbook_dir }}/../"
+    collection_path: "{{ playbook_dir }}/../../awx_collection_build"
+  pre_tasks:
+    - file:
+        path: "{{ collection_path }}"
+        state: absent
+
+    - copy:
+        src: "{{ collection_source }}"
+        dest: "{{ collection_path }}"
+        remote_src: true
+
   roles:
     - template_galaxy
+
+  tasks:
+    - name: Make substitutions in source to sync with templates
+      set_fact:
+        collection_version_override: devel
+
+    - name: Template the galaxy.yml file
+      template:
+        src: "{{ collection_source }}/tools/roles/template_galaxy/templates/galaxy.yml.j2"
+        dest: "{{ collection_source }}/galaxy.yml"
+        force: true
+
+    - name: Template the README.md file
+      template:
+        src: "{{ collection_source }}/tools/roles/template_galaxy/templates/README.md.j2"
+        dest: "{{ collection_source }}/README.md"
+        force: true


### PR DESCRIPTION
##### SUMMARY
This is a continuation of https://github.com/ansible/awx/pull/7123 (ping @john-westcott-iv ), to the logical conclusion of that train of thought.

This is also to obtain a form of compliance with https://github.com/ansible/ansible/pull/69154, such that you can install the collection with the requirements file:

```yaml
collections:
   - name: https://github.com/alancoding/awx.git#awx_collection,in_place_everything
     type: git
```

You can check `ansible-galaxy collection list` after this and see the placeholder version. ~We might want to get consistency with placeholder versions, and put it here too:~

https://github.com/ansible/awx/blob/442d539ff89ecfdd6cf7fb706d4e86f25aa96a8e/awx_collection/plugins/module_utils/tower_api.py#L36

~That just might take more work.~ (this has been done)

##### ISSUE TYPE
 - Feature Pull Request

##### WHAT THIS DOES

Instead of templating everything in-place (which has hazards for someone accidentally committing those changes), it templates it to a new "build" folder, and doesn't keep around old `*.tar.gz` files.

This separates the "source" version of the collection from the templated version of the collection.

It also templates 2 files a second time direction into the "source" version. This is to keep them synced with the template, and also allow for installing & using from source. If you see the version `0.0.1-devel` then you know you're running from source, that's the idea.