### PR TITLE
Refactor to hook in programmatic use of inventory import saving-to-DB code

### DIFF
--- a/awx/main/exceptions.py
+++ b/awx/main/exceptions.py
@@ -30,3 +30,10 @@ class _AwxTaskError():
 
 
 AwxTaskError = _AwxTaskError()
+
+
+class PostRunError(Exception):
+    def __init__(self, msg, status='failed', tb=''):
+        self.status = status
+        self.tb = tb
+        super(PostRunError, self).__init__(msg)

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -31,7 +31,11 @@ from awx.main.utils.safe_yaml import sanitize_jinja
 
 # other AWX imports
 from awx.main.models.rbac import batch_role_ancestor_rebuilding
+# TODO: remove proot utils once we move to running inv. updates in containers
 from awx.main.utils import (
+    check_proot_installed,
+    wrap_args_with_proot,
+    build_proot_temp_dir,
     ignore_inventory_computed_fields,
     get_licenser
 )
@@ -134,15 +138,50 @@ class AnsibleInventoryLoader(object):
         logger.debug('Using base command: {}'.format(' '.join(bargs)))
         return bargs
 
+    # TODO: Remove this once we move to running ansible-inventory in containers
+    # and don't need proot for process isolation anymore
+    def get_proot_args(self, cmd, env):
+        cwd = os.getcwd()
+        if not check_proot_installed():
+            raise RuntimeError("proot is not installed but is configured for use")
+
+        kwargs = {}
+        # we cannot safely store tmp data in source dir or trust script contents
+        if env['AWX_PRIVATE_DATA_DIR']:
+            # If this is non-blank, file credentials are being used and we need access
+            private_data_dir = functioning_dir(env['AWX_PRIVATE_DATA_DIR'])
+            logger.debug("Using private credential data in '{}'.".format(private_data_dir))
+            kwargs['private_data_dir'] = private_data_dir
+        self.tmp_private_dir = build_proot_temp_dir()
+        logger.debug("Using fresh temporary directory '{}' for isolation.".format(self.tmp_private_dir))
+        kwargs['proot_temp_dir'] = self.tmp_private_dir
+        kwargs['proot_show_paths'] = [functioning_dir(self.source), settings.AWX_ANSIBLE_COLLECTIONS_PATHS]
+        logger.debug("Running from `{}` working directory.".format(cwd))
+
+        if self.venv_path != settings.ANSIBLE_VENV_PATH:
+            kwargs['proot_custom_virtualenv'] = self.venv_path
+
+        return wrap_args_with_proot(cmd, cwd, **kwargs)
+
+
     def command_to_json(self, cmd):
         data = {}
         stdout, stderr = '', ''
         env = self.build_env()
 
+        # TODO: remove proot args once inv. updates run in containers
+        if (('AWX_PRIVATE_DATA_DIR' in env) and
+                                getattr(settings, 'AWX_PROOT_ENABLED', False)):
+            cmd = self.get_proot_args(cmd, env)
+
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         stdout, stderr = proc.communicate()
         stdout = smart_text(stdout)
         stderr = smart_text(stderr)
