### PR TITLE
Fix the `Failed to set locale` during build.

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -24,6 +24,7 @@ USER root
 
 # Install build dependencies
 RUN dnf -y update && \
+    localectl set-locale LANG=en_US.UTF-8 && \
     dnf -y install epel-release 'dnf-command(config-manager)' && \
     dnf module -y enable 'postgresql:10' && \
     dnf config-manager --set-enabled PowerTools && \


### PR DESCRIPTION
This fixes the error:
```
Failed to set locale, defaulting to C.UTF-8
```
Even though the below is in the `Dockerfile.js`
```
ENV LANG en_US.UTF-8
ENV LANGUAGE en_US:en
ENV LC_ALL en_US.UTF-8
```
It looks like it isn't honored by the `dnf` installtion.
This is a cosmetic fix, so when people build these containers they don't
see red scary text.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
 - UI
 - Installer

##### AWX VERSION

```
awx: 13.0.0
```