### PR TITLE
Enforce single owner field when serializing creds

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2644,8 +2644,16 @@ class CredentialSerializerCreate(CredentialSerializer):
                     owner_fields.add(field)
                 else:
                     attrs.pop(field)
+
         if not owner_fields:
             raise serializers.ValidationError({"detail": _("Missing 'user', 'team', or 'organization'.")})
+
+        if len(owner_fields) > 1:
+            received = ", ".join(sorted(owner_fields))
+            raise serializers.ValidationError({"detail": _(
+                "Only one of 'user', 'team', or 'organization' should be provided, "
+                "received {} fields.".format(received)
+            )})
 
         if attrs.get('team'):
             attrs['organization'] = attrs['team'].organization

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -61,6 +61,36 @@ def test_credential_validation_error_with_bad_user(post, admin, credentialtype_s
 
 
 @pytest.mark.django_db
+def test_credential_validation_error_with_no_owner_field(post, admin, credentialtype_ssh):
+    params = {
+        'credential_type': credentialtype_ssh.id,
+        'inputs': {'username': 'someusername'},
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, admin)
+    assert response.status_code == 400
+    assert response.data['detail'][0] == "Missing 'user', 'team', or 'organization'."
+
+
+@pytest.mark.django_db
+def test_credential_validation_error_with_multiple_owner_fields(post, admin, alice, team, organization, credentialtype_ssh):
+    params = {
+        'credential_type': credentialtype_ssh.id,
+        'inputs': {'username': 'someusername'},
+        'team': team.id,
+        'user': alice.id,
+        'organization': organization.id,
+        'name': 'Some name',
+    }
+    response = post(reverse('api:credential_list'), params, admin)
+    assert response.status_code == 400
+    assert response.data['detail'][0] == (
+        "Only one of 'user', 'team', or 'organization' should be provided, "
+        "received organization, team, user fields."
+    )
+
+
+@pytest.mark.django_db
 def test_create_user_credential_via_user_credentials_list(post, get, alice, credentialtype_ssh):
     params = {
         'credential_type': 1,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The CredentialSerializerCreate expect a single owner field according to
its help text but was not validating that. This makes it validate for a
single owner field when creating a Credential.

Related #7376 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 12.0.0
```