### PR TITLE
Disables template and workflow template fields.

### DIFF
--- a/awx/ui_next/src/components/FieldWithPrompt/FieldWithPrompt.jsx
+++ b/awx/ui_next/src/components/FieldWithPrompt/FieldWithPrompt.jsx
@@ -23,6 +23,7 @@ function FieldWithPrompt({
   promptId,
   promptName,
   tooltip,
+  isDisabled,
 }) {
   return (
     <div className="pf-c-form__group">
@@ -39,6 +40,7 @@ function FieldWithPrompt({
           {tooltip && <FieldTooltip content={tooltip} />}
         </div>
         <StyledCheckboxField
+          isDisabled={isDisabled}
           id={promptId}
           label={i18n._(t`Prompt on launch`)}
           name={promptName}

--- a/awx/ui_next/src/components/FormField/CheckboxField.jsx
+++ b/awx/ui_next/src/components/FormField/CheckboxField.jsx
@@ -9,10 +9,19 @@ const QuestionCircleIcon = styled(PFQuestionCircleIcon)`
   margin-left: 10px;
 `;
 
-function CheckboxField({ id, name, label, tooltip, validate, ...rest }) {
+function CheckboxField({
+  id,
+  name,
+  label,
+  tooltip,
+  validate,
+  isDisabled,
+  ...rest
+}) {
   const [field] = useField({ name, validate });
   return (
     <Checkbox
+      isDisabled={isDisabled}
       aria-label={label}
       label={
         <span>

--- a/awx/ui_next/src/components/Lookup/CredentialLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/CredentialLookup.jsx
@@ -33,6 +33,7 @@ function CredentialLookup({
   history,
   i18n,
   tooltip,
+  isDisabled,
 }) {
   const {
     result: { count, credentials, relatedSearchableKeys, searchableKeys },
@@ -108,6 +109,7 @@ function CredentialLookup({
         onChange={onChange}
         required={required}
         qsConfig={QS_CONFIG}
+        isDisabled={isDisabled}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList
             value={state.selectedItems}

--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -10,6 +10,7 @@ import OptionsList from '../OptionsList';
 import useRequest from '../../util/useRequest';
 import { getQSConfig, parseQueryString } from '../../util/qs';
 import LookupErrorMessage from './shared/LookupErrorMessage';
+import FieldWithPrompt from '../FieldWithPrompt';
 
 const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
@@ -17,7 +18,18 @@ const QS_CONFIG = getQSConfig('inventory', {
   order_by: 'name',
 });
 
-function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
+function InventoryLookup({
+  value,
+  onChange,
+  onBlur,
+  i18n,
+  history,
+  required,
+  isPromptableField,
+  fieldId,
+  promptId,
+  promptName,
+}) {
   const {
     result: {
       inventories,
@@ -61,7 +73,70 @@ function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
     fetchInventories();
   }, [fetchInventories]);
 
-  return (
+  return isPromptableField ? (
+    <>
+      <FieldWithPrompt
+        fieldId={fieldId}
+        isRequired={required}
+        label={i18n._(t`Inventory`)}
+        promptId={promptId}
+        promptName={promptName}
+        isDisabled={!canEdit}
+        tooltip={i18n._(t`Select the inventory containing the hosts
+            you want this job to manage.`)}
+      >
+        <Lookup
+          id="inventory-lookup"
+          header={i18n._(t`Inventory`)}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          required={required}
+          isLoading={isLoading}
+          isDisabled={!canEdit}
+          qsConfig={QS_CONFIG}
+          renderOptionsList={({ state, dispatch, canDelete }) => (
+            <OptionsList
+              value={state.selectedItems}
+              options={inventories}
+              optionCount={count}
+              searchColumns={[
+                {
+                  name: i18n._(t`Name`),
+                  key: 'name__icontains',
+                  isDefault: true,
+                },
+                {
+                  name: i18n._(t`Created By (Username)`),
+                  key: 'created_by__username__icontains',
+                },
+                {
+                  name: i18n._(t`Modified By (Username)`),
+                  key: 'modified_by__username__icontains',
+                },
+              ]}
+              sortColumns={[
+                {
+                  name: i18n._(t`Name`),
+                  key: 'name',
+                },
+              ]}
+              searchableKeys={searchableKeys}
+              relatedSearchableKeys={relatedSearchableKeys}
+              multiple={state.multiple}
+              header={i18n._(t`Inventory`)}
+              name="inventory"
+              qsConfig={QS_CONFIG}
+              readOnly={!canDelete}
+              selectItem={item => dispatch({ type: 'SELECT_ITEM', item })}
+              deselectItem={item => dispatch({ type: 'DESELECT_ITEM', item })}
+            />
+          )}
+        />
+        <LookupErrorMessage error={error} />
+      </FieldWithPrompt>
+    </>
+  ) : (
     <>
       <Lookup
         id="inventory-lookup"

--- a/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.jsx
@@ -19,7 +19,13 @@ const QS_CONFIG = getQSConfig('inventory', {
 
 function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
   const {
-    result: { inventories, count, relatedSearchableKeys, searchableKeys },
+    result: {
+      inventories,
+      count,
+      relatedSearchableKeys,
+      searchableKeys,
+      canEdit,
+    },
     request: fetchInventories,
     error,
     isLoading,
@@ -39,9 +45,16 @@ function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
         searchableKeys: Object.keys(
           actionsResponse.data.actions?.GET || {}
         ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
+        canEdit: Boolean(actionsResponse.data.actions.POST),
       };
     }, [history.location]),
-    { inventories: [], count: 0, relatedSearchableKeys: [], searchableKeys: [] }
+    {
+      inventories: [],
+      count: 0,
+      relatedSearchableKeys: [],
+      searchableKeys: [],
+      canEdit: false,
+    }
   );
 
   useEffect(() => {
@@ -58,6 +71,7 @@ function InventoryLookup({ value, onChange, onBlur, required, i18n, history }) {
         onBlur={onBlur}
         required={required}
         isLoading={isLoading}
+        isDisabled={!canEdit}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -27,6 +27,8 @@ import { QSConfig } from '../../types';
 
 const ChipHolder = styled.div`
   --pf-c-form-control--Height: auto;
+  background-color: ${props =>
+    props.isDisabled ? 'var(--pf-global--disabled-color--300)' : null};
 `;
 function Lookup(props) {
   const {
@@ -43,6 +45,7 @@ function Lookup(props) {
     renderOptionsList,
     history,
     i18n,
+    isDisabled,
   } = props;
 
   const [state, dispatch] = useReducer(
@@ -103,11 +106,15 @@ function Lookup(props) {
           id={id}
           onClick={() => dispatch({ type: 'TOGGLE_MODAL' })}
           variant={ButtonVariant.control}
-          isDisabled={isLoading}
+          isDisabled={isLoading || isDisabled}
         >
           <SearchIcon />
         </Button>
-        <ChipHolder className="pf-c-form-control">
+        <ChipHolder
+          isDisabled={isDisabled}
+          // css="background-color: #d2d2d2"
+          className="pf-c-form-control"
+        >
           <ChipGroup numChips={5} totalChips={items.length}>
             {items.map(item =>
               renderItemChip({

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -91,7 +91,8 @@ function Lookup(props) {
   };
 
   const { isModalOpen, selectedItems } = state;
-  const canDelete = !required || (multiple && value.length > 1);
+  const canDelete =
+    (!required || (multiple && value.length > 1)) && !isDisabled;
   let items = [];
   if (multiple) {
     items = value;
@@ -110,11 +111,7 @@ function Lookup(props) {
         >
           <SearchIcon />
         </Button>
-        <ChipHolder
-          isDisabled={isDisabled}
-          // css="background-color: #d2d2d2"
-          className="pf-c-form-control"
-        >
+        <ChipHolder isDisabled={isDisabled} className="pf-c-form-control">
           <ChipGroup numChips={5} totalChips={items.length}>
             {items.map(item =>
               renderItemChip({

--- a/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/ProjectLookup.jsx
@@ -32,7 +32,7 @@ function ProjectLookup({
   history,
 }) {
   const {
-    result: { projects, count, relatedSearchableKeys, searchableKeys },
+    result: { projects, count, relatedSearchableKeys, searchableKeys, canEdit },
     request: fetchProjects,
     error,
     isLoading,
@@ -55,6 +55,7 @@ function ProjectLookup({
         searchableKeys: Object.keys(
           actionsResponse.data.actions?.GET || {}
         ).filter(key => actionsResponse.data.actions?.GET[key].filterable),
+        canEdit: Boolean(actionsResponse.data.actions.POST),
       };
     }, [history.location.search, autocomplete]),
     {
@@ -62,6 +63,7 @@ function ProjectLookup({
       projects: [],
       relatedSearchableKeys: [],
       searchableKeys: [],
+      canEdit: false,
     }
   );
 
@@ -87,6 +89,7 @@ function ProjectLookup({
         onChange={onChange}
         required={required}
         isLoading={isLoading}
+        isDisabled={!canEdit}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList

--- a/awx/ui_next/src/components/MultiSelect/useSyncedSelectValue.js
+++ b/awx/ui_next/src/components/MultiSelect/useSyncedSelectValue.js
@@ -11,11 +11,21 @@ export default function useSyncedSelectValue(value, onChange) {
   const [selections, setSelections] = useState([]);
 
   useEffect(() => {
+    const newOptions = [];
     if (value !== selections && options.length) {
-      const syncedValue = value.map(item =>
-        options.find(i => i.id === item.id)
-      );
+      const syncedValue = value.map(item => {
+        const match = options.find(i => {
+          return i.id === item.id;
+        });
+        if (!match) {
+          newOptions.push(item);
+        }
+        return match || item;
+      });
       setSelections(syncedValue);
+    }
+    if (newOptions.length > 0) {
+      setOptions(options.concat(newOptions));
     }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [value, options]);
@@ -27,7 +37,6 @@ export default function useSyncedSelectValue(value, onChange) {
       onChange(selections.concat(item));
     }
   };
-
   return {
     selections: options.length ? addToStringToObjects(selections) : [],
     onSelect,

--- a/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.jsx
@@ -4,13 +4,11 @@ import { withRouter, Redirect } from 'react-router-dom';
 import { CardBody } from '../../../components/Card';
 import ContentError from '../../../components/ContentError';
 import ContentLoading from '../../../components/ContentLoading';
-import { JobTemplatesAPI, ProjectsAPI } from '../../../api';
+import { JobTemplatesAPI } from '../../../api';
 import { JobTemplate } from '../../../types';
 import { getAddedAndRemoved } from '../../../util/lists';
 import JobTemplateForm from '../shared/JobTemplateForm';
 
-const loadRelatedProjectPlaybooks = async project =>
-  ProjectsAPI.readPlaybooks(project);
 class JobTemplateEdit extends Component {
   static propTypes = {
     template: JobTemplate.isRequired,
@@ -43,17 +41,8 @@ class JobTemplateEdit extends Component {
   }
 
   async loadRelated() {
-    const {
-      template: { project },
-    } = this.props;
     this.setState({ contentError: null, hasContentLoading: true });
     try {
-      if (project) {
-        const { data: playbook = [] } = await loadRelatedProjectPlaybooks(
-          project
-        );
-        this.setState({ relatedProjectPlaybooks: playbook });
-      }
       const [relatedCredentials] = await this.loadRelatedCredentials();
       this.setState({
         relatedCredentials,

--- a/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.test.jsx
@@ -12,6 +12,7 @@ import {
   JobTemplatesAPI,
   LabelsAPI,
   ProjectsAPI,
+  InventoriesAPI,
 } from '../../../api';
 import JobTemplateEdit from './JobTemplateEdit';
 
@@ -180,6 +181,12 @@ JobTemplatesAPI.readCredentials.mockResolvedValue({
 });
 ProjectsAPI.readPlaybooks.mockResolvedValue({
   data: mockRelatedProjectPlaybooks,
+});
+InventoriesAPI.readOptions.mockResolvedValue({
+  data: { actions: { GET: {}, POST: {} } },
+});
+ProjectsAPI.readOptions.mockResolvedValue({
+  data: { actions: { GET: {}, POST: {} } },
 });
 LabelsAPI.read.mockResolvedValue({ data: { results: [] } });
 CredentialsAPI.read.mockResolvedValue({

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -234,17 +234,15 @@ function JobTemplateForm({
             }}
           />
         </FieldWithPrompt>
-        <FieldWithPrompt
-          fieldId="template-inventory"
-          isRequired={!askInventoryOnLaunchField.value}
-          label={i18n._(t`Inventory`)}
-          promptId="template-ask-inventory-on-launch"
-          promptName="ask_inventory_on_launch"
-          tooltip={i18n._(t`Select the inventory containing the hosts
-            you want this job to manage.`)}
-        >
+        <>
           <InventoryLookup
             value={inventory}
+            fieldId="template-inventory"
+            promptId="template-ask-inventory-on-launch"
+            promptName="ask_inventory_on_launch"
+            isPromptableField
+            tooltip={i18n._(t`Select the inventory containing the hosts
+            you want this job to manage.`)}
             onBlur={() => inventoryHelpers.setTouched()}
             onChange={value => {
               inventoryHelpers.setValue(value ? value.id : null);
@@ -263,7 +261,7 @@ function JobTemplateForm({
                 {inventoryMeta.error}
               </div>
             )}
-        </FieldWithPrompt>
+        </>
         <ProjectLookup
           value={projectField.value}
           onBlur={() => projectHelpers.setTouched()}

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -39,7 +39,7 @@ import {
   ProjectLookup,
   MultiCredentialsLookup,
 } from '../../../components/Lookup';
-import { JobTemplatesAPI, ProjectsAPI } from '../../../api';
+import { JobTemplatesAPI } from '../../../api';
 import LabelSelect from './LabelSelect';
 import PlaybookSelect from './PlaybookSelect';
 import WebhookSubForm from './WebhookSubForm';
@@ -101,18 +101,6 @@ function JobTemplateForm({
   );
 
   const {
-    request: fetchProject,
-    error: projectContentError,
-    contentLoading: hasProjectLoading,
-  } = useRequest(
-    useCallback(async () => {
-      if (template?.project) {
-        await ProjectsAPI.readDetail(template?.project);
-      }
-    }, [template])
-  );
-
-  const {
     request: loadRelatedInstanceGroups,
     error: instanceGroupError,
     contentLoading: instanceGroupLoading,
@@ -126,10 +114,6 @@ function JobTemplateForm({
       setFieldValue('instanceGroups', [...data.results]);
     }, [setFieldValue, template])
   );
-
-  useEffect(() => {
-    fetchProject();
-  }, [fetchProject]);
 
   useEffect(() => {
     loadRelatedInstanceGroups();
@@ -204,16 +188,12 @@ function JobTemplateForm({
     callbackUrl = `${origin}${path}`;
   }
 
-  if (instanceGroupLoading || hasProjectLoading) {
+  if (instanceGroupLoading) {
     return <ContentLoading />;
   }
 
-  if (contentError || instanceGroupError || projectContentError) {
-    return (
-      <ContentError
-        error={contentError || instanceGroupError || projectContentError}
-      />
-    );
+  if (contentError || instanceGroupError) {
+    return <ContentError error={contentError || instanceGroupError} />;
   }
 
   return (

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.test.jsx
@@ -14,6 +14,7 @@ import {
   ProjectsAPI,
   CredentialsAPI,
   CredentialTypesAPI,
+  InventoriesAPI,
 } from '../../../api';
 
 jest.mock('../../../api');
@@ -111,13 +112,22 @@ describe('<JobTemplateForm />', () => {
     JobTemplatesAPI.updateWebhookKey.mockReturnValue({
       data: { webhook_key: 'webhook key' },
     });
-    ProjectsAPI.readPlaybooks.mockReturnValue({
-      data: ['debug.yml'],
+    JobTemplatesAPI.updateWebhookKey.mockReturnValue({
+      data: { webhook_key: 'webhook key' },
     });
     ProjectsAPI.readDetail.mockReturnValue({
       name: 'foo',
       id: 1,
       allow_override: true,
+    });
+    ProjectsAPI.readPlaybooks.mockReturnValue({
+      data: ['debug.yml'],
+    });
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
+    });
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
     });
   });
 

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
@@ -35,7 +35,7 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
       });
       return opts;
     }, [projectId, i18n]),
-    [field.value]
+    []
   );
 
   useEffect(() => {

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { number, string, oneOfType } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
@@ -7,6 +7,7 @@ import { ProjectsAPI } from '../../../api';
 import useRequest from '../../../util/useRequest';
 
 function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
+  const [isDisabled, setIsDisabled] = useState(false);
   const {
     result: options,
     request: fetchOptions,
@@ -18,6 +19,7 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
         return [];
       }
       const { data } = await ProjectsAPI.readPlaybooks(projectId);
+
       const opts = (data || []).map(playbook => ({
         value: playbook,
         key: playbook,
@@ -33,7 +35,7 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
       });
       return opts;
     }, [projectId, i18n]),
-    []
+    [field.value]
   );
 
   useEffect(() => {
@@ -42,18 +44,30 @@ function PlaybookSelect({ projectId, isValid, field, onBlur, onError, i18n }) {
 
   useEffect(() => {
     if (error) {
-      onError(error);
+      if (error.response.status === 403) {
+        setIsDisabled(true);
+      } else {
+        onError(error);
+      }
     }
   }, [error, onError]);
 
+  const isDisabledData = [
+    {
+      value: field.value || '',
+      label: field.value || '',
+      key: 1,
+      isDisabled: true,
+    },
+  ];
   return (
     <AnsibleSelect
       id="template-playbook"
-      data={options}
+      data={isDisabled ? isDisabledData : options}
       isValid={isValid}
       {...field}
       onBlur={onBlur}
-      isDisabled={isLoading}
+      isDisabled={isLoading || isDisabled}
     />
   );
 }

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
@@ -110,23 +110,21 @@ function WorkflowJobTemplateForm({
           value={organizationField.value}
           isValid={!organizationMeta.error}
         />
-
-        <FieldWithPrompt
-          fieldId="wfjt-inventory"
-          label={i18n._(t`Inventory`)}
-          promptId="wfjt-ask-inventory-on-launch"
-          promptName="ask_inventory_on_launch"
-          tooltip={i18n._(
-            t`Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory.`
-          )}
-        >
+        <>
           <InventoryLookup
+            promptId="wfjt-ask-inventory-on-launch"
+            promptName="ask_inventory_on_launch"
+            tooltip={i18n._(
+              t`Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory.`
+            )}
+            fieldId="wfjt-inventory"
+            isPromptableField
             value={inventoryField.value}
             onBlur={() => inventoryHelpers.setTouched()}
             onChange={value => {
               inventoryHelpers.setValue(value);
             }}
-            required={askInventoryOnLaunchField.value}
+            required={!askInventoryOnLaunchField.value}
             touched={inventoryMeta.touched}
             error={inventoryMeta.error}
           />
@@ -139,8 +137,7 @@ function WorkflowJobTemplateForm({
                 {inventoryMeta.error}
               </div>
             )}
-        </FieldWithPrompt>
-
+        </>
         <FieldWithPrompt
           fieldId="wjft-limit"
           label={i18n._(t`Limit`)}

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.test.jsx
@@ -11,6 +11,8 @@ import {
   LabelsAPI,
   OrganizationsAPI,
   InventoriesAPI,
+  ProjectsAPI,
+  CredentialTypesAPI,
 } from '../../../api';
 
 jest.mock('../../../api/models/CredentialTypes');
@@ -18,6 +20,8 @@ jest.mock('../../../api/models/WorkflowJobTemplates');
 jest.mock('../../../api/models/Labels');
 jest.mock('../../../api/models/Organizations');
 jest.mock('../../../api/models/Inventories');
+jest.mock('../../../api/models/Projects');
+jest.mock('../../../api/models/Credentials');
 
 describe('<WorkflowJobTemplateForm/>', () => {
   let wrapper;
@@ -70,6 +74,15 @@ describe('<WorkflowJobTemplateForm/>', () => {
         { id: 1, name: 'Foo' },
         { id: 2, name: 'Bar' },
       ],
+    });
+    CredentialTypesAPI.read.mockResolvedValue({
+      data: { results: [{ id: 1 }] },
+    });
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
+    });
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
     });
 
     history = createMemoryHistory({


### PR DESCRIPTION


##### SUMMARY
This addresses #7973. It also addresses a bug where a user might temporarily not have labels while the label select component is doing its fetching and loading.  I did file a feature request with PF that would allow use to disable all child of `<InputGroup>` so that we would not have add styling to `<ChipHolder>` component in the template form. https://github.com/patternfly/patternfly-react/issues/4709

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

##### ADDITIONAL INFORMATION
![Screen Shot 2020-08-24 at 12 11 17 PM](https://user-images.githubusercontent.com/39280967/91068901-f0a6ae80-e602-11ea-9ee1-970e1a0789a6.png)
![Screen Shot 2020-08-24 at 12 11 02 PM](https://user-images.githubusercontent.com/39280967/91068905-f3090880-e602-11ea-8d24-b31582982bd6.png)
