### PR TITLE
Update Django and channels_redis

### DIFF
--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -1,5 +1,3 @@
-import collections
-import functools
 import json
 import logging
 import time
@@ -14,38 +12,10 @@ from django.contrib.auth.models import User
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from channels.layers import get_channel_layer
 from channels.db import database_sync_to_async
-from channels_redis.core import RedisChannelLayer
 
 
 logger = logging.getLogger('awx.main.consumers')
 XRF_KEY = '_auth_user_xrf'
-
-
-class BoundedQueue(asyncio.Queue):
-
-    def put_nowait(self, item):
-        if self.full():
-            # dispose the oldest item
-            # if we actually get into this code block, it likely means that
-            # this specific consumer has stopped reading
-            # unfortunately, channels_redis will just happily continue to
-            # queue messages specific to their channel until the heat death
-            # of the sun: https://github.com/django/channels_redis/issues/212
-            # this isn't a huge deal for browser clients that disconnect,
-            # but it *does* cause a problem for our global broadcast topic
-            # that's used to broadcast messages to peers in a cluster
-            # if we get into this code block, it's better to drop messages
-            # than to continue to malloc() forever
-            self.get_nowait()
-        return super(BoundedQueue, self).put_nowait(item)
-
-
-class ExpiringRedisChannelLayer(RedisChannelLayer):
-    def __init__(self, *args, **kw):
-        super(ExpiringRedisChannelLayer, self).__init__(*args, **kw)
-        self.receive_buffer = collections.defaultdict(
-            functools.partial(BoundedQueue, self.capacity)
-        )
 
 
 class WebsocketSecretAuthHelper:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -790,7 +790,7 @@ ASGI_APPLICATION = "awx.main.routing.application"
 
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "awx.main.consumers.ExpiringRedisChannelLayer",
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [BROKER_URL],
             "capacity": 10000,

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,9 +4,9 @@ ansiconv==1.0.0  # UPGRADE BLOCKER: from 2013, consider replacing instead of upg
 azure-keyvault==1.1.0  # see UPGRADE BLOCKERs
 boto  # replacement candidate https://github.com/ansible/awx/issues/2115
 channels
-channels-redis
+channels-redis>=3.1.0  # https://github.com/django/channels_redis/issues/212
 daphne
-django==2.2.11  # see UPGRADE BLOCKERs
+django==2.2.16  # see UPGRADE BLOCKERs
 django-auth-ldap
 django-cors-headers
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,7 +15,7 @@ boto==2.49.0              # via -r /awx_devel/requirements/requirements.in
 cachetools==4.0.0         # via google-auth
 certifi==2019.11.28       # via kubernetes, msrest, requests
 cffi==1.14.0              # via cryptography
-channels-redis==2.4.2     # via -r /awx_devel/requirements/requirements.in
+channels-redis==3.1.0     # via -r /awx_devel/requirements/requirements.in
 channels==2.4.0           # via -r /awx_devel/requirements/requirements.in, channels-redis
 chardet==3.0.4            # via aiohttp, requests
 constantly==15.1.0        # via twisted
@@ -37,7 +37,7 @@ django-redis==4.5.0       # via -r /awx_devel/requirements/requirements.in
 django-solo==1.1.3        # via -r /awx_devel/requirements/requirements.in
 django-split-settings==1.0.0  # via -r /awx_devel/requirements/requirements.in
 django-taggit==1.2.0      # via -r /awx_devel/requirements/requirements.in
-django==2.2.11            # via -r /awx_devel/requirements/requirements.in, channels, django-auth-ldap, django-cors-headers, django-crum, django-jsonfield, django-oauth-toolkit, django-polymorphic, django-taggit, djangorestframework
+django==2.2.16            # via -r /awx_devel/requirements/requirements.in, channels, django-auth-ldap, django-cors-headers, django-crum, django-jsonfield, django-oauth-toolkit, django-polymorphic, django-taggit, djangorestframework
 djangorestframework-yaml==1.0.3  # via -r /awx_devel/requirements/requirements.in
 djangorestframework==3.11.0  # via -r /awx_devel/requirements/requirements.in
 docutils==0.16            # via python-daemon
@@ -68,7 +68,7 @@ lxml==4.5.0               # via xmlsec
 markdown==3.2.1           # via -r /awx_devel/requirements/requirements.in
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.2.0     # via irc, jaraco.classes, jaraco.functools
-msgpack==0.6.2            # via channels-redis
+msgpack==1.0.0            # via channels-redis
 msrest==0.6.11            # via azure-keyvault, msrestazure
 msrestazure==0.6.3        # via azure-keyvault
 multidict==4.7.5          # via aiohttp, yarl


### PR DESCRIPTION
see: https://www.djangoproject.com/weblog/2020/sep/01/security-releases/

This isn't _that_ critical given that we run Python 3.6 (not 3.7+).

but also related: https://github.com/django/channels_redis/issues/212