### PR TITLE
remove some references to memcached

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -38,7 +38,7 @@ dockerhub_base=ansible
 # kubernetes_ingress_tls_secret=awx-cert
 
 # Kubernetes and Openshift Install Resource Requests
-# These are the request and limit values for a pod's container for task/web/redis/memcached/management.
+# These are the request and limit values for a pod's container for task/web/redis/management.
 # The total amount of requested resources for a pod is the sum of all
 # resources requested by all containers in the pod
 # A cpu_request of 1500 is 1.5 cores for the container to start out with.
@@ -54,8 +54,6 @@ dockerhub_base=ansible
 # web_mem_limit=2
 # redis_cpu_limit=1000
 # redis_mem_limit=3
-# memcached_cpu_limit=1000
-# memcached_mem_limit=2
 # management_cpu_limit=2000
 # management_mem_limit=2
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -108,7 +108,7 @@ ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via openshift
 schedule==0.6.0           # via -r /awx_devel/requirements/requirements.in
 service-identity==18.1.0  # via twisted
-six==1.14.0               # via ansible-runner, automat, cryptography, django-extensions, django-pglocks, google-auth, isodate, jaraco.collections, jaraco.logging, jaraco.text, jsonschema, kubernetes, openshift, pygerduty, pyopenssl, pyrad, pyrsistent, python-dateutil, python-memcached, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, twilio, txaio, websocket-client
+six==1.14.0               # via ansible-runner, automat, cryptography, django-extensions, django-pglocks, google-auth, isodate, jaraco.collections, jaraco.logging, jaraco.text, jsonschema, kubernetes, openshift, pygerduty, pyopenssl, pyrad, pyrsistent, python-dateutil, slackclient, social-auth-app-django, social-auth-core, tacacs-plus, twilio, txaio, websocket-client
 slackclient==1.1.2        # via -r /awx_devel/requirements/requirements.in
 smmap==3.0.1              # via gitdb
 social-auth-app-django==3.1.0  # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
AFAIK we removed memcached depedency but I still see lots of references to it....this is a start but there are a good number of other references at least in comments + docs. Would be good to go ahead and clear up what that code is now doing if it is not using memcached