### PR TITLE
Fix analytics logging

### DIFF
--- a/awx/api/views/metrics.py
+++ b/awx/api/views/metrics.py
@@ -22,7 +22,7 @@ from awx.api.generics import (
 )
 
 
-logger = logging.getLogger('awx.main.analytics')
+logger = logging.getLogger('awx.analytics')
 
 
 class MetricsView(APIView):

--- a/awx/main/analytics/broadcast_websocket.py
+++ b/awx/main/analytics/broadcast_websocket.py
@@ -20,7 +20,7 @@ from django.conf import settings
 BROADCAST_WEBSOCKET_REDIS_KEY_NAME = 'broadcast_websocket_stats'
 
 
-logger = logging.getLogger('awx.main.analytics.broadcast_websocket')
+logger = logging.getLogger('awx.analytics.broadcast_websocket')
 
 
 def dt_to_seconds(dt):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -987,6 +987,11 @@ LOGGING = {
             'handlers': ['task_system', 'external_logger'],
             'propagate': False
         },
+        'awx.main.analytics': {
+            'handlers': ['task_system', 'external_logger'],
+            'level': 'INFO',
+            'propagate': False
+        },
         'awx.main.scheduler': {
             'handlers': ['task_system', 'external_logger'],
             'propagate': False
@@ -1001,7 +1006,7 @@ LOGGING = {
             'level': 'INFO',  # very verbose debug-level logs
         },
         'awx.analytics': {
-            'handlers': ['task_system', 'external_logger'],
+            'handlers': ['external_logger'],
             'level': 'INFO',
             'propagate': False
         },


### PR DESCRIPTION
The analytics change PR adjusted the logging for awx.analytics,
which solved the issue, but should have used the targeted awx.main.analytics.

Also flip a couple of loggers to use the regular awx.analytics (awx analytics)
logger instead of awx.main.analytics (the automation anayltics task system).