+
+        # TODO: can be removed when proot is removed
+        if self.tmp_private_dir:
+            shutil.rmtree(self.tmp_private_dir, True)
 
         if proc.returncode != 0:
             raise RuntimeError('%s failed (rc=%d) with stdout:\n%s\nstderr:\n%s' % (

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -171,7 +171,7 @@ class AnsibleInventoryLoader(object):
 
         # TODO: remove proot args once inv. updates run in containers
         if (('AWX_PRIVATE_DATA_DIR' in env) and
-                                getattr(settings, 'AWX_PROOT_ENABLED', False)):
+                getattr(settings, 'AWX_PROOT_ENABLED', False)):
             cmd = self.get_proot_args(cmd, env)
 
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -967,7 +967,6 @@ class Command(BaseCommand):
 
         begin = time.time()
         with advisory_lock('inventory_{}_update'.format(self.inventory.id)):
-            self.load_inventory_from_database()
 
             try:
                 self.check_license()

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -904,15 +904,15 @@ class Command(BaseCommand):
         self.inventory_update.save(update_fields=['org_host_limit_error'])
 
     def handle(self, *args, **options):
-        with advisory_lock('inventory_{}_import'.format(self.inventory.id)):
-            # Load inventory and related objects from database.
-            inventory_name = options.get('inventory_name', None)
-            inventory_id = options.get('inventory_id', None)
-            if inventory_name and inventory_id:
-                raise CommandError('--inventory-name and --inventory-id are mutually exclusive')
-            elif not inventory_name and not inventory_id:
-                raise CommandError('--inventory-name or --inventory-id is required')
+        # Load inventory and related objects from database.
+        inventory_name = options.get('inventory_name', None)
+        inventory_id = options.get('inventory_id', None)
+        if inventory_name and inventory_id:
+            raise CommandError('--inventory-name and --inventory-id are mutually exclusive')
+        elif not inventory_name and not inventory_id:
+            raise CommandError('--inventory-name or --inventory-id is required')
 
+        with advisory_lock('inventory_{}_import'.format(inventory_id)):
             # Obtain rest of the options needed to run update
             raw_source = options.get('source', None)
             if not raw_source:

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -875,7 +875,6 @@ class Command(BaseCommand):
         raw_source = options.get('source', None)
         if not raw_source:
             raise CommandError('--source is required')
-        source = Command.get_source_absolute_path(raw_source)
         verbosity = int(options.get('verbosity', 1))
         self.set_logging_level(verbosity)
         venv_path = options.get('venv', None)
@@ -893,8 +892,11 @@ class Command(BaseCommand):
             raise CommandError('Inventory with %s = %s returned multiple results' % list(q.items())[0])
         logger.info('Updating inventory %d: %s' % (inventory.pk, inventory.name))
 
+
         # Create ad-hoc inventory source and inventory update objects
         with ignore_inventory_computed_fields():
+            source = Command.get_source_absolute_path(raw_source)
+
             inventory_source, created = InventorySource.objects.get_or_create(
                 inventory=inventory,
                 source='file',

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -79,6 +79,8 @@ class AnsibleInventoryLoader(object):
     def __init__(self, source, venv_path=None, verbosity=0):
         self.source = source
         self.verbosity = verbosity
+        # TODO: remove once proot has been removed
+        self.tmp_private_dir = None
         if venv_path:
             self.venv_path = venv_path
         else:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2503,7 +2503,7 @@ class RunInventoryUpdate(BaseTask):
                                                         private_data_files=private_data_files)
         if private_data_files is None:
             private_data_files = {}
-        self.add_ansible_venv(settings.ANSIBLE_VENV_PATH, env)
+        self.add_ansible_venv(inventory_update.ansible_virtualenv_path, env, isolated=isolated)
 
         # Legacy environment variables, were used as signal to awx-manage command
         # now they are provided in case some scripts may be relying on them

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2763,6 +2763,9 @@ class RunInventoryUpdate(BaseTask):
         except PermissionDenied as exc:
             logger.exception('License error saving {} content'.format(inventory_update.log_format))
             raise PostRunError(str(exc), status='error')
+        except PostRunError:
+            logger.exception('Error saving {} content, rolling back changes'.format(inventory_update.log_format))
+            raise
         except Exception:
             logger.exception('Exception saving {} content, rolling back changes.'.format(
                 inventory_update.log_format))

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2797,6 +2797,7 @@ class RunInventoryUpdate(BaseTask):
 
         from awx.main.management.commands.inventory_import import Command as InventoryImportCommand
         cmd = InventoryImportCommand()
+        exc = None
         try:
             # note that we are only using the management command to
             # save the inventory data to the database.
@@ -2806,6 +2807,8 @@ class RunInventoryUpdate(BaseTask):
             # for us.
             save_status, tb, exc = cmd.perform_update(options, data, inventory_update)
         except Exception as raw_exc:
+            if exc is None:
+                exc = raw_exc
             # Ignore license errors specifically
             if 'Host limit for organization' not in str(exc) and 'License' not in str(exc):
                 raise raw_exc

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2461,6 +2461,12 @@ class RunInventoryUpdate(BaseTask):
     event_model = InventoryUpdateEvent
     event_data_key = 'inventory_update_id'
 
+    def should_use_proot(self, inventory_update):
+        '''
+        Return whether this task should use proot.
+        '''
+        return getattr(settings, 'AWX_PROOT_ENABLED', False)
+
     @property
     def proot_show_paths(self):
         return [settings.AWX_ANSIBLE_COLLECTIONS_PATHS]

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -63,7 +63,7 @@ from awx.main.models import (
     build_safe_env, enforce_bigint_pk_migration
 )
 from awx.main.constants import ACTIVE_STATES
-from awx.main.exceptions import AwxTaskError
+from awx.main.exceptions import AwxTaskError, PostRunError
 from awx.main.queue import CallbackQueueDispatcher
 from awx.main.isolated import manager as isolated_manager
 from awx.main.dispatch.publish import task
@@ -1229,14 +1229,7 @@ class BaseTask(object):
         # ansible-inventory and the awx.main.commands.inventory_import
         # logger
         if isinstance(self, RunInventoryUpdate):
-            if not getattr(self, 'end_line', None):
-                # this is the very first event
-                # note the end_line
-                self.end_line = event_data['end_line']
-            else:
-                num_lines = event_data['end_line'] - event_data['start_line']
-                event_data['start_line'] = self.end_line + 1
-                self.end_line = event_data['end_line'] = event_data['start_line'] + num_lines
+            self.end_line = event_data['end_line']
 
         if event_data.get(self.event_data_key, None):
             if self.event_data_key != 'job_id':
@@ -1534,6 +1527,12 @@ class BaseTask(object):
 
         try:
             self.post_run_hook(self.instance, status)
+        except PostRunError as exc:
+            if status == 'successful':
+                status = exc.status
+                extra_update_fields['job_explanation'] = exc.args[0]
+                if exc.tb:
+                    extra_update_fields['result_traceback'] = exc.tb
         except Exception:
             logger.exception('{} Post run hook errored.'.format(self.instance.log_format))
 
@@ -2744,27 +2743,28 @@ class RunInventoryUpdate(BaseTask):
         # Mock ansible-runner events
         class CallbackHandler(logging.Handler):
             def __init__(self, event_handler, cancel_callback, job_timeout, verbosity,
-                         counter=0, **kwargs):
+                         start_time=None, counter=0, initial_line=0, **kwargs):
                 self.event_handler = event_handler
                 self.cancel_callback = cancel_callback
                 self.job_timeout = job_timeout
