### PR TITLE
Update from pip to pip3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ For Linux platforms, refer to the following from Docker:
 If you're not using Docker for Mac, or Docker for Windows, you may need, or choose to, install the Docker compose Python module separately, in which case you'll need to run the following:
 
 ```bash
-(host)$ pip install docker-compose
+(host)$ pip3 install docker-compose
 ```
 
 #### Frontend Development


### PR DESCRIPTION
##### SUMMARY
The contribution guide recommends Python 3 but the command for pip in the docs is pip (typically python 2). Made this change to reflect the Python 3 recommendation.

##### ISSUE TYPE
 - Docs Pull Request