### PR TITLE
Add pagination/item count to DataListToolbar

### DIFF
--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -37,7 +37,7 @@ class DataListToolbar extends React.Component {
       additionalControls,
       i18n,
       qsConfig,
-      pagination
+      pagination,
     } = this.props;
 
     const showExpandCollapse = onCompact && onExpand;
@@ -92,11 +92,9 @@ class DataListToolbar extends React.Component {
               <ToolbarItem key={control.key}>{control}</ToolbarItem>
             ))}
           </ToolbarGroup>
-          {(pagination && itemCount > 0) &&
-            <ToolbarItem variant="pagination">
-              {pagination}
-            </ToolbarItem>
-          }
+          {pagination && itemCount > 0 && (
+            <ToolbarItem variant="pagination">{pagination}</ToolbarItem>
+          )}
         </ToolbarContent>
       </Toolbar>
     );

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -37,6 +37,7 @@ class DataListToolbar extends React.Component {
       additionalControls,
       i18n,
       qsConfig,
+      pagination
     } = this.props;
 
     const showExpandCollapse = onCompact && onExpand;
@@ -86,14 +87,16 @@ class DataListToolbar extends React.Component {
               </Fragment>
             </ToolbarGroup>
           )}
-          <ToolbarItem id="item-count">
-            {itemCount} {i18n._(t`results`)}
-          </ToolbarItem>
           <ToolbarGroup>
             {additionalControls.map(control => (
               <ToolbarItem key={control.key}>{control}</ToolbarItem>
             ))}
           </ToolbarGroup>
+          {(pagination && itemCount > 0) &&
+            <ToolbarItem variant="pagination">
+              {pagination}
+            </ToolbarItem>
+          }
         </ToolbarContent>
       </Toolbar>
     );

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -20,6 +20,7 @@ import { SearchColumns, SortColumns, QSConfig } from '../../types';
 class DataListToolbar extends React.Component {
   render() {
     const {
+      itemCount,
       clearAllFilters,
       searchColumns,
       sortColumns,
@@ -85,6 +86,9 @@ class DataListToolbar extends React.Component {
               </Fragment>
             </ToolbarGroup>
           )}
+          <ToolbarItem id="item-count">
+            {itemCount} {i18n._(t`results`)}
+          </ToolbarItem>
           <ToolbarGroup>
             {additionalControls.map(control => (
               <ToolbarItem key={control.key}>{control}</ToolbarItem>
@@ -97,6 +101,7 @@ class DataListToolbar extends React.Component {
 }
 
 DataListToolbar.propTypes = {
+  itemCount: PropTypes.number,
   clearAllFilters: PropTypes.func,
   qsConfig: QSConfig.isRequired,
   searchColumns: SearchColumns.isRequired,
@@ -114,6 +119,7 @@ DataListToolbar.propTypes = {
 };
 
 DataListToolbar.defaultProps = {
+  itemCount: 0,
   clearAllFilters: null,
   showSelectAll: false,
   isAllSelected: false,

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -285,21 +285,4 @@ describe('<DataListToolbar />', () => {
     const checkbox = toolbar.find('Checkbox');
     expect(checkbox.prop('isChecked')).toBe(true);
   });
-
-  test('it shows item count', () => {
-    const searchColumns = [{ name: 'Name', key: 'name', isDefault: true }];
-    const sortColumns = [{ name: 'Name', key: 'name' }];
-    const itemCount = 5;
-
-    toolbar = mountWithContexts(
-      <DataListToolbar
-        qsConfig={QS_CONFIG}
-        searchColumns={searchColumns}
-        sortColumns={sortColumns}
-        itemCount={itemCount}
-      />
-    );
-    const count = toolbar.find('#item-count');
-    expect(count.at(0).text()).toEqual('5 results');
-  });
 });

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -285,4 +285,21 @@ describe('<DataListToolbar />', () => {
     const checkbox = toolbar.find('Checkbox');
     expect(checkbox.prop('isChecked')).toBe(true);
   });
+
+  test('it shows item count', () => {
+    const searchColumns = [{ name: 'Name', key: 'name', isDefault: true }];
+    const sortColumns = [{ name: 'Name', key: 'name' }];
+    const itemCount = 5;
+
+    toolbar = mountWithContexts(
+      <DataListToolbar
+        qsConfig={QS_CONFIG}
+        searchColumns={searchColumns}
+        sortColumns={sortColumns}
+        itemCount={itemCount}
+      />
+    );
+    const count = toolbar.find('#item-count');
+    expect(count.at(0).text()).toEqual('5 results');
+  });
 });

--- a/awx/ui_next/src/components/ListHeader/ListHeader.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.jsx
@@ -98,6 +98,7 @@ class ListHeader extends React.Component {
       renderToolbar,
       qsConfig,
       location,
+      pagination
     } = this.props;
     const params = parseQueryString(qsConfig, location.search);
     const isEmpty = itemCount === 0 && Object.keys(params).length === 0;
@@ -127,6 +128,7 @@ class ListHeader extends React.Component {
               onRemove: this.handleRemove,
               clearAllFilters: this.handleRemoveAll,
               qsConfig,
+              pagination
             })}
           </Fragment>
         )}
