### PR TITLE
Installer: remove quote filter from docker_registry_password

### DIFF
--- a/installer/roles/image_push/tasks/main.yml
+++ b/installer/roles/image_push/tasks/main.yml
@@ -3,7 +3,7 @@
   docker_login:
     registry: "{{ docker_registry }}"
     username: "{{ docker_registry_username }}"
-    password: "{{ docker_registry_password | quote }}"
+    password: "{{ docker_registry_password }}"
     reauthorize: true
   when: docker_registry is defined and docker_registry_password is defined
   delegate_to: localhost


### PR DESCRIPTION
The docker_registry_password var isn't interpolated by the shell, so it shouldn't be quoted

Fixes: #7695
Signed-off-by: Philip Douglass <philip@philipdouglass.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
#3987 introduced the `quote` filter to handle the situations where the password was handled by shell interpolation, however it also added `quote` to the `docker_registry_password` when handed directly to the `docker_image` module. This causes authentication to fail, as the quotes are sent as part of the password. 

This PR reverts the quote for only this var.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
<!-- - Feature Pull Request -->
 - Bugfix Pull Request
<!-- - Docs Pull Request -->

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 <!-- - API
 - UI --
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

