### PR TITLE
Force containers in k8s to run under root group

### DIFF
--- a/installer/roles/kubernetes/templates/configmap.yml.j2
+++ b/installer/roles/kubernetes/templates/configmap.yml.j2
@@ -202,6 +202,6 @@ data:
 
   {{ kubernetes_deployment_name }}_redis_conf: |
     unixsocket /var/run/redis/redis.sock
-    unixsocketperm 777
+    unixsocketperm 660
     port 0
     bind 127.0.0.1

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -40,6 +40,8 @@ spec:
         app: {{ kubernetes_deployment_name }}
     spec:
       serviceAccountName: awx
+      securityContext:
+        fsGroup: 0
       terminationGracePeriodSeconds: 10
 {% if custom_venvs is defined %}
 {% set trusted_hosts = "" %}


### PR DESCRIPTION
Normally containers belong to the 'root' group, but for some reason the downstream red hat scl redis image only belongs to the 'redis' group by default. This fixes that.