### PR TITLE
Allow anyone to start awx and awx_task [#7545]

### DIFF
--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -110,14 +110,14 @@
   copy:
     src: launch_awx.sh
     dest: "{{ docker_base_path }}/launch_awx.sh"
-    mode: '0700'
+    mode: '0755'
   delegate_to: localhost
 
 - name: Stage launch_awx_task
   template:
     src: launch_awx_task.sh.j2
     dest: "{{ docker_base_path }}/launch_awx_task.sh"
-    mode: '0700'
+    mode: '0755'
   delegate_to: localhost
 
 - name: Stage rsyslog.conf


### PR DESCRIPTION
##### SUMMARY
Fixes #7545 by adding exec bits to start scripts for awx and awx task processes.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
13, git devel head.

##### ADDITIONAL INFORMATION
This change is needed, as at current AWX start fails if run with podman, as non root. Podman uses non root user, so I add here read and execution bit to group and others as well, so the processes get started. Without this, start fails with "no permissions".


