### PR TITLE
Improve nav behavior

### DIFF
--- a/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
+++ b/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter, Link } from 'react-router-dom';
+import { matchPath, Link, withRouter } from 'react-router-dom';
 import { NavExpandable, NavItem } from '@patternfly/react-core';
 
 class NavExpandableGroup extends Component {
   constructor(props) {
     super(props);
     const { routes } = this.props;
+    this.state = { isExpanded: false };
+
     // Extract a list of paths from the route params and store them for later. This creates
     // an array of url paths associated with any NavItem component rendered by this component.
     this.navItemPaths = routes.map(({ path }) => path);
-
+    this.handleExpand = this.handleExpand.bind(this);
     this.isActiveGroup = this.isActiveGroup.bind(this);
     this.isActivePath = this.isActivePath.bind(this);
   }
@@ -21,20 +23,24 @@ class NavExpandableGroup extends Component {
 
   isActivePath(path) {
     const { history } = this.props;
+    return Boolean(matchPath(history.location.pathname, { path }));
+  }
 
-    return history.location.pathname.startsWith(path);
+  handleExpand(e, isExpanded) {
+    this.setState({ isExpanded });
   }
 
   render() {
     const { groupId, groupTitle, routes } = this.props;
-    const isActive = this.isActiveGroup();
+    const { isExpanded } = this.state;
 
     return (
       <NavExpandable
-        isActive={isActive}
-        isExpanded={isActive}
+        isActive={this.isActiveGroup()}
+        isExpanded={isExpanded}
         groupId={groupId}
         title={groupTitle}
+        onExpand={this.handleExpand}
       >
         {routes.map(({ path, title }) => (
           <NavItem


### PR DESCRIPTION
![nav](https://user-images.githubusercontent.com/9753817/87574470-66cb0380-c69c-11ea-9bde-a86fbf3a17d4.gif)

**Use more selective route matching when determining if a nav item is active**
views/jobs and settings/jobs were colliding, addresses #7511 

**Don't automatically collapse nav groups when user navigates to a different group**
It shouldn't do this so I fixed it. Navbar sections should stay expanded until a user explicitly closes them. It works like the pf examples now https://www.patternfly.org/v4/documentation/react/components/nav#default-link3