### PR TITLE
Add kubernetes_web_svc_type variable to installer/inventory

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -20,6 +20,7 @@ dockerhub_base=ansible
 # Kubernetes Install
 # kubernetes_context=test-cluster
 # kubernetes_namespace=awx
+# kubernetes_web_svc_type=NodePort
 # Optional Kubernetes Variables
 # pg_image_registry=docker.io
 # pg_serviceaccount=awx

--- a/installer/roles/kubernetes/defaults/main.yml
+++ b/installer/roles/kubernetes/defaults/main.yml
@@ -10,6 +10,7 @@ kubernetes_base_path: "{{ local_base_config_path|default('/tmp') }}/{{ kubernete
 
 kubernetes_awx_version: "{{ dockerhub_version }}"
 kubernetes_awx_image: "ansible/awx"
+kubernetes_web_svc_type: "NodePort"
 
 awx_psp_create: false
 awx_psp_name: 'awx'

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -487,9 +487,13 @@ metadata:
   labels:
     name: {{ kubernetes_deployment_name }}-web-svc
 spec:
+  type: {{ kubernetes_web_svc_type }}
   ports:
     - name: http
       port: 80
+{% if kubernetes_web_svc_type == "ClusterIP" %}
+      nodePort: null
+{% endif %}
       targetPort: 8052
   selector:
     name: {{ kubernetes_deployment_name }}-web-deploy


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
awx-web-svc was set up as ClusterIP, but ingress service expects LoadBalancer or NodePort

The service type is now settable, e.g. ClusterIP or NodePort. Default is NodePort

in inventory file
`kubernetes_web_svc_type=NodePort`

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```
