### PR TITLE
Fix AWX collection import test interference with Default organization

### DIFF
--- a/awx_collection/tests/integration/targets/tower_import/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_import/tasks/main.yml
@@ -25,7 +25,7 @@
                 notification_templates_error: []
                 notification_templates_approvals: []
               natural_key:
-                name: "Default"
+                name: "{{ org_name1 }}"
                 type: "organization"
       register: import_output
 
@@ -48,7 +48,7 @@
                 notification_templates_error: []
                 notification_templates_approvals: []
               natural_key:
-                name: "Default"
+                name: "{{ org_name1 }}"
                 type: "organization"
       register: import_output
       ignore_errors: true
@@ -76,7 +76,7 @@
                                 "notification_templates_approvals": []
                            },
                            "natural_key": {
-                                "name": "Default",
+                                "name": "{{ org_name2 }}",
                                 "type": "organization"
                            }
                       }

--- a/awx_collection/tests/integration/targets/tower_import/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_import/tasks/main.yml
@@ -33,7 +33,7 @@
         that:
           - import_output is changed
 
-    - name: "Import something again (awxkit is not idempotent, this tests a failure)"
+    - name: "Import the same thing again"
       tower_import:
         assets:
           organizations:
@@ -55,8 +55,8 @@
 
     - assert:
         that:
-          - import_output is failed
-          - "'Organization with this Name already exists' in import_output.msg"
+          - import_output is not failed
+          # - import_output is not changed  # FIXME: module not idempotent
 
     - name: "Write out a json file"
       copy:


### PR DESCRIPTION
Other tests rely on the Default organization existing, and this test was renaming it.