### PR TITLE
make event stdout encoding more resilient to UTF-16 surrogate pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a list of high-level changes for each release of AWX. A full list of com
 - Upgraded git-python to fix a bug that caused workflows to sometimes fail - https://github.com/ansible/awx/issues/6119
 - Fixed a bug in the AWX CLI that prevented Workflow nodes from importing properly - https://github.com/ansible/awx/issues/7793
 - Fixed a bug in the awx.awx collection release process that templated the wrong version - https://github.com/ansible/awx/issues/7870
+- Fixed a bug that caused errors rendering stdout that contained UTF-16 surrogate pairs - https://github.com/ansible/awx/pull/7918
 
 ## 14.0.0 (Aug 6, 2020)
 - As part of our commitment to inclusivity in open source, we recently took some time to audit AWX's source code and user interface and replace certain terminology with more inclusive language.  Strictly speaking, this isn't a bug or a feature, but we think it's important and worth calling attention to:

--- a/awx/api/renderers.py
+++ b/awx/api/renderers.py
@@ -7,6 +7,24 @@ from prometheus_client.parser import text_string_to_metric_families
 # Django REST Framework
 from rest_framework import renderers
 from rest_framework.request import override_method
+from rest_framework.utils import encoders
+
+
+class SurrogateEncoder(encoders.JSONEncoder):
+
+    def encode(self, obj):
+        ret = super(SurrogateEncoder, self).encode(obj)
+        try:
+            ret.encode()
+        except UnicodeEncodeError as e:
+            if 'surrogates not allowed' in e.reason:
+                ret = ret.encode('utf-8', 'replace').decode()
+        return ret
+
+
+class DefaultJSONRenderer(renderers.JSONRenderer):
+
+    encoder_class = SurrogateEncoder
 
 
 class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -310,7 +310,7 @@ REST_FRAMEWORK = {
         'awx.api.parsers.JSONParser',
     ),
     'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
+        'awx.api.renderers.DefaultJSONRenderer',
         'awx.api.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'awx.api.metadata.Metadata',


### PR DESCRIPTION
Given that we're returning literally any bytestream that Ansible can muster, it probably makes sense to relax `errors='strict'` a bit to avoid 500 errors.

see: https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs

Run this adhoc command w/ `-m shell`:

`printf '\uD83D\uDE00'`

![image](https://user-images.githubusercontent.com/214912/90434818-0c0e3880-e09c-11ea-9d75-4c1041f968dc.png)

after (better than a 500 error):

![image](https://user-images.githubusercontent.com/214912/90435242-bb4b0f80-e09c-11ea-93c6-93f0f8fc75e3.png)
