### PR TITLE
Change Dockerfile to copy custom venv

### DIFF
--- a/docs/custom_virtualenvs.md
+++ b/docs/custom_virtualenvs.md
@@ -83,15 +83,17 @@ index aa8b304..eb05f91 100644
 +	virtualenv /opt/my-envs/my-custom-env
 +	/opt/my-envs/my-custom-env/bin/pip install psutil
 +
-diff --git a/installer/image_build/templates/Dockerfile.j2 b/installer/image_build/templates/Dockerfile.j2
-index d69e2c9..a08bae5 100644
---- a/installer/image_build/templates/Dockerfile.j2
-+++ b/installer/image_build/templates/Dockerfile.j2
-@@ -34,6 +34,7 @@ RUN yum -y install epel-release && \
-     pip install virtualenv supervisor && \
-     VENV_BASE=/var/lib/awx/venv make requirements_ansible && \
-     VENV_BASE=/var/lib/awx/venv make requirements_awx && \
-+    VENV_BASE=/var/lib/awx/venv make requirements_custom && \
+diff --git a/installer/roles/image_build/templates/Dockerfile.j2 b/installer/roles/image_build/templates/Dockerfile.j2
+index d3b582ffcb..220ac760a3 100644
+--- a/installer/roles/image_build/templates/Dockerfile.j2
++++ b/installer/roles/image_build/templates/Dockerfile.j2
+@@ -165,6 +165,7 @@ RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/n
+     chmod 640 /etc/nginx/nginx.{csr,key,crt}
+ {% else %}
+ COPY --from=builder /var/lib/awx /var/lib/awx
++COPY --from=builder /opt/my-envs /opt/my-envs
+ RUN ln -s /var/lib/awx/venv/awx/bin/awx-manage /usr/bin/awx-manage
+ {% endif %}
 ```
 
 Once the AWX API is available, update the `CUSTOM_VENV_PATHS` setting as described in `Preparing a New Custom Virtualenv`.


### PR DESCRIPTION
##### SUMMARY

The container build process has changed with AWX 12.0.0. The new process copies the default virtual environment from a build container to the final awx container. Unfortunately, the custom virtual environments, which are located in /opt, get lost with this.

This PR updates the documentation to highlight that the custom virtual environment path must be copied to the final awx container, too.

Another option would be to change the Dockerfile to always copy the /opt directory, regardless of custom virtual environments or not. But I'm not sure if /opt is really the "supported" place for custom virtual environments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0

```
