### PR TITLE
Ability to import standard pgdump into Openshift

### DIFF
--- a/installer/roles/kubernetes/tasks/restore.yml
+++ b/installer/roles/kubernetes/tasks/restore.yml
@@ -25,6 +25,18 @@
     dest: "{{ playbook_dir }}/tower-openshift-restore"
     extra_opts: [--strip-components=1]
 
+- name: Verify if common.tar.gz exists
+  stat:
+    path: "{{ playbook_dir }}/tower-openshift-restore/common.tar.gz"
+  register: common_tarball
+
+- name: Unarchive Tower backup from common.tar.gz
+  unarchive:
+    src: "{{ playbook_dir }}/tower-openshift-restore/common.tar.gz"
+    dest: "{{ playbook_dir }}/tower-openshift-restore"
+    extra_opts: [--strip-components=1]
+  when: common_tarball.stat.exists
+
 - set_fact:
     deployment_object: "deployment"
 
@@ -38,6 +50,11 @@
   shell: |
     {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
       scale {{ deployment_object }} {{ kubernetes_deployment_name }} --replicas=0
+
+- name: Delete management pod
+  shell: |
+    {{ kubectl_or_oc }} -n {{ kubernetes_namespace }} \
+      delete pod ansible-tower-management --grace-period=0 --ignore-not-found
 
 - name: Wait for scale down
   shell: |


### PR DESCRIPTION
Fixes: https://github.com/ansible/tower-packaging/issues/901

cc: @shanemcd 

This PR introduces the ability to import a database dump generated by the standard Ansible Tower installer and import into on a Openshift environment (external DB or auto deployed DB in OCP). 

----

To facilitate the process, I' ve created a journal below with the steps performed. 

First we start by deploying a fresh Ansible Tower on OCP4 environment 

```bash
(py38) mdemello@p50 ~/d/P/t/setup_openshift> ./setup_openshift.sh  -i inventory-ocp4                                 01:14:47
Using /home/mdemello/.ansible.cfg as config file

PLAY [Deploy Tower] *********************************************************************************************************

TASK [preflight : include_tasks] ********************************************************************************************
included: /home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/roles/preflight/tasks/check_openshift.yml for localhost

....SNIP.....

TASK [kubernetes : create django super user if it does not exist] ***********************************************************
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [kubernetes : update django super user password] ***********************************************************************
changed: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}

TASK [kubernetes : Create the default organization if it is needed.] ********************************************************
ok: [localhost] => {"changed": false, "cmd": "oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower exec ansible-tower-management --  bash -c \"awx-manage create_preload_data\"\n", "delta": "0:00:08.392339", "end": "2020-09-23 01:30:11.946572", "rc": 0, "start": "2020-09-23 01:30:03.554233", "stderr": "", "stderr_lines": [], "stdout": "An organization is already in the system, exiting.\n(changed: False)", "stdout_lines": ["An organization is already in the system, exiting.", "(changed: False)"]}

TASK [kubernetes : Delete management pod] ***********************************************************************************
changed: [localhost] => {"changed": true, "cmd": "oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower  delete pod ansible-tower-management --grace-period=0 --ignore-not-found\n", "delta": "0:00:16.703380", "end": "2020-09-23 01:30:28.880359", "rc": 0, "start": "2020-09-23 01:30:12.176979", "stderr": "", "stderr_lines": [], "stdout": "pod \"ansible-tower-management\" deleted", "stdout_lines": ["pod \"ansible-tower-management\" deleted"]}

TASK [kubernetes : Scale up deployment] *************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower  scale deployment ansible-tower --replicas=1\n", "delta": "0:00:00.177143", "end": "2020-09-23 01:30:29.292636", "rc": 0, "start": "2020-09-23 01:30:29.115493", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/ansible-tower scaled", "stdout_lines": ["deployment.apps/ansible-tower scaled"]}

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=43   changed=17   unreachable=0    failed=0    skipped=30   rescued=0    ignored=0   

The setup process completed successfully.
Setup log saved to /home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/setup_container_cluster-2020-09-23-01:28:59.log
```

As expected, we will have all pods created at the namespace specified once the installer finishes as we can see below:

```bash
(py38) mdemello@p50 ~/D/ansible-tower-openshift-setup-3.7.2-1> kubectl get pods -n tower                                                                                                                                                          01:31:16
NAME                             READY   STATUS      RESTARTS   AGE
ansible-tower-7b66f9955b-wnvsm   3/3     Running     0          2m7s
postgresql-1-deploy              0/1     Completed   0          10m
postgresql-1-t49dw               1/1     Running     0          10m
```

The webUI is responsive and we can query the database as expected:

```bash
(py38) mdemello@p50 ~/d/P/t/setup_openshift> kubectl iexec tower -n tower                                            01:32:21
Container: ✔ ansible-tower-web
sh-4.2$ awx-manage dbshell
psql (10.6, server 10.12)
Type "help" for help.

tower=> select count(*) from main_activitystream_project;
 count 
-------
     1
(1 row)
```

 Now this PR will allow a database backup generated on a standard Ansible Tower installer to be fed into the Openshift Installer. 

 Before restoring the database, observe the location from the `tower.db` generated by the `setup.sh` is different than the one generated by the `setup_openshift.sh` script. The standard installer will place the `tower.db`  file into the `common.tar.gz`  tarball. 


Looking at the difference:

```bash
==== generated by `setup_openshift.sh`  =====
(py38) mdemello@p50 ~/d/P/t/setup_openshift> tar ztvf tower-openshift-backup-latest.tar.gz                           01:35:57
-rw------- mdemello/mdemello 541588 2020-09-23 01:35 tower-openshift-backup-2020-09-23-01:35:22/tower.db
-rw------- mdemello/mdemello   2937 2020-09-23 01:35 tower-openshift-backup-2020-09-23-01:35:22/inventory-ocp4
(py38) mdemello@p50 ~/d/P/t/setup_openshift> md5sum tower-openshift-backup-latest.tar.gz                             01:41:31
ed0634abec0318d544b6888098302ca4  tower-openshift-backup-latest.tar.gz
```

```bash
=== generated by `setup.sh`======
[root@rh-tower-latest ansible-tower-setup-bundle-3.7.2-1]# tar ztvf tower-backup-latest.tar.gz
drwx------ root/root         0 2020-09-23 01:37 ./
-rw------- root/root 153169269 2020-09-23 01:37 ./localhost.tar.gz
-rw------- root/root   1286570 2020-09-23 01:37 ./common.tar.gz
[root@rh-tower-latest ansible-tower-setup-bundle-3.7.2-1]# md5sum  tower-backup-latest.tar.gz
5e46f136c4df5cc0ec053b0db7ed218d  tower-backup-latest.tar.gz
```

Given the scenario above, let's migrate the database into the Openshift environment. The pre-requisites will be:

1) Make sure the SECRET_KEY matches with the old environment
2) The database name must match with the original deployment

