### PR TITLE
Fix inventory file dropdown placeholder value

### DIFF
--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceForm.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceForm.jsx
@@ -47,6 +47,7 @@ const InventorySourceFormFields = ({ source, sourceOptions, i18n }) => {
     values,
     initialValues,
     resetForm,
+    setFieldTouched,
     setFieldValue,
   } = useFormikContext();
   const [sourceField, sourceMeta] = useField({
@@ -92,6 +93,7 @@ const InventorySourceFormFields = ({ source, sourceOptions, i18n }) => {
       };
       Object.keys(defaults).forEach(label => {
         setFieldValue(label, defaults[label]);
+        setFieldTouched(label, false);
       });
     }
   };
@@ -255,7 +257,7 @@ const InventorySourceForm = ({
     overwrite: source?.overwrite || false,
     overwrite_vars: source?.overwrite_vars || false,
     source: source?.source || '',
-    source_path: source?.source_path === '' ? '/ (project root)' : '',
+    source_path: source?.source_path || '',
     source_project: source?.summary_fields?.source_project || null,
     source_script: source?.summary_fields?.source_script || null,
     source_vars: source?.source_vars || '---\n',

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx
@@ -21,7 +21,7 @@ import {
 } from './SharedFields';
 
 const SCMSubForm = ({ autoPopulateProject, i18n }) => {
-  const { setFieldValue } = useFormikContext();
+  const { setFieldValue, setFieldTouched } = useFormikContext();
   const [credentialField] = useField('credential');
   const [projectField, projectMeta, projectHelpers] = useField({
     name: 'source_project',
@@ -47,16 +47,20 @@ const SCMSubForm = ({ autoPopulateProject, i18n }) => {
   useEffect(() => {
     if (projectMeta.initialValue) {
       fetchSourcePath(projectMeta.initialValue.id);
-    }
+      if (sourcePathField.value === '') {
+        sourcePathHelpers.setValue('/ (project root)');
+      }
+    } // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchSourcePath, projectMeta.initialValue]);
 
   const handleProjectUpdate = useCallback(
     value => {
-      setFieldValue('source_path', '');
       setFieldValue('source_project', value);
+      setFieldValue('source_path', '');
+      setFieldTouched('source_path', false);
       fetchSourcePath(value.id);
     },
-    [fetchSourcePath, setFieldValue]
+    [fetchSourcePath, setFieldValue, setFieldTouched]
   );
 
   const handleCredentialUpdate = useCallback(


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/8044

The inventory source form placeholder value and source_path project root value both defaulted to empty strings, which caused a bug where the source_path dropdown placeholder would never be selected.

To address the issue, the form sets the source_path project root value from an empty string to "/ (project root)".

![inv](https://user-images.githubusercontent.com/15881645/94723298-86caa480-0326-11eb-8df0-a6d27d571cae.gif)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
