### PR TITLE
Add parameter update_password to tower_user module

### DIFF
--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -55,6 +55,13 @@ options:
       description:
         - Write-only field used to change the password.
       type: str
+    update_password:
+      description:
+        - C(always) will update passwords if they differ.
+        - C(on_create) will only set the password for newly created users.
+      type: str
+      choices: [ always, on_create ]
+      default: always
     state:
       description:
         - Desired state of the resource.
@@ -115,6 +122,7 @@ def main():
         is_superuser=dict(type='bool', default=False, aliases=['superuser']),
         is_system_auditor=dict(type='bool', default=False, aliases=['auditor']),
         password=dict(no_log=True),
+        update_password=dict(choices=['always', 'on_create'], default='always', no_log=False),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -129,6 +137,7 @@ def main():
     is_superuser = module.params.get('is_superuser')
     is_system_auditor = module.params.get('is_system_auditor')
     password = module.params.get('password')
+    update_password = module.params.get('update_password')
     state = module.params.get('state')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
@@ -158,7 +167,7 @@ def main():
         new_fields['is_superuser'] = is_superuser
     if is_system_auditor:
         new_fields['is_system_auditor'] = is_system_auditor
-    if password:
+    if password and (not existing_item or update_password == 'always'):
         new_fields['password'] = password
 
     # If the state was present and we can let the module build or update the existing item, this will return on its own

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -44,3 +44,16 @@ def test_password_no_op_warning(run_module, admin_user, mock_auth_stuff, silence
     silence_warning.assert_called_once_with(
         "The field password of user {0} has encrypted data and "
         "may inaccurately report task is changed.".format(result['id']))
+
+
+@pytest.mark.django_db
+def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
+    for i in range(2):
+        result = run_module('tower_user', dict(
+            username='Bob',
+            password='pass4word',
+            update_password='on_create'
+        ), admin_user)
+        assert not result.get('failed', False), result.get('msg', result)
+
+    assert not result.get('changed')


### PR DESCRIPTION
##### SUMMARY

Add a parameter **update_password** to **tower_user** module.

Available values are **always** (default) or **on_create**.

- When update_password=on_create, password is set only if a new user is created.
- When update_password=always, password is set for new and existing users (if password is provided). That's the way it works, currently.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 12.0.0
```


##### ADDITIONAL INFORMATION

This new parameter is particularly useful when you want to generate random passwords for new users but do not want to change passwords for any existing users.

The implementation is based on the System User module: https://docs.ansible.com/ansible/latest/modules/user_module.html#parameter-update_password