### PR TITLE
Fix malformed urls

### DIFF
--- a/awx/ui_next/src/api/models/JobTemplates.js
+++ b/awx/ui_next/src/api/models/JobTemplates.js
@@ -25,7 +25,7 @@ class JobTemplates extends SchedulesMixin(
   }
 
   readTemplateOptions(id) {
-    return this.http.options(`${this.baseUrl}/${id}/`);
+    return this.http.options(`${this.baseUrl}${id}/`);
   }
 
   readLaunch(id) {

--- a/awx/ui_next/src/api/models/Roles.js
+++ b/awx/ui_next/src/api/models/Roles.js
@@ -7,14 +7,14 @@ class Roles extends Base {
   }
 
   disassociateUserRole(roleId, userId) {
-    return this.http.post(`${this.baseUrl}/${roleId}/users/`, {
+    return this.http.post(`${this.baseUrl}${roleId}/users/`, {
       disassociate: true,
       id: userId,
     });
   }
 
   disassociateTeamRole(roleId, teamId) {
-    return this.http.post(`${this.baseUrl}/${roleId}/teams/`, {
+    return this.http.post(`${this.baseUrl}${roleId}/teams/`, {
       disassociate: true,
       id: teamId,
     });

--- a/awx/ui_next/src/api/models/WorkflowJobTemplates.js
+++ b/awx/ui_next/src/api/models/WorkflowJobTemplates.js
@@ -13,7 +13,7 @@ class WorkflowJobTemplates extends SchedulesMixin(NotificationsMixin(Base)) {
   }
 
   readWorkflowJobTemplateOptions(id) {
-    return this.http.options(`${this.baseUrl}/${id}/`);
+    return this.http.options(`${this.baseUrl}${id}/`);
   }
 
   updateWebhookKey(id) {


### PR DESCRIPTION
##### SUMMARY
The `baseUrl` in our models contains a trailing slash:

```javascript
this.baseUrl = '/api/v2/workflow_job_templates/';`
```

and so an additional slash before joining it to an id can cause problems in the build:

```javascript
return this.http.options(`${this.baseUrl}/${id}/`); // '/api/v2/workflow_job_templates//:id'
```

