### PR TITLE
Update wording to equal mock up

### DIFF
--- a/awx/ui_next/src/screens/CredentialType/CredentialTypes.jsx
+++ b/awx/ui_next/src/screens/CredentialType/CredentialTypes.jsx
@@ -11,7 +11,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 function CredentialTypes({ i18n }) {
   const [breadcrumbConfig, setBreadcrumbConfig] = useState({
     '/credential_types': i18n._(t`Credential Types`),
-    '/credential_types/add': i18n._(t`Create Credential Types`),
+    '/credential_types/add': i18n._(t`Create new credential type`),
   });
 
   const buildBreadcrumbConfig = useCallback(
@@ -21,10 +21,10 @@ function CredentialTypes({ i18n }) {
       }
       setBreadcrumbConfig({
         '/credential_types': i18n._(t`Credential Types`),
-        '/credential_types/add': i18n._(t`Create Credential Types`),
+        '/credential_types/add': i18n._(t`Create new credential Type`),
         [`/credential_types/${credentialTypes.id}`]: `${credentialTypes.name}`,
         [`/credential_types/${credentialTypes.id}/edit`]: i18n._(
-          t`Edit Details`
+          t`Edit details`
         ),
         [`/credential_types/${credentialTypes.id}/details`]: i18n._(t`Details`),
       });

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -122,7 +122,7 @@ function TemplateList({ i18n }) {
 
   if (canAddJT) {
     addButtonOptions.push({
-      label: i18n._(t`Template`),
+      label: i18n._(t`Job Template`),
       url: `/templates/job_template/add/`,
     });
   }


### PR DESCRIPTION
Update wording used for 'Job Templates' and 'Credential Types' to be
equal mock up.

See: https://tower-mockups.testing.ansible.com/patternfly/cred-types/cred-types/
Also: https://tower-mockups.testing.ansible.com/patternfly/templates/templates/
