### PR TITLE
Add username to tooltip

### DIFF
--- a/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
@@ -87,7 +87,7 @@ function ToolbarDeleteButton({
   const renderTooltip = () => {
     const itemsUnableToDelete = itemsToDelete
       .filter(cannotDelete)
-      .map(item => item.name)
+      .map(item => item.name || item.username)
       .join(', ');
     if (itemsToDelete.some(cannotDelete)) {
       return (

--- a/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.test.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.test.jsx
@@ -12,6 +12,11 @@ const itemB = {
   name: 'Foo',
   summary_fields: { user_capabilities: { delete: false } },
 };
+const itemC = {
+  id: 1,
+  username: 'Foo',
+  summary_fields: { user_capabilities: { delete: false } },
+};
 
 describe('<ToolbarDeleteButton />', () => {
   test('should render button', () => {
@@ -60,5 +65,15 @@ describe('<ToolbarDeleteButton />', () => {
     );
     expect(wrapper.find('Tooltip')).toHaveLength(1);
     expect(wrapper.find('Tooltip').prop('content')).toEqual('Delete');
+  });
+
+  test('should render tooltip for username', () => {
+    const wrapper = mountWithContexts(
+      <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[itemC]} />
+    );
+    expect(wrapper.find('Tooltip')).toHaveLength(1);
+    expect(wrapper.find('Tooltip').prop('content').props.children).toEqual(
+      'You do not have permission to delete Items: Foo'
+    );
   });
 });


### PR DESCRIPTION
Add username to tooltip when user cannot be deleted.

See: https://github.com/ansible/awx/issues/7751

Users:

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/9053044/94194543-d53bf700-fe7f-11ea-8e21-bc76df9936c4.png">

Others:

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/9053044/94194705-0caaa380-fe80-11ea-9f94-c6529b68600a.png">


