### PR TITLE
Safely enable HTML in Custom Login Info

### DIFF
--- a/awx/ui/client/src/login/loginModal/loginModal.controller.js
+++ b/awx/ui/client/src/login/loginModal/loginModal.controller.js
@@ -88,6 +88,7 @@ export default ['$log', '$cookies', '$rootScope', 'ProcessErrors',
         }
         scope.customLoginInfo = $AnsibleConfig.custom_login_info;
         scope.customLoginInfoPresent = (scope.customLoginInfo) ? true : false;
+        scope.customLoginInfoIsHTML = /<\/?[a-z][\s\S]*>/i.test(scope.customLoginInfo);
     });
 
     if (scope.removeAuthorizationGetLicense) {

--- a/awx/ui/client/src/login/loginModal/loginModal.partial.html
+++ b/awx/ui/client/src/login/loginModal/loginModal.partial.html
@@ -98,7 +98,12 @@
                         </div>
                     </div>
                 </form>
-                <div id="login_modal_notice" class="LoginModalNotice" ng-if="customLoginInfoPresent"><div class="LoginModalNotice-title" translate>NOTICE</div>{{ customLoginInfo | sanitize }}</div>
+                <div id="login_modal_notice" class="LoginModalNotice" ng-if="customLoginInfoPresent">
+                    <div class="LoginModalNotice-title" translate>NOTICE</div>
+                    <ng-bind-html ng-bind-html="customLoginInfo"
+                        ng-style="{'white-space' : customLoginInfoIsHTML ? 'initial' : 'pre-wrap'}">
+                    </ng-bind-html>
+                </div>
             </div>
             <div class="LoginModal-footer">
                 <div class="LoginModal-footerBlock">

--- a/awx/ui/client/src/login/loginModal/loginModalNotice.block.less
+++ b/awx/ui/client/src/login/loginModal/loginModalNotice.block.less
@@ -12,7 +12,6 @@
     color: @login-notice-text;
     overflow-y: scroll;
     overflow-x: visible;
-    white-space: pre-wrap;
 }
 
 .LoginModalNotice-title {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
###### Rationale:
We are required to include a link to our privacy policy on the login page. In plain text this looks like:

    Please review our GDPR privacy statement before proceeding:
    https://global.intranet.company.com/homesites/GDPRHOME/GDPR%20documents/Company%20Internal%20Technologies%20Privacy%20Notice_version%2019062019.pdf

This is not very user friendly, so we would like to embed this as an HTML link.

###### Changes:
* Use ng-bind-html to safely include HTML content in the Custom Login Info.
  > "Evaluates the expression and inserts the resulting HTML into the element in a secure way. By default, the resulting HTML content will be sanitized using the $sanitize service."
  > [https://docs.angularjs.org/api/ng/directive/ngBindHtml](https://docs.angularjs.org/api/ng/directive/ngBindHtml)

* In order to maintain backwards compatibility with the `white-space: pre-wrap` CSS, a simple check for HTML-like contents is added to only switch to `white-space: normal` if the content looks like HTML.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
<!--- - Bugfix Pull Request -->
<!--- - Docs Pull Request -->

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
<!--- - API -->
 - UI
<!--- - Installer -->

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
A picture is worth a thousand words:
###### Before, in plain text:
![Before](https://user-images.githubusercontent.com/908201/86965698-eb1a0580-c135-11ea-9626-581da777e204.png)
###### After, in basic HTML
![jjPsUwlqqH](https://user-images.githubusercontent.com/908201/86965717-ef462300-c135-11ea-90db-746bb40367c7.png)

