### PR TITLE
Remove self-closing tags for tag component

### DIFF
--- a/awx/ui/client/lib/components/input/secret.partial.html
+++ b/awx/ui/client/lib/components/input/secret.partial.html
@@ -23,12 +23,12 @@
                   icon="external"
                   tag="state._tagValue"
                   remove-tag="state._onRemoveTag(state)"
-                />
+                ></at-tag>
                 <at-tag
                   ng-show="state._disabled && state._tagValue"
                   icon="external"
                   tag="state._tagValue"
-                />
+                ></at-tag>
               </div>
             </span>
             <input ng-if="!state.asTag" type="{{ type }}"


### PR DESCRIPTION
##### SUMMARY
This fixes a bug where credential plugin tags aren't shown for linked credential fields.
