### PR TITLE
Add custom root ca certificate via configmap

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -91,6 +91,12 @@ pg_database=awx
 pg_port=5432
 #pg_sslmode=require
 
+# If requiring SSL communication (e.g. pg_sslmode='verify-full') with Postgres
+# and using a self-signed certificate or a certificate signed by a custom CA
+# set pg_root_ca_file to a file containing the self-signed certificate or the
+# root CA certificate chain.
+# pg_root_ca_file='example_root_ca.crt'
+
 # The following variable is only required when using the provided
 # containerized postgres deployment on OpenShift
 # pg_admin_password=postgrespass

--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -201,6 +201,34 @@
   set_fact:
     kubernetes_deployment_api_version: "{{ 'apps/v1' if kube_api_version is version('1.9', '>=') else 'apps/v1beta1' }}"
 
+- name: Use Custom Root CA file for PosgtreSQL SSL communication
+  block:
+    - name: Get Root CA file contents
+      set_fact:
+        postgres_root_ca_cert: "{{ lookup('file', pg_root_ca_file) }}"
+      no_log: true
+
+    - name: Render Root CA template
+      set_fact:
+        postgres_root_ca: "{{ lookup('template', 'postgres_root_ca.yml.j2') }}"
+      no_log: true
+
+    - name: Apply Root CA template
+      shell: |
+        echo {{ postgres_root_ca | quote }} | {{ kubectl_or_oc }} apply -f -
+      no_log: true
+
+    - name: Set Root CA file name
+      set_fact:
+        postgres_root_ca_filename: 'postgres_root_ca.crt'
+
+    - name: Set Root CA file location
+      set_fact:
+        ca_trust_bundle: '/etc/tower/{{ postgres_root_ca_filename }}'
+  when:
+    - pg_root_ca_file is defined
+    - pg_root_ca_file != ''
+
 - name: Render deployment templates
   set_fact:
     "{{ item }}": "{{ lookup('template', item + '.yml.j2') }}"

--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -171,6 +171,12 @@ spec:
               value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 {% endif %}
           volumeMounts:
+{% if postgres_root_ca_cert is defined %}
+            - name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+              mountPath: {{ ca_trust_bundle }}
+              subPath: {{ postgres_root_ca_filename }}
+              readOnly: true
+{% endif %}
             - name: supervisor-socket
               mountPath: "/var/run/supervisor"
             - name: rsyslog-socket
@@ -258,6 +264,12 @@ spec:
             - /usr/bin/launch_awx_task.sh
           imagePullPolicy: Always
           volumeMounts:
+{% if postgres_root_ca_cert is defined %}
+            - name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+              mountPath: {{ ca_trust_bundle }}
+              subPath: {{ postgres_root_ca_filename }}
+              readOnly: true
+{% endif %}
             - name: supervisor-socket
               mountPath: "/var/run/supervisor"
             - name: rsyslog-socket
@@ -386,6 +398,14 @@ spec:
 {{ affinity | to_nice_yaml(indent=2) | indent(width=8, indentfirst=True) }}
 {% endif %}
       volumes:
+{% if postgres_root_ca_cert is defined %}
+        - name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+          configMap:
+            name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+            items:
+            - key: postgres_root_ca.crt
+              path: postgres_root_ca.crt
+{% endif %}
         - name: supervisor-socket
           emptyDir: {}
         - name: rsyslog-socket

--- a/installer/roles/kubernetes/templates/management-pod.yml.j2
+++ b/installer/roles/kubernetes/templates/management-pod.yml.j2
@@ -25,7 +25,12 @@ spec:
           mountPath: "/etc/tower/settings.py"
           subPath: settings.py
           readOnly: true
-
+{% if postgres_root_ca_cert is defined %}
+        - name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+          mountPath: {{ ca_trust_bundle }}
+          subPath: {{ postgres_root_ca_filename }}
+          readOnly: true
+{% endif %}
         - name: "{{ kubernetes_deployment_name }}-application-credentials"
           mountPath: "/etc/tower/conf.d/"
           readOnly: true
@@ -70,7 +75,14 @@ spec:
         items:
           - key: {{ kubernetes_deployment_name }}_settings
             path: settings.py
