### PR TITLE
add current working directory when using `make docker-compose-build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ IMAGE_REPOSITORY_AUTH ?=
 IMAGE_REPOSITORY_BASE ?= https://gcr.io
 VERSION := $(shell cat VERSION)
 PYCURL_SSL_LIBRARY ?= openssl
+CWD := $(shell pwd)
 
 # NOTE: This defaults the container image version to the branch that's active
 COMPOSE_TAG ?= $(GIT_BRANCH)
@@ -676,7 +677,7 @@ docker-compose-clean: awx/projects
 
 # Base development image build
 docker-compose-build:
-	ansible localhost -m template -a "src=installer/roles/image_build/templates/Dockerfile.j2 dest=tools/docker-compose/Dockerfile" -e build_dev=True
+	ansible localhost -m template -a "src=$(CWD)/installer/roles/image_build/templates/Dockerfile.j2 dest=$(CWD)/tools/docker-compose/Dockerfile" -e build_dev=True
 	docker build -t ansible/awx_devel -f tools/docker-compose/Dockerfile \
 		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) .
 	docker tag ansible/awx_devel $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)


### PR DESCRIPTION
##### SUMMARY
During the `make docker-compose-build` command, the makefile use the command
`ansible localhost -m template -a "src=$(CWD)/installer/roles/image_build/templates/Dockerfile.j2 dest=$(CWD)/tools/docker-compose/Dockerfile" -e build_dev=True`
It's using the current user `$HOME` as base directory for path when executing the `shell` module : specified path will not work (except if the clone directory is your `$HOME`)

The CWD variable has been added to the makefile to handle all location correctly 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - makefile

##### AWX VERSION
awx: 14.1.0

##### ADDITIONAL INFORMATION

#### Previous error
```
$> make docker-compose-build
ansible localhost -m template -a "src=installer/roles/image_build/templates/Dockerfile.j2 dest=tools/docker-compose/Dockerfile" -e build_dev=True
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "checksum": "e68a2c284d9abdca8a25de9b2aa8a13cf8aad5f0",
    "msg": "Destination directory tools/docker-compose does not exist"
}
make: *** [docker-compose-build] Error 2
```