### PR TITLE
Use a docker volume instead of bind mount for postgres data in docker-compose

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -167,7 +167,7 @@ services:
     container_name: awx_postgres
     restart: unless-stopped
     volumes:
-      - {{ postgres_data_dir }}/10/data/:/var/lib/postgresql/data:Z
+      - postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: {{ pg_username }}
       POSTGRES_PASSWORD: {{ pg_password }}
@@ -195,3 +195,4 @@ volumes:
   supervisor-socket:
   rsyslog-socket:
   rsyslog-config:
+  postgres-data:


### PR DESCRIPTION
##### SUMMARY

For background, see: https://github.com/ansible/awx/issues/7699

Currently, on Docker for Mac, if you try installing with the Docker Compose configuration, the first time the postgres container starts, it doesn't initialize a database correctly, due to some issue with the default bind mount.

It would make for a much faster experience, and also solve this bug, to use a Docker volume instead of a bind mount by default for the postgres container. That's what this PR does.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

```
make: Nothing to be done for `version'. (devel)
```

##### ADDITIONAL INFORMATION

Alternatively, the configuration for the mount could be templated, so you could choose a bind mount or a docker volume.

Also, I'm not sure what the rationale is for a bind mount (vs a Docker volume), but if the main concern is backup, it's easy enough to [back up the contents of a Docker volume](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes).