### PR TITLE
Fix awx.awx version replacement regex

### DIFF
--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set the collection version in the tower_api.py file
   replace:
     path: "{{ collection_path }}/plugins/module_utils/tower_api.py"
-    regexp: '^    _COLLECTION_VERSION = "devel"'
+    regexp: '^    _COLLECTION_VERSION = "0.0.1-devel"'
     replace: '    _COLLECTION_VERSION = "{{ collection_version }}"'
   when:
     - "awx_template_version | default(True)"


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/7870

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
14.0.0
```


##### ADDITIONAL INFORMATION
Testing with 

```diff
diff --git a/Makefile b/Makefile
index ca76648499..f58eae828e 100644
--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ symlink_collection:
        ln -s $(shell pwd)/awx_collection $(COLLECTION_INSTALL)
 
 build_collection:
-       ansible-playbook -i localhost, awx_collection/tools/template_galaxy.yml -e collection_package=$(COLLECTION_PACKAGE) -e collection_namespace=$(COLLECTION_NAMESPACE) -e collection_version=$(VERSION) -e '{"awx_template_version":false}'
+       ansible-playbook -i localhost, awx_collection/tools/template_galaxy.yml -e collection_package=$(COLLECTION_PACKAGE) -e collection_namespace=$(COLLECTION_NAMESPACE) -e collection_version=$(VERSION)
        ansible-galaxy collection build awx_collection_build --force --output-path=awx_collection_build
 
 install_collection: build_collection
```

and it fills in 14.0.0