### PR TITLE
hashivault_kv auth_path moved from metadata to inputs

### DIFF
--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -41,11 +41,11 @@ base_inputs = {
         'secret': True,
         'help_text': _('The Secret ID for AppRole Authentication')
     }, {
-        'id': 'auth_path',
-        'label': _('Path to Auth'),
+        'id': 'approle_auth_path',
+        'label': _('Path to Approle Auth'),
         'type': 'string',
         'multiline': False,
-        'help_text': _('The path where the Authentication method is mounted e.g, approle')
+        'help_text': _('The path where the AppRole Authentication method is mounted e.g, approle')
     }
     ],
     'metadata': [{
@@ -53,6 +53,12 @@ base_inputs = {
         'label': _('Path to Secret'),
         'type': 'string',
         'help_text': _('The path to the secret stored in the secret backend e.g, /some/secret/')
+    }, {
+        'id': 'auth_path',
+        'label': _('Path to Auth'),
+        'type': 'string',
+        'multiline': False,
+        'help_text': _('The path where the Authentication method is mounted e.g, approle')
     }],
     'required': ['url', 'secret_path'],
 }
@@ -119,7 +125,11 @@ def handle_auth(**kwargs):
 def approle_auth(**kwargs):
     role_id = kwargs['role_id']
     secret_id = kwargs['secret_id']
-    auth_path = kwargs.get('auth_path') or 'approle'
+    # we first try to use the 'auth_path' from the metadata
+    # if not found we try to fetch the 'approle_auth_path' from inputs
+    # if not found we use the default value 'approle'
+    auth_path = \
+        kwargs.get('auth_path', kwargs.get('approle_auth_path', "approle"))
 
     url = urljoin(kwargs['url'], 'v1')
     cacert = kwargs.get('cacert', None)

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -40,6 +40,12 @@ base_inputs = {
         'multiline': False,
         'secret': True,
         'help_text': _('The Secret ID for AppRole Authentication')
+    }, {
+        'id': 'auth_path',
+        'label': _('Path to Auth'),
+        'type': 'string',
+        'multiline': False,
+        'help_text': _('The path where the Authentication method is mounted e.g, approle')
     }
     ],
     'metadata': [{
@@ -47,11 +53,6 @@ base_inputs = {
         'label': _('Path to Secret'),
         'type': 'string',
         'help_text': _('The path to the secret stored in the secret backend e.g, /some/secret/')
-    },{
-        'id': 'auth_path',
-        'label': _('Path to Auth'),
-        'type': 'string',
-        'help_text': _('The path where the Authentication method is mounted e.g, approle')
     }],
     'required': ['url', 'secret_path'],
 }

--- a/awx/main/credential_plugins/hashivault.py
+++ b/awx/main/credential_plugins/hashivault.py
@@ -41,11 +41,12 @@ base_inputs = {
         'secret': True,
         'help_text': _('The Secret ID for AppRole Authentication')
     }, {
-        'id': 'approle_auth_path',
+        'id': 'default_auth_path',
         'label': _('Path to Approle Auth'),
         'type': 'string',
         'multiline': False,
-        'help_text': _('The path where the AppRole Authentication method is mounted e.g, approle')
+        'default': 'approle',
+        'help_text': _('The AppRole Authentication path to use if one isn\'t provided in the metadata when linking to an input field. Defaults to \'approle\'')
     }
     ],
     'metadata': [{
@@ -126,10 +127,8 @@ def approle_auth(**kwargs):
     role_id = kwargs['role_id']
     secret_id = kwargs['secret_id']
     # we first try to use the 'auth_path' from the metadata
-    # if not found we try to fetch the 'approle_auth_path' from inputs
-    # if not found we use the default value 'approle'
-    auth_path = \
-        kwargs.get('auth_path', kwargs.get('approle_auth_path', "approle"))
+    # if not found we try to fetch the 'default_auth_path' from inputs
+    auth_path = kwargs.get('auth_path') or kwargs['default_auth_path']
 
     url = urljoin(kwargs['url'], 'v1')
     cacert = kwargs.get('cacert', None)

--- a/awx_collection/test/awx/test_credential_input_source.py
+++ b/awx_collection/test/awx/test_credential_input_source.py
@@ -122,7 +122,8 @@ def source_cred_hashi_secret(organization):
             "url": "https://secret.hash.example.com",
             "token": "myApiKey",
             "role_id": "role",
-            "secret_id": "secret"
+            "secret_id": "secret",
+            "approle_auth_path": "path-to-approle"
         }
     )
 
