### PR TITLE
Upgrade gitpython to pick up bug fix

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -8,6 +8,8 @@ Commands should be run from inside the `./requirements` directory of the awx rep
 
 Make sure you have `patch, awk, python3, python2, python3-venv, python2-virtualenv, pip2, pip3` installed. The development container image should have all these.
 
+Even in the dev container, you may still have to dnf install `libpq-devel libcurl-devel`.
+
 ### Upgrading or Adding Select Libraries
 
 If you need to add or upgrade one targeted library, then modify `requirements.in`,

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -23,7 +23,7 @@ django-split-settings
 django-taggit
 djangorestframework
 djangorestframework-yaml
-GitPython
+GitPython>=3.1.1  # minimum to fix https://github.com/ansible/awx/issues/6119
 irc
 jinja2
 jsonschema

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -43,7 +43,7 @@ djangorestframework==3.11.0  # via -r /awx_devel/requirements/requirements.in
 docutils==0.16            # via python-daemon
 future==0.16.0            # via django-radius
 gitdb==4.0.2              # via gitpython
-gitpython==3.1.0          # via -r /awx_devel/requirements/requirements.in
+gitpython==3.1.7          # via -r /awx_devel/requirements/requirements.in
 google-auth==1.11.3       # via kubernetes
 hiredis==1.0.1            # via aioredis
 hyperlink==19.0.0         # via twisted

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -26,7 +26,7 @@ azure-mgmt-loganalytics==0.2.0  # via -r /awx_devel/requirements/requirements_an
 azure-mgmt-marketplaceordering==0.1.0  # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-monitor==0.5.2  # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-network==2.3.0  # via -r /awx_devel/requirements/requirements_ansible.in
-azure-mgmt-nspkg==2.0.0 # via -r /awx_devel/requirements/requirements_ansible.in, azure-mgmt-authorization, azure-mgmt-automation, azure-mgmt-batch, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-hdinsight, azure-mgmt-iothub, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-marketplaceordering, azure-mgmt-monitor, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-redis, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-trafficmanager, azure-mgmt-web
+azure-mgmt-nspkg==2.0.0; python_version < "3" # via -r /awx_devel/requirements/requirements_ansible.in, azure-mgmt-authorization, azure-mgmt-automation, azure-mgmt-batch, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-hdinsight, azure-mgmt-iothub, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-marketplaceordering, azure-mgmt-monitor, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-redis, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-trafficmanager, azure-mgmt-web
 azure-mgmt-rdbms==1.4.1   # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-redis==5.0.0   # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-resource==2.1.0  # via -r /awx_devel/requirements/requirements_ansible.in
@@ -96,7 +96,7 @@ pynacl==1.3.0             # via paramiko
 pyopenssl==19.1.0         # via azure-cli-core, requests-credssp
 pyparsing==2.4.5          # via packaging
 python-dateutil==2.8.1    # via adal, azure-storage, botocore, kubernetes
-python-string-utils==0.6.0; python_version < "3" # via openshift
+python-string-utils==0.6.0  # via openshift
 pyvmomi==6.7.3            # via -r /awx_devel/requirements/requirements_ansible.in
 pywinrm[kerberos]==0.3.0  # via -r /awx_devel/requirements/requirements_ansible.in
 pyyaml==5.2               # via azure-cli-core, knack, kubernetes, openstacksdk

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -26,7 +26,7 @@ azure-mgmt-loganalytics==0.2.0  # via -r /awx_devel/requirements/requirements_an
 azure-mgmt-marketplaceordering==0.1.0  # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-monitor==0.5.2  # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-network==2.3.0  # via -r /awx_devel/requirements/requirements_ansible.in
-azure-mgmt-nspkg==2.0.0; python_version < "3" # via -r /awx_devel/requirements/requirements_ansible.in, azure-mgmt-authorization, azure-mgmt-automation, azure-mgmt-batch, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-hdinsight, azure-mgmt-iothub, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-marketplaceordering, azure-mgmt-monitor, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-redis, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-trafficmanager, azure-mgmt-web
+azure-mgmt-nspkg==2.0.0 # via -r /awx_devel/requirements/requirements_ansible.in, azure-mgmt-authorization, azure-mgmt-automation, azure-mgmt-batch, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-hdinsight, azure-mgmt-iothub, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-marketplaceordering, azure-mgmt-monitor, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-redis, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-trafficmanager, azure-mgmt-web
 azure-mgmt-rdbms==1.4.1   # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-redis==5.0.0   # via -r /awx_devel/requirements/requirements_ansible.in
 azure-mgmt-resource==2.1.0  # via -r /awx_devel/requirements/requirements_ansible.in
@@ -96,7 +96,7 @@ pynacl==1.3.0             # via paramiko
 pyopenssl==19.1.0         # via azure-cli-core, requests-credssp
 pyparsing==2.4.5          # via packaging
 python-dateutil==2.8.1    # via adal, azure-storage, botocore, kubernetes
-python-string-utils==0.6.0  # via openshift
+python-string-utils==0.6.0; python_version < "3" # via openshift
 pyvmomi==6.7.3            # via -r /awx_devel/requirements/requirements_ansible.in
 pywinrm[kerberos]==0.3.0  # via -r /awx_devel/requirements/requirements_ansible.in
 pyyaml==5.2               # via azure-cli-core, knack, kubernetes, openstacksdk


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/6119

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
14.0.0
```


##### ADDITIONAL INFORMATION
To pick up

https://github.com/gitpython-developers/GitPython/commit/dbf3d2745c3758490f31199e31b098945ea81fca

in tags 3.1.7  3.1.6 3.1.5 3.1.4 3.1.3 3.1.2 3.1.1, because they were speedy in merging and releasing our patch.

Also, the `./updater.sh` script wasn't running out-of-the-box anymore, I suspect it's related to recent changes to the Dockerfile. @wenottingham you did some work consolidating development / production versions, so on a basic gut-check level, it makes sense to me that `-devel` packages that were previously present are no longer there. I don't want to change the image, I just want instructions here to be complete.
