### PR TITLE
Fix extra GET requests on Notif Template/Container Groups forms

### DIFF
--- a/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.jsx
@@ -21,7 +21,7 @@ import {
 import CredentialLookup from '../../../components/Lookup/CredentialLookup';
 import { VariablesField } from '../../../components/CodeMirrorInput';
 
-function ContainerGroupFormFields({ i18n }) {
+function ContainerGroupFormFields({ i18n, instanceGroup }) {
   const { setFieldValue } = useFormikContext();
   const [credentialField, credentialMeta, credentialHelpers] = useField(
     'credential'
@@ -57,6 +57,7 @@ function ContainerGroupFormFields({ i18n }) {
         tooltip={i18n._(
           t`Credential to authenticate with Kubernetes or OpenShift.  Must be of type "Kubernetes/OpenShift API Bearer Token”.`
         )}
+        autoPopulate={!instanceGroup?.id}
       />
 
       <FormGroup
@@ -120,7 +121,7 @@ function ContainerGroupForm({
       {formik => (
         <Form autoComplete="off" onSubmit={formik.handleSubmit}>
           <FormColumnLayout>
-            <ContainerGroupFormFields {...rest} />
+            <ContainerGroupFormFields instanceGroup={instanceGroup} {...rest} />
             {submitError && <FormSubmitError error={submitError} />}
             <FormActionGroup
               onCancel={onCancel}

--- a/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { func, shape } from 'prop-types';
-import { Formik, useField } from 'formik';
+import { Formik, useField, useFormikContext } from 'formik';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Form, FormGroup } from '@patternfly/react-core';
@@ -22,10 +22,18 @@ import CredentialLookup from '../../../components/Lookup/CredentialLookup';
 import { VariablesField } from '../../../components/CodeMirrorInput';
 
 function ContainerGroupFormFields({ i18n }) {
+  const { setFieldValue } = useFormikContext();
   const [credentialField, credentialMeta, credentialHelpers] = useField(
     'credential'
   );
   const [overrideField] = useField('override');
+
+  const onCredentialChange = useCallback(
+    value => {
+      setFieldValue('credential', value);
+    },
+    [setFieldValue]
+  );
 
   return (
     <>
@@ -43,9 +51,7 @@ function ContainerGroupFormFields({ i18n }) {
         helperTextInvalid={credentialMeta.error}
         isValid={!credentialMeta.touched || !credentialMeta.error}
         onBlur={() => credentialHelpers.setTouched()}
-        onChange={value => {
-          credentialHelpers.setValue(value);
-        }}
+        onChange={onCredentialChange}
         value={credentialField.value}
         required
         tooltip={i18n._(

--- a/awx/ui_next/src/screens/NotificationTemplate/shared/NotificationTemplateForm.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/shared/NotificationTemplateForm.jsx
@@ -16,7 +16,7 @@ import CustomMessagesSubForm from './CustomMessagesSubForm';
 import hasCustomMessages from './hasCustomMessages';
 import typeFieldNames, { initialConfigValues } from './typeFieldNames';
 
-function NotificationTemplateFormFields({ i18n, defaultMessages }) {
+function NotificationTemplateFormFields({ i18n, defaultMessages, template }) {
   const { setFieldValue } = useFormikContext();
   const [orgField, orgMeta, orgHelpers] = useField('organization');
   const [typeField, typeMeta] = useField({
@@ -56,6 +56,7 @@ function NotificationTemplateFormFields({ i18n, defaultMessages }) {
         touched={orgMeta.touched}
         error={orgMeta.error}
         required
+        autoPopulate={!template?.id}
       />
       <FormGroup
         fieldId="notification-type"
@@ -185,6 +186,7 @@ function NotificationTemplateForm({
             <NotificationTemplateFormFields
               i18n={i18n}
               defaultMessages={defaultMessages}
+              template={template}
             />
             <FormSubmitError error={submitError} />
             <FormActionGroup

--- a/awx/ui_next/src/screens/NotificationTemplate/shared/NotificationTemplateForm.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/shared/NotificationTemplateForm.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { shape, func } from 'prop-types';
-import { Formik, useField } from 'formik';
+import { Formik, useField, useFormikContext } from 'formik';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Form, FormGroup } from '@patternfly/react-core';
@@ -17,11 +17,19 @@ import hasCustomMessages from './hasCustomMessages';
 import typeFieldNames, { initialConfigValues } from './typeFieldNames';
 
 function NotificationTemplateFormFields({ i18n, defaultMessages }) {
+  const { setFieldValue } = useFormikContext();
   const [orgField, orgMeta, orgHelpers] = useField('organization');
   const [typeField, typeMeta] = useField({
     name: 'notification_type',
     validate: required(i18n._(t`Select a value for this field`), i18n),
   });
+
+  const onOrganizationChange = useCallback(
+    value => {
+      setFieldValue('organization', value);
+    },
+    [setFieldValue]
+  );
 
   return (
     <>
@@ -43,9 +51,7 @@ function NotificationTemplateFormFields({ i18n, defaultMessages }) {
         helperTextInvalid={orgMeta.error}
         isValid={!orgMeta.touched || !orgMeta.error}
         onBlur={() => orgHelpers.setTouched()}
-        onChange={value => {
-          orgHelpers.setValue(value);
-        }}
+        onChange={onOrganizationChange}
         value={orgField.value}
         touched={orgMeta.touched}
         error={orgMeta.error}


### PR DESCRIPTION
##### SUMMARY
link #8219 

I also hooked up autopopulate on those two forms because that was what was causing the issue.  `onChange` functions that get passed to lookups with autopopulate functionality now have to be wrapped in `useCallback` to stop them from being redefined on every render.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI