### PR TITLE
awxkit dropped py2 support awhile ago; stop running tests in py2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ test:
 	fi; \
 	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto $(TEST_DIRS)
 	cmp VERSION awxkit/VERSION || "VERSION and awxkit/VERSION *must* match"
-	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py2,py3
+	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py3
 	awx-manage check_migrations --dry-run --check  -n 'vNNN_missing_migration_file'
 
 COLLECTION_TEST_DIRS ?= awx_collection/test/awx


### PR DESCRIPTION
This is unnecessary and should shave some time off our zuul runs