### PR TITLE
Don't traceback on KeyboardInterrupt

### DIFF
--- a/awxkit/awxkit/cli/__init__.py
+++ b/awxkit/awxkit/cli/__init__.py
@@ -23,6 +23,8 @@ def run(stdout=sys.stdout, stderr=sys.stderr, argv=[]):
         cli.parse_args(argv or sys.argv)
         cli.connect()
         cli.parse_resource()
+    except KeyboardInterrupt:
+        sys.exit(1)
     except ConnectionError as e:
         cli.parser.print_help()
         msg = (


### PR DESCRIPTION
##### SUMMARY

Don't print a Python traceback when a user is running the awx CLI and presses Control-C.  Just exit.

##### ISSUE TYPE
 - Bughancement Pull Request

##### COMPONENT NAME
 - awxkit CLI

##### AWX VERSION
```
awx: 13.0.0
```