### PR TITLE
update newly useRequested lists to get advanced searchableKeys

### DIFF
--- a/awx/ui_next/src/api/models/Credentials.js
+++ b/awx/ui_next/src/api/models/Credentials.js
@@ -6,6 +6,7 @@ class Credentials extends Base {
     this.baseUrl = '/api/v2/credentials/';
 
     this.readAccessList = this.readAccessList.bind(this);
+    this.readAccessOptions = this.readAccessOptions.bind(this);
     this.readInputSources = this.readInputSources.bind(this);
   }
 
@@ -13,6 +14,10 @@ class Credentials extends Base {
     return this.http.get(`${this.baseUrl}${id}/access_list/`, {
       params,
     });
+  }
+
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
   }
 
   readInputSources(id, params) {

--- a/awx/ui_next/src/api/models/Inventories.js
+++ b/awx/ui_next/src/api/models/Inventories.js
@@ -7,6 +7,7 @@ class Inventories extends InstanceGroupsMixin(Base) {
     this.baseUrl = '/api/v2/inventories/';
 
     this.readAccessList = this.readAccessList.bind(this);
+    this.readAccessOptions = this.readAccessOptions.bind(this);
     this.readHosts = this.readHosts.bind(this);
     this.readHostDetail = this.readHostDetail.bind(this);
     this.readGroups = this.readGroups.bind(this);
@@ -18,6 +19,10 @@ class Inventories extends InstanceGroupsMixin(Base) {
     return this.http.get(`${this.baseUrl}${id}/access_list/`, {
       params,
     });
+  }
+
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
   }
 
   createHost(id, data) {

--- a/awx/ui_next/src/api/models/JobTemplates.js
+++ b/awx/ui_next/src/api/models/JobTemplates.js
@@ -16,6 +16,7 @@ class JobTemplates extends SchedulesMixin(
     this.disassociateLabel = this.disassociateLabel.bind(this);
     this.readCredentials = this.readCredentials.bind(this);
     this.readAccessList = this.readAccessList.bind(this);
+    this.readAccessOptions = this.readAccessOptions.bind(this);
     this.readWebhookKey = this.readWebhookKey.bind(this);
   }
 
@@ -64,6 +65,10 @@ class JobTemplates extends SchedulesMixin(
     return this.http.get(`${this.baseUrl}${id}/access_list/`, {
       params,
     });
+  }
+
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
   }
 
   readScheduleList(id, params) {

--- a/awx/ui_next/src/api/models/Organizations.js
+++ b/awx/ui_next/src/api/models/Organizations.js
@@ -12,8 +12,16 @@ class Organizations extends InstanceGroupsMixin(NotificationsMixin(Base)) {
     return this.http.get(`${this.baseUrl}${id}/access_list/`, { params });
   }
 
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
+  }
+
   readTeams(id, params) {
     return this.http.get(`${this.baseUrl}${id}/teams/`, { params });
+  }
+
+  readTeamsOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/teams/`);
   }
 
   createUser(id, data) {

--- a/awx/ui_next/src/api/models/Projects.js
+++ b/awx/ui_next/src/api/models/Projects.js
@@ -11,6 +11,7 @@ class Projects extends SchedulesMixin(
     this.baseUrl = '/api/v2/projects/';
 
     this.readAccessList = this.readAccessList.bind(this);
+    this.readAccessOptions = this.readAccessOptions.bind(this);
     this.readInventories = this.readInventories.bind(this);
     this.readPlaybooks = this.readPlaybooks.bind(this);
     this.readSync = this.readSync.bind(this);
@@ -19,6 +20,10 @@ class Projects extends SchedulesMixin(
 
   readAccessList(id, params) {
     return this.http.get(`${this.baseUrl}${id}/access_list/`, { params });
+  }
+
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
   }
 
   readInventories(id) {

--- a/awx/ui_next/src/api/models/Teams.js
+++ b/awx/ui_next/src/api/models/Teams.js
@@ -35,6 +35,10 @@ class Teams extends Base {
     });
   }
 
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
+  }
+
   readUsersAccessOptions(teamId) {
     return this.http.options(`${this.baseUrl}${teamId}/users/`);
   }

--- a/awx/ui_next/src/api/models/WorkflowJobTemplates.js
+++ b/awx/ui_next/src/api/models/WorkflowJobTemplates.js
@@ -54,6 +54,10 @@ class WorkflowJobTemplates extends SchedulesMixin(NotificationsMixin(Base)) {
     });
   }
 
+  readAccessOptions(id) {
+    return this.http.options(`${this.baseUrl}${id}/access_list/`);
+  }
+
   readSurvey(id) {
     return this.http.get(`${this.baseUrl}${id}/survey_spec/`);
   }

--- a/awx/ui_next/src/components/AddRole/AddResourceRole.jsx
+++ b/awx/ui_next/src/components/AddRole/AddResourceRole.jsx
@@ -11,7 +11,11 @@ import { TeamsAPI, UsersAPI } from '../../api';
 const readUsers = async queryParams =>
   UsersAPI.read(Object.assign(queryParams, { is_superuser: false }));
 
+const readUsersOptions = async () => UsersAPI.readOptions();
+
 const readTeams = async queryParams => TeamsAPI.read(queryParams);
+
+const readTeamsOptions = async () => TeamsAPI.readOptions();
 
 class AddResourceRole extends React.Component {
   constructor(props) {
@@ -259,6 +263,7 @@ class AddResourceRole extends React.Component {
                 displayKey="username"
                 onRowClick={this.handleResourceCheckboxClick}
                 fetchItems={readUsers}
+                fetchOptions={readUsersOptions}
                 selectedLabel={i18n._(t`Selected`)}
                 selectedResourceRows={selectedResourceRows}
                 sortedColumnKey="username"
@@ -270,6 +275,7 @@ class AddResourceRole extends React.Component {
                 sortColumns={teamSortColumns}
                 onRowClick={this.handleResourceCheckboxClick}
                 fetchItems={readTeams}
+                fetchOptions={readTeamsOptions}
                 selectedLabel={i18n._(t`Selected`)}
                 selectedResourceRows={selectedResourceRows}
               />

--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
@@ -35,6 +35,7 @@ describe('<SelectResourceStep />', () => {
         displayKey="username"
         onRowClick={() => {}}
         fetchItems={() => {}}
+        fetchOptions={() => {}}
       />
     );
   });
@@ -49,6 +50,15 @@ describe('<SelectResourceStep />', () => {
         ],
       },
     });
+    const options = jest.fn().mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
@@ -58,6 +68,7 @@ describe('<SelectResourceStep />', () => {
           displayKey="username"
           onRowClick={() => {}}
           fetchItems={handleSearch}
+          fetchOptions={options}
         />
       );
     });
@@ -78,6 +89,15 @@ describe('<SelectResourceStep />', () => {
         { id: 2, username: 'bar', url: 'item/2' },
       ],
     };
+    const options = jest.fn().mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
@@ -87,6 +107,7 @@ describe('<SelectResourceStep />', () => {
           displayKey="username"
           onRowClick={handleRowClick}
           fetchItems={() => ({ data })}
+          fetchOptions={options}
           selectedResourceRows={[]}
         />
       );

--- a/awx/ui_next/src/components/AssociateModal/AssociateModal.test.jsx
+++ b/awx/ui_next/src/components/AssociateModal/AssociateModal.test.jsx
@@ -15,6 +15,15 @@ describe('<AssociateModal />', () => {
   const onClose = jest.fn();
   const onAssociate = jest.fn().mockResolvedValue();
   const fetchRequest = jest.fn().mockReturnValue({ data: { ...mockHosts } });
+  const optionsRequest = jest.fn().mockResolvedValue({
+    data: {
+      actions: {
+        GET: {},
+        POST: {},
+      },
+      related_search_fields: [],
+    },
+  });
 
   beforeEach(async () => {
     await act(async () => {
@@ -23,6 +32,7 @@ describe('<AssociateModal />', () => {
           onClose={onClose}
           onAssociate={onAssociate}
           fetchRequest={fetchRequest}
+          optionsRequest={optionsRequest}
           isModalOpen
         />
       );

--- a/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.test.jsx
+++ b/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.test.jsx
@@ -76,6 +76,15 @@ describe('<ResourceAccessList />', () => {
 
   beforeEach(async () => {
     OrganizationsAPI.readAccessList.mockResolvedValue({ data });
+    OrganizationsAPI.readAccessOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     TeamsAPI.disassociateRole.mockResolvedValue({});
     UsersAPI.disassociateRole.mockResolvedValue({});
     await act(async () => {

--- a/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.jsx
+++ b/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.jsx
@@ -96,6 +96,7 @@ function UserAndTeamAccessAdd({
           displayKey="name"
           onRowClick={handleResourceSelect}
           fetchItems={selectedResourceType.fetchItems}
+          fetchOptions={selectedResourceType.fetchOptions}
           selectedLabel={i18n._(t`Selected`)}
           selectedResourceRows={resourcesSelected}
           sortedColumnKey="username"

--- a/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.test.jsx
+++ b/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.test.jsx
@@ -43,6 +43,15 @@ describe('<UserAndTeamAccessAdd/>', () => {
       count: 1,
     },
   };
+  const options = {
+    data: {
+      actions: {
+        GET: {},
+        POST: {},
+      },
+      related_search_fields: [],
+    },
+  };
   let wrapper;
   beforeEach(async () => {
     await act(async () => {
@@ -111,11 +120,13 @@ describe('<UserAndTeamAccessAdd/>', () => {
 
   test('should call api to associate role', async () => {
     JobTemplatesAPI.read.mockResolvedValue(resources);
+    JobTemplatesAPI.readOptions.mockResolvedValue(options);
     UsersAPI.associateRole.mockResolvedValue({});
 
     await act(async () =>
       wrapper.find('SelectableCard[label="Job templates"]').prop('onClick')({
         fetchItems: JobTemplatesAPI.read,
+        fetchOptions: JobTemplatesAPI.readOptions,
         label: 'Job template',
         selectedResource: 'jobTemplate',
         searchColumns: [
@@ -169,6 +180,7 @@ describe('<UserAndTeamAccessAdd/>', () => {
 
   test('should throw error', async () => {
     JobTemplatesAPI.read.mockResolvedValue(resources);
+    JobTemplatesAPI.readOptions.mockResolvedValue(options);
     UsersAPI.associateRole.mockRejectedValue(
       new Error({
         response: {
@@ -192,6 +204,7 @@ describe('<UserAndTeamAccessAdd/>', () => {
     await act(async () =>
       wrapper.find('SelectableCard[label="Job templates"]').prop('onClick')({
         fetchItems: JobTemplatesAPI.read,
+        fetchOptions: JobTemplatesAPI.readOptions,
         label: 'Job template',
         selectedResource: 'jobTemplate',
         searchColumns: [

--- a/awx/ui_next/src/components/UserAndTeamAccessAdd/getResourceAccessConfig.js
+++ b/awx/ui_next/src/components/UserAndTeamAccessAdd/getResourceAccessConfig.js
@@ -39,6 +39,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => JobTemplatesAPI.read(queryParams),
+      fetchOptions: () => JobTemplatesAPI.readOptions(),
     },
     {
       selectedResource: 'workflowJobTemplate',
@@ -69,6 +70,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => WorkflowJobTemplatesAPI.read(queryParams),
+      fetchOptions: () => WorkflowJobTemplatesAPI.readOptions(),
     },
     {
       selectedResource: 'credential',
@@ -110,6 +112,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => CredentialsAPI.read(queryParams),
+      fetchOptions: () => CredentialsAPI.readOptions(),
     },
     {
       selectedResource: 'inventory',
@@ -136,6 +139,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => InventoriesAPI.read(queryParams),
+      fetchOptions: () => InventoriesAPI.readOptions(),
     },
     {
       selectedResource: 'project',
@@ -177,6 +181,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => ProjectsAPI.read(queryParams),
+      fetchOptions: () => ProjectsAPI.readOptions(),
     },
     {
       selectedResource: 'organization',
@@ -203,6 +208,7 @@ export default function getResourceAccessConfig(i18n) {
         },
       ],
       fetchItems: queryParams => OrganizationsAPI.read(queryParams),
+      fetchOptions: () => OrganizationsAPI.readOptions(),
     },
   ];
 }

--- a/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.jsx
+++ b/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.jsx
@@ -118,6 +118,11 @@ function HostGroupsList({ i18n, host }) {
     [invId, hostId]
   );
 
+  const fetchGroupsOptions = useCallback(
+    () => InventoriesAPI.readGroupsOptions(invId),
+    [invId]
+  );
+
   const { request: handleAssociate, error: associateError } = useRequest(
     useCallback(
       async groupsToAssociate => {
@@ -224,6 +229,7 @@ function HostGroupsList({ i18n, host }) {
         <AssociateModal
           header={i18n._(t`Groups`)}
           fetchRequest={fetchGroupsToAssociate}
+          optionsRequest={fetchGroupsOptions}
           isModalOpen={isModalOpen}
           onAssociate={handleAssociate}
           onClose={() => setIsModalOpen(false)}

--- a/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.test.jsx
@@ -207,6 +207,15 @@ describe('<HostGroupsList />', () => {
         results: [{ id: 123, name: 'foo', url: '/api/v2/groups/123/' }],
       },
     });
+    InventoriesAPI.readGroupsOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper.find('ToolbarAddButton').simulate('click');
     });

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -111,6 +111,11 @@ function InventoryGroupHostList({ i18n }) {
     [groupId, inventoryId]
   );
 
+  const fetchHostsOptions = useCallback(
+    () => InventoriesAPI.readHostsOptions(inventoryId),
+    [inventoryId]
+  );
+
   const { request: handleAssociate, error: associateErr } = useRequest(
     useCallback(
       async hostsToAssociate => {
@@ -227,6 +232,7 @@ function InventoryGroupHostList({ i18n }) {
         <AssociateModal
           header={i18n._(t`Hosts`)}
           fetchRequest={fetchHostsToAssociate}
+          optionsRequest={fetchHostsOptions}
           isModalOpen={isModalOpen}
           onAssociate={handleAssociate}
           onClose={() => setIsModalOpen(false)}

--- a/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.jsx
@@ -47,7 +47,13 @@ function InventoryGroupsList({ i18n }) {
   const { id: inventoryId } = useParams();
 
   const {
-    result: { groups, groupCount, actions },
+    result: {
+      groups,
+      groupCount,
+      actions,
+      relatedSearchableKeys,
+      searchableKeys,
+    },
     error: contentError,
     isLoading,
     request: fetchGroups,
@@ -62,12 +68,20 @@ function InventoryGroupsList({ i18n }) {
         groups: response.data.results,
         groupCount: response.data.count,
         actions: actionsResponse.data.actions,
+        relatedSearchableKeys: (
+          actionsResponse?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(
+          actionsResponse.data.actions?.GET || {}
+        ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
       };
     }, [inventoryId, location]),
     {
       groups: [],
       groupCount: 0,
       actions: {},
+      relatedSearchableKeys: [],
+      searchableKeys: [],
     }
   );
 
@@ -168,6 +182,8 @@ function InventoryGroupsList({ i18n }) {
             key: 'name',
           },
         ]}
+        toolbarSearchableKeys={searchableKeys}
+        toolbarRelatedSearchableKeys={relatedSearchableKeys}
         renderItem={item => (
           <InventoryGroupItem
             key={item.id}

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
@@ -116,6 +116,11 @@ function InventoryHostGroupsList({ i18n }) {
     [invId, hostId]
   );
 
+  const fetchGroupsOptions = useCallback(
+    () => InventoriesAPI.readGroupsOptions(invId),
+    [invId]
+  );
+
   const { request: handleAssociate, error: associateError } = useRequest(
     useCallback(
       async groupsToAssociate => {
@@ -221,6 +226,7 @@ function InventoryHostGroupsList({ i18n }) {
         <AssociateModal
           header={i18n._(t`Groups`)}
           fetchRequest={fetchGroupsToAssociate}
+          optionsRequest={fetchGroupsOptions}
           isModalOpen={isModalOpen}
           onAssociate={handleAssociate}
           onClose={() => setIsModalOpen(false)}

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
@@ -199,6 +199,15 @@ describe('<InventoryHostGroupsList />', () => {
         results: [{ id: 123, name: 'foo', url: '/api/v2/groups/123/' }],
       },
     });
+    InventoriesAPI.readGroupsOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper.find('ToolbarAddButton').simulate('click');
     });

--- a/awx/ui_next/src/screens/Organization/OrganizationTeams/OrganizationTeamList.test.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationTeams/OrganizationTeamList.test.jsx
@@ -53,6 +53,15 @@ const listData = {
 describe('<OrganizationTeamList />', () => {
   beforeEach(() => {
     OrganizationsAPI.readTeams.mockResolvedValue(listData);
+    OrganizationsAPI.readTeamsOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
   });
 
   afterEach(() => {

--- a/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx
@@ -27,7 +27,13 @@ function ProjectJobTemplatesList({ i18n }) {
   const location = useLocation();
 
   const {
-    result: { jobTemplates, itemCount, actions },
+    result: {
+      jobTemplates,
+      itemCount,
+      actions,
+      relatedSearchableKeys,
+      searchableKeys,
+    },
     error: contentError,
     isLoading,
     request: fetchTemplates,
@@ -43,12 +49,20 @@ function ProjectJobTemplatesList({ i18n }) {
         jobTemplates: response.data.results,
         itemCount: response.data.count,
         actions: actionsResponse.data.actions,
+        relatedSearchableKeys: (
+          actionsResponse?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(
+          actionsResponse.data.actions?.GET || {}
+        ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
       };
     }, [location, projectId]),
     {
       jobTemplates: [],
       itemCount: 0,
       actions: {},
+      relatedSearchableKeys: [],
+      searchableKeys: [],
     }
   );
 
@@ -142,6 +156,8 @@ function ProjectJobTemplatesList({ i18n }) {
               key: 'type',
             },
           ]}
+          toolbarSearchableKeys={searchableKeys}
+          toolbarRelatedSearchableKeys={relatedSearchableKeys}
           renderToolbar={props => (
             <DatalistToolbar
               {...props}

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
@@ -40,6 +40,15 @@ describe('NodeModal', () => {
         ],
       },
     });
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     ProjectsAPI.read.mockResolvedValue({
       data: {
         count: 1,
@@ -51,6 +60,15 @@ describe('NodeModal', () => {
             url: '/api/v2/projects/1',
           },
         ],
+      },
+    });
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
       },
     });
     InventorySourcesAPI.read.mockResolvedValue({
@@ -66,6 +84,15 @@ describe('NodeModal', () => {
         ],
       },
     });
+    InventorySourcesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     WorkflowJobTemplatesAPI.read.mockResolvedValue({
       data: {
         count: 1,
@@ -77,6 +104,15 @@ describe('NodeModal', () => {
             url: '/api/v2/workflow_job_templates/1',
           },
         ],
+      },
+    });
+    WorkflowJobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
       },
     });
   });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
@@ -20,22 +20,33 @@ function InventorySourcesList({ i18n, nodeResource, onUpdateNodeResource }) {
   const location = useLocation();
 
   const {
-    result: { inventorySources, count },
+    result: { inventorySources, count, relatedSearchableKeys, searchableKeys },
     error,
     isLoading,
     request: fetchInventorySources,
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, location.search);
-      const results = await InventorySourcesAPI.read(params);
+      const [response, actionsResponse] = await Promise.all([
+        InventorySourcesAPI.read(params),
+        InventorySourcesAPI.readOptions(),
+      ]);
       return {
-        inventorySources: results.data.results,
-        count: results.data.count,
+        inventorySources: response.data.results,
+        count: response.data.count,
+        relatedSearchableKeys: (
+          actionsResponse?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(
+          actionsResponse.data.actions?.GET || {}
+        ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
       };
     }, [location]),
     {
       inventorySources: [],
       count: 0,
+      relatedSearchableKeys: [],
+      searchableKeys: [],
     }
   );
 
@@ -94,6 +105,8 @@ function InventorySourcesList({ i18n, nodeResource, onUpdateNodeResource }) {
           key: 'name',
         },
       ]}
+      toolbarSearchableKeys={searchableKeys}
+      toolbarRelatedSearchableKeys={relatedSearchableKeys}
     />
   );
 }

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.test.jsx
@@ -38,6 +38,15 @@ describe('InventorySourcesList', () => {
         ],
       },
     });
+    InventorySourcesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <InventorySourcesList

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
@@ -20,24 +20,35 @@ function JobTemplatesList({ i18n, nodeResource, onUpdateNodeResource }) {
   const location = useLocation();
 
   const {
-    result: { jobTemplates, count },
+    result: { jobTemplates, count, relatedSearchableKeys, searchableKeys },
     error,
     isLoading,
     request: fetchJobTemplates,
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, location.search);
-      const results = await JobTemplatesAPI.read(params, {
-        role_level: 'execute_role',
-      });
+      const [response, actionsResponse] = await Promise.all([
+        JobTemplatesAPI.read(params, {
+          role_level: 'execute_role',
+        }),
+        JobTemplatesAPI.readOptions(),
+      ]);
       return {
-        jobTemplates: results.data.results,
-        count: results.data.count,
+        jobTemplates: response.data.results,
+        count: response.data.count,
+        relatedSearchableKeys: (
+          actionsResponse?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(
+          actionsResponse.data.actions?.GET || {}
+        ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
       };
     }, [location]),
     {
       jobTemplates: [],
       count: 0,
+      relatedSearchableKeys: [],
+      searchableKeys: [],
     }
   );
 
@@ -92,6 +103,8 @@ function JobTemplatesList({ i18n, nodeResource, onUpdateNodeResource }) {
           key: 'name',
         },
       ]}
+      toolbarSearchableKeys={searchableKeys}
+      toolbarRelatedSearchableKeys={relatedSearchableKeys}
     />
   );
 }

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
@@ -38,6 +38,15 @@ describe('JobTemplatesList', () => {
         ],
       },
     });
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <JobTemplatesList
@@ -67,6 +76,15 @@ describe('JobTemplatesList', () => {
   });
   test('Error shown when read() request errors', async () => {
     JobTemplatesAPI.read.mockRejectedValue(new Error());
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <JobTemplatesList

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.test.jsx
@@ -35,6 +35,15 @@ describe('NodeTypeStep', () => {
         ],
       },
     });
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     ProjectsAPI.read.mockResolvedValue({
       data: {
         count: 1,
@@ -46,6 +55,15 @@ describe('NodeTypeStep', () => {
             url: '/api/v2/projects/1',
           },
         ],
+      },
+    });
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
       },
     });
     InventorySourcesAPI.read.mockResolvedValue({
@@ -61,6 +79,15 @@ describe('NodeTypeStep', () => {
         ],
       },
     });
+    InventorySourcesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     WorkflowJobTemplatesAPI.read.mockResolvedValue({
       data: {
         count: 1,
@@ -72,6 +99,15 @@ describe('NodeTypeStep', () => {
             url: '/api/v2/workflow_job_templates/1',
           },
         ],
+      },
+    });
+    WorkflowJobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
       },
     });
   });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.test.jsx
@@ -38,6 +38,15 @@ describe('ProjectsList', () => {
         ],
       },
     });
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <ProjectsList

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.test.jsx
@@ -38,6 +38,15 @@ describe('WorkflowJobTemplatesList', () => {
         ],
       },
     });
+    WorkflowJobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <WorkflowJobTemplatesList

--- a/awx/ui_next/src/screens/User/UserList/UserList.jsx
+++ b/awx/ui_next/src/screens/User/UserList/UserList.jsx
@@ -27,7 +27,13 @@ function UserList({ i18n }) {
   const match = useRouteMatch();
 
   const {
-    result: { users, itemCount, actions },
+    result: {
+      users,
+      itemCount,
+      actions,
+      relatedSearchableKeys,
+      searchableKeys,
+    },
     error: contentError,
     isLoading,
     request: fetchUsers,
@@ -42,12 +48,20 @@ function UserList({ i18n }) {
         users: response.data.results,
         itemCount: response.data.count,
         actions: actionsResponse.data.actions,
+        relatedSearchableKeys: (
+          actionsResponse?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(
+          actionsResponse.data.actions?.GET || {}
+        ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
       };
     }, [location]),
     {
       users: [],
       itemCount: 0,
       actions: {},
+      relatedSearchableKeys: [],
+      searchableKeys: [],
     }
   );
 
@@ -124,6 +138,8 @@ function UserList({ i18n }) {
                 key: 'last_name',
               },
             ]}
+            toolbarSearchableKeys={searchableKeys}
+            toolbarRelatedSearchableKeys={relatedSearchableKeys}
             renderToolbar={props => (
               <DataListToolbar
                 {...props}


### PR DESCRIPTION
link #7740 

Adds support for advanced search searchable keys for these lists:
UserList.jsx - #7743
WFJTList - #7745
(Templates) ProjectsList.jsx - #7752
JTList - #7754
InventorySourcesList.jsx - #7755
ProjectJobTemplatesList.jsx - #7759
OrganizationTeamList.jsx - #7761
InventoryGroupsList.jsx - #7765
ResourceAccessList.jsx - #7772
NotificationList.jsx - #7785
OrganizationLookup - #7786
AddResourceRole lists
UserAndTeamAccessAdd /SelectResourceStep lists*
AssociateModal lists*