### PR TITLE
add certificates to the list of CAs trusted (in case anchors is mounted)

### DIFF
--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -5,6 +5,8 @@ if [ `id -u` -ge 500 ]; then
     rm /tmp/passwd
 fi
 
+update-ca-trust
+
 source /etc/tower/conf.d/environment.sh
 
 ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all


### PR DESCRIPTION
##### SUMMARY
The local docker example also includes volume mount for `/etc/pki/ca-trust/source/anchors`. 
Certificates are not automatically added to the trusted list of CAs without running `update-ca-trust`.

Run this command later via `docker exec`.

Another alternative is to change the container mount point to the compiled bundle, located on the OS and in the container at: `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
