### PR TITLE
Use default path for pgdata volume in docker-compose template

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -167,12 +167,11 @@ services:
     container_name: awx_postgres
     restart: unless-stopped
     volumes:
-      - {{ postgres_data_dir }}/10/data/:/var/lib/postgresql/data/pgdata:Z
+      - {{ postgres_data_dir }}/10/data/:/var/lib/postgresql/data:Z
     environment:
       POSTGRES_USER: {{ pg_username }}
       POSTGRES_PASSWORD: {{ pg_password }}
       POSTGRES_DB: {{ pg_database }}
-      PGDATA: /var/lib/postgresql/data/pgdata
       http_proxy: {{ http_proxy | default('') }}
       https_proxy: {{ https_proxy | default('') }}
       no_proxy: {{ no_proxy | default('') }}


### PR DESCRIPTION
##### SUMMARY

Use the default pgdata volume path for the `postgres:10` docker container in the templated `docker-compose.yml.j2` file.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

```
make: Nothing to be done for `version'. (devel)
```

##### ADDITIONAL INFORMATION

See https://github.com/ansible/awx/issues/4736#issuecomment-662067865 — the Docker library `postgres:10` image that is used in the docker-compose configuration recommends using the default volume path of `/var/lib/postgresql/data` for a mounted data directory.

Currently AWX sets this path to `/var/lib/postgresql/data/pgdata` and overrides the `PGDATA` environment variable, but that doesn't seem like it's necessary (unless there's something I'm missing).