@@ -157,6 +158,8 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
     assert cis.metadata['secret_backend'] == "backend"
     assert cis.metadata['secret_key'] == "a_key"
     assert cis.source_credential.name == source_cred_hashi_secret.name
+    assert cis.source_credential.approle_auth_path == \
+           source_cred_hashi_secret.inputs["approle_auth_path"]
     assert cis.target_credential.name == tgt_cred.name
     assert cis.input_field_name == 'password'
     assert result['id'] == cis.pk

--- a/awx_collection/test/awx/test_credential_input_source.py
+++ b/awx_collection/test/awx/test_credential_input_source.py
@@ -123,7 +123,7 @@ def source_cred_hashi_secret(organization):
             "token": "myApiKey",
             "role_id": "role",
             "secret_id": "secret",
-            "approle_auth_path": "path-to-approle"
+            "default_auth_path": "path-to-approle"
         }
     )
 
@@ -158,8 +158,6 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
     assert cis.metadata['secret_backend'] == "backend"
     assert cis.metadata['secret_key'] == "a_key"
     assert cis.source_credential.name == source_cred_hashi_secret.name
-    assert cis.source_credential.approle_auth_path == \
-           source_cred_hashi_secret.inputs["approle_auth_path"]
     assert cis.target_credential.name == tgt_cred.name
     assert cis.input_field_name == 'password'
     assert result['id'] == cis.pk

--- a/awx_collection/test/awx/test_credential_input_source.py
+++ b/awx_collection/test/awx/test_credential_input_source.py
@@ -122,8 +122,7 @@ def source_cred_hashi_secret(organization):
             "url": "https://secret.hash.example.com",
             "token": "myApiKey",
             "role_id": "role",
-            "secret_id": "secret",
-            "auth_path": "/path/to/auth"
+            "secret_id": "secret"
         }
     )
 
@@ -143,7 +142,7 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
         source_credential=source_cred_hashi_secret.name,
         target_credential=tgt_cred.name,
         input_field_name='password',
-        metadata={"secret_path": "/path/to/secret", "secret_backend": "backend", "secret_key": "a_key"},
+        metadata={"secret_path": "/path/to/secret", "auth_path": "/path/to/auth", "secret_backend": "backend", "secret_key": "a_key"},
         state='present'
     ), admin_user)
 
@@ -154,6 +153,7 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
     cis = CredentialInputSource.objects.first()
 
     assert cis.metadata['secret_path'] == "/path/to/secret"
+    assert cis.metadata['auth_path'] == "/path/to/auth"
     assert cis.metadata['secret_backend'] == "backend"
     assert cis.metadata['secret_key'] == "a_key"
     assert cis.source_credential.name == source_cred_hashi_secret.name
@@ -188,14 +188,14 @@ def test_hashi_ssh_credential_source(run_module, admin_user, organization, sourc
         name='Test Machine Credential',
         organization=organization,
         credential_type=ct,
-        inputs={'username': 'bob', "auth_path": "/path/to/auth"}
+        inputs={'username': 'bob'}
     )
 
     result = run_module('tower_credential_input_source', dict(
         source_credential=source_cred_hashi_ssh.name,
         target_credential=tgt_cred.name,
         input_field_name='password',
-        metadata={"secret_path": "/path/to/secret", "role": "role", "public_key": "a_key", "valid_principals": "some_value"},
+        metadata={"secret_path": "/path/to/secret", "auth_path": "/path/to/auth", "role": "role", "public_key": "a_key", "valid_principals": "some_value"},
         state='present'
     ), admin_user)
 
