### PR TITLE
Update help_text for Custom Login Info to show support for HTML

### DIFF
--- a/awx/ui/conf.py
+++ b/awx/ui/conf.py
@@ -31,8 +31,8 @@ register(
     label=_('Custom Login Info'),
     help_text=_('If needed, you can add specific information (such as a legal '
                 'notice or a disclaimer) to a text box in the login modal using '
-                'this setting. Any content added must be in plain text, as '
-                'custom HTML or other markup languages are not supported.'),
+                'this setting. Any content added must be in plain text or an '
+                'HTML fragment, as other markup languages are not supported.'),
     category=_('UI'),
     category_slug='ui',
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Update the help_text for the change merged in #7585.

related #7600 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Before
```
If needed, you can add specific information (such as a
legal notice or a disclaimer) to a text box in the login
modal using this setting. Any content added must be
in plain text, as custom HTML or other markup           <-- DELETE
languages are not supported.
```
###### After
```
If needed, you can add specific information (such as a
legal notice or a disclaimer) to a text box in the login
modal using this setting. Any content added must be
in plain text or an HTML fragment, as other markup     <-- ADD
languages are not supported.