### PR TITLE
Adds visualizer button to workflow template rows on templates list

### DIFF
--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.jsx
@@ -15,6 +15,7 @@ import { withI18n } from '@lingui/react';
 import {
   ExclamationTriangleIcon,
   PencilAltIcon,
+  ProjectDiagramIcon,
   RocketIcon,
 } from '@patternfly/react-icons';
 import styled from 'styled-components';
@@ -32,7 +33,7 @@ const DataListAction = styled(_DataListAction)`
   align-items: center;
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(3, 40px);
+  grid-template-columns: repeat(4, 40px);
 `;
 
 function TemplateListItem({
@@ -104,6 +105,20 @@ function TemplateListItem({
           ]}
         />
         <DataListAction aria-label="actions" aria-labelledby={labelId}>
+          {template.type === 'workflow_job_template' && (
+            <Tooltip content={i18n._(t`Visualizer`)} position="top">
+              <Button
+                isDisabled={isDisabled}
+                aria-label={i18n._(t`Visualizer`)}
+                css="grid-column: 1"
+                variant="plain"
+                component={Link}
+                to={`/templates/workflow_job_template/${template.id}/visualizer`}
+              >
+                <ProjectDiagramIcon />
+              </Button>
+            </Tooltip>
+          )}
           {template.summary_fields.user_capabilities.start && (
             <Tooltip content={i18n._(t`Launch Template`)} position="top">
               <LaunchButton resource={template}>
@@ -111,7 +126,7 @@ function TemplateListItem({
                   <Button
                     isDisabled={isDisabled}
                     aria-label={i18n._(t`Launch template`)}
-                    css="grid-column: 1"
+                    css="grid-column: 2"
                     variant="plain"
                     onClick={handleLaunch}
                   >
@@ -126,7 +141,7 @@ function TemplateListItem({
               <Button
                 isDisabled={isDisabled}
                 aria-label={i18n._(t`Edit Template`)}
-                css="grid-column: 2"
+                css="grid-column: 3"
                 variant="plain"
                 component={Link}
                 to={`/templates/${template.type}/${template.id}/edit`}

--- a/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateList/TemplateListItem.test.jsx
@@ -239,4 +239,29 @@ describe('<TemplateListItem />', () => {
     );
     expect(wrapper.find('CopyButton').length).toBe(0);
   });
+
+  test('should render visualizer button for workflow', async () => {
+    const wrapper = mountWithContexts(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={{
+          ...mockJobTemplateData,
+          type: 'workflow_job_template',
+        }}
+      />
+    );
+    expect(wrapper.find('ProjectDiagramIcon').length).toBe(1);
+  });
+
+  test('should not render visualizer button for job template', async () => {
+    const wrapper = mountWithContexts(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={mockJobTemplateData}
+      />
+    );
+    expect(wrapper.find('ProjectDiagramIcon').length).toBe(0);
+  });
 });


### PR DESCRIPTION
##### SUMMARY
link #7663 

<img width="1454" alt="Screen Shot 2020-08-26 at 5 04 09 PM" src="https://user-images.githubusercontent.com/9889020/91356835-45425900-e7be-11ea-940d-082ff348dbf8.png">

I don't think we need to worry about rbac on this button.  If the user can see the row, they should be able to see the graph.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
