### PR TITLE
Make 'inputs' Unchanged When Blank in Credentials Module

### DIFF
--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -384,19 +384,25 @@ def main():
         team_id = module.resolve_name_to_id('teams', team)
 
     # Create credential input from legacy inputs
+    has_inputs = False
     credential_inputs = {}
     for legacy_input in OLD_INPUT_NAMES:
         if module.params.get(legacy_input) is not None:
+            has_inputs = True
             credential_inputs[legacy_input] = module.params.get(legacy_input)
+
     if inputs:
+        has_inputs = True
         credential_inputs.update(inputs)
 
     # Create the data that gets sent for create and update
     credential_fields = {
         'name': new_name if new_name else name,
         'credential_type': cred_type_id,
-        'inputs': credential_inputs,
     }
+    if has_inputs:
+        credential_fields['inputs'] = credential_inputs
+
     if description:
         credential_fields['description'] = description
     if organization:

--- a/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
@@ -191,6 +191,19 @@
     that:
       - result is changed
 
+- name: Check for inputs idempotency (when "inputs" is blank)
+  tower_credential:
+    name: "{{ ssh_cred_name2 }}"
+    organization: Default
+    state: present
+    credential_type: Machine
+    description: An example SSH credential
+  register: result
+
+- assert:
+    that:
+      - result is not changed
+
 - name: Create a valid SSH credential from lookup source (old school)
   tower_credential:
     name: "{{ ssh_cred_name3 }}"


### PR DESCRIPTION
Addressing Issue https://github.com/ansible/awx/issues/7619

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previously-set `inputs` parameters will no longer be wiped out when no inputs are provided in a separate playbook task for the same credential.  When inputs ARE present, passwords still come back as `$encrypted$` so those always return as "changed" if the input specifies it. 

(this solution has been discussed/developed with @john-westcott-iv )

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