-                self.job_start = time.time()
+                if start_time is None:
+                    self.job_start = now()
+                else:
+                    self.job_start = start_time
                 self.last_check = self.job_start
-                # TODO: we do not have events from the ansible-inventory process
-                # so there is no way to know initial counter of start line
                 self.counter = counter
                 self.skip_level = [logging.WARNING, logging.INFO, logging.DEBUG, 0][verbosity]
-                self._start_line = 0
+                self._start_line = initial_line
                 super(CallbackHandler, self).__init__(**kwargs)
 
             def emit(self, record):
-                this_time = time.time()
-                if this_time - self.last_check > 0.5:
+                this_time = now()
+                if (this_time - self.last_check).total_seconds() > 0.5:
                     self.last_check = this_time
                     if self.cancel_callback():
-                        raise RuntimeError('Inventory update has been canceled')
-                if self.job_timeout and ((this_time - self.job_start) > self.job_timeout):
-                    raise RuntimeError('Inventory update has timed out')
+                        raise PostRunError('Inventory update has been canceled', status='canceled')
+                if self.job_timeout and ((this_time - self.job_start).total_seconds() > self.job_timeout):
+                    raise PostRunError('Inventory update has timed out', status='canceled')
 
                 # skip logging for low severity logs
                 if record.levelno < self.skip_level:
@@ -2772,16 +2772,16 @@ class RunInventoryUpdate(BaseTask):
 
                 self.counter += 1
                 msg = self.format(record)
-                n_lines = msg.strip().count('\n')  # don't count new-lines at boundry of text
+                n_lines = len(msg.strip().split('\n'))  # don't count new-lines at boundry of text
                 dispatch_data = dict(
                     created=now().isoformat(),
                     event='verbose',
                     counter=self.counter,
-                    stdout=msg + '\n',
+                    stdout=msg,
                     start_line=self._start_line,
                     end_line=self._start_line + n_lines
                 )
