### PR TITLE
Fix broadcast_websocket_secret length

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Generate broadcast websocket secret
   set_fact:
-    broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
+    broadcast_websocket_secret: "{{ lookup('password', '/dev/null length=128') }}"
   run_once: true
   no_log: true
   when: broadcast_websocket_secret is not defined

--- a/installer/roles/local_docker/tasks/main.yml
+++ b/installer/roles/local_docker/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Generate broadcast websocket secret
   set_fact:
-    broadcast_websocket_secret: "{{ lookup('password', '/dev/null', length=128) }}"
+    broadcast_websocket_secret: "{{ lookup('password', '/dev/null length=128') }}"
   run_once: true
   no_log: true
   when: broadcast_websocket_secret is not defined


### PR DESCRIPTION
##### SUMMARY
Password lookup parameters must be within the same set of quotes.
Otherwise a default value of length is used (20).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 14.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ cat test.yml 
- hosts: localhost
  gather_facts: False
  tasks:
    - set_fact:
        foo: "{{ lookup('password', '/dev/null', length=128) }}"
        bar: "{{ lookup('password', '/dev/null length=128') }}"
    - debug:
        msg: |
          foo length is: {{ foo | length }}
          bar length is: {{ bar | length }}
$ ansible-playbook test.yml
PLAY [localhost] ********************************************************************************

TASK [set_fact] *********************************************************************************
Friday 21 August 2020  20:50:41 +0300 (0:00:00.040)       0:00:00.040 ********* 
ok: [localhost]

TASK [debug] ************************************************************************************
Friday 21 August 2020  20:50:42 +0300 (0:00:00.062)       0:00:00.103 ********* 
ok: [localhost] => 
  msg: |-
    foo length is: 20
    bar length is: 128

PLAY RECAP **************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
    