### PR TITLE
Fix garbage being printed when exporting as YAML - related #7795

### DIFF
--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -130,7 +130,6 @@ def format_yaml(output, fmt):
     return yaml.safe_dump(
         output,
         default_flow_style=False,
-        encoding='utf-8',
         allow_unicode=True
     )
 


### PR DESCRIPTION
##### SUMMARY
This resolves issue #7795, by passing the `encoding` keyword argument
only when the code is run on a Python 2 interpreter.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
CLI

##### AWX VERSION
```
awx: 13.0.0
```
