### PR TITLE
Fix early return in assign related method

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -268,9 +268,9 @@ class ApiV2(base.Base):
     def _assign_related(self):
         for _page, name, related_set in self._related:
             endpoint = _page.related[name]
-            if isinstance(related_set, dict):  # Relateds that are just json blobs, e.g. survey_spec
+            if isinstance(related_set, dict):  # Related that are just json blobs, e.g. survey_spec
                 endpoint.post(related_set)
-                return
+                continue
 
             if 'natural_key' not in related_set[0]:  # It is an attach set
                 # Try to impedance match


### PR DESCRIPTION
##### SUMMARY
This change fixes an erroneus early return in a private method that was
preventing more than one type of related object from being correctly
assigned to the parent object, and therefore imported.

Also, a minor spelling mistake was corrected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- CLI

##### AWX VERSION
```
awx: 14.0.0
```

##### ADDITIONAL INFORMATION
See #7793.