-                self._start_line += n_lines + 1
+                self._start_line += n_lines
 
                 self.event_handler(dispatch_data)
 
@@ -2789,7 +2789,8 @@ class RunInventoryUpdate(BaseTask):
             self.event_handler, self.cancel_callback,
             verbosity=inventory_update.verbosity,
             job_timeout=self.get_instance_timeout(self.instance),
-            counter=self.event_ct
+            start_time=inventory_update.started,
+            counter=self.event_ct, initial_line=self.end_line
         )
         inv_logger = logging.getLogger('awx.main.commands.inventory_import')
         handler.formatter = inv_logger.handlers[0].formatter
@@ -2797,36 +2798,19 @@ class RunInventoryUpdate(BaseTask):
 
         from awx.main.management.commands.inventory_import import Command as InventoryImportCommand
         cmd = InventoryImportCommand()
-        exc = None
         try:
-            # note that we are only using the management command to
-            # save the inventory data to the database.
-            # we are not asking it to actually fetch hosts / groups.
-            # that work was taken care of earlier, when
-            # BaseTask.run called ansible-inventory (by way of ansible-runner)
-            # for us.
-            save_status, tb, exc = cmd.perform_update(options, data, inventory_update)
-        except Exception as raw_exc:
-            if exc is None:
-                exc = raw_exc
-            # Ignore license errors specifically
-            if 'Host limit for organization' not in str(exc) and 'License' not in str(exc):
-                raise raw_exc
-
-        model_updates = {}
-        if save_status != status:
-            model_updates['status'] = save_status
-        if tb:
-            model_updates['result_traceback'] = tb
-
-        if model_updates:
-            logger.info('{} had problems saving to database with {}'.format(
-                inventory_update.log_format, ', '.join(list(model_updates.keys()))
-            ))
-            model_updates['job_explanation'] = 'Update failed to save all changes to database properly.'
-            if exc:
-                model_updates['job_explanation'] += ' {}'.format(exc)
-            self.update_model(inventory_update.pk, **model_updates)
+            # save the inventory data to database.
+            # canceling exceptions will be handled in the global post_run_hook
+            cmd.perform_update(options, data, inventory_update)
+        except PermissionDenied as exc:
+            logger.exception('License error saving {} content'.format(inventory_update.log_format))
+            raise PostRunError(str(exc), status='error')
+        except Exception:
+            logger.exception('Exception saving {} content, rolling back changes.'.format(
+                inventory_update.log_format))
+            raise PostRunError(
+                'Error occured while saving inventory data, see traceback or server logs',
+                status='error', tb=traceback.format_exc())
 
 
 @task(queue=get_local_queuename)

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2461,12 +2461,14 @@ class RunInventoryUpdate(BaseTask):
     event_model = InventoryUpdateEvent
     event_data_key = 'inventory_update_id'
 
+    # TODO: remove once inv updates run in containers
     def should_use_proot(self, inventory_update):
         '''
         Return whether this task should use proot.
         '''
         return getattr(settings, 'AWX_PROOT_ENABLED', False)
 
+    # TODO: remove once inv updates run in containers
     @property
     def proot_show_paths(self):
         return [settings.AWX_ANSIBLE_COLLECTIONS_PATHS]
@@ -2503,6 +2505,7 @@ class RunInventoryUpdate(BaseTask):
                                                         private_data_files=private_data_files)
         if private_data_files is None:
             private_data_files = {}
+        # TODO: remove once containers replace custom venvs
         self.add_ansible_venv(inventory_update.ansible_virtualenv_path, env, isolated=isolated)
 
         # Legacy environment variables, were used as signal to awx-manage command

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2784,6 +2784,12 @@ class RunInventoryUpdate(BaseTask):
         from awx.main.management.commands.inventory_import import Command as InventoryImportCommand
         cmd = InventoryImportCommand()
         try:
+            # note that we are only using the management command to
+            # save the inventory data to the database.
+            # we are not asking it to actually fetch hosts / groups.
+            # that work was taken care of earlier, when
+            # BaseTask.run called ansible-inventory (by way of ansible-runner)
+            # for us.
             save_status, tb, exc = cmd.perform_update(options, data, inventory_update)
         except Exception as raw_exc:
             # Ignore license errors specifically

