### PR TITLE
Adding unzip dnf package

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -137,6 +137,7 @@ RUN dnf -y update && \
     sudo \
     vim-minimal \
     which \
+    unzip \
     xmlsec1-openssl && \
     dnf -y install centos-release-stream && dnf -y install "rsyslog >= 8.1911.0" && dnf -y remove centos-release-stream && \
     dnf -y clean all


### PR DESCRIPTION
##### SUMMARY
You can't extract zip files with the unarchive module locally (using the local_action), since the unzip command is not installed on the runtime image

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX: 14.1.0
```


##### ADDITIONAL INFORMATION

```

```
