### PR TITLE
Adding check that we are authenticated and also have a token

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -551,7 +551,7 @@ class TowerAPIModule(TowerModule):
             return self.create_if_needed(existing_item, new_item, endpoint, on_create=on_create, item_type=item_type, associations=associations)
 
     def logout(self):
-        if self.authenticated:
+        if self.authenticated and self.oauth_token_id:
             # Attempt to delete our current token from /api/v2/tokens/
             # Post to the tokens endpoint with baisc auth to try and get a token
             api_token_url = (


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In tower_instance_group we found an issue where we were trying to delete a None toke:
```
2020-08-28 14:53:59,311 INFO     awx.main.tests DELETE /api/v2/tokens/None/ by admin, code:404
```

This can happen if the modules did not get a (username and password) or token. It will set the authenticated flag so that we don't try to authenticate a second time but the token_id will never be set. Later, when logout is called it was only checking the authenticated flag and would pass None as the token_id. This change requires the token_id to be set in addition to the authentication flag before making a call to delete it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