@@ -141,10 +143,11 @@ ListHeader.propTypes = {
   searchColumns: SearchColumns.isRequired,
   sortColumns: SortColumns.isRequired,
   renderToolbar: PropTypes.func,
+  pagination: PropTypes.element
 };
 
 ListHeader.defaultProps = {
-  renderToolbar: props => <DataListToolbar {...props} />,
+  renderToolbar: props => <DataListToolbar {...props} />
 };
 
 export default withRouter(ListHeader);

--- a/awx/ui_next/src/components/ListHeader/ListHeader.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.jsx
@@ -118,6 +118,7 @@ class ListHeader extends React.Component {
         ) : (
           <Fragment>
             {renderToolbar({
+              itemCount,
               searchColumns,
               sortColumns,
               onSearch: this.handleSearch,

--- a/awx/ui_next/src/components/ListHeader/ListHeader.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.jsx
@@ -98,7 +98,7 @@ class ListHeader extends React.Component {
       renderToolbar,
       qsConfig,
       location,
-      pagination
+      pagination,
     } = this.props;
     const params = parseQueryString(qsConfig, location.search);
     const isEmpty = itemCount === 0 && Object.keys(params).length === 0;
@@ -128,7 +128,7 @@ class ListHeader extends React.Component {
               onRemove: this.handleRemove,
               clearAllFilters: this.handleRemoveAll,
               qsConfig,
-              pagination
+              pagination,
             })}
           </Fragment>
         )}
@@ -143,11 +143,10 @@ ListHeader.propTypes = {
   searchColumns: SearchColumns.isRequired,
   sortColumns: SortColumns.isRequired,
   renderToolbar: PropTypes.func,
-  pagination: PropTypes.element
 };
 
 ListHeader.defaultProps = {
-  renderToolbar: props => <DataListToolbar {...props} />
+  renderToolbar: props => <DataListToolbar {...props} />,
 };
 
 export default withRouter(ListHeader);

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
@@ -121,7 +121,7 @@ class PaginatedDataList extends React.Component {
       );
     }
 
-    let ToolbarPagination = (
+    const ToolbarPagination = (
       <Pagination
         isCompact
         dropDirection="down"
@@ -141,7 +141,7 @@ class PaginatedDataList extends React.Component {
         onSetPage={this.handleSetPage}
         onPerPageSelect={this.handleSetPageSize}
       />
-    )
+    );
 
     return (
       <Fragment>
@@ -153,8 +153,7 @@ class PaginatedDataList extends React.Component {
           sortColumns={sortColumns}
           qsConfig={qsConfig}
           pagination={ToolbarPagination}
-        >
-        </ListHeader>
+        />
         {Content}
         {items.length ? (
           <Pagination

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.jsx
@@ -121,6 +121,28 @@ class PaginatedDataList extends React.Component {
       );
     }
 
+    let ToolbarPagination = (
+      <Pagination
+        isCompact
+        dropDirection="down"
+        itemCount={itemCount}
+        page={queryParams.page || 1}
+        perPage={queryParams.page_size}
+        perPageOptions={
+          showPageSizeOptions
+            ? [
+                { title: '5', value: 5 },
+                { title: '10', value: 10 },
+                { title: '20', value: 20 },
+                { title: '50', value: 50 },
+              ]
+            : []
+        }
+        onSetPage={this.handleSetPage}
+        onPerPageSelect={this.handleSetPageSize}
+      />
+    )
+
     return (
       <Fragment>
         <ListHeader
@@ -130,7 +152,9 @@ class PaginatedDataList extends React.Component {
           searchColumns={searchColumns}
           sortColumns={sortColumns}
           qsConfig={qsConfig}
-        />
+          pagination={ToolbarPagination}
+        >
+        </ListHeader>
         {Content}
         {items.length ? (
           <Pagination

--- a/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/PaginatedDataList.test.jsx
@@ -55,7 +55,7 @@ describe('<PaginatedDataList />', () => {
       { context: { router: { history } } }
     );
 
-    const pagination = wrapper.find('Pagination');
+    const pagination = wrapper.find('Pagination').at(1);
     pagination.prop('onSetPage')(null, 2);
     expect(history.location.search).toEqual('?item.page=2');
     wrapper.update();
@@ -82,7 +82,7 @@ describe('<PaginatedDataList />', () => {
       { context: { router: { history } } }
     );
 
-    const pagination = wrapper.find('Pagination');
+    const pagination = wrapper.find('Pagination').at(1);
     pagination.prop('onPerPageSelect')(null, 25, 2);
     expect(history.location.search).toEqual('?item.page=2&item.page_size=25');
     wrapper.update();


### PR DESCRIPTION
### SUMMARY
This PR resolves #5626 by adding the result count to the DataListToolbar. It auto-updates the count when filters are applied, it is automatically shown on pages using `<DataList>` and remains visible on smaller devices.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

![image](https://user-images.githubusercontent.com/2340997/87340324-31150600-c548-11ea-8b44-8ee1ee7285e4.png)

![image](https://user-images.githubusercontent.com/2340997/87340367-3d995e80-c548-11ea-8fe0-b167c40e6ff1.png)
