### PR TITLE
Add new option update_secrets to allow lazy or strict updating

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -22,7 +22,6 @@ class TowerAPIModule(TowerModule):
         'tower': 'Red Hat Ansible Tower',
     }
     session = None
-    cookie_jar = CookieJar()
     IDENTITY_FIELDS = {
         'users': 'username',
         'workflow_job_template_nodes': 'identifier',

--- a/awx_collection/plugins/module_utils/tower_module.py
+++ b/awx_collection/plugins/module_utils/tower_module.py
@@ -52,7 +52,6 @@ class TowerModule(AnsibleModule):
     oauth_token_id = None
     authenticated = False
     config_name = 'tower_cli.cfg'
-    ENCRYPTED_STRING = "$encrypted$"
     version_checked = False
     error_callback = None
     warn_callback = None

--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -52,6 +52,12 @@ options:
           Refer to the Ansible Tower documentation for example syntax.
         - Any fields in this dict will take prescedence over any fields mentioned below (i.e. host, username, etc)
       type: dict
+    update_secrets:
+      description:
+        - C(true) will always update encrypted values.
+        - C(false) will only updated encrypted values if a change is absolutely known to be needed.
+      type: bool
+      default: true
     user:
       description:
         - User that should own this credential.
@@ -308,6 +314,7 @@ def main():
         organization=dict(),
         credential_type=dict(),
         inputs=dict(type='dict', no_log=True),
+        update_secrets=dict(type='bool', default=True, no_log=False),
         user=dict(),
         team=dict(),
         # These are for backwards compatability

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -55,13 +55,12 @@ options:
       description:
         - Write-only field used to change the password.
       type: str
-    update_password:
+    update_secrets:
       description:
-        - C(always) will update passwords if they differ.
-        - C(on_create) will only set the password for newly created users.
-      type: str
-      choices: [ always, on_create ]
-      default: always
+        - C(true) will always password if user specifies password and API gives $encrypted$ for password.
+        - C(false) will only set the password if other values change too.
+      type: bool
+      default: true
     state:
       description:
         - Desired state of the resource.
@@ -122,7 +121,7 @@ def main():
         is_superuser=dict(type='bool', default=False, aliases=['superuser']),
         is_system_auditor=dict(type='bool', default=False, aliases=['auditor']),
         password=dict(no_log=True),
-        update_password=dict(choices=['always', 'on_create'], default='always', no_log=False),
+        update_secrets=dict(type='bool', default=True, no_log=False),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -137,7 +136,6 @@ def main():
     is_superuser = module.params.get('is_superuser')
     is_system_auditor = module.params.get('is_system_auditor')
     password = module.params.get('password')
-    update_password = module.params.get('update_password')
     state = module.params.get('state')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
@@ -163,7 +161,7 @@ def main():
         new_fields['is_superuser'] = is_superuser
     if is_system_auditor:
         new_fields['is_system_auditor'] = is_system_auditor
-    if password and (not existing_item or update_password == 'always'):
+    if password:
         new_fields['password'] = password
 
     # If the state was present and we can let the module build or update the existing item, this will return on its own

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -55,6 +55,13 @@ options:
       description:
         - Write-only field used to change the password.
       type: str
+    update_password:
+      description:
+        - C(always) will update passwords if they differ.
+        - C(on_create) will only set the password for newly created users.
+      type: str
+      choices: [ always, on_create ]
+      default: always
     state:
       description:
         - Desired state of the resource.
@@ -115,6 +122,7 @@ def main():
         is_superuser=dict(type='bool', default=False, aliases=['superuser']),
         is_system_auditor=dict(type='bool', default=False, aliases=['auditor']),
         password=dict(no_log=True),
+        update_password=dict(choices=['always', 'on_create'], default='always', no_log=False),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -129,6 +137,7 @@ def main():
     is_superuser = module.params.get('is_superuser')
     is_system_auditor = module.params.get('is_system_auditor')
     password = module.params.get('password')
+    update_password = module.params.get('update_password')
     state = module.params.get('state')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
@@ -154,7 +163,7 @@ def main():
         new_fields['is_superuser'] = is_superuser
     if is_system_auditor:
         new_fields['is_system_auditor'] = is_system_auditor
-    if password:
+    if password and (not existing_item or update_password == 'always'):
         new_fields['password'] = password
 
     # If the state was present and we can let the module build or update the existing item, this will return on its own

--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -57,7 +57,7 @@ options:
       type: str
     update_secrets:
       description:
-        - C(true) will always password if user specifies password and API gives $encrypted$ for password.
+        - C(true) will always change password if user specifies password, even if API gives $encrypted$ for password.
         - C(false) will only set the password if other values change too.
       type: bool
       default: true

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -30,7 +30,7 @@ no_endpoint_for_module = [
 
 # Global module parameters we can ignore
 ignore_parameters = [
-    'state', 'new_name',
+    'state', 'new_name', 'update_secrets'
 ]
 
 # Some modules take additional parameters that do not appear in the API

--- a/awx_collection/test/awx/test_credential.py
+++ b/awx_collection/test/awx/test_credential.py
@@ -154,7 +154,8 @@ def test_make_use_of_custom_credential_type(run_module, organization, admin_user
 
 
 @pytest.mark.django_db
-def test_secret_field_write_twice(run_module, organization, admin_user, cred_type):
+@pytest.mark.parametrize('update_secrets', [True, False])
+def test_secret_field_write_twice(run_module, organization, admin_user, cred_type, update_secrets):
     val1 = '7rEZK38DJl58A7RxA6EC7lLvUHbBQ1'
     result = run_module('tower_credential', dict(
         name='Galaxy Token for Steve',
@@ -172,9 +173,14 @@ def test_secret_field_write_twice(run_module, organization, admin_user, cred_typ
         name='Galaxy Token for Steve',
         organization=organization.name,
         credential_type=cred_type.name,
-        inputs={'token': val2}
+        inputs={'token': val2},
+        update_secrets=update_secrets
     ), admin_user)
     assert not result.get('failed', False), result.get('msg', result)
 
     Credential.objects.get(id=result['id']).inputs['token'] == val2
-    assert result.get('changed'), result
+    print(result)
+    if update_secrets:
+        assert result.get('changed'), result
+    else:
+        assert result.get('changed') is False, result

--- a/awx_collection/test/awx/test_credential.py
+++ b/awx_collection/test/awx/test_credential.py
@@ -157,30 +157,22 @@ def test_make_use_of_custom_credential_type(run_module, organization, admin_user
 @pytest.mark.parametrize('update_secrets', [True, False])
 def test_secret_field_write_twice(run_module, organization, admin_user, cred_type, update_secrets):
     val1 = '7rEZK38DJl58A7RxA6EC7lLvUHbBQ1'
-    result = run_module('tower_credential', dict(
-        name='Galaxy Token for Steve',
-        organization=organization.name,
-        credential_type=cred_type.name,
-        inputs={'token': val1}
-    ), admin_user)
-    assert not result.get('failed', False), result.get('msg', result)
-
-    Credential.objects.get(id=result['id']).inputs['token'] == val1
-
     val2 = '7rEZ238DJl5837rxA6xxxlLvUHbBQ1'
+    for val in (val1, val2):
+        result = run_module('tower_credential', dict(
+            name='Galaxy Token for Steve',
+            organization=organization.name,
+            credential_type=cred_type.name,
+            inputs={'token': val},
+            update_secrets=update_secrets
+        ), admin_user)
+        assert not result.get('failed', False), result.get('msg', result)
 
-    result = run_module('tower_credential', dict(
-        name='Galaxy Token for Steve',
-        organization=organization.name,
-        credential_type=cred_type.name,
-        inputs={'token': val2},
-        update_secrets=update_secrets
-    ), admin_user)
-    assert not result.get('failed', False), result.get('msg', result)
+        if update_secrets:
+            assert Credential.objects.get(id=result['id']).get_input('token') == val
 
-    Credential.objects.get(id=result['id']).inputs['token'] == val2
-    print(result)
     if update_secrets:
         assert result.get('changed'), result
     else:
         assert result.get('changed') is False, result
+        assert Credential.objects.get(id=result['id']).get_input('token') == val1

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -44,3 +44,16 @@ def test_password_no_op_warning(run_module, admin_user, mock_auth_stuff, silence
     silence_warning.assert_called_once_with(
         "The field password of user {0} has encrypted data and "
         "may inaccurately report task is changed.".format(result['id']))
+
+
+@pytest.mark.django_db
+def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
+    for i in range(2):
+        result = run_module('tower_user', dict(
+            username='Bob',
+            password='pass4word',
+            update_password='on_create'
+        ), admin_user)
+        assert not result.get('failed', False), result.get('msg', result)
+
+    assert not result.get('changed')

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -52,7 +52,7 @@ def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
         result = run_module('tower_user', dict(
             username='Bob',
             password='pass4word',
-            update_password='on_create'
+            update_secrets=False
         ), admin_user)
         assert not result.get('failed', False), result.get('msg', result)
 


### PR DESCRIPTION
This is my attempt to modify the solution for `tower_user` updating passwords, so that it can be rolled out generally to other modules, and so that it follows a universal API principal.