### PR TITLE
Add extraction of strings to be translated as part of build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ awx/ui/client/languages
 awx/ui/templates/ui/index.html
 awx/ui/templates/ui/installing.html
 awx/ui_next/node_modules/
+awx/ui_next/src/locales/
 awx/ui_next/coverage/
 awx/ui_next/build
 awx/ui_next/.env.local

--- a/Makefile
+++ b/Makefile
@@ -576,6 +576,8 @@ ui-release-next:
 	touch awx/ui_next/build/static/.placeholder
 
 ui-devel-next: awx/ui_next/node_modules
+	$(NPM_BIN) --prefix awx/ui_next run extract-strings
+	$(NPM_BIN) --prefix awx/ui_next run compile-strings
 	$(NPM_BIN) --prefix awx/ui_next run build
 	mkdir -p awx/public/static/css
 	mkdir -p awx/public/static/js

--- a/awx/ui_next/.linguirc
+++ b/awx/ui_next/.linguirc
@@ -1,5 +1,6 @@
 {
    "localeDir": "src/locales/",
    "srcPathDirs": ["src/"],
-   "format": "po"
+   "format": "po",
+   "sourceLocale": "en"
 }


### PR DESCRIPTION
Add extraction of strings to be translated as part of build process for
ui_next.

Also, sets the source locale. See: https://lingui.js.org/tutorials/cli.html#configuring-source-locale

closes: https://github.com/ansible/awx/issues/7451
