### PR TITLE
Add support for a `--status` to the callback receiver (and improve our approach to stats collection in general)

### DIFF
--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -2,6 +2,9 @@ import logging
 import uuid
 import json
 
+from django.conf import settings
+import redis
+
 from awx.main.dispatch import get_local_queuename
 
 from . import pg_bus_conn
@@ -21,7 +24,9 @@ class Control(object):
         self.queuename = host or get_local_queuename()
 
     def status(self, *args, **kwargs):
-        return self.control_with_reply('status', *args, **kwargs)
+        r = redis.Redis.from_url(settings.BROKER_URL)
+        stats = r.get(f'awx_{self.service}_statistics') or b''
+        return stats.decode('utf-8')
 
     def running(self, *args, **kwargs):
         return self.control_with_reply('running', *args, **kwargs)

--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -4,6 +4,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from awx.main.dispatch.control import Control
 from awx.main.dispatch.worker import AWXConsumerRedis, CallbackBrokerWorker
 
 
@@ -15,7 +16,14 @@ class Command(BaseCommand):
     '''
     help = 'Launch the job callback receiver'
 
+    def add_arguments(self, parser):
+        parser.add_argument('--status', dest='status', action='store_true',
+                            help='print the internal state of any running dispatchers')
+
     def handle(self, *arg, **options):
+        if options.get('status'):
+            print(Control('callback_receiver').status())
+            return
         consumer = None
         try:
             consumer = AWXConsumerRedis(

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -10,7 +10,7 @@ import pytest
 
 from awx.main.models import Job, WorkflowJob, Instance
 from awx.main.dispatch import reaper
-from awx.main.dispatch.pool import PoolWorker, WorkerPool, AutoscalePool
+from awx.main.dispatch.pool import StatefulPoolWorker, WorkerPool, AutoscalePool
 from awx.main.dispatch.publish import task
 from awx.main.dispatch.worker import BaseWorker, TaskWorker
 
@@ -80,7 +80,7 @@ class SlowResultWriter(BaseWorker):
 class TestPoolWorker:
 
     def setup_method(self, test_method):
-        self.worker = PoolWorker(1000, self.tick, tuple())
+        self.worker = StatefulPoolWorker(1000, self.tick, tuple())
 
     def tick(self):
         self.worker.finished.put(self.worker.queue.get()['uuid'])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/214912/93515936-5717a780-f8f7-11ea-9fb6-b7c86c84ac4d.png)

Worth mentioning that I removed the `finished` and `current_task` state tracking from the callback receiver because all of that IPC at high volume workloads is just too expensive and not worth it.