Feed the tarball generated into the Openshift Installer

```bash
(py38) mdemello@p50 ~/d/P/t/setup_openshift> md5sum ~/Desktop/tower-backup-latest.tar.gz                             01:45:30
5e46f136c4df5cc0ec053b0db7ed218d  /home/mdemello/Desktop/tower-backup-latest.tar.gz
(py38) mdemello@p50 ~/d/P/t/setup_openshift> 
./setup_openshift.sh  -r -e 'restore_backup_file=/home/mdemello/Desktop/tower-backup-latest.tar.gz'  -i inventory-ocp4
Using /home/mdemello/.ansible.cfg as config file

... SNIP ....

TASK [kubernetes : Unarchive Tower backup] **********************************************************************************
changed: [localhost] => {"changed": true, "dest": "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore", "extract_results": {"cmd": ["/usr/bin/tar", "--extract", "-C", "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore", "-z", "--show-transformed-names", "--strip-components=1", "-f", "/home/mdemello/.ansible/tmp/ansible-tmp-1600841670.331674-22311-171036701021163/source"], "err": "", "out": "", "rc": 0}, "gid": 1000, "group": "mdemello", "handler": "TgzArchive", "mode": "0775", "owner": "mdemello", "size": 4096, "src": "/home/mdemello/.ansible/tmp/ansible-tmp-1600841670.331674-22311-171036701021163/source", "state": "directory", "uid": 1000}

TASK [kubernetes : Verify if common.tar.gz exists] **************************************************************************
ok: [localhost] => {"changed": false, "stat": {"atime": 1600841674.2657363, "attr_flags": "e", "attributes": ["extents"], "block_size": 4096, "blocks": 2520, "charset": "binary", "checksum": "7d0ba2c64698956e087d670a3c5f9efbfde59781", "ctime": 1600841674.2777364, "dev": 64771, "device_type": 0, "executable": false, "exists": true, "gid": 1000, "gr_name": "mdemello", "inode": 19140534, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mimetype": "application/gzip", "mode": "0600", "mtime": 1600839478.0, "nlink": 1, "path": "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore/common.tar.gz", "pw_name": "mdemello", "readable": true, "rgrp": false, "roth": false, "rusr": true, "size": 1286570, "uid": 1000, "version": "1044640716", "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}}

TASK [kubernetes : Unarchive Tower backup from common.tar.gz] ***************************************************************
changed: [localhost] => {"changed": true, "dest": "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore", "extract_results": {"cmd": ["/usr/bin/tar", "--extract", "-C", "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore", "-z", "--show-transformed-names", "--strip-components=1", "-f", "/home/mdemello/.ansible/tmp/ansible-tmp-1600841674.5434186-22406-281164865282554/source"], "err": "", "out": "", "rc": 0}, "gid": 1000, "group": "mdemello", "handler": "TgzArchive", "mode": "0775", "owner": "mdemello", "size": 4096, "src": "/home/mdemello/.ansible/tmp/ansible-tmp-1600841674.5434186-22406-281164865282554/source", "state": "directory", "uid": 1000}

.... SNIP ....

TASK [kubernetes : Temporarily grant createdb role] *************************************************************************
changed: [localhost] => {"changed": true, "cmd": "POD=$(oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower  get pods -l=name=postgresql --field-selector status.phase=Running -o jsonpath=\"{.items[0].metadata.name}\")\noc --kubeconfig=/tmp/ansible-tower-config/.kube/config exec $POD -n tower -- bash -c \"\\\n  psql --dbname=template1 -c 'ALTER USER \\\"awx\\\" CREATEDB;'\"\n", "delta": "0:00:00.471453", "end": "2020-09-23 02:14:58.779933", "rc": 0, "start": "2020-09-23 02:14:58.308480", "stderr": "", "stderr_lines": [], "stdout": "ALTER ROLE", "stdout_lines": ["ALTER ROLE"]}

TASK [kubernetes : Perform a PostgreSQL restore] ****************************************************************************
changed: [localhost] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}

TASK [kubernetes : Revoke createdb role] ************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "POD=$(oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower  get pods -l=name=postgresql --field-selector status.phase=Running -o jsonpath=\"{.items[0].metadata.name}\")\noc --kubeconfig=/tmp/ansible-tower-config/.kube/config exec $POD -n tower -- bash -c \"\\\n  psql --dbname=template1 -c 'ALTER USER \\\"awx\\\" NOCREATEDB;'\"\n", "delta": "0:00:00.553213", "end": "2020-09-23 02:15:07.456093", "rc": 0, "start": "2020-09-23 02:15:06.902880", "stderr": "", "stderr_lines": [], "stdout": "ALTER ROLE", "stdout_lines": ["ALTER ROLE"]}

TASK [kubernetes : Remove restore directory] ********************************************************************************
changed: [localhost] => {"changed": true, "path": "/home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/tower-openshift-restore", "state": "absent"}

TASK [kubernetes : Scale deployment back up] ********************************************************************************
changed: [localhost] => {"changed": true, "cmd": "oc --kubeconfig=/tmp/ansible-tower-config/.kube/config -n tower  scale deployment ansible-tower --replicas=1\n", "delta": "0:00:00.150938", "end": "2020-09-23 02:15:08.015242", "rc": 0, "start": "2020-09-23 02:15:07.864304", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/ansible-tower scaled", "stdout_lines": ["deployment.apps/ansible-tower scaled"]}

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=27   changed=14   unreachable=0    failed=0    skipped=13   rescued=0    ignored=0   

The setup process completed successfully.
Setup log saved to /home/mdemello/devel/PERSONAL/tower-packaging/setup_openshift/setup_container_cluster-2020-09-23-02:14:25.log
```

Finally, from my backup generated on a standard install, I had 5 rows at main_activitystream_project. So testing it with against the new environment worked as expected:

```bash
(py38) mdemello@p50 ~/d/P/t/setup_openshift> kubectl iexec tower -n tower                                            02:26:28
Container: ✔ ansible-tower-web
sh-4.2$ awx-manage  dbshell
psql (10.6, server 10.12)
Type "help" for help.

awx=> select * from main_activitystream_project;
 id | activitystream_id | project_id 
----+-------------------+------------
  1 |                28 |          6
  2 |               238 |         10
  3 |               387 |         18
  4 |               558 |         10
  5 |               798 |         10
(5 rows)

awx-> \q
```
I have tested with an external database and the changes works as well. 

Thanks!