-
+{% if postgres_root_ca_cert is defined %}
+    - name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+      configMap:
+        name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+        items:
+        - key: postgres_root_ca.crt
+          path: postgres_root_ca.crt
+{% endif %}
     - name: {{ kubernetes_deployment_name }}-secret-key
       secret:
         secretName: "{{ kubernetes_deployment_name }}-secrets"

--- a/installer/roles/kubernetes/templates/postgres_root_ca.yml.j2
+++ b/installer/roles/kubernetes/templates/postgres_root_ca.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kubernetes_deployment_name }}-postgres-root-ca-cert
+  namespace: {{ kubernetes_namespace }}
+data:
+  postgres_root_ca.crt: |
+    {{ postgres_root_ca_cert | indent(width=4) }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The PR adds the ability to provide a custom root CA certificate file for connection to an external Postgres database requiring SSL connectivity where the servers SSL certificate is self-signed or signed by a custom CA.

This allows for the certificate to be used without building a custom container image.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
With this PR the user will be able to provide the path/filename to a file containing a self-signed or a root CA certificate/chain. If the variable is defined and not empty the installer will create a configmap with the contents of the file and mount that the configmap into the management, web, and task containers. It will also set the `ca_trust_bundle` to point to the mounted file so that the database configuration is correct and allow the Postgres connection certificate to be validated.

To be able to test this an external Postgres database must be configured to require SSL connections.

* Modify `postgresql.conf` to modify the ssl option:
```
ssl = on
```
* Modify pg_hba.conf` to require ssl when connecting:
```
hostssl    awx       tower         0.0.0.0/0                 scram-sha-256
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Using an inventory file like:
```
localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python3"

[all:vars]
dockerhub_base=ansible
openshift_host=<OpenShift API URI>
openshift_project=awx
openshift_user=<Redacted>
openshift_token=<Redacted>
openshift_skip_tls_verify=True
awx_task_hostname=awx
awx_web_hostname=awxweb
postgres_data_dir="~/.awx/pgdocker"
host_port=80
host_port_ssl=443
docker_compose_dir="~/.awx/awxcompose"
pg_hostname=awx-ext-db.example.com
pg_username=awx
pg_password=awx
pg_database=awx
pg_port=5432
pg_sslmode='verify-full'
pg_root_ca_file='/awx-ocp-testing/root_ca.crt'
admin_user=admin
admin_password=password
create_preload_data=True
secret_key=awxsecret
```

Produces the below Ansible output when running `ansible-playbook -i inventory install.yml` and results in a successful deployment with this change:
 
```
PLAY [Build and deploy AWX] ******************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
[WARNING]: error loading fact - please check content
ok: [localhost]

TASK [check_vars : include_tasks] ************************************************************************************
included: /home/bevans/git-repos/my_forks/awx/installer/roles/check_vars/tasks/check_openshift.yml for localhost

TASK [check_vars : openshift_project should be defined] **************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [check_vars : openshift_user should be defined] *****************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [check_vars : openshift_password or openshift_token should be defined] ******************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [check_vars : docker_registry should be defined if not using dockerhub] *****************************************
skipping: [localhost]

TASK [check_vars : docker_registry_repository should be defined if not using dockerhub] ******************************
skipping: [localhost]

TASK [check_vars : docker_registry_username should be defined if not using dockerhub] ********************************
skipping: [localhost]

TASK [check_vars : docker_registry_password should be defined] *******************************************************
skipping: [localhost]

TASK [check_vars : include_tasks] ************************************************************************************
skipping: [localhost]

TASK [image_build : Set global version if not provided] **************************************************************
skipping: [localhost]

TASK [image_build : Verify awx-logos directory exists for official install] ******************************************
skipping: [localhost]

TASK [image_build : Copy logos for inclusion in sdist] ***************************************************************
skipping: [localhost]

TASK [image_build : Set sdist file name] *****************************************************************************
skipping: [localhost]

TASK [image_build : AWX Distribution] ********************************************************************************
skipping: [localhost]

TASK [image_build : Stat distribution file] **************************************************************************
skipping: [localhost]

TASK [image_build : Clean distribution] ******************************************************************************
skipping: [localhost]

TASK [image_build : Build sdist builder image] ***********************************************************************
skipping: [localhost]

TASK [image_build : Build AWX distribution using container] **********************************************************
skipping: [localhost]

TASK [image_build : Build AWX distribution locally] ******************************************************************
skipping: [localhost]

TASK [image_build : Set docker build base path] **********************************************************************
skipping: [localhost]

TASK [image_build : Set awx image name] ******************************************************************************
skipping: [localhost]

TASK [image_build : Ensure directory exists] *************************************************************************
skipping: [localhost]

TASK [image_build : Stage sdist] *************************************************************************************
skipping: [localhost]

TASK [image_build : Template web Dockerfile] *************************************************************************
skipping: [localhost]

TASK [image_build : Stage launch_awx] ********************************************************************************
skipping: [localhost]

TASK [image_build : Stage launch_awx_task] ***************************************************************************
skipping: [localhost]

TASK [image_build : Stage rsyslog.conf] ******************************************************************************
skipping: [localhost]

TASK [image_build : Stage supervisor.conf] ***************************************************************************
skipping: [localhost]

TASK [image_build : Stage supervisor_task.conf] **********************************************************************
skipping: [localhost]

TASK [image_build : Stage settings.py] *******************************************************************************
skipping: [localhost]

TASK [image_build : Stage requirements] ******************************************************************************
skipping: [localhost]

TASK [image_build : Stage config watcher] ****************************************************************************
skipping: [localhost]

TASK [image_build : Stage Makefile] **********************************************************************************
skipping: [localhost]

TASK [image_build : Build base awx image] ****************************************************************************
skipping: [localhost]

TASK [image_build : Tag awx images as latest] ************************************************************************
skipping: [localhost] => (item=awx) 

TASK [image_build : Clean docker base directory] *********************************************************************
skipping: [localhost]

TASK [image_push : Authenticate with Docker registry if registry password given] *************************************
skipping: [localhost]

TASK [image_push : Remove awx image] *********************************************************************************
skipping: [localhost]

TASK [image_push : Tag and push awx image to registry] ***************************************************************
skipping: [localhost]

TASK [image_push : Set full image path for Registry] *****************************************************************
skipping: [localhost]

TASK [kubernetes : Generate broadcast websocket secret] **************************************************************
skipping: [localhost]

TASK [kubernetes : fail] *********************************************************************************************
skipping: [localhost]

TASK [kubernetes : include_tasks] ************************************************************************************
included: /home/bevans/git-repos/my_forks/awx/installer/roles/kubernetes/tasks/openshift_auth.yml for localhost
included: /home/bevans/git-repos/my_forks/awx/installer/roles/kubernetes/tasks/openshift.yml for localhost

TASK [kubernetes : include_vars] *************************************************************************************
ok: [localhost]

TASK [Set kubernetes_namespace] **************************************************************************************
ok: [localhost]

TASK [kubernetes : Ensure workspace directories exist] ***************************************************************
ok: [localhost] => (item=/tmp/awx-config)
ok: [localhost] => (item=/tmp/awx-config/.kube)

TASK [kubernetes : Authenticate with OpenShift via user and password] ************************************************
skipping: [localhost]

TASK [kubernetes : OpenShift authentication failed on TLS verification] **********************************************
skipping: [localhost]

TASK [kubernetes : OpenShift authentication failed] ******************************************************************
skipping: [localhost]

TASK [kubernetes : Authenticate with OpenShift via token] ************************************************************
changed: [localhost]

TASK [kubernetes : OpenShift authentication failed] ******************************************************************
skipping: [localhost]

TASK [kubernetes : Get Project Detail] *******************************************************************************
changed: [localhost]

TASK [kubernetes : Create AWX Openshift Project] *********************************************************************
skipping: [localhost]

TASK [kubernetes : Check PVC status] *********************************************************************************
skipping: [localhost]

TASK [kubernetes : Ensure PostgreSQL PVC is available] ***************************************************************
skipping: [localhost]

TASK [kubernetes : Set postgresql service name] **********************************************************************
skipping: [localhost]

TASK [kubernetes : Add privileged SCC to service account] ************************************************************
changed: [localhost]

TASK [kubernetes : Get Kubernetes Config] ****************************************************************************
changed: [localhost]

TASK [kubernetes : Convert kube config to dictionary] ****************************************************************
ok: [localhost]

TASK [kubernetes : Extract current context from kube config] *********************************************************
ok: [localhost]

TASK [kubernetes : Find cluster for current context] *****************************************************************
ok: [localhost]

TASK [kubernetes : Find server for current context] ******************************************************************
ok: [localhost]

TASK [kubernetes : Get kube version from api server] *****************************************************************
ok: [localhost]

TASK [kubernetes : Extract server version from command output] *******************************************************
ok: [localhost]

TASK [kubernetes : include_tasks] ************************************************************************************
skipping: [localhost] => (item=kubernetes_auth.yml) 
skipping: [localhost] => (item=kubernetes.yml) 

TASK [kubernetes : Use kubectl or oc] ********************************************************************************
ok: [localhost]

TASK [kubernetes : set_fact] *****************************************************************************************
ok: [localhost]

TASK [kubernetes : Record deployment size] ***************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc --kubeconfig=/tmp/awx-config/.kube/config get deployment  awx  -n awx -o=jsonpath='{.status.replicas}'\n", "delta": "0:00:00.176665", "end": "2020-09-22 17:01:31.491313", "msg": "non-zero return code", "rc": 1, "start": "2020-09-22 17:01:31.314648", "stderr": "Error from server (NotFound): deployments.apps \"awx\" not found", "stderr_lines": ["Error from server (NotFound): deployments.apps \"awx\" not found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [kubernetes : Set expected post-deployment Replicas value] ******************************************************
skipping: [localhost]

TASK [kubernetes : Delete existing Deployment (or StatefulSet)] ******************************************************
changed: [localhost]

TASK [kubernetes : Get Postgres Service Detail] **********************************************************************
skipping: [localhost]

TASK [kubernetes : Template PostgreSQL Deployment (OpenShift)] *******************************************************
skipping: [localhost]

TASK [kubernetes : Deploy and Activate Postgres (OpenShift)] *********************************************************
skipping: [localhost]

TASK [kubernetes : Create Temporary Values File (Kubernetes)] ********************************************************
skipping: [localhost]

TASK [kubernetes : Populate Temporary Values File (Kubernetes)] ******************************************************
skipping: [localhost]

TASK [kubernetes : Deploy and Activate Postgres (Kubernetes)] ********************************************************
skipping: [localhost]

TASK [kubernetes : Remove tempfile] **********************************************************************************
skipping: [localhost]

TASK [kubernetes : Set postgresql hostname to helm package service (Kubernetes)] *************************************
skipping: [localhost]

TASK [kubernetes : Wait for Postgres to activate] ********************************************************************
skipping: [localhost]

TASK [kubernetes : Check if Postgres 9.6 is being used] **************************************************************
skipping: [localhost]

TASK [kubernetes : Set new pg image] *********************************************************************************
skipping: [localhost]

TASK [kubernetes : Wait for change to take affect] *******************************************************************
skipping: [localhost]

TASK [kubernetes : Set env var for pg upgrade] ***********************************************************************
skipping: [localhost]

TASK [kubernetes : Wait for change to take affect] *******************************************************************
skipping: [localhost]

TASK [kubernetes : Set env var for new pg version] *******************************************************************
skipping: [localhost]

TASK [kubernetes : Wait for Postgres to redeploy] ********************************************************************
skipping: [localhost]

TASK [kubernetes : Wait for Postgres to finish upgrading] ************************************************************
skipping: [localhost]

TASK [kubernetes : Unset upgrade env var] ****************************************************************************
skipping: [localhost]

TASK [kubernetes : Wait for Postgres to redeploy] ********************************************************************
skipping: [localhost]

TASK [kubernetes : Set awx image name] *******************************************************************************
skipping: [localhost]

TASK [kubernetes : Determine Deployment api version] *****************************************************************
ok: [localhost]

TASK [kubernetes : Get Root CA file contents] ************************************************************************
ok: [localhost]

TASK [kubernetes : Render Root CA template] **************************************************************************
ok: [localhost]

TASK [kubernetes : Apply Root CA template] ***************************************************************************
changed: [localhost]

TASK [kubernetes : Set Root CA file name] ****************************************************************************
ok: [localhost]

TASK [kubernetes : Set Root CA file location] ************************************************************************
ok: [localhost]

TASK [kubernetes : Render deployment templates] **********************************************************************
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost]

TASK [kubernetes : Apply Deployment] *********************************************************************************
changed: [localhost] => (item=None)
changed: [localhost] => (item=None)
changed: [localhost] => (item=None)
changed: [localhost] => (item=None)
changed: [localhost] => (item=None)
changed: [localhost]

TASK [kubernetes : Delete any existing management pod] ***************************************************************
changed: [localhost]

TASK [kubernetes : Template management pod] **************************************************************************
ok: [localhost]

TASK [kubernetes : Create management pod] ****************************************************************************
changed: [localhost]

TASK [kubernetes : Wait for management pod to start] *****************************************************************
FAILED - RETRYING: Wait for management pod to start (60 retries left).
changed: [localhost]

TASK [kubernetes : Migrate database] *********************************************************************************
changed: [localhost]

TASK [kubernetes : Check for Tower Super users] **********************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc --kubeconfig=/tmp/awx-config/.kube/config -n awx exec ansible-tower-management --  bash -c \"echo 'from django.contrib.auth.models import User; nsu = User.objects.filter(is_superuser=True).count(); exit(0 if nsu > 0 else 1)' | awx-manage shell\"\n", "delta": "0:00:03.486136", "end": "2020-09-22 17:05:52.525169", "msg": "non-zero return code", "rc": 1, "start": "2020-09-22 17:05:49.039033", "stderr": "command terminated with exit code 1", "stderr_lines": ["command terminated with exit code 1"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [kubernetes : create django super user if it does not exist] ****************************************************
changed: [localhost]

TASK [kubernetes : update django super user password] ****************************************************************
ok: [localhost]

TASK [kubernetes : Create the default organization if it is needed.] *************************************************
changed: [localhost]

TASK [kubernetes : Delete management pod] ****************************************************************************
changed: [localhost]

TASK [kubernetes : Scale up deployment] ******************************************************************************
changed: [localhost]

TASK [local_docker : Generate broadcast websocket secret] ************************************************************
skipping: [localhost]

TASK [local_docker : Check for existing Postgres data] ***************************************************************
skipping: [localhost]

TASK [local_docker : Record Postgres version] ************************************************************************
skipping: [localhost]

TASK [local_docker : Determine whether to upgrade postgres] **********************************************************
skipping: [localhost]

TASK [local_docker : Set up new postgres paths pre-upgrade] **********************************************************
skipping: [localhost] => (item=~/.awx/pgdocker/10/data) 

TASK [local_docker : Stop AWX before upgrading postgres] *************************************************************
skipping: [localhost]

TASK [local_docker : Upgrade Postgres] *******************************************************************************
skipping: [localhost]

TASK [local_docker : Copy old pg_hba.conf] ***************************************************************************
skipping: [localhost]

TASK [local_docker : Remove old data directory] **********************************************************************
skipping: [localhost]

TASK [local_docker : Export Docker awx image if it isnt local and there isnt a registry defined] *********************
skipping: [localhost]

TASK [local_docker : Set docker base path] ***************************************************************************
skipping: [localhost]

TASK [local_docker : Ensure directory exists] ************************************************************************
skipping: [localhost]

TASK [local_docker : Copy awx image to docker execution] *************************************************************
skipping: [localhost]

TASK [local_docker : Load awx image] *********************************************************************************
skipping: [localhost]

TASK [local_docker : Set full image path for local install] **********************************************************
skipping: [localhost]

TASK [local_docker : Set DockerHub Image Paths] **********************************************************************
skipping: [localhost]

TASK [local_docker : Create ~/.awx/awxcompose directory] *************************************************************
skipping: [localhost]

TASK [local_docker : Create Redis socket directory] ******************************************************************
skipping: [localhost]

TASK [local_docker : Create Docker Compose Configuration] ************************************************************
skipping: [localhost] => (item={'file': 'environment.sh', 'mode': '0600'}) 
skipping: [localhost] => (item={'file': 'credentials.py', 'mode': '0600'}) 
skipping: [localhost] => (item={'file': 'docker-compose.yml', 'mode': '0600'}) 
skipping: [localhost] => (item={'file': 'nginx.conf', 'mode': '0600'}) 
skipping: [localhost] => (item={'file': 'redis.conf', 'mode': '0664'}) 

TASK [local_docker : Render SECRET_KEY file] *************************************************************************
skipping: [localhost]

TASK [local_docker : Start the containers] ***************************************************************************
skipping: [localhost]

TASK [local_docker : Update CA trust in awx_web container] ***********************************************************
skipping: [localhost]

TASK [local_docker : Update CA trust in awx_task container] **********************************************************
skipping: [localhost]

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=43   changed=17   unreachable=0    failed=0    skipped=91   rescued=0    ignored=2   
```
