### PR TITLE
Fixing issue with lookup plugin not able to load host, user, etc

### DIFF
--- a/awx_collection/plugins/lookup/tower_api.py
+++ b/awx_collection/plugins/lookup/tower_api.py
@@ -131,6 +131,8 @@ class LookupModule(LookupBase):
         if len(terms) != 1:
             raise AnsibleError('You must pass exactly one endpoint to query')
 
+        self.set_options(direct=kwargs)
+
         # Defer processing of params to logic shared with the modules
         module_params = {}
         for plugin_param, module_param in TowerAPIModule.short_params.items():
@@ -143,8 +145,6 @@ class LookupModule(LookupBase):
             argument_spec={}, direct_params=module_params,
             error_callback=self.handle_error, warn_callback=self.warn_callback
         )
-
-        self.set_options(direct=kwargs)
 
         response = module.get_endpoint(terms[0], data=self.get_option('query_params', {}))
 

--- a/awx_collection/plugins/lookup/tower_api.py
+++ b/awx_collection/plugins/lookup/tower_api.py
@@ -72,6 +72,10 @@ EXAMPLES = """
   set_fact:
     tower_settings: "{{ lookup('awx.awx.tower_api', 'settings/ui') }}"
 
+- name: Load the UI settings specifying the connection info
+  set_fact:
+    tower_settings: "{{ lookup('awx.awx.tower_api', 'settings/ui' host='tower.example.com', username='admin', password=my_pass_var, verify_ssl=False) }}"
+
 - name: Report the usernames of all users with admin privs
   debug:
     msg: "Admin users: {{ query('awx.awx.tower_api', 'users', query_params={ 'is_superuser': true }) | map(attribute='username') | join(', ') }}"

--- a/awx_collection/tests/integration/targets/tower_lookup_api_plugin/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_lookup_api_plugin/tasks/main.yml
@@ -32,6 +32,16 @@
   register: user_creation_results
 
 - block:
+    - name: Specify the connection params
+      debug:
+        msg: "{{ query(plugin_name, 'ping', host='DNE://junk.com', username='john', password='not_legit', verify_ssl=True) }}"
+      register: results
+      ignore_errors: True
+
+    - assert:
+        that:
+          - "'DNE' in results.msg"
+
     - name: Create our hosts
       tower_host:
         name: "{{ item }}"

--- a/awx_collection/tests/integration/targets/tower_lookup_api_plugin/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_lookup_api_plugin/tasks/main.yml
@@ -36,7 +36,7 @@
       debug:
         msg: "{{ query(plugin_name, 'ping', host='DNE://junk.com', username='john', password='not_legit', verify_ssl=True) }}"
       register: results
-      ignore_errors: True
+      ignore_errors: true
 
     - assert:
         that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The lookup plugin was not properly getting values for connection information like host, user, password, etc.
Also adding a test to validate that the passed host was correctly being reported in an error message.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