@@ -206,6 +206,7 @@ def test_hashi_ssh_credential_source(run_module, admin_user, organization, sourc
     cis = CredentialInputSource.objects.first()
 
     assert cis.metadata['secret_path'] == "/path/to/secret"
+    assert cis.metadata['auth_path'] == "/path/to/auth"
     assert cis.metadata['role'] == "role"
     assert cis.metadata['public_key'] == "a_key"
     assert cis.metadata['valid_principals'] == "some_value"

--- a/awx_collection/test/awx/test_credential_input_source.py
+++ b/awx_collection/test/awx/test_credential_input_source.py
@@ -122,7 +122,8 @@ def source_cred_hashi_secret(organization):
             "url": "https://secret.hash.example.com",
             "token": "myApiKey",
             "role_id": "role",
-            "secret_id": "secret"
+            "secret_id": "secret",
+            "auth_path": "/path/to/auth"
         }
     )
 
@@ -142,7 +143,7 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
         source_credential=source_cred_hashi_secret.name,
         target_credential=tgt_cred.name,
         input_field_name='password',
-        metadata={"secret_path": "/path/to/secret", "auth_path": "/path/to/auth", "secret_backend": "backend", "secret_key": "a_key"},
+        metadata={"secret_path": "/path/to/secret", "secret_backend": "backend", "secret_key": "a_key"},
         state='present'
     ), admin_user)
 
@@ -153,7 +154,6 @@ def test_hashi_secret_credential_source(run_module, admin_user, organization, so
     cis = CredentialInputSource.objects.first()
 
     assert cis.metadata['secret_path'] == "/path/to/secret"
-    assert cis.metadata['auth_path'] == "/path/to/auth"
     assert cis.metadata['secret_backend'] == "backend"
     assert cis.metadata['secret_key'] == "a_key"
     assert cis.source_credential.name == source_cred_hashi_secret.name
@@ -188,14 +188,14 @@ def test_hashi_ssh_credential_source(run_module, admin_user, organization, sourc
         name='Test Machine Credential',
         organization=organization,
         credential_type=ct,
-        inputs={'username': 'bob'}
+        inputs={'username': 'bob', "auth_path": "/path/to/auth"}
     )
 
     result = run_module('tower_credential_input_source', dict(
         source_credential=source_cred_hashi_ssh.name,
         target_credential=tgt_cred.name,
         input_field_name='password',
-        metadata={"secret_path": "/path/to/secret", "auth_path": "/path/to/auth", "role": "role", "public_key": "a_key", "valid_principals": "some_value"},
+        metadata={"secret_path": "/path/to/secret", "role": "role", "public_key": "a_key", "valid_principals": "some_value"},
         state='present'
     ), admin_user)
 
@@ -206,7 +206,6 @@ def test_hashi_ssh_credential_source(run_module, admin_user, organization, sourc
     cis = CredentialInputSource.objects.first()
 
     assert cis.metadata['secret_path'] == "/path/to/secret"
-    assert cis.metadata['auth_path'] == "/path/to/auth"
     assert cis.metadata['role'] == "role"
     assert cis.metadata['public_key'] == "a_key"
     assert cis.metadata['valid_principals'] == "some_value"


### PR DESCRIPTION
##### SUMMARY
The auth_path is used with the approle auth method

As specified here: https://github.com/ansible/awx-custom-credential-plugin-example/blob/master/awx_custom_credential_plugin_example/__init__.py
`inputs.fields represents fields the user will specify *when they create* a credential of this type`
`inputs.metadata represents values the user will specify *every time* they link two credentials together*`

It's not linked to the secret we are reading but to the auth method so this parameter has to be moved to inputs.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - credential_plugins/hashivault

##### AWX VERSION
awx: 14.0.0

##### ADDITIONAL INFORMATION