--- a/awx/main/tests/functional/commands/test_inventory_import.py
+++ b/awx/main/tests/functional/commands/test_inventory_import.py
@@ -83,7 +83,7 @@ class MockLoader:
         return self._data
 
 
-def mock_logging(self):
+def mock_logging(self, level):
     pass
 
 

--- a/awx/main/tests/functional/commands/test_inventory_import.py
+++ b/awx/main/tests/functional/commands/test_inventory_import.py
@@ -9,6 +9,9 @@ import os
 # Django
 from django.core.management.base import CommandError
 
+# for license errors
+from rest_framework.exceptions import PermissionDenied
+
 # AWX
 from awx.main.management.commands import inventory_import
 from awx.main.models import Inventory, Host, Group, InventorySource
@@ -322,6 +325,6 @@ def test_tower_version_compare():
             "version": "2.0.1-1068-g09684e2c41"
         }
     }
-    with pytest.raises(CommandError):
+    with pytest.raises(PermissionDenied):
         cmd.remote_tower_license_compare('very_supported')
     cmd.remote_tower_license_compare('open')

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -216,6 +216,7 @@ def test_inventory_update_injected_content(this_kind, inventory, fake_credential
         env.pop('ANSIBLE_COLLECTIONS_PATHS', None)  # collection paths not relevant to this test
         env.pop('PYTHONPATH')
         env.pop('VIRTUAL_ENV')
+        env.pop('PROOT_TMP_DIR')
         base_dir = os.path.join(DATA, 'plugins')
         if not os.path.exists(base_dir):
             os.mkdir(base_dir)

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -214,6 +214,8 @@ def test_inventory_update_injected_content(this_kind, inventory, fake_credential
             f"'{inventory_filename}' file not found in inventory update runtime files {content.keys()}"
 
         env.pop('ANSIBLE_COLLECTIONS_PATHS', None)  # collection paths not relevant to this test
+        env.pop('PYTHONPATH')
+        env.pop('VIRTUAL_ENV')
         base_dir = os.path.join(DATA, 'plugins')
         if not os.path.exists(base_dir):
             os.mkdir(base_dir)

--- a/awx/main/tests/unit/commands/test_inventory_import.py
+++ b/awx/main/tests/unit/commands/test_inventory_import.py
@@ -33,32 +33,6 @@ class TestInvalidOptions:
         assert 'inventory-id' in str(err.value)
         assert 'exclusive' in str(err.value)
 
-    def test_invalid_options_id_and_keep_vars(self):
-        # You can't overwrite and keep_vars at the same time, that wouldn't make sense
-        cmd = Command()
-        with pytest.raises(CommandError) as err:
-            cmd.handle(
-                inventory_id=42, overwrite=True, keep_vars=True
-            )
-        assert 'overwrite-vars' in str(err.value)
-        assert 'exclusive' in str(err.value)
-
-    def test_invalid_options_id_but_no_source(self):
-        # Need a source to import
-        cmd = Command()
-        with pytest.raises(CommandError) as err:
-            cmd.handle(
-                inventory_id=42, overwrite=True, keep_vars=True
-            )
-        assert 'overwrite-vars' in str(err.value)
-        assert 'exclusive' in str(err.value)
-        with pytest.raises(CommandError) as err:
-            cmd.handle(
-                inventory_id=42, overwrite_vars=True, keep_vars=True
-            )
-        assert 'overwrite-vars' in str(err.value)
-        assert 'exclusive' in str(err.value)
-
     def test_invalid_options_missing_source(self):
         cmd = Command()
         with pytest.raises(CommandError) as err:

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -2061,8 +2061,8 @@ class TestInventoryUpdateCredentials(TestJobExecution):
                     credential, env, {}, [], private_data_dir
                 )
 
-        assert '--custom' in ' '.join(args)
-        script = args[args.index('--source') + 1]
+        assert '-i' in ' '.join(args)
+        script = args[args.index('-i') + 1]
         with open(script, 'r') as f:
             assert f.read() == inventory_update.source_script.script
         assert env['FOO'] == 'BAR'

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -9,6 +9,7 @@ import socket
 from datetime import datetime
 
 from dateutil.tz import tzutc
+from django.utils.timezone import now
 from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
 
@@ -17,8 +18,15 @@ class TimeFormatter(logging.Formatter):
     '''
     Custom log formatter used for inventory imports
     '''
+    def __init__(self, start_time=None, **kwargs):
+        if start_time is None:
+            self.job_start = now()
+        else:
+            self.job_start = start_time
+        super(TimeFormatter, self).__init__(**kwargs)
+
     def format(self, record):
-        record.relativeSeconds = record.relativeCreated / 1000.0
+        record.relativeSeconds = (now() - self.job_start).total_seconds()
         return logging.Formatter.format(self, record)
 
 

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -7,6 +7,10 @@ import os.path
 
 # Django
 from django.conf import settings
+from django.utils.timezone import now
+
+# AWX
+from awx.main.exceptions import PostRunError
 
 
 class RSysLogHandler(logging.handlers.SysLogHandler):
@@ -38,6 +42,58 @@ class RSysLogHandler(logging.handlers.SysLogHandler):
             # because the alternative is blocking the socket.send() in the
             # Python process, which we definitely don't want to do)
             pass
+
+
+class SpecialInventoryHandler(logging.Handler):
+    """Logging handler used for the saving-to-database part of inventory updates
+    ran by the task system
+    this dispatches events directly to be processed by the callback receiver,
+    as opposed to ansible-runner
+    """
+
+    def __init__(self, event_handler, cancel_callback, job_timeout, verbosity,
+                 start_time=None, counter=0, initial_line=0, **kwargs):
+        self.event_handler = event_handler
+        self.cancel_callback = cancel_callback
+        self.job_timeout = job_timeout
+        if start_time is None:
+            self.job_start = now()
+        else:
+            self.job_start = start_time
+        self.last_check = self.job_start
+        self.counter = counter
+        self.skip_level = [logging.WARNING, logging.INFO, logging.DEBUG, 0][verbosity]
+        self._current_line = initial_line
+        super(SpecialInventoryHandler, self).__init__(**kwargs)
+
+    def emit(self, record):
+        # check cancel and timeout status regardless of log level
+        this_time = now()
+        if (this_time - self.last_check).total_seconds() > 0.5:  # cancel callback is expensive
+            self.last_check = this_time
+            if self.cancel_callback():
+                raise PostRunError('Inventory update has been canceled', status='canceled')
+        if self.job_timeout and ((this_time - self.job_start).total_seconds() > self.job_timeout):
+            raise PostRunError('Inventory update has timed out', status='canceled')
+
+        # skip logging for low severity logs
+        if record.levelno < self.skip_level:
+            return
+
+        self.counter += 1
+        msg = self.format(record)
+        n_lines = len(msg.strip().split('\n'))  # don't count line breaks at boundry of text
+        dispatch_data = dict(
+            created=now().isoformat(),
+            event='verbose',
+            counter=self.counter,
+            stdout=msg,
+            start_line=self._current_line,
+            end_line=self._current_line + n_lines
+        )
+        self._current_line += n_lines
+
+        self.event_handler(dispatch_data)
 
 
 ColorHandler = logging.StreamHandler


### PR DESCRIPTION
##### SUMMARY
~Sharing as a WIP because I may be pulled away for an extended leave soon.~

Refactor of inventory updates so that we can easily containerize the `ansible-inventory` subprocess.

This changes the `tasks.py` code to call `ansible-inventory` as opposed to `awx-manage`. We want inventory updates to run in the control plane, where the Ansible install will be available, but AWX utilities will not. Correspondingly, the processing of saving the data that is returned is shifted to the main code - instead of saving in the management command, we save in `pre_run_hook`, and some clever tricks are employed to emit logs in the same style they always have been.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
15.0.0
```


##### ADDITIONAL INFORMATION
This is picking up some really old work, but only taking the _absolutely_ necessary parts to get inventory updates into containers.

~As of opening this PR, this is only progressing to the point of making the `awx-manage inventory_import` interface work.~

~With this established, I'm diving into `awx/main/tasks.py` in order to change the `args` file from `awx-manage` to `ansible-inventory`, then the process of saving the inventory will get pushed to `post_run_hook`.~

Old related work includes https://github.com/ansible/awx/pull/451 and #3138
