### PR TITLE
Update awxkit credential page create_payload

### DIFF
--- a/awxkit/awxkit/api/pages/credentials.py
+++ b/awxkit/awxkit/api/pages/credentials.py
@@ -287,7 +287,7 @@ class Credential(HasCopy, HasCreate, base.Base):
 
         credential_type, organization, user, team = filter_by_class(
             (credential_type, CredentialType), (organization, Organization), (user, User), (team, Team))
-        if not any((user, team, organization)):
+        if not all((user, team, organization)):
             organization = Organization
         self.create_and_update_dependencies(
             credential_type, organization, user, team)
@@ -323,7 +323,7 @@ class Credential(HasCopy, HasCreate, base.Base):
         return self.update_identity(
             Credentials(
                 self.connection)).post(payload)
- 
+
     def test(self, data):
         """Test the credential endpoint."""
         response = self.connection.post(urljoin(str(self.url), 'test/'), data)


### PR DESCRIPTION
##### SUMMARY
Only assign an organization if none of user, team or organization is
passed. When creating a credential just one of those fields are expected
and now that https://github.com/ansible/awx/pull/7381 is merged, that is
being enforced.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
awxkit

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 12.0.0
```

PS.: I am currently testing these changes