### PR TITLE
Add required variables to ClipboardCopyButton test

### DIFF
--- a/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.test.jsx
+++ b/awx/ui_next/src/components/ClipboardCopyButton/ClipboardCopyButton.test.jsx
@@ -12,6 +12,8 @@ describe('ClipboardCopyButton', () => {
       <ClipboardCopyButton
         clickTip="foo"
         hoverTip="bar"
+        copyTip="baz"
+        copiedSuccessTip="qux"
         stringToCopy="foobar!"
         isDisabled={false}
       />
@@ -23,6 +25,8 @@ describe('ClipboardCopyButton', () => {
       <ClipboardCopyButton
         clickTip="foo"
         hoverTip="bar"
+        copyTip="baz"
+        copiedSuccessTip="qux"
         stringToCopy="foobar!"
         isDisabled={false}
       />
@@ -40,6 +44,8 @@ describe('ClipboardCopyButton', () => {
       <ClipboardCopyButton
         clickTip="foo"
         hoverTip="bar"
+        copyTip="baz"
+        copiedSuccessTip="qux"
         stringToCopy="foobar!"
         isDisabled
       />


### PR DESCRIPTION
Add required variables to `ClipboardCopyButton` test to remove warnings
during test execution.
