### PR TITLE
Fix container groups

### DIFF
--- a/awx/main/isolated/manager.py
+++ b/awx/main/isolated/manager.py
@@ -58,7 +58,7 @@ class IsolatedManager(object):
                 os.chmod(temp.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
             for host in hosts:
                 inventory['all']['hosts'][host] = {
-                    "ansible_connection": "community.kubernetes.kubectl",
+                    "ansible_connection": "kubectl",
                     "ansible_kubectl_config": path,
                 }
         else:


### PR DESCRIPTION
There's a bug in the upstream community.kubernetes plugin. We can open up a
follow-up PR once that has been patched.