### PR TITLE
Remove local port binding for postgres in dev env

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -107,6 +107,7 @@ RUN dnf -y install \
     make \
     patch \
     wget \
+    diffutils \
     unzip && \
     npm install -g n && n 10.15.0 && dnf remove -y nodejs
 {% endif %}

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -46,8 +46,6 @@ services:
   postgres:
     image: postgres:10
     container_name: tools_postgres_1
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:


### PR DESCRIPTION
I dont think we need to bind this port at the host level. This will allow us to run the galaxy_ng dev tooling side-by-side with AWX.
