### PR TITLE
Remove psutil from ansible venv

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -51,8 +51,6 @@ netaddr
 # oVirt/RHV
 ovirt-engine-sdk-python==4.3.0    # minimum set inside Ansible facts module requirements
 pycurl==7.43.0.1    # higher versions will not install without SSL backend specified
-# AWX usage
-psutil==5.4.3    # same as AWX requirement
 # VMware
 pyvmomi==6.7.3
 # WinRM

--- a/requirements/requirements_ansible.txt
+++ b/requirements/requirements_ansible.txt
@@ -84,7 +84,6 @@ ovirt-engine-sdk-python==4.3.0  # via -r /awx_devel/requirements/requirements_an
 packaging==19.2           # via -r /awx_devel/requirements/requirements_ansible.in
 paramiko==2.7.1           # via azure-cli-core, ncclient
 pbr==5.4.4                # via keystoneauth1, openstacksdk, os-service-types, stevedore
-psutil==5.4.3             # via -r /awx_devel/requirements/requirements_ansible.in
 pyasn1-modules==0.2.7     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, requests-credssp, rsa
 pycparser==2.19           # via cffi


### PR DESCRIPTION
Hypothesis: it is not needed by anything, this is all encapsulated in
runner (which doesn't run out of this venv).

