### PR TITLE
Hack to delete orphaned organizations, consolidate get_one methods

### DIFF
--- a/awx_collection/plugins/modules/tower_role.py
+++ b/awx_collection/plugins/modules/tower_role.py
@@ -129,12 +129,7 @@ def main():
 
         resource_name = params.get(param)
         if resource_name:
-            resource = module.get_one_by_name_or_id(module.param_to_endpoint(param), resource_name)
-            if not resource:
-                module.fail_json(
-                    msg='Failed to update role, {0} not found in {1}'.format(param, endpoint),
-                    changed=False
-                )
+            resource = module.get_exactly_one(module.param_to_endpoint(param), resource_name)
             resource_data[param] = resource
 
     # separate actors from resources

--- a/awx_collection/test/awx/test_credential.py
+++ b/awx_collection/test/awx/test_credential.py
@@ -127,7 +127,9 @@ def test_missing_credential_type(run_module, admin_user, organization):
         state='present'
     ), admin_user)
     assert result.get('failed', False), result
-    assert 'foobar was not found on the Tower server' in result['msg']
+    assert 'credential_type' in result['msg']
+    assert 'foobar' in result['msg']
+    assert 'returned 0 items, expected 1' in result['msg']
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import json
 import sys
 
-from awx.main.models import Organization, Team
+from awx.main.models import Organization, Team, Project, Inventory
 from requests.models import Response
 from unittest import mock
 
@@ -125,3 +125,19 @@ def test_conflicting_name_and_id(run_module, admin_user):
         'Lookup by id should be preferenced over name in cases of conflict.'
     )
     assert team.organization.name == 'foo'
+
+def test_multiple_lookup(run_module, admin_user):
+    org1 = Organization.objects.create(name='foo')
+    org2 = Organization.objects.create(name='bar')
+    inv = Inventory.objects.create(name='Foo Inv')
+    proj1 = Project.objects.create(name='foo', organization=org1, scm_type='git', scm_url="https://github.com/ansible/ansible-tower-samples",)
+    proj2 = Project.objects.create(name='foo', organization=org2, scm_type='git', scm_url="https://github.com/ansible/ansible-tower-samples",)
+    result = run_module('tower_job_template', {
+        'name': 'Demo Job Template', 'project': proj1.name, 'inventory': inv.id, 'playbook': 'hello_world.yml'
+    }, admin_user)
+    assert result.get('failed', False)
+    assert 'projects' in result['msg']
+    assert 'foo' in result['msg']
+    assert 'returned 2 items, expected 1' in result['msg']
+    assert 'query' in result
+

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -126,6 +126,7 @@ def test_conflicting_name_and_id(run_module, admin_user):
     )
     assert team.organization.name == 'foo'
 
+
 def test_multiple_lookup(run_module, admin_user):
     org1 = Organization.objects.create(name='foo')
     org2 = Organization.objects.create(name='bar')
@@ -140,4 +141,3 @@ def test_multiple_lookup(run_module, admin_user):
     assert 'foo' in result['msg']
     assert 'returned 2 items, expected 1' in result['msg']
     assert 'query' in result
-

--- a/awx_collection/tests/integration/targets/demo_data/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/demo_data/tasks/main.yml
@@ -3,6 +3,18 @@
   tower_organization:
     name: Default
 
+- name: HACK - delete orphaned projects from preload data where organization deletd
+  tower_project:
+    name: "{{ item['id'] }}"
+    scm_type: git
+    state: absent
+  loop: >
+    {{ query('awx.awx.tower_api', 'projects',
+       query_params={'organization__isnull': true, 'name': 'Demo Project'})
+    }}
+  loop_control:
+    label: "Deleting Demo Project with null organization id={{ item['id'] }}"
+
 - name: Assure that demo project exists
   tower_project:
     name: "Demo Project"

--- a/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_credential/tasks/main.yml
@@ -288,7 +288,7 @@
 - name: Create an invalid SSH credential (Organization not found)
   tower_credential:
     name: SSH Credential
-    organization: Missing Organization
+    organization: Missing_Organization
     state: present
     kind: ssh
     username: joe
@@ -298,7 +298,9 @@
 - assert:
     that:
       - "result is failed"
-      - "'The organizations Missing Organization was not found on the Tower server' in result.msg"
+      - "result is not changed"
+      - "'Missing_Organization' in result.msg"
+      - "result.total_results == 0"
 
 - name: Delete an SSH credential
   tower_credential:
@@ -750,5 +752,7 @@
 
 - assert:
     that:
-      - result is failed
-      - "result.msg =='The organizations test-non-existing-org was not found on the Tower server'"
+      - "result is failed"
+      - "result is not changed"
+      - "'test-non-existing-org' in result.msg"
+      - "result.total_results == 0"

--- a/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_group/tasks/main.yml
@@ -51,8 +51,10 @@
 
 - assert:
     that:
-      - "result.msg =='Failed to update the group, inventory not found: The requested object could not be found.' or
-        result.msg =='The inventories test-non-existing-inventory was not found on the Tower server'"
+      - "result is failed"
+      - "result is not changed"
+      - "'test-non-existing-inventory' in result.msg"
+      - "result.total_results == 0"
 
 - name: add hosts
   tower_host:

--- a/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_host/tasks/main.yml
@@ -46,5 +46,6 @@
 
 - assert:
     that:
-      - "result.msg =='The inventories test-non-existing-inventory was not found on the Tower server' or
-        result.msg =='Failed to update host, inventory not found: The requested object could not be found.'"
+      - "result is failed"
+      - "'test-non-existing-inventory' in result.msg"
+      - "result.total_results == 0"

--- a/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory/tasks/main.yml
@@ -119,9 +119,11 @@
 
     - assert:
         that:
+          - "result is failed"
           - "result is not changed"
-          - "result.msg =='Failed to update inventory, organization not found: The requested object could not be found.'
-            or result.msg =='The organizations test-non-existing-org was not found on the Tower server'"
+          - "'test-non-existing-org' in result.msg"
+          - "result.total_results == 0"
+
   always:
     - name: Delete Inventories
       tower_inventory:

--- a/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
@@ -29,16 +29,16 @@
 
 - name: Check module fails with correct msg
   tower_job_launch:
-    job_template: "Non Existing Job Template"
-    inventory: "Test Inventory"
-    credential: "Test Credential"
+    job_template: "Non_Existing_Job_Template"
+    inventory: "Demo Inventory"
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg =='Unable to launch job, job_template/Non Existing Job Template was not found: The requested object could not be found.'
-        or result.msg == 'The inventories Test Inventory was not found on the Tower server'"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_Existing_Job_Template' in result.msg"
 
 - name: Create a Job Template for testing prompt on launch
   tower_job_template:

--- a/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_label/tasks/main.yml
@@ -12,13 +12,16 @@
 - name: Check module fails with correct msg
   tower_label:
     name: "Test Label"
-    organization: "Non existing org"
+    organization: "Non_existing_org"
     state: present
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "'Non existing org was not found on the Tower server' in result.msg"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_existing_org' in result.msg"
+      - "result.total_results == 0"
 
 # TODO: Deleting labels doesn't seem to work currently

--- a/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_project/tasks/main.yml
@@ -93,7 +93,7 @@
 - name: Check module fails with correct msg when given non-existing org as param
   tower_project:
     name: "{{ project_name2 }}"
-    organization: Non Existing Org
+    organization: Non_Existing_Org
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
     scm_credential: "{{ cred_name }}"
@@ -102,8 +102,10 @@
 
 - assert:
     that:
-      - "result.msg == 'The organizations Non Existing Org was not found on the Tower server' or
-        result.msg == 'Failed to update project, organization not found: Non Existing Org'"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_Existing_Org' in result.msg"
+      - "result.total_results == 0"
 
 - name: Check module fails with correct msg when given non-existing credential as param
   tower_project:
@@ -111,14 +113,16 @@
     organization: "{{ org_name }}"
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: Non Existing Credential
+    scm_credential: Non_Existing_Credential
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg =='The credentials Non Existing Credential was not found on the Tower server' or
-        result.msg =='Failed to update project, credential not found: Non Existing Credential'"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_Existing_Credential' in result.msg"
+      - "result.total_results == 0"
 
 - name: Create a git project without credentials without waiting
   tower_project:

--- a/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_team/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Attempt to add a Tower team to a non-existant Organization
   tower_team:
     name: Test Team
-    organization: Missing Organization
+    organization: Missing_Organization
     state: present
   register: result
   ignore_errors: true
@@ -14,9 +14,10 @@
 - name: Assert a meaningful error was provided for the failed Tower team creation
   assert:
     that:
-      - result is failed
-      - "result.msg =='Failed to update team, organization not found: The requested object could not be found.' or
-        result.msg =='The organizations Missing Organization was not found on the Tower server'"
+      - "result is failed"
+      - "result is not changed"
+      - "'Missing_Organization' in result.msg"
+      - "result.total_results == 0"
 
 - name: Create a Tower team
   tower_team:
@@ -42,12 +43,15 @@
 - name: Check module fails with correct msg
   tower_team:
     name: "{{ team_name }}"
-    organization: Non Existing Org
+    organization: Non_Existing_Org
     state: present
   register: result
   ignore_errors: true
 
-- assert:
+- name: Lookup of the related organization should cause a failure
+  assert:
     that:
-      - "result.msg =='Failed to update team, organization not found: The requested object could not be found.' or
-        result.msg =='The organizations Non Existing Org was not found on the Tower server'"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_Existing_Org' in result.msg"
+      - "result.total_results == 0"

--- a/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
@@ -207,13 +207,16 @@
 - name: Check module fails with correct msg
   tower_workflow_job_template:
     name: "{{ wfjt_name }}"
-    organization: Non Existing Organization
+    organization: Non_Existing_Organization
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "'The organizations Non Existing Organization was not found' in result.msg"
+      - "result is failed"
+      - "result is not changed"
+      - "'Non_Existing_Organization' in result.msg"
+      - "result.total_results == 0"
 
 - name: Delete the Job Template
   tower_job_template:


### PR DESCRIPTION
##### SUMMARY
This addresses some test fails we get when running the `demo_data` target.

This happens because of the series of events:

 - the `awx-manage create_preload_data` command was ran
 - the "Default" organization gets deleted, for some reason or another
 - the collection integration tests are ran, running demo_data first

When trying to create the job template, it fails because the "Demo Project" has 2 items that match the query.

This is because before getting to the JT creation, it creates the "Demo Project" in the "Default" organization. But 1 "Demo Project" already exists with a null organization.

This is pretty ugly, I don't like it, I don't think anyone should like it. But right now, for stability, we should have at least _some_ means of cleaning up orphaned objects so that playbooks written using the `awx.awx` collection can self-correct, and if this becomes a formula for that, it's not the worst thing that could happen.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
14.1.0
```


##### ADDITIONAL INFORMATION
I kind of have a draft for an improved solution, I started down this path but haven't been spending as much time directly writing stuff in the collection lately:

 - Instead of combining `name_or_id` with the query parameters, _first_ search exclusively with `{"name": "<name>"}`
 - _Then_, if that comes back with 0 results, try request with `{"id": <id>}` if the id is integer like
 - If the id is not integer-like, or both prior requests came back with >1, then 0 results, then combine name with lookup data

This would make 1 request into potentially 3 requests, but I don't think it would do this _very often_ because in 99% of cases the first request will find the object. Even if that's 90% instead... it's not a performance hit big enough to care about.

Anyway, I do not do that here, because I expect it to be more controversial.