### PR TITLE
add a deprecation warning for mercurial project syncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This is a list of high-level changes for each release of AWX. A full list of commits can be found at `https://github.com/ansible/awx/releases/tag/<version>`.
 
 ## 14.1.0 (TBD)
+- Deprecated official support for Mercurial-based project updates - https://github.com/ansible/awx/issues/7932
 - Added the ability to import YAML-based resources (instead of just JSON) when using the AWX CLI - https://github.com/ansible/awx/pull/7808
 - Updated the AWX CLI to export labels associated with Workflow Job Templates - https://github.com/ansible/awx/pull/7847
 - Updated to the latest python-ldap to address a bug - https://github.com/ansible/awx/issues/7868

--- a/awx/playbooks/action_plugins/hg_deprecation.py
+++ b/awx/playbooks/action_plugins/hg_deprecation.py
@@ -1,0 +1,15 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        self._supports_check_mode = False
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['changed'] = result['failed'] = False
+        result['msg'] = ''
+        self._display.deprecated("Mercurial support is deprecated")
+        return result

--- a/awx/playbooks/project_update_hg_tasks.yml
+++ b/awx/playbooks/project_update_hg_tasks.yml
@@ -1,4 +1,7 @@
 ---
+- name: Mercurial support is deprecated.
+  hg_deprecation:
+
 - name: update project using hg
   hg:
     dest: "{{project_path|quote}}"


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/7932

![image](https://user-images.githubusercontent.com/214912/90654359-4ef01d80-e20e-11ea-957e-2a07ec216419.png)
