### PR TITLE
Include Gettext in dev container image for translation automation

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -30,7 +30,6 @@ RUN dnf -y update && \
     dnf -y install ansible \
     gcc \
     gcc-c++ \
-    gettext \
     git-core \
     glibc-langpack-en \
     libcurl-devel \
@@ -95,6 +94,7 @@ USER root
 # Install development/test requirements
 RUN dnf -y install \
     gtk3 \
+    gettext \
     alsa-lib \
     libX11-xcb \
     libXScrnSaver \


### PR DESCRIPTION
##### SUMMARY

Include gettext package for translation automation.  Currently it is in the build deps section, which gets uninstalled.  We need this to be in the install deps section of the Dockerfile.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer


