### PR TITLE
Delete node_modules in project root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ clean-ui: clean-languages
 	rm -rf awx/ui/test/e2e/reports/
 	rm -rf awx/ui/client/languages/
 	rm -rf awx/ui_next/node_modules/
+	rm -rf node_modules
 	rm -rf awx/ui_next/coverage/
 	rm -rf awx/ui_next/build/locales/_build/
 	rm -f $(UI_DEPS_FLAG_FILE)
@@ -585,6 +586,7 @@ ui-devel-next: awx/ui_next/node_modules
 	cp -r awx/ui_next/build/static/media/* awx/public/static/media
 
 clean-ui-next:
+	rm -rf node_modules
 	rm -rf awx/ui_next/node_modules
 	rm -rf awx/ui_next/build
 


### PR DESCRIPTION
##### SUMMARY
It's easy enough to create a `node_modules` dir in the project root by mistake just by running an npm command without a `--prefix` flag. Since this will break some make targets we can just make sure to delete that folder if it exists.
