### PR TITLE
Picky Openshift clusters need some more options

### DIFF
--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -14,6 +14,9 @@ kubernetes_awx_image: "{{ tower_package_name | default('ansible/awx') }}"
 kubernetes_web_image: "{{ kubernetes_awx_image }}"
 kubernetes_task_image: "{{ kubernetes_awx_image }}"
 
+awx_deployment_security_context_enabled: true
+awx_deployment_fsgroup: 0
+
 awx_psp_create: false
 awx_psp_name: 'awx'
 awx_psp_privileged: true

--- a/installer/roles/kubernetes/tasks/openshift.yml
+++ b/installer/roles/kubernetes/tasks/openshift.yml
@@ -32,6 +32,7 @@
 - name: Add privileged SCC to service account
   shell: |
     {{ openshift_oc_bin }} adm policy add-scc-to-user privileged system:serviceaccount:{{ openshift_project }}:awx
+  when: (awx_psp_privileged or web_security_context_privileged or task_security_context_privileged or redis_security_context_privileged) | bool
 
 # https://github.com/openshift/origin/issues/19182#issuecomment-378233606
 # If oc version ever grows a -o json option, remove the following tasks

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -104,8 +104,12 @@ spec:
         app: {{ kubernetes_deployment_name }}
     spec:
       serviceAccountName: awx
+{% if awx_deployment_security_context_enabled is defined and awx_deployment_security_context_enabled | bool %}
       securityContext:
-        fsGroup: 0
+{% if awx_deployment_fsgroup is defined %}
+        fsGroup: {{ awx_deployment_fsgroup }}
+{% endif %}
+{% endif %}
       terminationGracePeriodSeconds: 10
 {% if custom_venvs is defined %}
 {% set trusted_hosts = "" %}


### PR DESCRIPTION
If a user does not have right privileges to the cluster, they cannot
install awx with these settings. Make sure we allow them to configure them
the way it works for their cluster.

These are blocking us installing awx on an internal openshift cluster where I have limited privileges.

Goal is no behavior change if don't change defaults. `awx_psp_privileged` and `task_security_context_privileged` are default `true` so `Add privileged SCC to service account` will continue to run by default and I set the defaults for the new vars to values that cause them to stll do the same thing if nothing modified:

```
awx_deployment_security_context_enabled: true
awx_deployment_fsgroup: 0
```