### PR TITLE
Exposes created attribute via API for User django ORM

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -257,6 +257,11 @@ class FieldLookupBackend(BaseFilterBackend):
                 if key in self.RESERVED_NAMES:
                     continue
 
+                # HACK: make `created` available via API for the Django User ORM model
+                # so it keep compatiblity with other objects which exposes the `created` attr.
+                if queryset.model._meta.object_name == 'User' and key.startswith('created'):
+                    key = key.replace('created', 'date_joined')
+
                 # HACK: Make job event filtering by host name mostly work even
                 # when not capturing job event hosts M2M.
                 if queryset.model._meta.object_name == 'JobEvent' and key.startswith('hosts__name'):

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -127,9 +127,15 @@ def user_get_auditor_of_organizations(user):
     return Organization.objects.filter(auditor_role__members=user)
 
 
+@property
+def created(user):
+    return user.date_joined
+
+
 User.add_to_class('organizations', user_get_organizations)
 User.add_to_class('admin_of_organizations', user_get_admin_of_organizations)
 User.add_to_class('auditor_of_organizations', user_get_auditor_of_organizations)
+User.add_to_class('created', created)
 
 
 @property

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -61,3 +61,9 @@ def test_user_cannot_update_last_login(patch, admin):
         middleware=SessionMiddleware()
     )
     assert User.objects.get(pk=admin.pk).last_login is None
+
+
+@pytest.mark.django_db
+def test_user_verify_attribute_created(admin):
+    assert admin.created == admin.date_joined
+    User.objects.get(pk=admin.pk).created == User.objects.get(pk=admin.pk).date_joined


### PR DESCRIPTION
##### SUMMARY
Many of the API endpoints allow us to search by the `created` attribute, however, the `User` model (inherited from Django ORM) does not have the `created` by `date_joined`. 

So this patch allows users explore the API by filtering Users by date of creation. 


##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**before**
```json
### API

# curl -k  -u api_user-L "https://tower.tatu.home/api/v2/users/?created__gt=2020-06-15T21:35:56.845726" 2>/dev/null| jq
{
  "detail": "User has no field named 'created'"
}

## cmd
>>> User.objects.get(username='admin')
<User: admin>
>>> User.objects.get(username='admin').created
Traceback (most recent call last):
  File "<console>", line 1, in <module>
AttributeError: 'User' object has no attribute 'created'
```

**after**
```json
### API

# curl -k  -u api_user-L "https://tower.tatu.home/api/v2/users/?created__gt=2020-06-15T21:35:56.845726" 2>/dev/null| jq
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 6,
      "type": "user",
      "url": "/api/v2/users/6/",
      "related": {
        "teams": "/api/v2/users/6/teams/",
        "organizations": "/api/v2/users/6/organizations/",
        "admin_of_organizations": "/api/v2/users/6/admin_of_organizations/",
        "projects": "/api/v2/users/6/projects/",
        "credentials": "/api/v2/users/6/credentials/",
        "roles": "/api/v2/users/6/roles/",
        "activity_stream": "/api/v2/users/6/activity_stream/",
        "access_list": "/api/v2/users/6/access_list/",
        "tokens": "/api/v2/users/6/tokens/",
        "authorized_tokens": "/api/v2/users/6/authorized_tokens/",
        "personal_tokens": "/api/v2/users/6/personal_tokens/"
      },
      "summary_fields": {
        "user_capabilities": {
          "edit": true,
          "delete": true
        }
      },
      "created": "2020-06-16T21:10:06.503737Z",
      "username": "rider",
      "first_name": "rider",
      "last_name": "",
      "email": "rider@localhost",
      "is_superuser": false,
      "is_system_auditor": false,
      "ldap_dn": "",
      "last_login": null,
      "external_account": null,
      "auth": []
    }
  ]
}

### cmd
In [2]: User.objects.get(username='admin')                                                                                                                             
Out[2]: <User: admin>

In [3]: User.objects.get(username='admin').created                                                                                                                     
Out[3]: datetime.datetime(2020, 6, 1, 20, 57, 37, 325849, tzinfo=<UTC>)
```