### PR TITLE
[foreman] add backwards support for ssl_verify in foreman plugin

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -2596,6 +2596,7 @@ class satellite6(PluginFileInjector):
 
     def inventory_as_dict(self, inventory_update, private_data_dir):
         ret = super(satellite6, self).inventory_as_dict(inventory_update, private_data_dir)
+        ret['validate_certs'] = False
 
         group_patterns = '[]'
         group_prefix = 'foreman_'
@@ -2615,6 +2616,10 @@ class satellite6(PluginFileInjector):
                 want_ansible_ssh_host = v
             elif k == 'satellite6_want_facts' and isinstance(v, bool):
                 want_facts = v
+            # add backwards support for ssl_verify
+            # plugin uses new option, validate_certs, instead
+            elif k == 'ssl_verify' and isinstance(v, bool):
+                ret['validate_certs'] = v
             else:
                 ret[k] = str(v)
 

--- a/awx/main/tests/data/inventory/plugins/satellite6/files/foreman.yml
+++ b/awx/main/tests/data/inventory/plugins/satellite6/files/foreman.yml
@@ -24,6 +24,7 @@ keyed_groups:
   separator: ''
 legacy_hostvars: true
 plugin: theforeman.foreman.foreman
+validate_certs: false
 want_facts: true
 want_hostcollections: true
 want_params: true

--- a/awx/main/tests/unit/models/test_inventory.py
+++ b/awx/main/tests/unit/models/test_inventory.py
@@ -72,6 +72,23 @@ def test_invalid_kind_clean_insights_credential():
     assert json.dumps(str(e.value)) == json.dumps(str([u'Assignment not allowed for Smart Inventory']))
 
 
+@pytest.mark.parametrize('source_vars,validate_certs', [
+    ({'ssl_verify': True}, True),
+    ({'ssl_verify': False}, False),
+    ({'validate_certs': True}, True),
+    ({'validate_certs': False}, False)])
+def test_satellite_plugin_backwards_support_for_ssl_verify(source_vars, validate_certs):
+    injector = InventorySource.injectors['satellite6']('2.9')
+    inv_src = InventorySource(
+        name='satellite source', source='satellite6',
+        source_vars=source_vars
+    )
+
+    ret = injector.inventory_as_dict(inv_src, '/tmp/foo')
+    assert 'validate_certs' in ret
+    assert ret['validate_certs'] in (validate_certs, str(validate_certs))
+
+
 class TestControlledBySCM(): 
     def test_clean_source_path_valid(self):
         inv_src = InventorySource(source_path='/not_real/',


### PR DESCRIPTION
If you wanted to ensure certificates were validated when using the satellite / foreman inventory:
* the (old) script expected the `ssl_verify` source_var
* .. while the plugin expects `validate_certs`

This PR adds support for the old `ssl_verify` source_var in the plugin.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx 12.0.0
```