### PR TITLE
Test console cleanup

### DIFF
--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
@@ -208,8 +208,10 @@ describe('<CredentialForm />', () => {
       });
       wrapper.update();
       expect(
-        wrapper.find('FormGroup[fieldId="credential-gce-file"]').prop('isValid')
-      ).toBe(false);
+        wrapper
+          .find('FormGroup[fieldId="credential-gce-file"]')
+          .prop('validated')
+      ).toBe('error');
 
       expect(
         wrapper

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.jsx
@@ -41,7 +41,7 @@ function BecomeMethodField({ fieldOptions, isRequired }) {
         )
       }
       isRequired={isRequired}
-      isValid={!(meta.touched && meta.error)}
+      validated={!(meta.touched && meta.error) ? 'default' : 'error'}
     >
       <Select
         maxHeight={200}

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.jsx
@@ -29,7 +29,7 @@ function CredentialInput({ fieldOptions, credentialKind, ...rest }) {
         onChange={(value, event) => {
           subFormField.onChange(event);
         }}
-        isValid={isValid}
+        validated={isValid ? 'default' : 'error'}
       />
     );
   }
@@ -38,7 +38,6 @@ function CredentialInput({ fieldOptions, credentialKind, ...rest }) {
       <PasswordInput
         {...subFormField}
         id={`credential-${fieldOptions.id}`}
-        isValid={isValid}
         {...rest}
       />
     );
@@ -55,7 +54,7 @@ function CredentialInput({ fieldOptions, credentialKind, ...rest }) {
       onChange={(value, event) => {
         subFormField.onChange(event);
       }}
-      isValid={isValid}
+      validated={isValid ? 'default' : 'error'}
     />
   );
 }
@@ -107,7 +106,7 @@ function CredentialField({ credentialType, fieldOptions, i18n }) {
         helperTextInvalid={meta.error}
         label={fieldOptions.label}
         isRequired={isRequired}
-        isValid={isValid}
+        validated={isValid ? 'default' : 'error'}
       >
         <AnsibleSelect
           {...subFormField}
@@ -132,7 +131,7 @@ function CredentialField({ credentialType, fieldOptions, i18n }) {
           )
         }
         isRequired={isRequired}
-        isValid={isValid}
+        validated={isValid ? 'default' : 'error'}
       >
         <CredentialInput
           credentialKind={credentialType.kind}
