### PR TITLE
fix a display bug in notification bodies with unicode characters

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -393,7 +393,11 @@ class JobNotificationMixin(object):
             'job': job_context,
             'job_friendly_name': self.get_notification_friendly_name(),
             'url': self.get_ui_url(),
-            'job_metadata': json.dumps(self.notification_data(), indent=4)
+            'job_metadata': json.dumps(
+                self.notification_data(),
+                ensure_ascii=False,
+                indent=4
+            )
         }
 
         def build_context(node, fields, allowed_fields):

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -123,6 +123,15 @@ class TestJobNotificationMixin(object):
         context = job.context(job_serialization)
         check_structure(TestJobNotificationMixin.CONTEXT_STRUCTURE, context)
 
+
+    @pytest.mark.django_db
+    def test_context_job_metadata_with_unicode(self):
+        job = Job.objects.create(name='批量安装项目')
+        job_serialization = UnifiedJobSerializer(job).to_representation(job)
+        context = job.context(job_serialization)
+        assert '批量安装项目' in context['job_metadata']
+
+
     def test_context_stub(self):
         """The context stub is a fake context used to validate custom notification messages. Ensure that
         this also has the expected structure. Furthermore, ensure that the stub context contains


### PR DESCRIPTION
see: https://github.com/ansible/awx/issues/7400

https://docs.python.org/3/library/json.html#json.dump
> If ensure_ascii is true (the default), the output is guaranteed to have all incoming non-ASCII characters escaped. If ensure_ascii is false, these characters will be output as-is.