### PR TITLE
Prevent task manager timeout by limiting number of jobs to start

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -203,6 +203,9 @@ JOB_EVENT_MAX_QUEUE_SIZE = 10000
 # The number of job events to migrate per-transaction when moving from int -> bigint
 JOB_EVENT_MIGRATION_CHUNK_SIZE = 1000000
 
+# The maximum allowed jobs to start on a given task manager cycle
+START_TASK_LIMIT = 100
+
 # Disallow sending session cookies over insecure connections
 SESSION_COOKIE_SECURE = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related #7655 

There are two expensive code loops in the task manager:
- Finding the preferred instance to run a job on (in `process_pending_tasks()`)
- Starting a task (db saves take a while)

If you queue up 500+ jobs (concurrent enabled), have a lot of instances and organizations, it's very possible that the task manager will time out (it reaps after running for 5 minutes). After a time out, it loses progress and the next cycle will start again from scratch. This creates a scenario where no jobs can be started.

The change here limits the number of jobs that the task manager can start to 150. Once this limit is reached, it can no longer turn pending jobs into running jobs. If the limit is reached, it will immediately schedule another task manager to run once the current one finishes, that way another set of 100 jobs can be started.

There is still a potential scenario where the task manager will time out. If we are under the limit (150), but we are at max capacity across available instances, we can still hit that heavy `find preferred instance` loop and might hit a timeout. Maybe this isn't so bad given we won't be able to start jobs anyways. Even if this happens we still will get jobs starting eventually.

To explain the above, say you have jobA and jobB. jobA can only run on instanceA, and jobB can only run on instanceB.

- Queue up 5k of jobA, followed by 5k of jobB. 

- Say instanceA is at max capacity, while instanceB has plenty of capacity left.

- The next task manager run will loop through jobA first, then jobB (order of job creation).

- The task manager spends all of its time in `find preferred instance` for jobA and eventually times out. It didn't even get to jobB, which technically could be started because instanceB has capacity left and we are not at the `start_task_limit`.

I think the above scenario is unlikely for most situations, and even in that case we don't hit a deadlock and jobs will eventually complete, albeit much slower than it should.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```
