### PR TITLE
Use quotations when marking strings for translation

### DIFF
--- a/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
+++ b/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js
@@ -262,9 +262,9 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n){
                 parseTypeName: 'envParseType',
                 dataTitle: i18n._("Source Variables"),
                 dataPlacement: 'right',
-                awPopOver: i18n._(`Override variables found in openstack.yml and used by the inventory update script. For an example variable configuration
-                    <a href=\"https://github.com/openstack/ansible-collections-openstack/blob/master/scripts/inventory/openstack.yml\" target=\"_blank\">
-                    view openstack.yml in the Openstack github repo.</a> Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax.`),
+                awPopOver: i18n._("Override variables found in openstack.yml and used by the inventory update script. For an example variable configuration") +
+                    '<a href=\"https://github.com/openstack/ansible-collections-openstack/blob/master/scripts/inventory/openstack.yml\" target=\"_blank\">' +
+                    i18n._("view openstack.yml in the Openstack github repo.") + "</a>" + i18n._("Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."),
                 dataContainer: 'body',
                 subForm: 'sourceSubForm'
             },
@@ -279,9 +279,9 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n){
                 parseTypeName: 'envParseType',
                 dataTitle: i18n._("Source Variables"),
                 dataPlacement: 'right',
-                awPopOver: i18n._(`Override variables found in cloudforms.ini and used by the inventory update script. For an example variable configuration
-                    <a href=\"https://github.com/ansible-collections/community.general/blob/main/scripts/inventory/cloudforms.ini\" target=\"_blank\">
-                    view cloudforms.ini in the Ansible Collections github repo.</a> Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax.`),
+                awPopOver: i18n._("Override variables found in cloudforms.ini and used by the inventory update script. For an example variable configuration") +
+                    '<a href=\"https://github.com/ansible-collections/community.general/blob/main/scripts/inventory/cloudforms.ini\" target=\"_blank\">' +
+                    i18n._("view cloudforms.ini in the Ansible Collections github repo.") + "</a>" + i18n._(" Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."),
                 dataContainer: 'body',
                 subForm: 'sourceSubForm'
             },
@@ -296,9 +296,9 @@ export default ['NotificationsList', 'i18n', function(NotificationsList, i18n){
                 parseTypeName: 'envParseType',
                 dataTitle: i18n._("Source Variables"),
                 dataPlacement: 'right',
-                awPopOver: i18n._(`Override variables found in foreman.ini and used by the inventory update script. For an example variable configuration
-                    <a href=\"https://github.com/ansible-collections/community.general/blob/main/scripts/inventory/foreman.ini\" target=\"_blank\">
-                    view foreman.ini in the Ansible Collections github repo.</a> Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax.`),
+                awPopOver: i18n._("Override variables found in foreman.ini and used by the inventory update script. For an example variable configuration") + 
+                    '<a href=\"https://github.com/ansible-collections/community.general/blob/main/scripts/inventory/foreman.ini\" target=\"_blank\">' + 
+                    i18n._("view foreman.ini in the Ansible Collections github repo.") + "</a>" + i18n._("Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."),
                 dataContainer: 'body',
                 subForm: 'sourceSubForm'
             },


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug Report

##### SUMMARY

There are a number of places in our inventory sources pop-up help text where we use back ticks instead of quotes, which prevents `i18n._()` from marking the string for translation.  

Here is one example where it is broken: https://github.com/ansible/awx/blob/devel/awx/ui/client/src/inventories-hosts/inventories/related/sources/sources.form.js#L282-L284

![image](https://user-images.githubusercontent.com/11698892/88740201-8a656380-d10a-11ea-9e28-3b1d1fccd501.png)


##### ENVIRONMENT
* AWX version: devel


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - UI




