### PR TITLE
Catching runtime error

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1366,7 +1366,7 @@ class UnifiedJob(PolymorphicModel, PasswordFieldsModel, CommonModelNameNotUnique
                 running = self.celery_task_id in ControlDispatcher(
                     'dispatcher', self.controller_node or self.execution_node
                 ).running(timeout=timeout)
-            except socket.timeout:
+            except (socket.timeout, RuntimeError):
                 logger.error('could not reach dispatcher on {} within {}s'.format(
                     self.execution_node, timeout
                 ))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

It was found that a job which was running during an AWX backup and restored into a new cluster was throwing a 500 error when attempting to be canceled. See https://access.redhat.com/support/cases/#/case/02715439 for full issue and stack. In 
awx/main/dispatch/control.py if we can't reach the dispatcher we:
```
                if reply is None:
                    logger.error(f'{self.service} did not reply within {timeout}s')
                    raise RuntimeError(f"{self.service} did not reply within {timeout}s")
                break
```

But the cancel code was only excepting socket.timeout which was causing the raise to bubble up into a 500. This fix catches both the socket.timeout as well as the returned RuntimeError and then properly allows the job to be canceled when the dispatcher is unreachable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 13.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
See access ticket for details on problem replication.
```
