### PR TITLE
`local_path` can now contain several folder levels

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -189,9 +189,8 @@ class ProjectOptions(models.Model):
         return cred
 
     def get_project_path(self, check_if_exists=True):
-        local_path = os.path.basename(self.local_path)
-        if local_path and not local_path.startswith('.'):
-            proj_path = os.path.join(settings.PROJECTS_ROOT, local_path)
+        if self.local_path and not self.local_path.startswith('.'):
+            proj_path = os.path.join(settings.PROJECTS_ROOT, self.local_path)
             if not check_if_exists or os.path.exists(smart_str(proj_path)):
                 return proj_path
 


### PR DESCRIPTION
##### SUMMARY
`local_path` was previously defined using `os.path.basename` which means means specifying a `local_path` with several folder levels ended up in a wrong `project_path`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Models

##### AWX VERSION
awx: 14.1.0

##### ADDITIONAL INFORMATION

Lets take the following folder structure

```
/tmp/project
    ├── subproject1
    │   └── ansible
    ├── subproject2
    │   └── ansible
    └── subproject3
        └── ansible
```

If we configure a project for `subproject1`:
 - The `project_root` is `/tmp/project`
 - We specify the `local_path`: `subproject1/ansible`
Without this commit we ended the `local_path` `/tmp/project/ansible` which doesn't exists
