### PR TITLE
Allow to use an existing PVC for postgresql install with Helm

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -384,6 +384,8 @@ Before starting the install process, review the [inventory](./installer/inventor
 
 If you want the AWX installer to manage creating the database pod (rather than installing and configuring postgres on your own). Then you will need to have a working `helm` installation, you can find details here: [https://helm.sh/docs/intro/quickstart/](https://helm.sh/docs/intro/quickstart/).
 
+You do not need to create a [Persistent Volume Claim](https://docs.openshift.org/latest/dev_guide/persistent_volumes.html) as Helm does it for you. However, an existing one may be used by setting the `pg_persistence_existingclaim` variable.
+
 Newer Kubernetes clusters with RBAC enabled will need to make sure a service account is created, make sure to follow the instructions here [https://helm.sh/docs/topics/rbac/](https://helm.sh/docs/topics/rbac/)
 
 ### Run the installer

--- a/installer/inventory
+++ b/installer/inventory
@@ -25,6 +25,7 @@ dockerhub_base=ansible
 # pg_serviceaccount=awx
 # pg_volume_capacity=5
 # pg_persistence_storageClass=StorageClassName
+# pg_persistence_existingclaim=postgres_pvc
 # pg_cpu_limit=1000
 # pg_mem_limit=2
 

--- a/installer/roles/kubernetes/templates/postgresql-values.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-values.yml.j2
@@ -6,6 +6,9 @@ persistence:
 {% if pg_persistence_storageClass is defined %}
   storageClass: {{ pg_persistence_storageClass }}
 {% endif %}
+{% if pg_persistence_existingclaim is defined %}
+  existingClaim: {{ pg_persistence_existingclaim }}
+{% endif %}
 {% if pg_cpu_limit is defined or pg_mem_limit is defined %}
 resources:
   limits:


### PR DESCRIPTION


Signed-off-by: Benoît Chauvet <benoit.chauvet@gmail.com>

##### SUMMARY

Added a new variable to be able to use an existing PVC for Postgresql when installing AWX on Kubernetes (with Helm).

This was possible on Openshift with openshift_pg_pvc_name variable, but not with Helm installation.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION

The new variable is named `pg_persistence_existingclaim` (to be consistent with existing `pg_persistence_existingclaim`) and maps to the Helm chart's variable `persistence/existingClaim`

