### PR TITLE
Fix rbac on Add button on User Access/Team Roles lists

### DIFF
--- a/awx/ui_next/src/api/models/Users.js
+++ b/awx/ui_next/src/api/models/Users.js
@@ -54,6 +54,12 @@ class Users extends Base {
       params,
     });
   }
+
+  readAdminOfOrganizations(userId, params) {
+    return this.http.get(`${this.baseUrl}${userId}/admin_of_organizations/`, {
+      params,
+    });
+  }
 }
 
 export default Users;

--- a/awx/ui_next/src/screens/Team/Team.jsx
+++ b/awx/ui_next/src/screens/Team/Team.jsx
@@ -17,7 +17,7 @@ import ContentError from '../../components/ContentError';
 import TeamDetail from './TeamDetail';
 import TeamEdit from './TeamEdit';
 import { TeamsAPI } from '../../api';
-import TeamAccessList from './TeamRoles';
+import TeamRolesList from './TeamRoles';
 import { ResourceAccessList } from '../../components/ResourceAccessList';
 
 function Team({ i18n, setBreadcrumb }) {
@@ -104,9 +104,7 @@ function Team({ i18n, setBreadcrumb }) {
           {team && (
             <Route path="/teams/:id/roles">
               <Config>
-                {({ me }) => (
-                  <>{me && <TeamAccessList me={me} team={team} />}</>
-                )}
+                {({ me }) => <>{me && <TeamRolesList me={me} team={team} />}</>}
               </Config>
             </Route>
           )}

--- a/awx/ui_next/src/screens/Team/Team.jsx
+++ b/awx/ui_next/src/screens/Team/Team.jsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
+import { Config } from '../../contexts/Config';
 import RoutedTabs from '../../components/RoutedTabs';
 import ContentError from '../../components/ContentError';
 import TeamDetail from './TeamDetail';
@@ -102,7 +103,11 @@ function Team({ i18n, setBreadcrumb }) {
           )}
           {team && (
             <Route path="/teams/:id/roles">
-              <TeamAccessList />
+              <Config>
+                {({ me }) => (
+                  <>{me && <TeamAccessList me={me} team={team} />}</>
+                )}
+              </Config>
             </Route>
           )}
           <Route key="not-found" path="*">

--- a/awx/ui_next/src/screens/User/User.jsx
+++ b/awx/ui_next/src/screens/User/User.jsx
@@ -127,7 +127,7 @@ function User({ i18n, setBreadcrumb, me }) {
             </Route>
             {user && (
               <Route path="/users/:id/access">
-                <UserAccessList />
+                <UserAccessList user={user} />
               </Route>
             )}
             <Route path="/users/:id/tokens">

--- a/awx/ui_next/src/screens/User/UserAccess/index.js
+++ b/awx/ui_next/src/screens/User/UserAccess/index.js
@@ -1,2 +1,2 @@
-export { default as UserAccessListList } from './UserAccessList';
+export { default as UserAccessList } from './UserAccessList';
 export { default as UserAccessListItem } from './UserAccessListItem';


### PR DESCRIPTION
##### SUMMARY
link #7564 

To bring this in line with the old app we needed to apply the following rules:

1) On the User Access tab, the Add button should be hidden for users that cannot add other users (no POST in OPTIONS call to `/api/v2/users`) _and_ the logged in user cannot edit the user whose access list is currently being viewed (`user.summary_fields.user_capabilities.edit` is false).
2) On the Team Roles tab, the Add buttons hould be hidden for users that are not an admin of the team's organization _and_ the logged in user cannot edit the team whose role list is currently being viewed (`team.summary_fields.user_capabilities.edit` is false).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI