### PR TITLE
Instance id fallback

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2552,7 +2552,7 @@ class RunInventoryUpdate(BaseTask):
             args.append('--exclude-empty-groups')
         if getattr(settings, '%s_INSTANCE_ID_VAR' % src.upper(), False):
             args.extend(['--instance-id-var',
-                        getattr(settings, '%s_INSTANCE_ID_VAR' % src.upper()),])
+                        "'{}'".format(getattr(settings, '%s_INSTANCE_ID_VAR' % src.upper())),])
         # Add arguments for the source inventory script
         args.append('--source')
         args.append(self.pseudo_build_inventory(inventory_update, private_data_dir))

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -702,7 +702,7 @@ EC2_ENABLED_VAR = 'ec2_state'
 EC2_ENABLED_VALUE = 'running'
 
 # Inventory variable name containing unique instance ID.
-EC2_INSTANCE_ID_VAR = 'ec2_id'
+EC2_INSTANCE_ID_VAR = 'ec2_id,instance_id'
 
 # Filter for allowed group/host names when importing inventory from EC2.
 EC2_GROUP_FILTER = r'^.+$'

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -702,7 +702,7 @@ EC2_ENABLED_VAR = 'ec2_state'
 EC2_ENABLED_VALUE = 'running'
 
 # Inventory variable name containing unique instance ID.
-EC2_INSTANCE_ID_VAR = 'ec2_id,instance_id'
+EC2_INSTANCE_ID_VAR = 'ec2_id'
 
 # Filter for allowed group/host names when importing inventory from EC2.
 EC2_GROUP_FILTER = r'^.+$'

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -721,7 +721,7 @@ VMWARE_ENABLED_VAR = 'guest.gueststate'
 VMWARE_ENABLED_VALUE = 'running'
 
 # Inventory variable name containing the unique instance ID.
-VMWARE_INSTANCE_ID_VAR = 'config.instanceuuid'
+VMWARE_INSTANCE_ID_VAR = 'config.instanceUuid, config.instanceuuid'
 
 # Filter for allowed group and host names when importing inventory
 # from VMware.


### PR DESCRIPTION
When creating instance id refer to _list_ of hostvars. If first hostvar is not available, walk down list of hostvars until one is defined. This allows awx to be backwards compatible when forming instance id.

Fixes https://github.com/ansible/awx/issues/3461