### PR TITLE
Make ContainerGroupDetails a bit more robust

### DIFF
--- a/awx/ui_next/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx
@@ -48,15 +48,17 @@ function ContainerGroupDetails({ instanceGroup, i18n }) {
           value={i18n._(t`Container group`)}
           dataCy="container-group-type"
         />
-        <Detail
-          label={i18n._(t`Credential`)}
-          value={
-            <Label variant="outline" color="blue">
-              {instanceGroup.summary_fields.credential.name}
-            </Label>
-          }
-          dataCy="container-group-credential"
-        />
+        {instanceGroup.summary_fields.credential && (
+          <Detail
+            label={i18n._(t`Credential`)}
+            value={
+              <Label variant="outline" color="blue">
+                {instanceGroup.summary_fields.credential?.name}
+              </Label>
+            }
+            dataCy="container-group-credential"
+          />
+        )}
         <UserDateDetail
           label={i18n._(t`Created`)}
           date={instanceGroup.created}


### PR DESCRIPTION
In order to create a container group is necessary to provide a
credential.

See: https://github.com/ansible/awx/issues/8184

This change makes the code related to display the credential as part of
the container group details a bit more robust. Avoiding to attempt to
show a non-existent credential - what is not supposed to exist.

Closes: https://github.com/ansible/awx/issues/8199
