### PR TITLE
Enable custom settings during installation

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -139,6 +139,12 @@ secret_key=awxsecret
 # it manages from the docker host, you can set this to turn it into a volume for the container.
 #project_data_dir=/var/lib/awx/projects
 
+# Controls if custom settings (overrides) are deployed during installation.
+# For a complete list of settings: `awx settings list -f json`.
+# See inventory/settings.example.json for an example; the settings defined
+# in this file will be `PATCH`ed in.
+#custom_settings_file=/path/to/your/custom_settings.json
+
 # AWX custom virtual environment folder. Only usable for local install.
 #custom_venv_dir=/opt/my-envs/
 

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -289,3 +289,45 @@
   shell: |
     {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
       scale {{ deployment_object }} {{ kubernetes_deployment_name }} --replicas={{ replicas | default(kubernetes_deployment_replica_size) }}
+
+- name: Check if settings configmap exists
+  shell: |
+    {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
+      get configmap {{ kubernetes_namespace }}-settings
+  when:
+    - custom_settings_file is file
+  register: settings_configmap_exists
+  failed_when: false
+
+- name: Delete settings configmap if it exists
+  shell: |
+    {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
+      delete configmap {{ kubernetes_namespace }}-settings
+  when:
+    - custom_settings_file is file
+    - settings_configmap_exists.rc == 0
+
+- name: Create settings configmap
+  shell: |
+    {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
+      create configmap {{ kubernetes_namespace }}-settings --from-file {{ custom_settings_file }}
+  when:
+    - custom_settings_file is file
+
+- name: Render settings_job template
+  set_fact:
+    "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"
+  with_items:
+    - 'settings_job'
+  no_log: true
+  when:
+    - custom_settings_file is file
+
+- name: Apply settings_job
+  shell: |
+    echo {{ item | quote }} | {{ kubectl_or_oc }} apply -f -
+  with_items:
+    - "{{ settings_job }}"
+  no_log: true
+  when:
+    - custom_settings_file is file

--- a/installer/roles/kubernetes/templates/settings_job.yml.j2
+++ b/installer/roles/kubernetes/templates/settings_job.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ kubernetes_deployment_name }}-settings-job
+  namespace: {{ kubernetes_namespace }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ kubernetes_deployment_name }}-settings
+        image: alpine:latest
+        command: ["/bin/ash", "-c"]
+        args:
+          - apk add curl;
+            curl -v -u '{{ admin_user }}:{{ admin_password }}' -XPATCH -d@/tmp/{{ kubernetes_deployment_name }}-settings.json -H 'Content-type:application/json' http://{{ kubernetes_deployment_name}}-web-svc/api/v2/settings/all/;
+        env:
+          - name: TOWER_HOST
+            value: http://{{ kubernetes_deployment_name }}-web-svc
+          - name: TOWER_USERNAME
+            value: {{ admin_user }}
+          - name: TOWER_PASSWORD
+            value: {{ admin_password }}
+        volumeMounts:
+          - name:  settings
+            mountPath: /tmp/
+      volumes:
+        - name: settings
+          configMap:
+            name: {{ kubernetes_deployment_name }}-settings
+            items:
+              - key: {{ custom_settings_file | basename }}
+                path: {{ kubernetes_deployment_name }}-settings.json
+      restartPolicy: Never

--- a/installer/settings.example.json
+++ b/installer/settings.example.json
@@ -1,0 +1,7 @@
+{
+    "ACTIVITY_STREAM_ENABLED": true,
+    "REMOTE_HOST_HEADERS": [
+        "HTTP_X_FORWARDED_FOR"
+    ],
+    "TOWER_URL_BASE": "https://towerhost.example.com"
+}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds the ability to deploy custom settings during installation.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The input required is a JSON input file with AWX/Tower settings that the user would like to set. This file is turned into a Kubernetes/OpenShift ConfigMap, which is subsequently mounted into a new Kubernetes/OpenShift Job (which is responsible for applying the settings). The settings job is based on `alpine:latest` and does two things: installs `curl` and hits the AWX/Tower API in order to apply the settings.

Example from my home lab:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
❯ kubectl -n awx get configmap awx-settings -o jsonpath='{.data}'
map[settings.jonagold.json:{
     "ACTIVITY_STREAM_ENABLED": true,
     "ACTIVITY_STREAM_ENABLED_FOR_INVENTORY_SYNC": false,
     "ORG_ADMINS_CAN_SEE_ALL_USERS": true,
     "MANAGE_ORGANIZATION_AUTH": true,
     "TOWER_URL_BASE": "http://192.168.1.201",
     "REMOTE_HOST_HEADERS": [
          "HTTP_X_FORWARDED_FOR"
     ]
}
]
```

```
❯ kubectl -n awx get job awx-settings-job
NAME               COMPLETIONS   DURATION   AGE
awx-settings-job   1/1           4s         30m
```

```
❯ awx settings list | grep TOWER_URL_BASE
     "TOWER_URL_BASE": "http://192.168.1.201",
```
