### PR TITLE
Support workflow prompting on launch

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
@@ -9,7 +9,6 @@ import useRequest from '../../../util/useRequest';
 import OptionsList from '../../OptionsList';
 import ContentLoading from '../../ContentLoading';
 import ContentError from '../../ContentError';
-import { required } from '../../../util/validators';
 
 const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
@@ -20,7 +19,6 @@ const QS_CONFIG = getQSConfig('inventory', {
 function InventoryStep({ i18n }) {
   const [field, , helpers] = useField({
     name: 'inventory',
-    validate: required(null, i18n),
   });
   const history = useHistory();
 

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
@@ -9,7 +9,11 @@ export default function useInventoryStep(config, resource, visitedSteps, i18n) {
   const [stepErrors, setStepErrors] = useState({});
 
   const validate = values => {
-    if (!config.ask_inventory_on_launch) {
+    if (
+      !config.ask_inventory_on_launch ||
+      (['workflow_job', 'workflow_job_template'].includes(resource.type) &&
+        !resource.inventory)
+    ) {
       return {};
     }
     const errors = {};

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -103,10 +103,7 @@ function TemplateListItem({
             </DataListCell>,
           ]}
         />
-        <DataListAction
-          aria-label="actions"
-          aria-labelledby={labelId}
-        >
+        <DataListAction aria-label="actions" aria-labelledby={labelId}>
           {template.summary_fields.user_capabilities.start && (
             <Tooltip content={i18n._(t`Launch Template`)} position="top">
               <LaunchButton resource={template}>

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -44,9 +44,7 @@ function TemplateListItem({
   fetchTemplates,
 }) {
   const [isDisabled, setIsDisabled] = useState(false);
-
   const labelId = `check-action-${template.id}`;
-  const canLaunch = template.summary_fields.user_capabilities.start;
 
   const copyTemplate = useCallback(async () => {
     if (template.type === 'job_template') {
@@ -105,8 +103,11 @@ function TemplateListItem({
             </DataListCell>,
           ]}
         />
-        <DataListAction aria-label="actions" aria-labelledby={labelId}>
-          {canLaunch && template.type === 'job_template' && (
+        <DataListAction
+          aria-label="actions"
+          aria-labelledby={labelId}
+        >
+          {template.summary_fields.user_capabilities.start && (
             <Tooltip content={i18n._(t`Launch Template`)} position="top">
               <LaunchButton resource={template}>
                 {({ handleLaunch }) => (


### PR DESCRIPTION
##### SUMMARY
Link #5910 

The only real difference between workflow job launch prompting and job template job launch prompting is that with workflows the inventory is an optional field _if_ a default inventory is **not** present.  So I had to add a bit of conditional logic to the validator function for the inventory step to take that into account.  Also I _think_ that the validate passed into useField is not necessary in either case since we're handling validation up at a higher level.  If that is necessary for job template launching then we'll need to conditionally apply it since the field is only sometimes required when launching a workflow.  Otherwise the current solution was already sufficient for covering all of the possible workflow prompts.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
