### PR TITLE
Update status after sending test notification

### DIFF
--- a/awx/ui_next/src/api/index.js
+++ b/awx/ui_next/src/api/index.js
@@ -17,6 +17,7 @@ import Jobs from './models/Jobs';
 import Labels from './models/Labels';
 import Me from './models/Me';
 import NotificationTemplates from './models/NotificationTemplates';
+import Notifications from './models/Notifications';
 import Organizations from './models/Organizations';
 import ProjectUpdates from './models/ProjectUpdates';
 import Projects from './models/Projects';
@@ -53,6 +54,7 @@ const JobsAPI = new Jobs();
 const LabelsAPI = new Labels();
 const MeAPI = new Me();
 const NotificationTemplatesAPI = new NotificationTemplates();
+const NotificationsAPI = new Notifications();
 const OrganizationsAPI = new Organizations();
 const ProjectUpdatesAPI = new ProjectUpdates();
 const ProjectsAPI = new Projects();
@@ -90,6 +92,7 @@ export {
   LabelsAPI,
   MeAPI,
   NotificationTemplatesAPI,
+  NotificationsAPI,
   OrganizationsAPI,
   ProjectUpdatesAPI,
   ProjectsAPI,

--- a/awx/ui_next/src/api/models/Notifications.js
+++ b/awx/ui_next/src/api/models/Notifications.js
@@ -1,0 +1,10 @@
+import Base from '../Base';
+
+class Notifications extends Base {
+  constructor(http) {
+    super(http);
+    this.baseUrl = '/api/v2/notifications/';
+  }
+}
+
+export default Notifications;

--- a/awx/ui_next/src/components/StatusLabel/StatusLabel.jsx
+++ b/awx/ui_next/src/components/StatusLabel/StatusLabel.jsx
@@ -26,6 +26,7 @@ const RunningIcon = styled(SyncAltIcon)`
 
 const colors = {
   success: 'green',
+  successful: 'green',
   failed: 'red',
   error: 'red',
   running: 'blue',
@@ -35,6 +36,7 @@ const colors = {
 };
 const icons = {
   success: CheckCircleIcon,
+  successful: CheckCircleIcon,
   failed: ExclamationCircleIcon,
   error: ExclamationCircleIcon,
   running: RunningIcon,
@@ -58,6 +60,7 @@ export default function StatusLabel({ status }) {
 StatusLabel.propTypes = {
   status: oneOf([
     'success',
+    'successful',
     'failed',
     'error',
     'running',

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.test.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.test.jsx
@@ -39,7 +39,9 @@ describe('<NotificationTemplateListItem />', () => {
   });
 
   test('should send test notification', async () => {
-    NotificationTemplatesAPI.test.mockResolvedValue({});
+    NotificationTemplatesAPI.test.mockResolvedValue({
+      data: { notification: 1 },
+    });
 
     const wrapper = mountWithContexts(
       <NotificationTemplateListItem


### PR DESCRIPTION
##### SUMMARY
When sending a test notification, the status of the notification template is set to "Pending". This adds a poll request on a 5 second interval to detect when the status changes to Successful, Error, or any other state.

Addresses #7878 — after digging into the old UI, I discovered this is not accomplished with websockets, since notification status information isn't available via WS. This mimics the polling behavior of the old UI.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
