### PR TITLE
allow skipping provision instance and register queue

### DIFF
--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -12,7 +12,13 @@ ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c loca
 
 if [ -z "$AWX_SKIP_MIGRATIONS" ]; then
     awx-manage migrate --noinput
+fi
+
+if [ -z "$AWX_SKIP_PROVISION_INSTANCE" ]; then
     awx-manage provision_instance --hostname=$(hostname)
+fi
+
+if [ -z "$AWX_SKIP_REGISTERQUEUE" ]; then
     awx-manage register_queue --queuename=tower --instance_percent=100
 fi
 


### PR DESCRIPTION
##### SUMMARY
Skipping migrations when the environment variable "AWX_SKIP_MIGRATIONS" is set, should not skip instance provisioning, and queue registration.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION
We perform the DB migration manually but we do want the instances to be registered. 
We also register queues manually. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
