### PR TITLE
Use 'secure' cookies in containers/OCP as well.

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -232,6 +232,7 @@ START_TASK_LIMIT = 100
 
 # Disallow sending session cookies over insecure connections
 SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
 
 # Seconds before sessions expire.
 # Note: This setting may be overridden by database settings.

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -57,10 +57,10 @@ mimetypes.add_type("image/svg+xml", ".svg", True)
 mimetypes.add_type("image/svg+xml", ".svgz", True)
 
 # Disallow sending session cookies over insecure connections
-SESSION_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = True
 
 # Disallow sending csrf cookies over insecure connections
-CSRF_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = True
 
 # Override django.template.loaders.cached.Loader in defaults.py
 template = next((tpl_backend for tpl_backend in TEMPLATES if tpl_backend['NAME'] == 'default'), None) # noqa

--- a/docs/auth/session.md
+++ b/docs/auth/session.md
@@ -13,10 +13,6 @@ is *a random string which will be mapped to user authentication informations by 
 hijack cookies will only get the `session_id` itself, which does not imply any critical user info, is valid only for
 a limited time, and can be revoked at any time.
 
-> Note: The CSRF token will by default allow HTTP.  To increase security, the `CSRF_COOKIE_SECURE` setting should
-be set to True.
-
-
 ## Usage
 
 In session authentication, users log in using the `/api/login/` endpoint. A GET to `/api/login/` displays the

--- a/tools/ansible/roles/dockerfile/files/settings.py
+++ b/tools/ansible/roles/dockerfile/files/settings.py
@@ -29,8 +29,8 @@ AWX_PROOT_ENABLED = False
 CLUSTER_HOST_ID = "awx"
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
 
-CSRF_COOKIE_SECURE = False
-SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
 
 ###############################################################################
 # EMAIL SETTINGS


### PR DESCRIPTION
##### SUMMARY

This flips the default settings for the session & CSRF cookies for containerized deployments.
These settings were always configurable. I think they were unset before due to some load balancer
weirdness(?)

Tested:
- [:heavy_check_mark:] dev env
- [:heavy_check_mark:] OCP
- [:heavy_check_mark:] local docker

Untested:
- [ ] k8s

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - Installer

