### PR TITLE
8238 add related groups

### DIFF
--- a/awx/ui_next/src/api/models/Groups.js
+++ b/awx/ui_next/src/api/models/Groups.js
@@ -35,7 +35,7 @@ class Groups extends Base {
   }
 
   readChildren(id, params) {
-    return this.http.get(`${this.baseUrl}${id}/children/`, params);
+    return this.http.get(`${this.baseUrl}${id}/children/`, { params });
   }
 }
 

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommands.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommands.jsx
@@ -1,26 +1,27 @@
-import React, { useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useCallback, useEffect, useState, useContext } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import PropTypes from 'prop-types';
+import { Button, DropdownItem } from '@patternfly/react-core';
 
 import useRequest, { useDismissableError } from '../../util/useRequest';
-import { InventoriesAPI } from '../../api';
+import { InventoriesAPI, CredentialTypesAPI } from '../../api';
 
 import AlertModal from '../AlertModal';
 import ErrorDetail from '../ErrorDetail';
 import AdHocCommandsWizard from './AdHocCommandsWizard';
+import { KebabifiedContext } from '../../contexts/Kebabified';
 import ContentLoading from '../ContentLoading';
+import ContentError from '../ContentError';
 
-function AdHocCommands({
-  onClose,
-  adHocItems,
-  itemId,
-  i18n,
-  moduleOptions,
-  credentialTypeId,
-}) {
+function AdHocCommands({ adHocItems, i18n, hasListItems }) {
   const history = useHistory();
+  const { id } = useParams();
+
+  const [isWizardOpen, setIsWizardOpen] = useState(false);
+  const { isKebabified, onKebabModalChange } = useContext(KebabifiedContext);
+
   const verbosityOptions = [
     { value: '0', key: '0', label: i18n._(t`0 (Normal)`) },
     { value: '1', key: '1', label: i18n._(t`1 (Verbose)`) },
@@ -28,26 +29,51 @@ function AdHocCommands({
     { value: '3', key: '3', label: i18n._(t`3 (Debug)`) },
     { value: '4', key: '4', label: i18n._(t`4 (Connection Debug)`) },
   ];
+  useEffect(() => {
+    if (isKebabified) {
+      onKebabModalChange(isWizardOpen);
+    }
+  }, [isKebabified, isWizardOpen, onKebabModalChange]);
 
   const {
+    result: { moduleOptions, credentialTypeId, isAdHocDisabled },
+    request: fetchData,
+    error: fetchError,
+  } = useRequest(
+    useCallback(async () => {
+      const [options, cred] = await Promise.all([
+        InventoriesAPI.readAdHocOptions(id),
+        CredentialTypesAPI.read({ namespace: 'ssh' }),
+      ]);
+      return {
+        moduleOptions: options.data.actions.GET.module_name.choices,
+        credentialTypeId: cred.data.results[0].id,
+        isAdHocDisabled: !options.data.actions.POST,
+      };
+    }, [id]),
+    { moduleOptions: [], isAdHocDisabled: true }
+  );
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+  const {
     isloading: isLaunchLoading,
-    error,
+    error: launchError,
     request: launchAdHocCommands,
   } = useRequest(
     useCallback(
       async values => {
-        const { data } = await InventoriesAPI.launchAdHocCommands(
-          itemId,
-          values
-        );
+        const { data } = await InventoriesAPI.launchAdHocCommands(id, values);
         history.push(`/jobs/command/${data.id}/output`);
       },
 
-      [itemId, history]
+      [id, history]
     )
   );
 
-  const { dismissError } = useDismissableError(error);
+  const { error, dismissError } = useDismissableError(
+    launchError || fetchError
+  );
 
   const handleSubmit = async values => {
     const { credential, ...remainingValues } = values;
@@ -64,7 +90,7 @@ function AdHocCommands({
     return <ContentLoading />;
   }
 
-  if (error) {
+  if (error && isWizardOpen) {
     return (
       <AlertModal
         isOpen={error}
@@ -72,31 +98,63 @@ function AdHocCommands({
         title={i18n._(t`Error!`)}
         onClose={() => {
           dismissError();
+          setIsWizardOpen(false);
         }}
       >
-        <>
-          {i18n._(t`Failed to launch job.`)}
-          <ErrorDetail error={error} />
-        </>
+        {launchError ? (
+          <>
+            {i18n._(t`Failed to launch job.`)}
+            <ErrorDetail error={error} />
+          </>
+        ) : (
+          <ContentError error={error} />
+        )}
       </AlertModal>
     );
   }
   return (
-    <AdHocCommandsWizard
-      adHocItems={adHocItems}
-      moduleOptions={moduleOptions}
-      verbosityOptions={verbosityOptions}
-      credentialTypeId={credentialTypeId}
-      onCloseWizard={onClose}
-      onLaunch={handleSubmit}
-      onDismissError={() => dismissError()}
-    />
+    // render buttons for drop down and for toolbar
+    // if modal is open render the modal
+    <>
+      {isKebabified ? (
+        <DropdownItem
+          key="cancel-job"
+          isDisabled={isAdHocDisabled || !hasListItems}
+          component="button"
+          aria-label={i18n._(t`Run Command`)}
+          onClick={() => setIsWizardOpen(true)}
+        >
+          {i18n._(t`Run Command`)}
+        </DropdownItem>
+      ) : (
+        <Button
+          variant="secondary"
+          aria-label={i18n._(t`Run Command`)}
+          onClick={() => setIsWizardOpen(true)}
+          isDisabled={isAdHocDisabled || !hasListItems}
+        >
+          {i18n._(t`Run Command`)}
+        </Button>
+      )}
+
+      {isWizardOpen && (
+        <AdHocCommandsWizard
+          adHocItems={adHocItems}
+          moduleOptions={moduleOptions}
+          verbosityOptions={verbosityOptions}
+          credentialTypeId={credentialTypeId}
+          onCloseWizard={() => setIsWizardOpen(false)}
+          onLaunch={handleSubmit}
+          onDismissError={() => dismissError()}
+        />
+      )}
+    </>
   );
 }
 
 AdHocCommands.propTypes = {
   adHocItems: PropTypes.arrayOf(PropTypes.object).isRequired,
-  itemId: PropTypes.number.isRequired,
+  hasListItems: PropTypes.bool.isRequired,
 };
 
 export default withI18n()(AdHocCommands);

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
@@ -134,8 +134,7 @@ const FormikApp = withFormik({
 
 FormikApp.propTypes = {
   onLaunch: PropTypes.func.isRequired,
-  moduleOptions: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
-    .isRequired,
+  moduleOptions: PropTypes.arrayOf(PropTypes.array).isRequired,
   verbosityOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   onCloseWizard: PropTypes.func.isRequired,
   credentialTypeId: PropTypes.number.isRequired,

--- a/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
@@ -110,7 +110,6 @@ function AdHocDetailsStep({ i18n, verbosityOptions, moduleOptions }) {
             label={i18n._(t`Arguments`)}
             validated={isValid ? 'default' : 'error'}
             onBlur={() => argumentsHelpers.setTouched(true)}
-            placeholder={i18n._(t`Enter arguments`)}
             isRequired={
               moduleNameField.value === 'command' ||
               moduleNameField.value === 'shell'
@@ -317,8 +316,7 @@ function AdHocDetailsStep({ i18n, verbosityOptions, moduleOptions }) {
 }
 
 AdHocDetailsStep.propTypes = {
-  moduleOptions: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
-    .isRequired,
+  moduleOptions: PropTypes.arrayOf(PropTypes.array).isRequired,
   verbosityOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
@@ -59,7 +59,7 @@ function AdHocDetailsStep({ i18n, verbosityOptions, moduleOptions }) {
         <FormFullWidthLayout>
           <FormGroup
             fieldId="module_name"
-            aria-label={i18n._(t`Module`)}
+            aria-label={i18n._(t`select module`)}
             label={i18n._(t`Module`)}
             isRequired
             helperTextInvalid={moduleNameMeta.error}
@@ -136,7 +136,7 @@ function AdHocDetailsStep({ i18n, verbosityOptions, moduleOptions }) {
           />
           <FormGroup
             fieldId="verbosity"
-            aria-label={i18n._(t`Verbosity`)}
+            aria-label={i18n._(t`select verbosity`)}
             label={i18n._(t`Verbosity`)}
             isRequired
             validated={

--- a/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
+++ b/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
@@ -107,7 +107,11 @@ function DisassociateButton({
         >
           {modalNote && <ModalNote>{modalNote}</ModalNote>}
 
-          <div>{i18n._(t`This action will disassociate the following:`)}</div>
+          <div>
+            {i18n._(
+              t`This action will disassociate the following and any of their descendents:`
+            )}
+          </div>
 
           {itemsToDisassociate.map(item => (
             <span key={item.id}>

--- a/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
+++ b/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { arrayOf, func, object, string } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, Tooltip, DropdownItem } from '@patternfly/react-core';
 import styled from 'styled-components';
+import { KebabifiedContext } from '../../contexts/Kebabified';
+
 import AlertModal from '../AlertModal';
 
 const ModalNote = styled.div`
@@ -19,11 +21,18 @@ function DisassociateButton({
   verifyCannotDisassociate = true,
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const { isKebabified, onKebabModalChange } = useContext(KebabifiedContext);
 
   function handleDisassociate() {
     onDisassociate();
     setIsOpen(false);
   }
+
+  useEffect(() => {
+    if (isKebabified) {
+      onKebabModalChange(isOpen);
+    }
+  }, [isKebabified, isOpen, onKebabModalChange]);
 
   function cannotDisassociate(item) {
     return !item.summary_fields?.user_capabilities?.delete;
@@ -67,18 +76,29 @@ function DisassociateButton({
   // See: https://github.com/patternfly/patternfly-react/issues/1894
   return (
     <>
-      <Tooltip content={renderTooltip()} position="top">
-        <div>
-          <Button
-            variant="secondary"
-            aria-label={i18n._(t`Disassociate`)}
-            onClick={() => setIsOpen(true)}
-            isDisabled={isDisabled}
-          >
-            {i18n._(t`Disassociate`)}
-          </Button>
-        </div>
-      </Tooltip>
+      {isKebabified ? (
+        <DropdownItem
+          key="add"
+          isDisabled={isDisabled}
+          component="button"
+          onClick={() => setIsOpen(true)}
+        >
+          {i18n._(t`Delete`)}
+        </DropdownItem>
+      ) : (
+        <Tooltip content={renderTooltip()} position="top">
+          <div>
+            <Button
+              variant="secondary"
+              aria-label={i18n._(t`Disassociate`)}
+              onClick={() => setIsOpen(true)}
+              isDisabled={isDisabled}
+            >
+              {i18n._(t`Disassociate`)}
+            </Button>
+          </div>
+        </Tooltip>
+      )}
 
       {isOpen && (
         <AlertModal
@@ -107,11 +127,7 @@ function DisassociateButton({
         >
           {modalNote && <ModalNote>{modalNote}</ModalNote>}
 
-          <div>
-            {i18n._(
-              t`This action will disassociate the following and any of their descendents:`
-            )}
-          </div>
+          <div>{i18n._(t`This action will disassociate the following:`)}</div>
 
           {itemsToDisassociate.map(item => (
             <span key={item.id}>

--- a/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
+++ b/awx/ui_next/src/components/DisassociateButton/DisassociateButton.jsx
@@ -79,11 +79,12 @@ function DisassociateButton({
       {isKebabified ? (
         <DropdownItem
           key="add"
+          aria-label={i18n._(t`disassociate`)}
           isDisabled={isDisabled}
           component="button"
           onClick={() => setIsOpen(true)}
         >
-          {i18n._(t`Delete`)}
+          {i18n._(t`Disassociate`)}
         </DropdownItem>
       ) : (
         <Tooltip content={renderTooltip()} position="top">

--- a/awx/ui_next/src/screens/Inventory/InventoryGroup/InventoryGroup.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroup/InventoryGroup.jsx
@@ -134,7 +134,7 @@ function InventoryGroup({ i18n, setBreadcrumb, inventory }) {
             key="relatedGroups"
             path="/inventories/inventory/:id/groups/:groupId/nested_groups"
           >
-            <InventoryGroupsRelatedGroup inventoryGroup={inventoryGroup} />
+            <InventoryGroupsRelatedGroup />
           </Route>,
         ]}
         <Route key="not-found" path="*">

--- a/awx/ui_next/src/screens/Inventory/InventoryGroup/InventoryGroup.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroup/InventoryGroup.jsx
@@ -17,6 +17,7 @@ import ContentLoading from '../../../components/ContentLoading';
 import InventoryGroupEdit from '../InventoryGroupEdit/InventoryGroupEdit';
 import InventoryGroupDetail from '../InventoryGroupDetail/InventoryGroupDetail';
 import InventoryGroupHosts from '../InventoryGroupHosts';
+import InventoryGroupsRelatedGroup from '../InventoryRelatedGroups';
 
 import { GroupsAPI } from '../../../api';
 
@@ -128,6 +129,12 @@ function InventoryGroup({ i18n, setBreadcrumb, inventory }) {
             path="/inventories/inventory/:id/groups/:groupId/nested_hosts"
           >
             <InventoryGroupHosts inventoryGroup={inventoryGroup} />
+          </Route>,
+          <Route
+            key="relatedGroups"
+            path="/inventories/inventory/:id/groups/:groupId/nested_groups"
+          >
+            <InventoryGroupsRelatedGroup inventoryGroup={inventoryGroup} />
           </Route>,
         ]}
         <Route key="not-found" path="*">

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -25,7 +25,7 @@ import DisassociateButton from '../../../components/DisassociateButton';
 import { Kebabified } from '../../../contexts/Kebabified';
 import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import InventoryGroupHostListItem from './InventoryGroupHostListItem';
-import AddHostDropdown from './AddHostDropdown';
+import AddHostDropdown from '../shared/AddDropdown';
 
 const QS_CONFIG = getQSConfig('host', {
   page: 1,
@@ -216,6 +216,9 @@ function InventoryGroupHostList({ i18n }) {
                       key="associate"
                       onAddExisting={() => setIsModalOpen(true)}
                       onAddNew={() => history.push(addFormUrl)}
+                      newTitle={i18n._(t`Add new host`)}
+                      existingTitle={i18n._(t`Add existing host`)}
+                      label={i18n._(t`host`)}
                     />,
                   ]
                 : []),
@@ -283,6 +286,9 @@ function InventoryGroupHostList({ i18n }) {
               key="associate"
               onAddExisting={() => setIsModalOpen(true)}
               onAddNew={() => history.push(addFormUrl)}
+              newTitle={i18n._(t`Add new host`)}
+              existingTitle={i18n._(t`Add existing host`)}
+              label={i18n._(t`host`)}
             />
           )
         }

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -166,7 +166,26 @@ function InventoryGroupHostList({ i18n }) {
   const canAdd =
     actions && Object.prototype.hasOwnProperty.call(actions, 'POST');
   const addFormUrl = `/inventories/inventory/${inventoryId}/groups/${groupId}/nested_hosts/add`;
+  const addButtonOptions = [];
 
+  if (canAdd) {
+    addButtonOptions.push(
+      {
+        onAdd: () => setIsModalOpen(true),
+        title: i18n._(t`Add existing host`),
+        label: i18n._(t`host`),
+        key: 'existing',
+      },
+      {
+        onAdd: () => history.push(addFormUrl),
+        title: i18n._(t`Add new host`),
+        label: i18n._(t`host`),
+        key: 'new',
+      }
+    );
+  }
+
+  // const addButton = <AddDropdown key="add" dropdownItems={addButtonOptions} />;
   return (
     <>
       <PaginatedDataList

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx
@@ -25,7 +25,7 @@ import DisassociateButton from '../../../components/DisassociateButton';
 import { Kebabified } from '../../../contexts/Kebabified';
 import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import InventoryGroupHostListItem from './InventoryGroupHostListItem';
-import AddHostDropdown from '../shared/AddDropdown';
+import AddDropdown from '../shared/AddDropdown';
 
 const QS_CONFIG = getQSConfig('host', {
   page: 1,
@@ -185,7 +185,7 @@ function InventoryGroupHostList({ i18n }) {
     );
   }
 
-  // const addButton = <AddDropdown key="add" dropdownItems={addButtonOptions} />;
+  const addButton = <AddDropdown key="add" dropdownItems={addButtonOptions} />;
   return (
     <>
       <PaginatedDataList
@@ -229,18 +229,7 @@ function InventoryGroupHostList({ i18n }) {
             }
             qsConfig={QS_CONFIG}
             additionalControls={[
-              ...(canAdd
-                ? [
-                    <AddHostDropdown
-                      key="associate"
-                      onAddExisting={() => setIsModalOpen(true)}
-                      onAddNew={() => history.push(addFormUrl)}
-                      newTitle={i18n._(t`Add new host`)}
-                      existingTitle={i18n._(t`Add existing host`)}
-                      label={i18n._(t`host`)}
-                    />,
-                  ]
-                : []),
+              ...(canAdd ? [addButton] : []),
               <Kebabified>
                 {({ isKebabified }) =>
                   isKebabified ? (
@@ -299,18 +288,7 @@ function InventoryGroupHostList({ i18n }) {
             onSelect={() => handleSelect(o)}
           />
         )}
-        emptyStateControls={
-          canAdd && (
-            <AddHostDropdown
-              key="associate"
-              onAddExisting={() => setIsModalOpen(true)}
-              onAddNew={() => history.push(addFormUrl)}
-              newTitle={i18n._(t`Add new host`)}
-              existingTitle={i18n._(t`Add existing host`)}
-              label={i18n._(t`host`)}
-            />
-          )
-        }
+        emptyStateControls={canAdd && addButton}
       />
       {isModalOpen && (
         <AssociateModal

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
-import { GroupsAPI, InventoriesAPI, CredentialTypesAPI } from '../../../api';
+import { GroupsAPI, InventoriesAPI } from '../../../api';
 import {
   mountWithContexts,
   waitForElement,
@@ -34,17 +34,6 @@ describe('<InventoryGroupHostList />', () => {
           POST: {},
         },
       },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-          POST: {},
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
     });
     await act(async () => {
       wrapper = mountWithContexts(<InventoryGroupHostList />);
@@ -105,29 +94,6 @@ describe('<InventoryGroupHostList />', () => {
     wrapper.find('DataListCheck').forEach(el => {
       expect(el.props().checked).toBe(false);
     });
-  });
-
-  test('should render enabled ad hoc commands button', async () => {
-    GroupsAPI.readAllHosts.mockResolvedValue({
-      data: { ...mockHosts },
-    });
-    InventoriesAPI.readHostsOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />);
-    });
-
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run command"]',
-      el => el.prop('disabled') === false
-    );
   });
 
   test('should show add dropdown button according to permissions', async () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
@@ -131,7 +131,7 @@ describe('<InventoryGroupHostList />', () => {
   });
 
   test('should show add dropdown button according to permissions', async () => {
-    expect(wrapper.find('AddHostDropdown').length).toBe(1);
+    expect(wrapper.find('AddDropdown').length).toBe(1);
     InventoriesAPI.readHostsOptions.mockResolvedValueOnce({
       data: {
         actions: {
@@ -143,7 +143,7 @@ describe('<InventoryGroupHostList />', () => {
       wrapper = mountWithContexts(<InventoryGroupHostList />);
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
-    expect(wrapper.find('AddHostDropdown').length).toBe(0);
+    expect(wrapper.find('AddDropdown').length).toBe(0);
   });
 
   test('expected api calls are made for multi-delete', async () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
@@ -190,11 +190,11 @@ describe('<InventoryGroupHostList />', () => {
 
   test('should show associate host modal when adding an existing host', () => {
     const dropdownToggle = wrapper.find(
-      'DropdownToggle button[aria-label="add host"]'
+      'DropdownToggle button[aria-label="add"]'
     );
     dropdownToggle.simulate('click');
     wrapper
-      .find('DropdownItem[aria-label="add existing host"]')
+      .find('DropdownItem[aria-label="Add existing host"]')
       .simulate('click');
     expect(wrapper.find('AssociateModal').length).toBe(1);
     wrapper.find('ModalBoxCloseButton').simulate('click');
@@ -209,12 +209,10 @@ describe('<InventoryGroupHostList />', () => {
         results: [{ id: 123, name: 'foo', url: '/api/v2/hosts/123/' }],
       },
     });
-    wrapper
-      .find('DropdownToggle button[aria-label="add host"]')
-      .simulate('click');
+    wrapper.find('DropdownToggle button[aria-label="add"]').simulate('click');
     await act(async () => {
       wrapper
-        .find('DropdownItem[aria-label="add existing host"]')
+        .find('DropdownItem[aria-label="Add existing host"]')
         .simulate('click');
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
@@ -241,12 +239,10 @@ describe('<InventoryGroupHostList />', () => {
         results: [{ id: 123, name: 'foo', url: '/api/v2/hosts/123/' }],
       },
     });
-    wrapper
-      .find('DropdownToggle button[aria-label="add host"]')
-      .simulate('click');
+    wrapper.find('DropdownToggle button[aria-label="add"]').simulate('click');
     await act(async () => {
       wrapper
-        .find('DropdownItem[aria-label="add existing host"]')
+        .find('DropdownItem[aria-label="Add existing host"]')
         .simulate('click');
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
@@ -288,10 +284,10 @@ describe('<InventoryGroupHostList />', () => {
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     const dropdownToggle = wrapper.find(
-      'DropdownToggle button[aria-label="add host"]'
+      'DropdownToggle button[aria-label="add"]'
     );
     dropdownToggle.simulate('click');
-    wrapper.find('DropdownItem[aria-label="add new host"]').simulate('click');
+    wrapper.find('DropdownItem[aria-label="Add new host"]').simulate('click');
     expect(history.location.pathname).toEqual(
       '/inventories/inventory/1/groups/2/nested_hosts/add'
     );

--- a/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.jsx
@@ -6,7 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
-import { InventoriesAPI, GroupsAPI, CredentialTypesAPI } from '../../../api';
+import { InventoriesAPI, GroupsAPI } from '../../../api';
 import InventoryGroupsList from './InventoryGroupsList';
 
 jest.mock('../../../api');
@@ -70,17 +70,6 @@ describe('<InventoryGroupsList />', () => {
           POST: {},
         },
       },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-          POST: {},
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
     });
     const history = createMemoryHistory({
       initialEntries: ['/inventories/inventory/3/groups'],
@@ -158,13 +147,6 @@ describe('<InventoryGroupsList />', () => {
       expect(el.props().checked).toBe(false);
     });
   });
-  test('should render enabled ad hoc commands button', async () => {
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run command"]',
-      el => el.prop('disabled') === false
-    );
-  });
 });
 describe('<InventoryGroupsList/> error handling', () => {
   let wrapper;
@@ -194,16 +176,6 @@ describe('<InventoryGroupsList/> error handling', () => {
         },
       })
     );
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
-    });
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -230,21 +202,8 @@ describe('<InventoryGroupsList/> error handling', () => {
   });
 
   test('should show error modal when group is not successfully deleted from api', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/3/groups'],
-    });
-
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/inventory/:id/groups">
-          <InventoryGroupsList />
-        </Route>,
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
+      wrapper = mountWithContexts(<InventoryGroupsList />);
     });
     waitForElement(wrapper, 'ContentEmpty', el => el.length === 0);
 
@@ -280,28 +239,5 @@ describe('<InventoryGroupsList/> error handling', () => {
         .find('AlertModal[aria-label="deletion error"]')
         .invoke('onClose')();
     });
-  });
-  test('should render disabled ad hoc button', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/3/groups'],
-    });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/inventory/:id/groups">
-          <InventoryGroupsList />
-        </Route>,
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
-    });
-
-    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
-    expect(
-      wrapper.find('button[aria-label="Run command"]').prop('disabled')
-    ).toBe(true);
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.jsx
@@ -2,19 +2,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import {
-  Button,
-  Tooltip,
-  DropdownItem,
-  ToolbarItem,
-} from '@patternfly/react-core';
 import { getQSConfig, parseQueryString, mergeParams } from '../../../util/qs';
 import useRequest, {
   useDismissableError,
   useDeleteItems,
 } from '../../../util/useRequest';
 import useSelected from '../../../util/useSelected';
-import { HostsAPI, InventoriesAPI, CredentialTypesAPI } from '../../../api';
+import { HostsAPI, InventoriesAPI } from '../../../api';
 import DataListToolbar from '../../../components/DataListToolbar';
 import AlertModal from '../../../components/AlertModal';
 import ErrorDetail from '../../../components/ErrorDetail';
@@ -23,7 +17,6 @@ import PaginatedDataList, {
 } from '../../../components/PaginatedDataList';
 import AssociateModal from '../../../components/AssociateModal';
 import DisassociateButton from '../../../components/DisassociateButton';
-import { Kebabified } from '../../../contexts/Kebabified';
 import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import InventoryHostGroupItem from './InventoryHostGroupItem';
 
@@ -35,7 +28,6 @@ const QS_CONFIG = getQSConfig('group', {
 
 function InventoryHostGroupsList({ i18n }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isAdHocCommandsOpen, setIsAdHocCommandsOpen] = useState(false);
   const { hostId, id: invId } = useParams();
   const { search } = useLocation();
 
@@ -46,9 +38,6 @@ function InventoryHostGroupsList({ i18n }) {
       actions,
       relatedSearchableKeys,
       searchableKeys,
-      moduleOptions,
-      isAdHocDisabled,
-      credentialTypeId,
     },
     error: contentError,
     isLoading,
@@ -62,13 +51,9 @@ function InventoryHostGroupsList({ i18n }) {
           data: { count, results },
         },
         hostGroupOptions,
-        adHocOptions,
-        cred,
       ] = await Promise.all([
         HostsAPI.readAllGroups(hostId, params),
         HostsAPI.readGroupsOptions(hostId),
-        InventoriesAPI.readAdHocOptions(invId),
-        CredentialTypesAPI.read({ namespace: 'ssh' }),
       ]);
 
       return {
@@ -81,9 +66,6 @@ function InventoryHostGroupsList({ i18n }) {
         searchableKeys: Object.keys(
           hostGroupOptions.data.actions?.GET || {}
         ).filter(key => hostGroupOptions.data.actions?.GET[key].filterable),
-        moduleOptions: adHocOptions.data.actions.GET.module_name.choices,
-        credentialTypeId: cred.data.results[0].id,
-        isAdHocDisabled: !adHocOptions.data.actions.POST,
       };
     }, [hostId, search]), // eslint-disable-line react-hooks/exhaustive-deps
     {
@@ -92,8 +74,6 @@ function InventoryHostGroupsList({ i18n }) {
       actions: {},
       relatedSearchableKeys: [],
       searchableKeys: [],
-      moduleOptions: [],
-      isAdHocDisabled: true,
     }
   );
 
@@ -222,40 +202,10 @@ function InventoryHostGroupsList({ i18n }) {
                     />,
                   ]
                 : []),
-              <Kebabified>
-                {({ isKebabified }) =>
-                  isKebabified ? (
-                    <DropdownItem
-                      key="run command"
-                      aria-label={i18n._(t`Run command`)}
-                      onClick={() => setIsAdHocCommandsOpen(true)}
-                      isDisabled={itemCount === 0 || isAdHocDisabled}
-                    >
-                      {i18n._(t`Run command`)}
-                    </DropdownItem>
-                  ) : (
-                    <ToolbarItem>
-                      <Tooltip
-                        content={i18n._(
-                          t`Select an inventory source by clicking the check box beside it. The inventory source can be a single group or host, a selection of multiple hosts, or a selection of multiple groups.`
-                        )}
-                        position="top"
-                        key="adhoc"
-                      >
-                        <Button
-                          key="run command"
-                          variant="secondary"
-                          aria-label={i18n._(t`Run command`)}
-                          onClick={() => setIsAdHocCommandsOpen(true)}
-                          isDisabled={itemCount === 0 || isAdHocDisabled}
-                        >
-                          {i18n._(t`Run command`)}
-                        </Button>
-                      </Tooltip>
-                    </ToolbarItem>
-                  )
-                }
-              </Kebabified>,
+              <AdHocCommands
+                adHocItems={selected}
+                hasListItems={itemCount > 0}
+              />,
               <DisassociateButton
                 key="disassociate"
                 onDisassociate={handleDisassociate}
@@ -286,16 +236,6 @@ function InventoryHostGroupsList({ i18n }) {
           onAssociate={handleAssociate}
           onClose={() => setIsModalOpen(false)}
           title={i18n._(t`Select Groups`)}
-        />
-      )}
-      {isAdHocCommandsOpen && (
-        <AdHocCommands
-          css="margin-right: 20px"
-          adHocItems={selected}
-          itemId={parseInt(invId, 10)}
-          onClose={() => setIsAdHocCommandsOpen(false)}
-          credentialTypeId={credentialTypeId}
-          moduleOptions={moduleOptions}
         />
       )}
       {error && (

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
@@ -6,7 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
-import { HostsAPI, InventoriesAPI, CredentialTypesAPI } from '../../../api';
+import { HostsAPI, InventoriesAPI } from '../../../api';
 import InventoryHostGroupsList from './InventoryHostGroupsList';
 
 jest.mock('../../../api');
@@ -79,17 +79,6 @@ describe('<InventoryHostGroupsList />', () => {
           POST: {},
         },
       },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-          POST: {},
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
     });
     const history = createMemoryHistory({
       initialEntries: ['/inventories/inventory/1/hosts/3/groups'],
@@ -282,12 +271,5 @@ describe('<InventoryHostGroupsList />', () => {
     });
     wrapper.update();
     expect(wrapper.find('AlertModal ErrorDetail').length).toBe(1);
-  });
-  test('should render enabled ad hoc commands button', async () => {
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run command"]',
-      el => el.prop('disabled') === false
-    );
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
@@ -2,14 +2,8 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import {
-  Button,
-  Tooltip,
-  DropdownItem,
-  ToolbarItem,
-} from '@patternfly/react-core';
 import { getQSConfig, parseQueryString } from '../../../util/qs';
-import { InventoriesAPI, HostsAPI, CredentialTypesAPI } from '../../../api';
+import { InventoriesAPI, HostsAPI } from '../../../api';
 import useRequest, { useDeleteItems } from '../../../util/useRequest';
 import AlertModal from '../../../components/AlertModal';
 import DataListToolbar from '../../../components/DataListToolbar';
@@ -18,7 +12,6 @@ import PaginatedDataList, {
   ToolbarAddButton,
   ToolbarDeleteButton,
 } from '../../../components/PaginatedDataList';
-import { Kebabified } from '../../../contexts/Kebabified';
 import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import InventoryHostItem from './InventoryHostItem';
 
@@ -29,7 +22,6 @@ const QS_CONFIG = getQSConfig('host', {
 });
 
 function InventoryHostList({ i18n }) {
-  const [isAdHocCommandsOpen, setIsAdHocCommandsOpen] = useState(false);
   const [selected, setSelected] = useState([]);
   const { id } = useParams();
   const { search } = useLocation();
@@ -41,9 +33,6 @@ function InventoryHostList({ i18n }) {
       actions,
       relatedSearchableKeys,
       searchableKeys,
-      moduleOptions,
-      credentialTypeId,
-      isAdHocDisabled,
     },
     error: contentError,
     isLoading,
@@ -51,11 +40,9 @@ function InventoryHostList({ i18n }) {
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, search);
-      const [response, hostOptions, adHocOptions, cred] = await Promise.all([
+      const [response, hostOptions] = await Promise.all([
         InventoriesAPI.readHosts(id, params),
         InventoriesAPI.readHostsOptions(id),
-        InventoriesAPI.readAdHocOptions(id),
-        CredentialTypesAPI.read({ namespace: 'ssh' }),
       ]);
 
       return {
@@ -68,9 +55,6 @@ function InventoryHostList({ i18n }) {
         searchableKeys: Object.keys(hostOptions.data.actions?.GET || {}).filter(
           key => hostOptions.data.actions?.GET[key].filterable
         ),
-        moduleOptions: adHocOptions.data.actions.GET.module_name.choices,
-        credentialTypeId: cred.data.results[0].id,
-        isAdHocDisabled: !adHocOptions.data.actions.POST,
       };
     }, [id, search]),
     {
@@ -79,8 +63,6 @@ function InventoryHostList({ i18n }) {
       actions: {},
       relatedSearchableKeys: [],
       searchableKeys: [],
-      moduleOptions: [],
-      isAdHocDisabled: true,
     }
   );
 
@@ -162,40 +144,10 @@ function InventoryHostList({ i18n }) {
                     />,
                   ]
                 : []),
-              <Kebabified>
-                {({ isKebabified }) =>
-                  isKebabified ? (
-                    <DropdownItem
-                      key="run command"
-                      onClick={() => setIsAdHocCommandsOpen(true)}
-                      isDisabled={hostCount === 0 || isAdHocDisabled}
-                      aria-label={i18n._(t`Run command`)}
-                    >
-                      {i18n._(t`Run command`)}
-                    </DropdownItem>
-                  ) : (
-                    <ToolbarItem>
-                      <Tooltip
-                        content={i18n._(
-                          t`Select an inventory source by clicking the check box beside it. The inventory source can be a single host or a selection of multiple hosts.`
-                        )}
-                        position="top"
-                        key="adhoc"
-                      >
-                        <Button
-                          variant="secondary"
-                          key="run command"
-                          aria-label={i18n._(t`Run command`)}
-                          onClick={() => setIsAdHocCommandsOpen(true)}
-                          isDisabled={hostCount === 0 || isAdHocDisabled}
-                        >
-                          {i18n._(t`Run command`)}
-                        </Button>
-                      </Tooltip>
-                    </ToolbarItem>
-                  )
-                }
-              </Kebabified>,
+              <AdHocCommands
+                adHocItems={selected}
+                hasListItems={hostCount > 0}
+              />,
               <ToolbarDeleteButton
                 key="delete"
                 onDelete={deleteHosts}
@@ -224,16 +176,6 @@ function InventoryHostList({ i18n }) {
           )
         }
       />
-      {isAdHocCommandsOpen && (
-        <AdHocCommands
-          css="margin-right: 20px"
-          adHocItems={selected}
-          onClose={() => setIsAdHocCommandsOpen(false)}
-          credentialTypeId={credentialTypeId}
-          moduleOptions={moduleOptions}
-          itemId={parseInt(id, 10)}
-        />
-      )}
       {deletionError && (
         <AlertModal
           isOpen={deletionError}

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { InventoriesAPI, HostsAPI, CredentialTypesAPI } from '../../../api';
+import { InventoriesAPI, HostsAPI } from '../../../api';
 import {
   mountWithContexts,
   waitForElement,
@@ -92,17 +92,6 @@ describe('<InventoryHostList />', () => {
           POST: {},
         },
       },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-          POST: {},
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
     });
     await act(async () => {
       wrapper = mountWithContexts(<InventoryHostList />);
@@ -276,13 +265,6 @@ describe('<InventoryHostList />', () => {
     expect(wrapper.find('ToolbarAddButton').length).toBe(1);
   });
 
-  test('should render enabled ad hoc commands button', async () => {
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run command"]',
-      el => el.prop('disabled') === false
-    );
-  });
   test('should hide Add button for users without ability to POST', async () => {
     InventoriesAPI.readHostsOptions.mockResolvedValueOnce({
       data: {

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import {
-  Button,
-  Tooltip,
-  DropdownItem,
-  ToolbarItem,
-} from '@patternfly/react-core';
 import { useParams, useLocation, useHistory } from 'react-router-dom';
 
 import { GroupsAPI, InventoriesAPI } from '../../../api';
@@ -18,7 +12,6 @@ import DataListToolbar from '../../../components/DataListToolbar';
 import PaginatedDataList from '../../../components/PaginatedDataList';
 import InventoryGroupRelatedGroupListItem from './InventoryRelatedGroupListItem';
 import AddDropdown from '../shared/AddDropdown';
-import { Kebabified } from '../../../contexts/Kebabified';
 import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import AssociateModal from '../../../components/AssociateModal';
 import DisassociateButton from '../../../components/DisassociateButton';
@@ -157,56 +150,10 @@ function InventoryRelatedGroupList({ i18n }) {
             qsConfig={QS_CONFIG}
             additionalControls={[
               ...(canAdd ? [addButton] : []),
-              <Kebabified>
-                {({ isKebabified }) =>
-                  isKebabified ? (
-                    <AdHocCommands
-                      adHocItems={selected}
-                      apiModule={InventoriesAPI}
-                      itemId={parseInt(inventoryId, 10)}
-                    >
-                      {({ openAdHocCommands, isDisabled }) => (
-                        <DropdownItem
-                          key="run command"
-                          onClick={openAdHocCommands}
-                          isDisabled={itemCount === 0 || isDisabled}
-                        >
-                          {i18n._(t`Run command`)}
-                        </DropdownItem>
-                      )}
-                    </AdHocCommands>
-                  ) : (
-                    <ToolbarItem>
-                      <Tooltip
-                        content={i18n._(
-                          t`Select an inventory source by clicking the check box beside it.
-                          The inventory source can be a single host or a selection of multiple hosts.`
-                        )}
-                        position="top"
-                        key="adhoc"
-                      >
-                        <AdHocCommands
-                          css="margin-right: 20px"
-                          adHocItems={selected}
-                          apiModule={InventoriesAPI}
-                          itemId={parseInt(inventoryId, 10)}
-                        >
-                          {({ openAdHocCommands, isDisabled }) => (
-                            <Button
-                              variant="secondary"
-                              aria-label={i18n._(t`Run command`)}
-                              onClick={openAdHocCommands}
-                              isDisabled={itemCount === 0 || isDisabled}
-                            >
-                              {i18n._(t`Run command`)}
-                            </Button>
-                          )}
-                        </AdHocCommands>
-                      </Tooltip>
-                    </ToolbarItem>
-                  )
-                }
-              </Kebabified>,
+              <AdHocCommands
+                adHocItems={selected}
+                hasListItems={itemCount > 0}
+              />,
               <DisassociateButton
                 key="disassociate"
                 onDisassociate={() => {}}

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
@@ -19,7 +19,7 @@ import PaginatedDataList from '../../../components/PaginatedDataList';
 import InventoryGroupRelatedGroupListItem from './InventoryRelatedGroupListItem';
 import AddDropdown from '../shared/AddDropdown';
 import { Kebabified } from '../../../contexts/Kebabified';
-import AdHocCommandsButton from '../../../components/AdHocCommands/AdHocCommands';
+import AdHocCommands from '../../../components/AdHocCommands/AdHocCommands';
 import AssociateModal from '../../../components/AssociateModal';
 import DisassociateButton from '../../../components/DisassociateButton';
 
@@ -160,7 +160,7 @@ function InventoryRelatedGroupList({ i18n }) {
               <Kebabified>
                 {({ isKebabified }) =>
                   isKebabified ? (
-                    <AdHocCommandsButton
+                    <AdHocCommands
                       adHocItems={selected}
                       apiModule={InventoriesAPI}
                       itemId={parseInt(inventoryId, 10)}
@@ -174,7 +174,7 @@ function InventoryRelatedGroupList({ i18n }) {
                           {i18n._(t`Run command`)}
                         </DropdownItem>
                       )}
-                    </AdHocCommandsButton>
+                    </AdHocCommands>
                   ) : (
                     <ToolbarItem>
                       <Tooltip
@@ -185,7 +185,7 @@ function InventoryRelatedGroupList({ i18n }) {
                         position="top"
                         key="adhoc"
                       >
-                        <AdHocCommandsButton
+                        <AdHocCommands
                           css="margin-right: 20px"
                           adHocItems={selected}
                           apiModule={InventoriesAPI}
@@ -201,7 +201,7 @@ function InventoryRelatedGroupList({ i18n }) {
                               {i18n._(t`Run command`)}
                             </Button>
                           )}
-                        </AdHocCommandsButton>
+                        </AdHocCommands>
                       </Tooltip>
                     </ToolbarItem>
                   )

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
@@ -1,0 +1,246 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import {
+  Button,
+  Tooltip,
+  DropdownItem,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { useParams, useLocation, useHistory } from 'react-router-dom';
+
+import { GroupsAPI, InventoriesAPI } from '../../../api';
+import useRequest from '../../../util/useRequest';
+import { getQSConfig, parseQueryString, mergeParams } from '../../../util/qs';
+import useSelected from '../../../util/useSelected';
+
+import DataListToolbar from '../../../components/DataListToolbar';
+import PaginatedDataList from '../../../components/PaginatedDataList';
+import InventoryGroupRelatedGroupListItem from './InventoryRelatedGroupListItem';
+import AddDropdown from '../shared/AddDropdown';
+import { Kebabified } from '../../../contexts/Kebabified';
+import AdHocCommandsButton from '../../../components/AdHocCommands/AdHocCommands';
+import AssociateModal from '../../../components/AssociateModal';
+import DisassociateButton from '../../../components/DisassociateButton';
+
+const QS_CONFIG = getQSConfig('group', {
+  page: 1,
+  page_size: 20,
+  order_by: 'name',
+});
+function InventoryRelatedGroupList({ i18n, inventoryGroup }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { id: inventoryId, groupId } = useParams();
+  const location = useLocation();
+  const history = useHistory();
+  const {
+    request: fetchRelated,
+    result: {
+      groups,
+      itemCount,
+      relatedSearchableKeys,
+      searchableKeys,
+      canAdd,
+    },
+    isLoading,
+    error: contentError,
+  } = useRequest(
+    useCallback(async () => {
+      const params = parseQueryString(QS_CONFIG, location.search);
+      const [response, actions] = await Promise.all([
+        GroupsAPI.readChildren(groupId, params),
+        InventoriesAPI.readGroupsOptions(inventoryId),
+      ]);
+
+      return {
+        groups: response.data.results,
+        itemCount: response.data.count,
+        relatedSearchableKeys: (
+          actions?.data?.related_search_fields || []
+        ).map(val => val.slice(0, -8)),
+        searchableKeys: Object.keys(actions.data.actions?.GET || {}).filter(
+          key => actions.data.actions?.GET[key].filterable
+        ),
+        canAdd:
+          actions.data.actions &&
+          Object.prototype.hasOwnProperty.call(actions.data.actions, 'POST'),
+      };
+    }, [groupId, location.search, inventoryId]),
+    { groups: [], itemCount: 0, canAdd: false }
+  );
+  useEffect(() => {
+    fetchRelated();
+  }, [fetchRelated]);
+
+  const fetchGroupsToAssociate = useCallback(
+    params => {
+      return InventoriesAPI.readGroups(
+        inventoryId,
+        mergeParams(params, { not__id: inventoryId, not__parents: inventoryId })
+      );
+    },
+    [inventoryId]
+  );
+
+  const fetchGroupsOptions = useCallback(
+    () => InventoriesAPI.readGroupsOptions(inventoryId),
+    [inventoryId]
+  );
+
+  const { selected, isAllSelected, handleSelect, setSelected } = useSelected(
+    groups
+  );
+
+  const addFormUrl = `/home`;
+
+  return (
+    <>
+      <PaginatedDataList
+        contentError={contentError}
+        hasContentLoading={isLoading}
+        items={groups}
+        itemCount={itemCount}
+        pluralizedItemName={i18n._(t`Related Groups`)}
+        qsConfig={QS_CONFIG}
+        onRowClick={handleSelect}
+        toolbarSearchColumns={[
+          {
+            name: i18n._(t`Name`),
+            key: 'name__icontains',
+            isDefault: true,
+          },
+          {
+            name: i18n._(t`Created By (Username)`),
+            key: 'created_by__username__icontains',
+          },
+          {
+            name: i18n._(t`Modified By (Username)`),
+            key: 'modified_by__username__icontains',
+          },
+        ]}
+        toolbarSortColumns={[
+          {
+            name: i18n._(t`Name`),
+            key: 'name',
+          },
+        ]}
+        toolbarSearchableKeys={searchableKeys}
+        toolbarRelatedSearchableKeys={relatedSearchableKeys}
+        renderToolbar={props => (
+          <DataListToolbar
+            {...props}
+            showSelectAll
+            isAllSelected={isAllSelected}
+            onSelectAll={isSelected =>
+              setSelected(isSelected ? [...groups] : [])
+            }
+            qsConfig={QS_CONFIG}
+            additionalControls={[
+              ...(canAdd
+                ? [
+                    <AddDropdown
+                      key="associate"
+                      onAddExisting={() => setIsModalOpen(true)}
+                      onAddNew={() => history.push(addFormUrl)}
+                      newTitle={i18n._(t`Add new group`)}
+                      existingTitle={i18n._(t`Add existing group`)}
+                      label={i18n._(t`group`)}
+                    />,
+                  ]
+                : []),
+              <Kebabified>
+                {({ isKebabified }) =>
+                  isKebabified ? (
+                    <AdHocCommandsButton
+                      adHocItems={selected}
+                      apiModule={InventoriesAPI}
+                      itemId={parseInt(inventoryId, 10)}
+                    >
+                      {({ openAdHocCommands, isDisabled }) => (
+                        <DropdownItem
+                          key="run command"
+                          onClick={openAdHocCommands}
+                          isDisabled={itemCount === 0 || isDisabled}
+                        >
+                          {i18n._(t`Run command`)}
+                        </DropdownItem>
+                      )}
+                    </AdHocCommandsButton>
+                  ) : (
+                    <ToolbarItem>
+                      <Tooltip
+                        content={i18n._(
+                          t`Select an inventory source by clicking the check box beside it. The inventory source can be a single host or a selection of multiple hosts.`
+                        )}
+                        position="top"
+                        key="adhoc"
+                      >
+                        <AdHocCommandsButton
+                          css="margin-right: 20px"
+                          adHocItems={selected}
+                          apiModule={InventoriesAPI}
+                          itemId={parseInt(inventoryId, 10)}
+                        >
+                          {({ openAdHocCommands, isDisabled }) => (
+                            <Button
+                              variant="secondary"
+                              aria-label={i18n._(t`Run command`)}
+                              onClick={openAdHocCommands}
+                              isDisabled={itemCount === 0 || isDisabled}
+                            >
+                              {i18n._(t`Run command`)}
+                            </Button>
+                          )}
+                        </AdHocCommandsButton>
+                      </Tooltip>
+                    </ToolbarItem>
+                  )
+                }
+              </Kebabified>,
+              <DisassociateButton
+                key="disassociate"
+                onDisassociate={() => {}}
+                itemsToDisassociate={selected}
+                modalTitle={i18n._(t`Disassociate related group(s)?`)}
+              />,
+            ]}
+          />
+        )}
+        renderItem={o => (
+          <InventoryGroupRelatedGroupListItem
+            key={o.id}
+            group={o}
+            detailUrl={`/inventories/inventory/${inventoryId}/groups/${o.id}/details`}
+            editUrl={`/inventories/inventory/${inventoryId}/groups/${o.id}/edit`}
+            isSelected={selected.some(row => row.id === o.id)}
+            onSelect={() => handleSelect(o)}
+          />
+        )}
+        emptyStateControls={
+          canAdd && (
+            <AddDropdown
+              key="associate"
+              onAddExisting={() => setIsModalOpen(true)}
+              onAddNew={() => history.push(addFormUrl)}
+              newTitle={i18n._(t`Add new group`)}
+              existingTitle={i18n._(t`Add existing group`)}
+              label={i18n._(t`group`)}
+            />
+          )
+        }
+      />
+      {isModalOpen && (
+        <AssociateModal
+          header={i18n._(t`Groups`)}
+          fetchRequest={fetchGroupsToAssociate}
+          optionsRequest={fetchGroupsOptions}
+          isModalOpen={isModalOpen}
+          onAssociate={() => {}}
+          onClose={() => setIsModalOpen(false)}
+          title={i18n._(t`Select Groups`)}
+        />
+      )}
+    </>
+  );
+}
+export default withI18n()(InventoryRelatedGroupList);

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
@@ -28,7 +28,7 @@ const QS_CONFIG = getQSConfig('group', {
   page_size: 20,
   order_by: 'name',
 });
-function InventoryRelatedGroupList({ i18n, inventoryGroup }) {
+function InventoryRelatedGroupList({ i18n }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { id: inventoryId, groupId } = useParams();
   const location = useLocation();
@@ -92,6 +92,26 @@ function InventoryRelatedGroupList({ i18n, inventoryGroup }) {
   );
 
   const addFormUrl = `/home`;
+  const addButtonOptions = [];
+
+  if (canAdd) {
+    addButtonOptions.push(
+      {
+        onAdd: () => setIsModalOpen(true),
+        title: i18n._(t`Add existing group`),
+        label: i18n._(t`group`),
+        key: 'existing',
+      },
+      {
+        onAdd: () => history.push(addFormUrl),
+        title: i18n._(t`Add new group`),
+        label: i18n._(t`group`),
+        key: 'new',
+      }
+    );
+  }
+
+  const addButton = <AddDropdown key="add" dropdownItems={addButtonOptions} />;
 
   return (
     <>
@@ -136,18 +156,7 @@ function InventoryRelatedGroupList({ i18n, inventoryGroup }) {
             }
             qsConfig={QS_CONFIG}
             additionalControls={[
-              ...(canAdd
-                ? [
-                    <AddDropdown
-                      key="associate"
-                      onAddExisting={() => setIsModalOpen(true)}
-                      onAddNew={() => history.push(addFormUrl)}
-                      newTitle={i18n._(t`Add new group`)}
-                      existingTitle={i18n._(t`Add existing group`)}
-                      label={i18n._(t`group`)}
-                    />,
-                  ]
-                : []),
+              ...(canAdd ? [addButton] : []),
               <Kebabified>
                 {({ isKebabified }) =>
                   isKebabified ? (

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx
@@ -179,7 +179,8 @@ function InventoryRelatedGroupList({ i18n }) {
                     <ToolbarItem>
                       <Tooltip
                         content={i18n._(
-                          t`Select an inventory source by clicking the check box beside it. The inventory source can be a single host or a selection of multiple hosts.`
+                          t`Select an inventory source by clicking the check box beside it.
+                          The inventory source can be a single host or a selection of multiple hosts.`
                         )}
                         position="top"
                         key="adhoc"
@@ -228,7 +229,6 @@ function InventoryRelatedGroupList({ i18n }) {
         emptyStateControls={
           canAdd && (
             <AddDropdown
-              key="associate"
               onAddExisting={() => setIsModalOpen(true)}
               onAddNew={() => history.push(addFormUrl)}
               newTitle={i18n._(t`Add new group`)}

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { GroupsAPI, InventoriesAPI } from '../../../api';
+import {
+  mountWithContexts,
+  waitForElement,
+} from '../../../../testUtils/enzymeHelpers';
+import InventoryRelatedGroupList from './InventoryRelatedGroupList';
+import mockRelatedGroups from '../shared/data.relatedGroups.json';
+
+jest.mock('../../../api/models/Groups');
+jest.mock('../../../api/models/Inventories');
+jest.mock('../../../api/models/CredentialTypes');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    id: 1,
+    groupId: 2,
+  }),
+}));
+
+describe('<InventoryRelatedGroupList />', () => {
+  let wrapper;
+
+  beforeEach(async () => {
+    GroupsAPI.readChildren.mockResolvedValue({
+      data: { ...mockRelatedGroups },
+    });
+    InventoriesAPI.readGroupsOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [
+          'parents__search',
+          'inventory__search',
+          'inventory_sources__search',
+          'created_by__search',
+          'children__search',
+          'modified_by__search',
+          'hosts__search',
+        ],
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+    });
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    wrapper.unmount();
+  });
+
+  test('initially renders successfully ', () => {
+    expect(wrapper.find('InventoryRelatedGroupList').length).toBe(1);
+  });
+
+  test('should fetch inventory group hosts from api and render them in the list', () => {
+    expect(GroupsAPI.readChildren).toHaveBeenCalled();
+    expect(InventoriesAPI.readGroupsOptions).toHaveBeenCalled();
+    expect(wrapper.find('InventoryRelatedGroupListItem').length).toBe(3);
+  });
+
+  test('should check and uncheck the row item', async () => {
+    expect(
+      wrapper.find('DataListCheck[id="select-group-2"]').props().checked
+    ).toBe(false);
+    await act(async () => {
+      wrapper.find('DataListCheck[id="select-group-2"]').invoke('onChange')();
+    });
+    wrapper.update();
+    expect(
+      wrapper.find('DataListCheck[id="select-group-2"]').props().checked
+    ).toBe(true);
+    await act(async () => {
+      wrapper.find('DataListCheck[id="select-group-2"]').invoke('onChange')();
+    });
+    wrapper.update();
+    expect(
+      wrapper.find('DataListCheck[id="select-group-2"]').props().checked
+    ).toBe(false);
+  });
+
+  test('should check all row items when select all is checked', async () => {
+    wrapper.find('DataListCheck').forEach(el => {
+      expect(el.props().checked).toBe(false);
+    });
+    await act(async () => {
+      wrapper.find('Checkbox#select-all').invoke('onChange')(true);
+    });
+    wrapper.update();
+    wrapper.find('DataListCheck').forEach(el => {
+      expect(el.props().checked).toBe(true);
+    });
+    await act(async () => {
+      wrapper.find('Checkbox#select-all').invoke('onChange')(false);
+    });
+    wrapper.update();
+    wrapper.find('DataListCheck').forEach(el => {
+      expect(el.props().checked).toBe(false);
+    });
+  });
+
+  test('should show content error when api throws error on initial render', async () => {
+    GroupsAPI.readChildren.mockResolvedValueOnce({
+      data: { ...mockRelatedGroups },
+    });
+    InventoriesAPI.readGroupsOptions.mockImplementationOnce(() =>
+      Promise.reject(new Error())
+    );
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+    });
+    await waitForElement(wrapper, 'ContentError', el => el.length === 1);
+  });
+
+  test('should show add dropdown button according to permissions', async () => {
+    GroupsAPI.readChildren.mockResolvedValueOnce({
+      data: { ...mockRelatedGroups },
+    });
+    InventoriesAPI.readGroupsOptions.mockResolvedValueOnce({
+      data: {
+        actions: {
+          GET: {},
+        },
+        related_search_fields: [
+          'parents__search',
+          'inventory__search',
+          'inventory_sources__search',
+          'created_by__search',
+          'children__search',
+          'modified_by__search',
+          'hosts__search',
+        ],
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+    });
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
+    expect(wrapper.find('AddDropdown').length).toBe(0);
+  });
+});

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx
@@ -1,0 +1,90 @@
+import 'styled-components/macro';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { string, bool, func } from 'prop-types';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+
+import {
+  Button,
+  DataListAction as _DataListAction,
+  DataListCheck,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Tooltip,
+} from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import styled from 'styled-components';
+import DataListCell from '../../../components/DataListCell';
+
+import { Group } from '../../../types';
+
+const DataListAction = styled(_DataListAction)`
+  align-items: center;
+  display: grid;
+  grid-gap: 24px;
+  grid-template-columns: min-content 40px;
+`;
+
+function InventoryRelatedGroupListItem({
+  i18n,
+  detailUrl,
+  editUrl,
+  group,
+  isSelected,
+  onSelect,
+}) {
+  const labelId = `check-action-${group.id}`;
+
+  return (
+    <DataListItem key={group.id} aria-labelledby={labelId} id={`${group.id}`}>
+      <DataListItemRow>
+        <DataListCheck
+          id={`select-group-${group.id}`}
+          checked={isSelected}
+          onChange={onSelect}
+          aria-labelledby={labelId}
+        />
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="name">
+              <Link to={`${detailUrl}`}>
+                <b>{group.name}</b>
+              </Link>
+            </DataListCell>,
+          ]}
+        />
+        <DataListAction
+          aria-label="actions"
+          aria-labelledby={labelId}
+          id={labelId}
+        >
+          {group.summary_fields.user_capabilities?.edit && (
+            <Tooltip content={i18n._(t`Edit Group`)} position="top">
+              <Button
+                aria-label={i18n._(t`Edit Group`)}
+                css="grid-column: 2"
+                variant="plain"
+                component={Link}
+                to={`${editUrl}`}
+              >
+                <PencilAltIcon />
+              </Button>
+            </Tooltip>
+          )}
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  );
+}
+
+InventoryRelatedGroupListItem.propTypes = {
+  detailUrl: string.isRequired,
+  editUrl: string.isRequired,
+  group: Group.isRequired,
+  isSelected: bool.isRequired,
+  onSelect: func.isRequired,
+};
+
+export default withI18n()(InventoryRelatedGroupListItem);

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import InventoryRelatedGroupListItem from './InventoryRelatedGroupListItem';
+import mockRelatedGroups from '../shared/data.relatedGroups.json';
+
+jest.mock('../../../api');
+
+describe('<InventoryRelatedGroupListItem />', () => {
+  let wrapper;
+  const mockGroup = mockRelatedGroups.results[0];
+
+  beforeEach(() => {
+    wrapper = mountWithContexts(
+      <InventoryRelatedGroupListItem
+        detailUrl="/group/1"
+        editUrl="/group/1"
+        group={mockGroup}
+        isSelected={false}
+        onSelect={() => {}}
+      />
+    );
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  test('should display expected row item content', () => {
+    expect(
+      wrapper
+        .find('DataListCell')
+        .first()
+        .text()
+    ).toBe(' Group 2 Inventory 0');
+  });
+
+  test('edit button shown to users with edit capabilities', () => {
+    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  });
+
+  test('edit button hidden from users without edit capabilities', () => {
+    wrapper = mountWithContexts(
+      <InventoryRelatedGroupListItem
+        detailUrl="/group/1"
+        editUrl="/group/1"
+        group={mockRelatedGroups.results[2]}
+        isSelected={false}
+        onSelect={() => {}}
+      />
+    );
+    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  });
+});

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/index.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/index.js
@@ -1,0 +1,1 @@
+export { default } from './InventoryRelatedGroupList';

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { InventoriesAPI, CredentialTypesAPI } from '../../../api';
+import { InventoriesAPI } from '../../../api';
 import {
   mountWithContexts,
   waitForElement,
@@ -27,17 +27,6 @@ describe('<SmartInventoryHostList />', () => {
     InventoriesAPI.readHosts.mockResolvedValue({
       data: mockHosts,
     });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-          POST: {},
-        },
-      },
-    });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: { count: 1, results: [{ id: 1, name: 'cred' }] },
-    });
     await act(async () => {
       wrapper = mountWithContexts(
         <SmartInventoryHostList inventory={clonedInventory} />
@@ -58,15 +47,6 @@ describe('<SmartInventoryHostList />', () => {
   test('should fetch hosts from api and render them in the list', () => {
     expect(InventoriesAPI.readHosts).toHaveBeenCalled();
     expect(wrapper.find('SmartInventoryHostListItem').length).toBe(3);
-  });
-
-  test('should have run command button', () => {
-    wrapper.find('DataListCheck').forEach(el => {
-      expect(el.props().checked).toBe(false);
-    });
-    const runCommandsButton = wrapper.find('button[aria-label="Run command"]');
-    expect(runCommandsButton.length).toBe(1);
-    expect(runCommandsButton.prop('disabled')).toBe(false);
   });
 
   test('should select and deselect all items', async () => {
@@ -96,25 +76,5 @@ describe('<SmartInventoryHostList />', () => {
       );
     });
     await waitForElement(wrapper, 'ContentError', el => el.length === 1);
-  });
-  test('should disable run commands button', async () => {
-    InventoriesAPI.readHosts.mockResolvedValue({
-      data: { results: [], count: 0 },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-        },
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <SmartInventoryHostList inventory={clonedInventory} />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
-    const runCommandsButton = wrapper.find('button[aria-label="Run command"]');
-    expect(runCommandsButton.prop('disabled')).toBe(true);
   });
 });

--- a/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { func } from 'prop-types';
+import { func, string } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import {
@@ -9,25 +9,32 @@ import {
   DropdownToggle,
 } from '@patternfly/react-core';
 
-function AddHostDropdown({ i18n, onAddNew, onAddExisting }) {
+function AddDropdown({
+  i18n,
+  onAddNew,
+  onAddExisting,
+  newTitle,
+  existingTitle,
+  label,
+}) {
   const [isOpen, setIsOpen] = useState(false);
 
   const dropdownItems = [
     <DropdownItem
       key="add-new"
-      aria-label="add new host"
+      aria-label={`add new ${label}`}
       component="button"
       onClick={onAddNew}
     >
-      {i18n._(t`Add New Host`)}
+      {newTitle}
     </DropdownItem>,
     <DropdownItem
       key="add-existing"
-      aria-label="add existing host"
+      aria-label={`add existing ${label}`}
       component="button"
       onClick={onAddExisting}
     >
-      {i18n._(t`Add Existing Host`)}
+      {existingTitle}
     </DropdownItem>,
   ];
 
@@ -37,8 +44,8 @@ function AddHostDropdown({ i18n, onAddNew, onAddExisting }) {
       position={DropdownPosition.right}
       toggle={
         <DropdownToggle
-          id="add-host-dropdown"
-          aria-label="add host"
+          id={`add-${label}-dropdown`}
+          aria-label={`add ${label}`}
           isPrimary
           onToggle={() => setIsOpen(prevState => !prevState)}
         >
@@ -50,9 +57,12 @@ function AddHostDropdown({ i18n, onAddNew, onAddExisting }) {
   );
 }
 
-AddHostDropdown.propTypes = {
+AddDropdown.propTypes = {
   onAddNew: func.isRequired,
   onAddExisting: func.isRequired,
+  newTitle: string.isRequired,
+  existingTitle: string.isRequired,
+  label: string.isRequired,
 };
 
-export default withI18n()(AddHostDropdown);
+export default withI18n()(AddDropdown);

--- a/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { func, string } from 'prop-types';
+import React, { useState, useRef, useEffect, Fragment } from 'react';
+import { func, string, arrayOf, shape } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import {
@@ -8,61 +8,81 @@ import {
   DropdownPosition,
   DropdownToggle,
 } from '@patternfly/react-core';
+import { useKebabifiedMenu } from '../../../contexts/Kebabified';
 
-function AddDropdown({
-  i18n,
-  onAddNew,
-  onAddExisting,
-  newTitle,
-  existingTitle,
-  label,
-}) {
+function AddDropdown({ dropdownItems, i18n }) {
+  const { isKebabified } = useKebabifiedMenu();
   const [isOpen, setIsOpen] = useState(false);
+  const element = useRef(null);
 
-  const dropdownItems = [
-    <DropdownItem
-      key="add-new"
-      aria-label={`add new ${label}`}
-      component="button"
-      onClick={onAddNew}
-    >
-      {newTitle}
-    </DropdownItem>,
-    <DropdownItem
-      key="add-existing"
-      aria-label={`add existing ${label}`}
-      component="button"
-      onClick={onAddExisting}
-    >
-      {existingTitle}
-    </DropdownItem>,
-  ];
+  useEffect(() => {
+    const toggle = e => {
+      if (!isKebabified && (!element || !element.current.contains(e.target))) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('click', toggle, false);
+    return () => {
+      document.removeEventListener('click', toggle);
+    };
+  }, [isKebabified]);
+
+  if (isKebabified) {
+    return (
+      <Fragment>
+        {dropdownItems.map(item => (
+          <DropdownItem
+            key={item.key}
+            aria-label={item.title}
+            onClick={item.onAdd}
+          >
+            {item.title}
+          </DropdownItem>
+        ))}
+      </Fragment>
+    );
+  }
 
   return (
-    <Dropdown
-      isOpen={isOpen}
-      position={DropdownPosition.right}
-      toggle={
-        <DropdownToggle
-          id={`add-${label}-dropdown`}
-          aria-label={`add ${label}`}
-          isPrimary
-          onToggle={() => setIsOpen(prevState => !prevState)}
-        >
-          {i18n._(t`Add`)}
-        </DropdownToggle>
-      }
-      dropdownItems={dropdownItems}
-    />
+    <div ref={element} key="add">
+      <Dropdown
+        isOpen={isOpen}
+        position={DropdownPosition.right}
+        toggle={
+          <DropdownToggle
+            id="add"
+            aria-label="add"
+            isPrimary
+            onToggle={() => setIsOpen(prevState => !prevState)}
+          >
+            {i18n._(t`Add`)}
+          </DropdownToggle>
+        }
+        dropdownItems={dropdownItems.map(item => (
+          <DropdownItem
+            className="pf-c-dropdown__menu-item"
+            key={item.key}
+            aria-label={item.title}
+            onClick={item.onAdd}
+          >
+            {item.title}
+          </DropdownItem>
+        ))}
+      />
+    </div>
   );
 }
 
 AddDropdown.propTypes = {
-  onAddNew: func.isRequired,
-  onAddExisting: func.isRequired,
-  newTitle: string.isRequired,
-  existingTitle: string.isRequired,
-  label: string.isRequired,
+  dropdownItems: arrayOf(
+    shape({
+      label: string.isRequired,
+      onAdd: func.isRequired,
+      key: string.isRequired,
+    })
+  ).isRequired,
 };
 
+export { AddDropdown as _AddDropdown };
 export default withI18n()(AddDropdown);

--- a/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/AddDropdown.jsx
@@ -48,7 +48,7 @@ function AddDropdown({ dropdownItems, i18n }) {
     <div ref={element} key="add">
       <Dropdown
         isOpen={isOpen}
-        position={DropdownPosition.right}
+        position={DropdownPosition.left}
         toggle={
           <DropdownToggle
             id="add"

--- a/awx/ui_next/src/screens/Inventory/shared/AddDropdown.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/AddDropdown.test.jsx
@@ -5,13 +5,23 @@ import AddDropdown from './AddDropdown';
 describe('<AddDropdown />', () => {
   let wrapper;
   let dropdownToggle;
-  const onAddNew = jest.fn();
-  const onAddExisting = jest.fn();
+  const dropdownItems = [
+    {
+      onAdd: () => {},
+      title: 'Add existing group',
+      label: 'group',
+      key: 'existing',
+    },
+    {
+      onAdd: () => {},
+      title: 'Add new group',
+      label: 'group',
+      key: 'new',
+    },
+  ];
 
   beforeEach(() => {
-    wrapper = mountWithContexts(
-      <AddDropdown onAddNew={onAddNew} onAddExisting={onAddExisting} />
-    );
+    wrapper = mountWithContexts(<AddDropdown dropdownItems={dropdownItems} />);
     dropdownToggle = wrapper.find('DropdownToggle button');
   });
 

--- a/awx/ui_next/src/screens/Inventory/shared/AddDropdown.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/AddDropdown.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
-import AddHostDropdown from './AddHostDropdown';
+import AddDropdown from './AddDropdown';
 
-describe('<AddHostDropdown />', () => {
+describe('<AddDropdown />', () => {
   let wrapper;
   let dropdownToggle;
   const onAddNew = jest.fn();
@@ -10,7 +10,7 @@ describe('<AddHostDropdown />', () => {
 
   beforeEach(() => {
     wrapper = mountWithContexts(
-      <AddHostDropdown onAddNew={onAddNew} onAddExisting={onAddExisting} />
+      <AddDropdown onAddNew={onAddNew} onAddExisting={onAddExisting} />
     );
     dropdownToggle = wrapper.find('DropdownToggle button');
   });

--- a/awx/ui_next/src/screens/Inventory/shared/data.relatedGroups.json
+++ b/awx/ui_next/src/screens/Inventory/shared/data.relatedGroups.json
@@ -1,0 +1,181 @@
+{
+  "count": 3,
+  "results": [{
+      "id": 2,
+      "type": "group",
+      "url": "/api/v2/groups/2/",
+      "related": {
+        "created_by": "/api/v2/users/10/",
+        "modified_by": "/api/v2/users/14/",
+        "variable_data": "/api/v2/groups/2/variable_data/",
+        "hosts": "/api/v2/groups/2/hosts/",
+        "potential_children": "/api/v2/groups/2/potential_children/",
+        "children": "/api/v2/groups/2/children/",
+        "all_hosts": "/api/v2/groups/2/all_hosts/",
+        "job_events": "/api/v2/groups/2/job_events/",
+        "job_host_summaries": "/api/v2/groups/2/job_host_summaries/",
+        "activity_stream": "/api/v2/groups/2/activity_stream/",
+        "inventory_sources": "/api/v2/groups/2/inventory_sources/",
+        "ad_hoc_commands": "/api/v2/groups/2/ad_hoc_commands/",
+        "inventory": "/api/v2/inventories/1/"
+      },
+      "summary_fields": {
+        "inventory": {
+          "id": 1,
+          "name": " Inventory 1 Org 0",
+          "description": "",
+          "has_active_failures": false,
+          "total_hosts": 33,
+          "hosts_with_active_failures": 0,
+          "total_groups": 4,
+          "has_inventory_sources": false,
+          "total_inventory_sources": 0,
+          "inventory_sources_with_failures": 0,
+          "organization_id": 1,
+          "kind": ""
+        },
+        "created_by": {
+          "id": 10,
+          "username": "user-4",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 14,
+          "username": "user-8",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true
+        }
+      },
+      "created": "2020-09-23T14:30:55.263148Z",
+      "modified": "2020-09-23T14:30:55.263175Z",
+      "name": " Group 2 Inventory 0",
+      "description": "",
+      "inventory": 1,
+      "variables": ""
+    },
+    {
+      "id": 3,
+      "type": "group",
+      "url": "/api/v2/groups/3/",
+      "related": {
+        "created_by": "/api/v2/users/11/",
+        "modified_by": "/api/v2/users/15/",
+        "variable_data": "/api/v2/groups/3/variable_data/",
+        "hosts": "/api/v2/groups/3/hosts/",
+        "potential_children": "/api/v2/groups/3/potential_children/",
+        "children": "/api/v2/groups/3/children/",
+        "all_hosts": "/api/v2/groups/3/all_hosts/",
+        "job_events": "/api/v2/groups/3/job_events/",
+        "job_host_summaries": "/api/v2/groups/3/job_host_summaries/",
+        "activity_stream": "/api/v2/groups/3/activity_stream/",
+        "inventory_sources": "/api/v2/groups/3/inventory_sources/",
+        "ad_hoc_commands": "/api/v2/groups/3/ad_hoc_commands/",
+        "inventory": "/api/v2/inventories/1/"
+      },
+      "summary_fields": {
+        "inventory": {
+          "id": 1,
+          "name": " Inventory 1 Org 0",
+          "description": "",
+          "has_active_failures": false,
+          "total_hosts": 33,
+          "hosts_with_active_failures": 0,
+          "total_groups": 4,
+          "has_inventory_sources": false,
+          "total_inventory_sources": 0,
+          "inventory_sources_with_failures": 0,
+          "organization_id": 1,
+          "kind": ""
+        },
+        "created_by": {
+          "id": 11,
+          "username": "user-5",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 15,
+          "username": "user-9",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "edit": true,
+          "delete": true,
+          "copy": true
+        }
+      },
+      "created": "2020-09-23T14:30:55.281583Z",
+      "modified": "2020-09-23T14:30:55.281615Z",
+      "name": " Group 3 Inventory 0",
+      "description": "",
+      "inventory": 1,
+      "variables": ""
+    },
+    {
+      "id": 4,
+      "type": "group",
+      "url": "/api/v2/groups/4/",
+      "related": {
+        "created_by": "/api/v2/users/12/",
+        "modified_by": "/api/v2/users/16/",
+        "variable_data": "/api/v2/groups/4/variable_data/",
+        "hosts": "/api/v2/groups/4/hosts/",
+        "potential_children": "/api/v2/groups/4/potential_children/",
+        "children": "/api/v2/groups/4/children/",
+        "all_hosts": "/api/v2/groups/4/all_hosts/",
+        "job_events": "/api/v2/groups/4/job_events/",
+        "job_host_summaries": "/api/v2/groups/4/job_host_summaries/",
+        "activity_stream": "/api/v2/groups/4/activity_stream/",
+        "inventory_sources": "/api/v2/groups/4/inventory_sources/",
+        "ad_hoc_commands": "/api/v2/groups/4/ad_hoc_commands/",
+        "inventory": "/api/v2/inventories/1/"
+      },
+      "summary_fields": {
+        "inventory": {
+          "id": 1,
+          "name": " Inventory 1 Org 0",
+          "description": "",
+          "has_active_failures": false,
+          "total_hosts": 33,
+          "hosts_with_active_failures": 0,
+          "total_groups": 4,
+          "has_inventory_sources": false,
+          "total_inventory_sources": 0,
+          "inventory_sources_with_failures": 0,
+          "organization_id": 1,
+          "kind": ""
+        },
+        "created_by": {
+          "id": 12,
+          "username": "user-6",
+          "first_name": "",
+          "last_name": ""
+        },
+        "modified_by": {
+          "id": 16,
+          "username": "user-10",
+          "first_name": "",
+          "last_name": ""
+        },
+        "user_capabilities": {
+          "edit": false,
+          "delete": true,
+          "copy": true
+        }
+      },
+      "created": "2020-09-23T14:30:55.293574Z",
+      "modified": "2020-09-23T14:30:55.293603Z",
+      "name": " Group 4 Inventory 0",
+      "description": "",
+      "inventory": 1,
+      "variables": ""
+    }
+  ]
+}


### PR DESCRIPTION
##### SUMMARY
This addresses https://github.com/ansible/awx/issues/8238.  It does not add functionality for Adding new or existing inventory or Disassociating an inventory.  

Part of the work in this PR includes refactoring the Add Drop Down button that is used by this list and, by the Inventory Group Host List so that both lists can use that component.  It also includes refactoring so that those tool bar action items appear properly in the drop down during Advanced Search.  

It does render the modals necessary to add and disassociate list items, but there is no persistence.  See https://github.com/ansible/awx/issues/8262 and https://github.com/ansible/awx/issues/8261

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI






##### ADDITIONAL INFORMATION
![Screen Shot 2020-09-29 at 11 53 34 AM](https://user-images.githubusercontent.com/39280967/94582605-6e855780-024a-11eb-9518-d33f8699b436.png)
![Screen Shot 2020-09-29 at 11 54 17 AM](https://user-images.githubusercontent.com/39280967/94582681-85c44500-024a-11eb-8d0e-a41a5b1cff7e.png)
