### PR TITLE
Enable "On Fail" Notifications to Send Upon Timeout of Job Templates

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1506,6 +1506,8 @@ class BaseTask(object):
                 self.instance.job_explanation = "Job terminated due to timeout"
                 status = 'failed'
                 extra_update_fields['job_explanation'] = self.instance.job_explanation
+                # ensure failure notification sends even if playbook_on_stats event is not triggered
+                handle_success_and_failure_notifications.apply_async([self.instance.job.id])
 
         except InvalidVirtualenvError as e:
             extra_update_fields['job_explanation'] = e.message


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixing the bug described in Issue https://github.com/ansible/awx/issues/7402

Job Templates with a timeout and "send on fail" notifications attached were not correctly sending a notification upon timeout.  This PR should fix that faulty behavior.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
