### PR TITLE
Add label to identify isolated instance group JobDetail screen

### DIFF
--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button, Chip } from '@patternfly/react-core';
+import { Button, Chip, Label } from '@patternfly/react-core';
 import styled from 'styled-components';
 
 import AlertModal from '../../../components/AlertModal';
@@ -121,6 +121,22 @@ function JobDetail({ job, i18n }) {
     }
   };
 
+  const isIsolatedInstanceGroup = item => {
+    if (item.is_isolated) {
+      return (
+        <>
+          <Link to={`/instance_groups/${item.id}`}>{item.name}</Link>
+          <span css="margin-left: 12px">
+            <Label aria-label={i18n._(t`isolated instance`)}>
+              {i18n._(t`Isolated`)}
+            </Label>
+          </span>
+        </>
+      );
+    }
+    return <Link to={`/instance_groups/${item.id}`}>{item.name}</Link>;
+  };
+
   return (
     <CardBody>
       <DetailList>
@@ -211,11 +227,7 @@ function JobDetail({ job, i18n }) {
         {instanceGroup && (
           <Detail
             label={i18n._(t`Instance Group`)}
-            value={
-              <Link to={`/instance_groups/${instanceGroup.id}`}>
-                {instanceGroup.name}
-              </Link>
-            }
+            value={isIsolatedInstanceGroup(instanceGroup)}
           />
         )}
         {typeof job.job_slice_number === 'number' &&


### PR DESCRIPTION
Add label to identify isolated instance group JobDetail screen as per
mock up.

See: https://tower-mockups.testing.ansible.com/patternfly/jobs/jobs-detail/
