### PR TITLE
Update task manager docs

### DIFF
--- a/docs/task_manager_system.md
+++ b/docs/task_manager_system.md
@@ -67,8 +67,6 @@ The new task manager should, in essence, work like the old one. Old task manager
 * Tasks that are not blocked run whenever there is capacity available in the instance group that they are set to run in (one job is always allowed to run per instance group, even if there isn't enough capacity)
 * Only one Project Update for a Project may be running at a time
 * Only one Inventory Update for an Inventory Source may be running at a time
-* For a related Project, only a Job xor Project Update may be running at a time
-* For a related Inventory, only a Job xor Inventory Update(s) may be running at a time
 * Only one Job for a Job Template may be running at a time (the `allow_simultaneous` feature relaxes this condition)
 * Only one System Job may be running at a time
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Launch jobA. Then launch inventoryupdateA and projectupdateA. Both of these update jobs can start while jobA is running.

Note, this not the same for jobA's _dependencies_. If jobA launches dependency inventoryupdateA and projectupdateA, then it will block until both of those updates are finished.

https://github.com/ansible/awx/pull/5519
https://github.com/ansible/awx/pull/5489
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0

```