@@ -150,7 +149,7 @@ function CredentialField({ credentialType, fieldOptions, i18n }) {
     <CredentialPluginField
       fieldOptions={fieldOptions}
       isRequired={isRequired}
-      isValid={isValid}
+      validated={isValid ? 'default' : 'error'}
     >
       <CredentialInput fieldOptions={fieldOptions} />
     </CredentialPluginField>

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialPlugins/CredentialPluginField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialPlugins/CredentialPluginField.jsx
@@ -43,7 +43,7 @@ function CredentialPluginInput(props) {
           {React.cloneElement(children, {
             ...inputField,
             isRequired,
-            isValid,
+            validated: isValid ? 'default' : 'error',
             isDisabled: !!passwordPromptField.value,
             onChange: (_, event) => {
               inputField.onChange(event);
@@ -125,7 +125,7 @@ function CredentialPluginField(props) {
           fieldId={`credential-${fieldOptions.id}`}
           helperTextInvalid={meta.error}
           isRequired={isRequired}
-          isValid={isValid}
+          validated={isValid ? 'default' : 'error'}
           label={fieldOptions.label}
           labelIcon={
             fieldOptions.help_text && (

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/GceFileUploadField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/GceFileUploadField.jsx
@@ -20,7 +20,7 @@ function GceFileUploadField({ i18n }) {
   return (
     <FormGroup
       fieldId="credential-gce-file"
-      isValid={!fileError}
+      validated={!fileError ? 'default' : 'error'}
       label={i18n._(t`Service account JSON file`)}
       helperText={i18n._(
         t`Select a JSON formatted service account key to autopopulate the following fields.`

--- a/awx/ui_next/src/screens/Inventory/InventoryAdd/InventoryAdd.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryAdd/InventoryAdd.test.jsx
@@ -51,11 +51,13 @@ describe('<InventoryAdd />', () => {
     ];
     await waitForElement(wrapper, 'isLoading', el => el.length === 0);
 
-    wrapper.find('InventoryForm').prop('onSubmit')({
-      name: 'new Foo',
-      organization: { id: 2 },
-      insights_credential: { id: 47 },
-      instanceGroups,
+    await act(async () => {
+      wrapper.find('InventoryForm').prop('onSubmit')({
+        name: 'new Foo',
+        organization: { id: 2 },
+        insights_credential: { id: 47 },
+        instanceGroups,
+      });
     });
     await sleep(1);
     expect(InventoriesAPI.create).toHaveBeenCalledWith({
@@ -74,7 +76,9 @@ describe('<InventoryAdd />', () => {
 
   test('handleCancel should return the user back to the inventories list', async () => {
     await waitForElement(wrapper, 'isLoading', el => el.length === 0);
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    await act(async () => {
+      wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    });
     expect(history.location.pathname).toEqual('/inventories');
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryEdit/InventoryEdit.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryEdit/InventoryEdit.test.jsx
@@ -102,7 +102,9 @@ describe('<InventoryEdit />', () => {
 
   test('handleCancel returns the user to inventory detail', async () => {
     await waitForElement(wrapper, 'isLoading', el => el.length === 0);
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    await act(async () => {
+      wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    });
     expect(history.location.pathname).toEqual(
       '/inventories/inventory/1/details'
     );
@@ -114,12 +116,14 @@ describe('<InventoryEdit />', () => {
       { name: 'Bizz', id: 2 },
       { name: 'Buzz', id: 3 },
     ];
-    wrapper.find('InventoryForm').prop('onSubmit')({
-      name: 'Foo',
-      id: 13,
-      organization: { id: 1 },
-      insights_credential: { id: 13 },
-      instanceGroups,
+    await act(async () => {
+      wrapper.find('InventoryForm').prop('onSubmit')({
+        name: 'Foo',
+        id: 13,
+        organization: { id: 1 },
+        insights_credential: { id: 13 },
+        instanceGroups,
+      });
     });
     await sleep(0);
     instanceGroups.map(IG =>

--- a/awx/ui_next/src/screens/Template/JobTemplateAdd/JobTemplateAdd.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateAdd/JobTemplateAdd.test.jsx
@@ -241,7 +241,9 @@ describe('<JobTemplateAdd />', () => {
       });
     });
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
-    wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+    await act(async () => {
+      wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+    });
     expect(history.location.pathname).toEqual('/templates');
   });
 });

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
@@ -131,7 +131,9 @@ function WorkflowJobTemplateForm({
           <TextInput
             id="text-wfjt-limit"
             {...limitField}
-            isValid={!limitMeta.touched || !limitMeta.error}
+            validated={
+              !limitMeta.touched || !limitMeta.error ? 'default' : 'error'
+            }
             onChange={value => {
               limitHelpers.setValue(value);
             }}

--- a/awx/ui_next/src/setupTests.js
+++ b/awx/ui_next/src/setupTests.js
@@ -12,3 +12,10 @@ require('@nteract/mockument');
 
 // eslint-disable-next-line import/prefer-default-export
 export const asyncFlush = () => new Promise(resolve => setImmediate(resolve));
+
+// this ensures that debug messages don't get logged out to the console
+// while tests are running i.e. websocket connect/disconnect
+global.console = {
+  ...console,
+  debug: jest.fn(),
+};


### PR DESCRIPTION
##### SUMMARY
All of the noise fell into one of 3 categories:

1) Console errors regarding isValid - I think that this prop changed to `validated` with the most recent PF major version bump but there were a few places where we were still using it and it needed to be cleaned up.
2) Console errors regarding certain code snippets in tests not being wrapped in act().
3) Socket debug messages - connect/disconnect, that type of thing.

I addressed the first two with code changes.  To address the third, I decided to globally mock `console.debug` to prevent those messages from being logged to the console.  At this point I don't know if I see a lot of value in having debug statements show up in the output of tests but if someone has a good reason why they're needed then I'm happy to come up with an alternative solution.

The only thing that's still being logged is a warning in the App.jsx test:

```
console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
Warning: You are attempting to use a basename on a page whose URL path does not begin with the basename. Expected path "/" to begin with "/next".
```

which I think is fine.  The `/next` solution will be around for a while but eventually we'll get rid of it when the app can fully replace the existing UI.  At that time this would go away.
