### PR TITLE
defer loading Job.artifacts and .extra_vars on host views to improve performance

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1702,7 +1702,10 @@ class HostSerializer(BaseSerializerWithVariables):
             'type': j.job.job_type_name,
             'status': j.job.status,
             'finished': j.job.finished,
-        } for j in obj.job_host_summaries.select_related('job__job_template').order_by('-created')[:5]])
+        } for j in obj.job_host_summaries.select_related('job__job_template').order_by('-created').defer(
+            'job__extra_vars',
+            'job__artifacts',
+        )[:5]])
         return d
 
     def _get_host_port_from_name(self, name):

--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -48,7 +48,13 @@ class HostManager(models.Manager):
         """When the parent instance of the host query set has a `kind=smart` and a `host_filter`
         set. Use the `host_filter` to generate the queryset for the hosts.
         """
-        qs = super(HostManager, self).get_queryset()
+        qs = super(HostManager, self).get_queryset().defer(
+            'last_job__extra_vars',
+            'last_job_host_summary__job__extra_vars',
+            'last_job__artifacts',
+            'last_job_host_summary__job__artifacts',
+        )
+
         if (hasattr(self, 'instance') and
            hasattr(self.instance, 'host_filter') and
            hasattr(self.instance, 'kind')):


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/8006

this data can be *really* large, and we don't actually need it for the summary fields on this API endpoint