### PR TITLE
Removes colon from survey list item

### DIFF
--- a/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
@@ -110,11 +110,11 @@ function SurveyListItem({
             </DataListCell>,
 
             <DataListCell key="type">
-              <Label>{i18n._(t`Type:`)}</Label>
+              <Label>{i18n._(t`Type`)}</Label>
               {question.type}
             </DataListCell>,
             <DataListCell key="default">
-              <Label>{i18n._(t`Default:`)}</Label>
+              <Label>{i18n._(t`Default`)}</Label>
               {[question.type].includes('password') && (
                 <span>{i18n._(t`encrypted`).toUpperCase()}</span>
               )}

--- a/awx/ui_next/src/screens/Template/Survey/SurveyListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyListItem.test.jsx
@@ -30,13 +30,13 @@ describe('<SurveyListItem />', () => {
         .find('b')
         .at(0)
         .text()
-    ).toBe('Type:');
+    ).toBe('Type');
     expect(
       wrapper
         .find('b')
         .at(1)
         .text()
-    ).toBe('Default:');
+    ).toBe('Default');
     expect(wrapper.find('DataListCheck').length).toBe(1);
     expect(wrapper.find('DataListCell').length).toBe(3);
   });


### PR DESCRIPTION
##### SUMMARY
Some list items have in line labels.  Per https://github.com/ansible/awx/pull/7967#issuecomment-680154244 they should not have colons.  This PR removes them from survey list item, the only place that I could see that had them.

##### ISSUE TYPE
-bughancement

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![Screen Shot 2020-08-25 at 1 35 40 PM](https://user-images.githubusercontent.com/39280967/91208259-ee625400-e6d7-11ea-9065-077551885e00.png)