### PR TITLE
Use organization api to create users

### DIFF
--- a/awx/ui_next/src/api/models/Organizations.js
+++ b/awx/ui_next/src/api/models/Organizations.js
@@ -15,6 +15,10 @@ class Organizations extends InstanceGroupsMixin(NotificationsMixin(Base)) {
   readTeams(id, params) {
     return this.http.get(`${this.baseUrl}${id}/teams/`, { params });
   }
+
+  createUser(id, data) {
+    return this.http.post(`${this.baseUrl}${id}/users/`, data);
+  }
 }
 
 export default Organizations;

--- a/awx/ui_next/src/screens/User/UserAdd/UserAdd.jsx
+++ b/awx/ui_next/src/screens/User/UserAdd/UserAdd.jsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from '../../../components/Card';
 import UserForm from '../shared/UserForm';
-import { UsersAPI } from '../../../api';
+import { OrganizationsAPI } from '../../../api';
 
 function UserAdd() {
   const [formSubmitError, setFormSubmitError] = useState(null);
@@ -11,10 +11,11 @@ function UserAdd() {
 
   const handleSubmit = async values => {
     setFormSubmitError(null);
+    const { organization, ...userValues } = values;
     try {
       const {
         data: { id },
-      } = await UsersAPI.create(values);
+      } = await OrganizationsAPI.createUser(organization, userValues);
       history.push(`/users/${id}/details`);
     } catch (error) {
       setFormSubmitError(error);

--- a/awx/ui_next/src/screens/User/UserAdd/UserAdd.test.jsx
+++ b/awx/ui_next/src/screens/User/UserAdd/UserAdd.test.jsx
@@ -6,7 +6,7 @@ import {
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
 import UserAdd from './UserAdd';
-import { UsersAPI } from '../../../api';
+import { OrganizationsAPI } from '../../../api';
 
 jest.mock('../../../api');
 let wrapper;
@@ -16,7 +16,7 @@ describe('<UserAdd />', () => {
     await act(async () => {
       wrapper = mountWithContexts(<UserAdd />);
     });
-    UsersAPI.create.mockResolvedValueOnce({ data: {} });
+    OrganizationsAPI.createUser.mockResolvedValueOnce({ data: {} });
     const updatedUserData = {
       username: 'sysadmin',
       email: 'sysadmin@ansible.com',
@@ -30,7 +30,11 @@ describe('<UserAdd />', () => {
     await act(async () => {
       wrapper.find('UserForm').prop('handleSubmit')(updatedUserData);
     });
-    expect(UsersAPI.create).toHaveBeenCalledWith(updatedUserData);
+
+    const { organization, ...userData } = updatedUserData;
+    expect(OrganizationsAPI.createUser.mock.calls).toEqual([
+      [organization, userData],
+    ]);
   });
 
   test('should navigate to users list when cancel is clicked', async () => {
@@ -58,7 +62,7 @@ describe('<UserAdd />', () => {
       is_superuser: true,
       is_system_auditor: false,
     };
-    UsersAPI.create.mockResolvedValueOnce({
+    OrganizationsAPI.createUser.mockResolvedValueOnce({
       data: {
         id: 5,
         ...userData,

--- a/awx/ui_next/src/screens/User/UserOrganizations/UserOrganizationListItem.jsx
+++ b/awx/ui_next/src/screens/User/UserOrganizations/UserOrganizationListItem.jsx
@@ -19,7 +19,7 @@ export default function UserOrganizationListItem({ organization }) {
                 to={`/organizations/${organization.id}/details`}
                 id={labelId}
               >
-                {organization.name}
+                <b>{organization.name}</b>
               </Link>
             </DataListCell>,
             <DataListCell key={organization.description}>


### PR DESCRIPTION
##### SUMMARY
for #7756 

* Use organization api to create users. This ensures that the user will be related to the chosen organization when it is created.
* Also makes user organization names bold to match other similar lists
