### PR TITLE
Serialize Workflow Job Template inventories by natural key - related #7798

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3404,6 +3404,12 @@ class WorkflowJobTemplateSerializer(JobTemplateMixin, LabelsListMixin, UnifiedJo
             res['organization'] = self.reverse('api:organization_detail',   kwargs={'pk': obj.organization.pk})
         if obj.webhook_credential_id:
             res['webhook_credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.webhook_credential_id})
+        if obj.inventory:
+            res['inventory'] = self.reverse(
+                'api:inventory_detail', kwargs={
+                    'pk': obj.inventory.pk
+                }
+            )
         return res
 
     def validate_extra_vars(self, value):


### PR DESCRIPTION
##### SUMMARY
Related #7798

This changeset introduces two changes:

 1. Update the API representation of Workflow Job Templates to use the
 natural key of the Inventory type instead of its id;
 2. Override the related property of the CLI's WorkflowJobTemplate page
 type to patch the related references during the export process,
 allowing the resource to be serialised using the natural key of the
 Inventory type instead of the id.

Change n.2 is a workaround that is used when exporting resources from
AWX/Tower instances that don't have change n.1. It can be removed in the
future.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - CLI

##### AWX VERSION
```
awx: 13.0.0
```