### PR TITLE
Override certifi in requests with the system cert store.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,8 @@ requirements_ansible: virtualenv_ansible
 	$(VENV_BASE)/ansible/bin/pip uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 	# Same effect as using --system-site-packages flag on venv creation
 	rm $(shell ls -d $(VENV_BASE)/ansible/lib/python* | head -n 1)/no-global-site-packages.txt
+	find $(VENV_BASE)/ansible -path "*/site-packages*/requests/certs.py" -exec cp -f requirements/certifi-vendor/certs.py {} \;
+	$(VENV_BASE)/ansible/bin/pip install $(shell pwd)/requirements/certifi-vendor
 
 requirements_ansible_py3: virtualenv_ansible_py3
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
@@ -193,6 +195,8 @@ requirements_ansible_py3: virtualenv_ansible_py3
 	$(VENV_BASE)/ansible/bin/pip3 uninstall --yes -r requirements/requirements_ansible_uninstall.txt
 	# Same effect as using --system-site-packages flag on venv creation
 	rm $(shell ls -d $(VENV_BASE)/ansible/lib/python* | head -n 1)/no-global-site-packages.txt
+	find $(VENV_BASE)/ansible -path "*/site-packages*/requests/certs.py" -exec cp -f requirements/certifi-vendor/certs.py {} \;
+	$(VENV_BASE)/ansible/bin/pip install $(shell pwd)/requirements/certifi-vendor
 
 requirements_ansible_dev:
 	if [ "$(VENV_BASE)" ]; then \
@@ -208,6 +212,8 @@ requirements_awx: virtualenv_awx
 	    cat requirements/requirements.txt requirements/requirements_git.txt | $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) -r /dev/stdin ; \
 	fi
 	$(VENV_BASE)/awx/bin/pip uninstall --yes -r requirements/requirements_tower_uninstall.txt
+	find $(VENV_BASE)/awx -path "*/site-packages*/requests/certs.py" -exec cp -f requirements/certifi-vendor/certs.py {} \;
+	$(VENV_BASE)/awx/bin/pip install $(shell pwd)/requirements/certifi-vendor
 
 requirements_awx_dev:
 	$(VENV_BASE)/awx/bin/pip install -r requirements/requirements_dev.txt

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -57,13 +57,7 @@ RUN python3 -m ensurepip && pip3 install "virtualenv < 20"
 # Install & build requirements
 ADD Makefile /tmp/Makefile
 RUN mkdir /tmp/requirements
-ADD requirements/requirements_ansible.txt \
-    requirements/requirements_ansible_uninstall.txt \
-    requirements/requirements_ansible_git.txt \
-    requirements/requirements.txt \
-    requirements/requirements_tower_uninstall.txt \
-    requirements/requirements_git.txt \
-    requirements/collections_requirements.yml \
+COPY requirements \
     /tmp/requirements/
 
 RUN cd /tmp && make requirements_awx requirements_ansible_py3

--- a/requirements/certifi-vendor/certifi/__init__.py
+++ b/requirements/certifi-vendor/certifi/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+"""
+(fake) certifi
+~~~~~~~~~~~~~~
+
+A minimal, system-CA-store-only, implementation of certifi.
+"""
+
+
+def where():
+    """Return the absolute path to the system CA bundle."""
+    return '/etc/pki/tls/certs/ca-bundle.crt'
+
+
+def contents():
+    with open(where(), "r", encoding="utf-8") as data:
+        return data.read()

--- a/requirements/certifi-vendor/certs.py
+++ b/requirements/certifi-vendor/certs.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+"""
+requests.certs
+~~~~~~~~~~~~~~
+
+This module returns the preferred default CA certificate bundle. There is
+only one — the one from the certifi package.
+
+If you are packaging Requests, e.g., for a Linux distribution or a managed
+environment, you can change the definition of where() to return a separately
+packaged CA bundle.
+
+This AWX-patched package returns "/etc/pki/tls/certs/ca-bundle.crt" provided
+by the ca-certificates RPM package.
+"""
+
+
+def where():
+    """Return the absolute path to the system CA bundle."""
+    return '/etc/pki/tls/certs/ca-bundle.crt'
+
+
+if __name__ == '__main__':
+    print(where())

--- a/requirements/certifi-vendor/setup.py
+++ b/requirements/certifi-vendor/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+setup(
+    name="certifi",
+    version="2038.12.31",
+    packages=find_packages(),
+)
+

--- a/requirements/requirements_ansible_uninstall.txt
+++ b/requirements/requirements_ansible_uninstall.txt
@@ -1,1 +1,2 @@
 rsa	# stop adding new crypto libs
+certifi	# use the system cert store

--- a/requirements/requirements_tower_uninstall.txt
+++ b/requirements/requirements_tower_uninstall.txt
@@ -1,1 +1,2 @@
 rsa	# stop adding new crypto libs
+certifi	# use the system cert store


### PR DESCRIPTION
There's not a good way to do this with pip, so just overwrite
the requests file after installing it.

Add a stub certifi library for things that call `certifi.where()` for their own use.
