### PR TITLE
correct error message when calling tower_AWXKit collections module and venv doesn't have it

### DIFF
--- a/awx_collection/plugins/module_utils/tower_awxkit.py
+++ b/awx_collection/plugins/module_utils/tower_awxkit.py
@@ -24,7 +24,7 @@ class TowerAWXKitModule(TowerModule):
 
         # Die if we don't have AWX_KIT installed
         if not HAS_AWX_KIT:
-            self.exit_json(msg=missing_required_lib('awxkit'))
+            self.fail_json(msg=missing_required_lib('awxkit'))
 
         # Establish our conneciton object
         self.connection = Connection(self.host, verify=self.verify_ssl)
@@ -38,7 +38,7 @@ class TowerAWXKitModule(TowerModule):
                 self.connection.login(username=self.username, password=self.password)
                 self.authenticated = True
         except Exception:
-            self.exit_json("Failed to authenticate")
+            self.fail_json("Failed to authenticate")
 
     def get_api_v2_object(self):
         if not self.apiV2Ref:


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
relates to #8127 -  The reason this issue arose in the first place is due to attempting to use an Ansible module (exit_json) when the correct one was instead fail_json. This triggered a different error message entirely, obfuscating from the venv's lack of correct set up. The logic of alerting if and when AWXKit was not present in a venv calling for it was already present within the module and now can be properly utilized.
Specifics:
- code was originally supposed to be hitting [this](https://github.com/ansible/ansible/blob/5cd489af061454565e036dd580d25e41487fbfcd/lib/ansible/module_utils/basic.py#L646) module, but instead was hitting [this](https://github.com/ansible/ansible/blob/5cd489af061454565e036dd580d25e41487fbfcd/lib/ansible/module_utils/basic.py#L1563) (and correctly so) due to it attempting to use unsupported parameters within the exit_json ansible module.
- pertinent ansible documentation regarding exit_json vs. fail_json [here](https://docs.ansible.com/ansible/latest/reference_appendices/module_utils.html)
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
- Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 14.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
prior to change the error spit out would have been:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (tower_export) module: inventory Supported parameters include: all, tower_config_file, tower_host, tower_oauthtoken, tower_password, tower_username, validate_certs"}
```
post change it should be: 
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (awxkit) on localhost.localdomain's Python /<path to venv>/bin/python3. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```
