### PR TITLE
Adding transaction to mock requests

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -17,6 +17,8 @@ import pytest
 from awx.main.tests.functional.conftest import _request
 from awx.main.models import Organization, Project, Inventory, JobTemplate, Credential, CredentialType
 
+from django.db import transaction
+
 try:
     import tower_cli  # noqa
     HAS_TOWER_CLI = True
@@ -107,8 +109,9 @@ def run_module(request, collection_import):
                         kwargs_copy['data'][k] = v
 
             # make request
-            rf = _request(method.lower())
-            django_response = rf(url, user=request_user, expect=None, **kwargs_copy)
+            with transaction.atomic():
+                rf = _request(method.lower())
+                django_response = rf(url, user=request_user, expect=None, **kwargs_copy)
 
             # requests library response object is different from the Django response, but they are the same concept
             # this converts the Django response object into a requests response object for consumption


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Provided by @AlanCoding 

When a module fails during a unit test you can end up with stacks like:
```
Traceback (most recent call last):
  File "/Users/jowestco/GIT/github/john-westcott-iv/awx/awx_collection/test/awx/test_instance_group.py", line 21, in test_instance_group_create
    ig = InstanceGroup.objects.get(name='foo-group')
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/query.py", line 402, in get
    num = len(clone)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/query.py", line 256, in __len__
    self._fetch_all()
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1140, in execute_sql
    cursor.execute(sql, params)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/backends/utils.py", line 79, in _execute
    self.db.validate_no_broken_transaction()
  File "/Users/jowestco/virtualenvs/awx/lib/python3.7/site-packages/django/db/backends/base/base.py", line 438, in validate_no_broken_transaction
    "An error occurred in the current transaction. You can't "
django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
```

This is because the module may leave a transaction opened in the database so subsequent requests can not complete. This fix modifies the mocked request to be wrapped up in an automatic transaction so that, even on failure, the database transaction will be closed.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 14.1.0
```
