### PR TITLE
fixing quotes to not fail smart quotes sanity test

### DIFF
--- a/awx_collection/TESTING.md
+++ b/awx_collection/TESTING.md
@@ -9,7 +9,7 @@ When trying to fix a bug, it is best to replicate its behavior within a test wit
 
 The unit tests are stored in the `test/awx` directory and, where possible, test interactions between the collections modules and the AWX database. This is achieved by  using a Python testing suite and having a mocked layer which emulates interactions with the Tower API. You do not need a server to run these unit tests. The depth of testing is not fixed and can change from module to module.
 
-Let’s take a closer look at the `test_token.py` file (which tests the `tower_token` module):
+Let's take a closer look at the `test_token.py` file (which tests the `tower_token` module):
 
 ```
 from __future__ import (absolute_import, division, print_function)
@@ -56,7 +56,7 @@ A completeness failure will generate a large ASCII table in the Zuul log indicat
 
 ![Completeness Test Output](images/completeness_test_output.png)
 
-To find the error, look at the last column and search for the term “failure”. There will most likely be some failures which have been deemed acceptable and will typically say “non-blocking” next to them. Those errors can be safely ignored.
+To find the error, look at the last column and search for the term "failure". There will most likely be some failures which have been deemed acceptable and will typically say "non-blocking" next to them. Those errors can be safely ignored.
 
 
 ## Integration Tests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API/Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
n/a
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Fixing failing sanity test no smart quotes for collection
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TESTING.md:12:4: use ASCII quotes `'` and `"` instead of Unicode quotes
TESTING.md:59:68: use ASCII quotes `'` and `"` instead of Unicode quotes
```
