### PR TITLE
Fix custom credential field validation

### DIFF
--- a/awx/ui/client/features/credentials/add-edit-credentials.controller.js
+++ b/awx/ui/client/features/credentials/add-edit-credentials.controller.js
@@ -53,16 +53,19 @@ function AddEditCredentialsController (
             vm.form.disabled = !isEditable;
         }
 
-        vm.form.organization._disabled = !isOrgEditableByUser;
+        vm.form._organization._disabled = !isOrgEditableByUser;
         // Only exists for permissions compatibility
         $scope.credential_obj = credential.get();
 
-        vm.form.organization._resource = 'organization';
-        vm.form.organization._model = organization;
-        vm.form.organization._route = 'credentials.edit.organization';
-        vm.form.organization._value = credential.get('summary_fields.organization.id');
-        vm.form.organization._displayValue = credential.get('summary_fields.organization.name');
-        vm.form.organization._placeholder = strings.get('inputs.ORGANIZATION_PLACEHOLDER');
+        // Custom credentials can have input fields named 'name', 'organization',
+        // 'description', etc. Underscore these variables to make collisions
+        // less likely to occur.
+        vm.form._organization._resource = 'organization';
+        vm.form._organization._model = organization;
+        vm.form._organization._route = 'credentials.edit.organization';
+        vm.form._organization._value = credential.get('summary_fields.organization.id');
+        vm.form._organization._displayValue = credential.get('summary_fields.organization.name');
+        vm.form._organization._placeholder = strings.get('inputs.ORGANIZATION_PLACEHOLDER');
 
         vm.form.credential_type._resource = 'credential_type';
         vm.form.credential_type._model = credentialType;
@@ -98,10 +101,10 @@ function AddEditCredentialsController (
         vm.form._formName = 'credential';
         vm.form.disabled = !credential.isCreatable();
 
-        vm.form.organization._resource = 'organization';
-        vm.form.organization._route = 'credentials.add.organization';
-        vm.form.organization._model = organization;
-        vm.form.organization._placeholder = strings.get('inputs.ORGANIZATION_PLACEHOLDER');
+        vm.form._organization._resource = 'organization';
+        vm.form._organization._route = 'credentials.add.organization';
+        vm.form._organization._model = organization;
+        vm.form._organization._placeholder = strings.get('inputs.ORGANIZATION_PLACEHOLDER');
 
         vm.form.credential_type._resource = 'credential_type';
         vm.form.credential_type._route = 'credentials.add.credentialType';
@@ -112,7 +115,7 @@ function AddEditCredentialsController (
 
     $scope.$watch('organization', () => {
         if ($scope.organization) {
-            vm.form.organization._idFromModal = $scope.organization;
+            vm.form._organization._idFromModal = $scope.organization;
         }
     });
 

--- a/awx/ui/client/features/credentials/add-edit-credentials.view.html
+++ b/awx/ui/client/features/credentials/add-edit-credentials.view.html
@@ -10,9 +10,9 @@
 
     <at-panel-body>
         <at-form state="vm.form" autocomplete="off" id="credential_form">
-            <at-input-text col="4" tab="1" state="vm.form.name" id="credential_name_group"></at-input-text>
-            <at-input-text col="4" tab="2" state="vm.form.description" id="credential_description_group"></at-input-text>
-            <at-input-lookup col="4" tab="3" state="vm.form.organization" id="credential_organization_group"></at-input-lookup>
+            <at-input-text col="4" tab="1" state="vm.form._name" id="credential_name_group"></at-input-text>
+            <at-input-text col="4" tab="2" state="vm.form._description" id="credential_description_group"></at-input-text>
+            <at-input-lookup col="4" tab="3" state="vm.form._organization" id="credential_organization_group"></at-input-lookup>
 
             <at-divider></at-divider>
 

--- a/awx/ui/client/lib/components/input/base.controller.js
+++ b/awx/ui/client/lib/components/input/base.controller.js
@@ -12,7 +12,13 @@ function BaseInputController (strings) {
 
         scope.state._touched = false;
         scope.state._required = scope.state.required || false;
-        scope.state._isValid = scope.state._isValid || false;
+
+        if (scope.state.type === 'boolean') {
+            scope.state._isValid = scope.state._isValid || true;
+        } else {
+            scope.state._isValid = scope.state._isValid || false;
+        }
+
         scope.state._disabled = scope.state._disabled || false;
         scope.state._activeModel = scope.state._activeModel || '_value';
 
@@ -57,6 +63,10 @@ function BaseInputController (strings) {
 
             if (scope.state._value || scope.state._displayValue) {
                 scope.state._touched = true;
+            }
+
+            if (scope.state.type === 'boolean') {
+                return { isValid, message };
             }
 
             if (scope.state._required && (!scope.state._value || !scope.state._value[0]) &&

--- a/awx/ui/client/lib/models/Credential.js
+++ b/awx/ui/client/lib/models/Credential.js
@@ -27,6 +27,16 @@ function createFormSchema (method, config) {
         }
     });
 
+    // Custom credentials can have input fields named 'name', 'organization',
+    // 'description', etc. Underscore these variables to make collisions
+    // less likely to occur.
+    schema._name = schema.name;
+    schema._organization = schema.organization;
+    schema._description = schema.description;
+    delete schema.name;
+    delete schema.organization;
+    delete schema.description;
+
     return schema;
 }
 


### PR DESCRIPTION
##### SUMMARY
for #7483 

User has a custom credential with `required` booleans and at least one custom field id that is identical to the name of a field on the actual credential model (`name`, `description`, etc).

- Ignore required field validations for booleans. You can't _not_ provide a value for these. Not checking the box is implicitly providing a value of `false`. 
- Underscore the property names of the common credential model fields on the ui state to avoid collisions w/ custom cred field ids.
