### PR TITLE
Logout session if config returns 401

### DIFF
--- a/awx/ui_next/src/components/AppContainer/AppContainer.jsx
+++ b/awx/ui_next/src/components/AppContainer/AppContainer.jsx
@@ -76,10 +76,6 @@ function AppContainer({ i18n, navRouteConfig = [], children }) {
     loadConfig();
   }, [config, pathname, handleLogout]);
 
-  if (!isReady) {
-    return null;
-  }
-
   const header = (
     <PageHeader
       showNavToggle
@@ -119,7 +115,7 @@ function AppContainer({ i18n, navRouteConfig = [], children }) {
   return (
     <>
       <Page isManagedSidebar header={header} sidebar={sidebar}>
-        <ConfigProvider value={config}>{children}</ConfigProvider>
+        {isReady && <ConfigProvider value={config}>{children}</ConfigProvider>}
       </Page>
       <About
         ansible_version={config?.ansible_version}

--- a/awx/ui_next/src/components/AppContainer/AppContainer.test.jsx
+++ b/awx/ui_next/src/components/AppContainer/AppContainer.test.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-
 import {
   mountWithContexts,
   waitForElement,
 } from '../../../testUtils/enzymeHelpers';
 import { ConfigAPI, MeAPI, RootAPI } from '../../api';
-
 import AppContainer from './AppContainer';
 
 jest.mock('../../api');
@@ -58,6 +56,7 @@ describe('<AppContainer />', () => {
         </AppContainer>
       );
     });
+    wrapper.update();
 
     // page components
     expect(wrapper.length).toBe(1);


### PR DESCRIPTION
##### SUMMARY
Fixes logout behavior when returning to a stale session.

When the config is loaded but receives a 401 response, the user is redirected to the login screen. I also prevented the main content of the page from displaying until this load is completed to avoid flashing content that isn't going to be interactive/useful

Addresses #3321

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
