### PR TITLE
Reset error/result only after the next request has resolved to prevent render flickering

### DIFF
--- a/awx/ui_next/src/util/useRequest.js
+++ b/awx/ui_next/src/util/useRequest.js
@@ -38,18 +38,16 @@ export default function useRequest(makeRequest, initialValue) {
     request: useCallback(
       async (...args) => {
         setIsLoading(true);
-        if (isMounted.current) {
-          setResult(initialValue);
-          setError(null);
-        }
         try {
           const response = await makeRequest(...args);
           if (isMounted.current) {
             setResult(response);
+            setError(null);
           }
         } catch (err) {
           if (isMounted.current) {
             setError(err);
+            setResult(initialValue);
           }
         } finally {
           if (isMounted.current) {
@@ -57,7 +55,6 @@ export default function useRequest(makeRequest, initialValue) {
           }
         }
       },
-      /* eslint-disable-next-line react-hooks/exhaustive-deps */
       [makeRequest]
     ),
     setValue: setResult,

--- a/awx/ui_next/src/util/useRequest.js
+++ b/awx/ui_next/src/util/useRequest.js
@@ -55,6 +55,7 @@ export default function useRequest(makeRequest, initialValue) {
           }
         }
       },
+      /* eslint-disable-next-line react-hooks/exhaustive-deps */
       [makeRequest]
     ),
     setValue: setResult,


### PR DESCRIPTION
##### SUMMARY
link #https://github.com/ansible/awx/issues/8252

The reason why this hook was modified in the first place was because a user can press the TEST button over and over again on several credential plugin views without re-initializing the hook.  Once an error was set, it was never cleared and would always be displayed.  I've modified the changes to be a bit safer now and should mitigate the mentioned issue.  I've tested the credential plugin TEST buttons and they still function as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI