### PR TITLE
tower_role.py 204 error field detail 

### DIFF
--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -170,7 +170,7 @@ def main():
                 if response['status_code'] == 204:
                     module.json_output['changed'] = True
                 else:
-                    module.fail_json(msg="Failed to grant role {0}".format(response['json']['detail']))
+                    module.fail_json(msg="Failed to grant role {0}".format(response['json']['msg']))
         else:
             for an_id in list(set(existing_associated_ids) & set(new_association_list)):
                 response = module.post_endpoint(association_endpoint, **{'data': {'id': int(an_id), 'disassociate': True}})


### PR DESCRIPTION
##### SUMMARY

ansible crash because the api don't return detail field in json

fix error 204 detail > msg return api

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

awx_collection

##### AWX VERSION
13.0.0


##### ADDITIONAL INFORMATION

The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 113, in <module>
  File "<stdin>", line 105, in _ansiballz_main
  File "<stdin>", line 48, in invoke_module
  File "/tmp/ansible_tower_role_payload_VOI9Tk/__main__.py", line 186, in <module>
  File "/tmp/ansible_tower_role_payload_VOI9Tk/__main__.py", line 173, in main
KeyError: 'detail'

failed: [localhost] (item={u'name': u'DQT_GDE_exploit', u'desc': u'equipe GDE exploit'}) => {
    "changed": false, 
    "item": {
        "desc": "equipe GDE exploit", 
        "name": "DQT_GDE_exploit"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/tmp/ansible_tower_role_payload_VOI9Tk/__main__.py\", line 186, in <module>\n  File \"/tmp/ansible_tower_role_payload_VOI9Tk/__main__.py\", line 173, in main\nKeyError: 'detail'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}


with msg field

failed: [localhost] (item={u'name': u'DQT_GDE_exploit', u'desc': u'equipe GDE exploit'}) => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "credential": null, 
            "inventory": null, 
            "job_template": null, 
            "organization": "CNAF", 
            "project": null, 
            "target_team": null, 
            "team": "DQT_GDE_exploit", 
            "tower_config_file": null, 
            "tower_host": "https://xxxxxxxxxxxxxx", 
            "tower_oauthtoken": null, 
            "tower_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "tower_username": "admin", 
            "user": null, 
            "validate_certs": false, 
            "workflow": null
        }
    }, 
    "item": {
        "desc": "equipe GDE exploit", 
        "name": "DQT_GDE_exploit"
    }, 
    "msg": "Failed to grant role You cannot assign an Organization participation role as a child role for a Team."
}
