### PR TITLE
Remove showExpandCollapse prop from the DataListToolbar calls

### DIFF
--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -36,7 +36,6 @@ describe('<DataListToolbar />', () => {
       <DataListToolbar
         qsConfig={QS_CONFIG}
         isAllSelected={false}
-        showExpandCollapse
         searchColumns={searchColumns}
         sortColumns={sortColumns}
         onSearch={onSearch}
@@ -272,7 +271,6 @@ describe('<DataListToolbar />', () => {
       <DataListToolbar
         qsConfig={QS_CONFIG}
         isAllSelected
-        showExpandCollapse
         searchColumns={searchColumns}
         sortColumns={sortColumns}
         onSearch={onSearch}

--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -213,7 +213,6 @@ function JobList({ i18n, defaultParams, showTypeColumn = false }) {
             <DatalistToolbar
               {...props}
               showSelectAll
-              showExpandCollapse
               isAllSelected={isAllSelected}
               onSelectAll={handleSelectAll}
               qsConfig={QS_CONFIG}

--- a/awx/ui_next/src/screens/Application/ApplicationTokens/ApplicationTokenList.jsx
+++ b/awx/ui_next/src/screens/Application/ApplicationTokens/ApplicationTokenList.jsx
@@ -120,7 +120,6 @@ function ApplicationTokenList({ i18n }) {
           <DatalistToolbar
             {...props}
             showSelectAll
-            showExpandCollapse
             isAllSelected={isAllSelected}
             onSelectAll={isSelected =>
               setSelected(isSelected ? [...tokens] : [])

--- a/awx/ui_next/src/screens/Application/ApplicationsList/ApplicationsList.jsx
+++ b/awx/ui_next/src/screens/Application/ApplicationsList/ApplicationsList.jsx
@@ -131,7 +131,6 @@ function ApplicationsList({ i18n }) {
               <DatalistToolbar
                 {...props}
                 showSelectAll
-                showExpandCollapse
                 isAllSelected={isAllSelected}
                 onSelectAll={isSelected =>
                   setSelected(isSelected ? [...applications] : [])

--- a/awx/ui_next/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx
+++ b/awx/ui_next/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx
@@ -104,7 +104,6 @@ function CredentialTypeList({ i18n }) {
               <DatalistToolbar
                 {...props}
                 showSelectAll
-                showExpandCollapse
                 isAllSelected={isAllSelected}
                 onSelectAll={isSelected =>
                   setSelected(isSelected ? [...credentialTypes] : [])

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx
@@ -175,7 +175,6 @@ function InstanceGroupList({ i18n }) {
               <DatalistToolbar
                 {...props}
                 showSelectAll
-                showExpandCollapse
                 isAllSelected={isAllSelected}
                 onSelectAll={isSelected =>
                   setSelected(isSelected ? [...instanceGroups] : [])

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -157,7 +157,6 @@ function InventoryList({ i18n }) {
             <DatalistToolbar
               {...props}
               showSelectAll
-              showExpandCollapse
               isAllSelected={isAllSelected}
               onSelectAll={handleSelectAll}
               qsConfig={QS_CONFIG}

--- a/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
@@ -150,7 +150,6 @@ function ProjectJobTemplatesList({ i18n }) {
             <DatalistToolbar
               {...props}
               showSelectAll
-              showExpandCollapse
               isAllSelected={isAllSelected}
               onSelectAll={isSelected =>
                 setSelected(isSelected ? [...jobTemplates] : [])

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateList.jsx
@@ -210,7 +210,6 @@ function TemplateList({ i18n }) {
             <DatalistToolbar
               {...props}
               showSelectAll
-              showExpandCollapse
               isAllSelected={isAllSelected}
               onSelectAll={handleSelectAll}
               qsConfig={QS_CONFIG}


### PR DESCRIPTION
Remove showExpandCollapse prop from the DataListToolbar calls. This is
not an expected prop to be passed to this component.

Inside DataListToolbar.

```
  const showExpandCollapse = onCompact && onExpand;
```

In order to use this feature, `onCompact` and `onExpand` props should
be passed.



