### PR TITLE
Updated the stable to newer version of postgres

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -101,14 +101,14 @@
 
     - name: Deploy and Activate Postgres (Kubernetes)
       shell: |
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com
+        helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo update
         helm upgrade {{ postgresql_service_name }} \
           --install \
           --namespace {{ kubernetes_namespace }} \
-          --version="8.3.0" \
+          --version="8.10.14" \
           --values {{ values_file.path }} \
-          stable/postgresql
+          bitnami/postgresql
       register: kubernetes_pg_activate
       no_log: true
 


### PR DESCRIPTION
##### SUMMARY

This change addresses the need by:
- the `stable` postgres helm chart doesn't work
- newer version from bitnami is a dropin replacement for stable
- tested via muliple ways
- `stable/postgres` is deprecated for the `bitnami/postgres` release

Signed-off-by: JJ Asghar <jjasghar@gmail.com>
Co-authored-by: Mofi Rahman <moficodes@gmail.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 14.0.0
```