### PR TITLE
Fix Show/Hide i18n buttons

### DIFF
--- a/awx/ui/client/src/shared/directives.js
+++ b/awx/ui/client/src/shared/directives.js
@@ -1207,18 +1207,19 @@ function(SettingsUtils, i18n, $rootScope) {
     };
 }])
 
-.directive('awPasswordToggle', [function() {
+.directive('awPasswordToggle', ['i18n',
+function(i18n) {
     return {
         restrict: 'A',
         link: function(scope, element) {
             $(element).click(function() {
-                var buttonInnerHTML = $(element).html();
-                if (buttonInnerHTML.indexOf("Show") > -1) {
-                    $(element).html("Hide");
-                    $(element).closest('.input-group').find('input').first().attr("type", "text");
+                var input = $(element).closest('.input-group').find('input').first();
+                if (input.attr("type") === "password") {
+                    $(element).html(i18n._("Hide"));
+                    input.attr("type", "text");
                 } else {
-                    $(element).html("Show");
-                    $(element).closest('.input-group').find('input').first().attr("type", "password");
+                    $(element).html(i18n._("Show"));
+                    input.attr("type", "password");
                 }
             });
         }

--- a/awx/ui/client/src/templates/survey-maker/render/survey-question.directive.js
+++ b/awx/ui/client/src/templates/survey-maker/render/survey-question.directive.js
@@ -82,9 +82,8 @@ function link($sce, $filter, Empty, scope, element, attrs) {
     //for toggling the input on password inputs
     scope.toggleInput = function(id) {
         var buttonId = id + "_show_input_button",
-            inputId = id,
-            buttonInnerHTML = $(buttonId).html();
-        if (buttonInnerHTML.indexOf("SHOW") > -1) {
+            inputId = id;
+        if ($(inputId).attr("type") === "password") {
             $(buttonId).html("HIDE");
             $(inputId).attr("type", "text");
         } else {

--- a/awx/ui/client/src/templates/survey-maker/surveys/init.factory.js
+++ b/awx/ui/client/src/templates/survey-maker/surveys/init.factory.js
@@ -493,9 +493,8 @@ export default
             scope.toggleInput = function(id) {
                 // Note that the id string passed into this function will have a "#" prepended
                 var buttonId = id + "_show_input_button",
-                    inputId = id,
-                    buttonInnerHTML = $(buttonId).html();
-                if (buttonInnerHTML.indexOf("SHOW") > -1) {
+                    inputId = id;
+                if ($(inputId).attr("type") === "password") {
                     $(buttonId).html(i18n._("HIDE"));
                     $(inputId).attr("type", "text");
                 } else {


### PR DESCRIPTION
##### SUMMARY

When i18n is enabled, dynamic Show/Hide buttons in INPUTs are translated. For example in French language SHOW/HIDE action is displayed as AFFICHER/MASQUER.

When the user click on one of these buttons, the button label changes dynamically (SHOW becomes HIDE, and vice-versa).

The button label was properly translated the first time the page was displayed, but when the label changed after clicking the button, it went back to the English label.

- Fixing translation for the dynamic label change
- Using an alternate method to detect the state: it's better to check the input type (text or password) rather than relying on the label which can vary from one language to another.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION

You can reproduce the bug or test the fix by:

- set up your browser to "French language" or any other language available in AWX
- Go to the "Add user" form in the UI (https://.../#/users/add) and click on "SHOW" or equivalent (this should appear as "AFFICHER" in French)
