### PR TITLE
Refactor FormSubmitError for easier testing, better error display

### DIFF
--- a/awx/ui_next/src/components/FormField/FormSubmitError.test.jsx
+++ b/awx/ui_next/src/components/FormField/FormSubmitError.test.jsx
@@ -21,7 +21,7 @@ describe('<FormSubmitError>', () => {
       },
     };
     const wrapper = mountWithContexts(
-      <Formik>
+      <Formik initialValues={{ name: '' }}>
         {({ errors }) => (
           <div>
             <p>{errors.name}</p>
@@ -51,31 +51,5 @@ describe('<FormSubmitError>', () => {
     expect(wrapper.find('Alert').prop('title')).toEqual('There was an error');
     expect(global.console.error).toHaveBeenCalledWith(error);
     global.console = realConsole;
-  });
-
-  test('should display error message if field error is nested', async () => {
-    const error = {
-      response: {
-        data: {
-          name: 'There was an error with name',
-          inputs: {
-            url: 'Error with url',
-          },
-        },
-      },
-    };
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>{() => <FormSubmitError error={error} />}</Formik>
-      );
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('Alert').contains(<div>There was an error with name</div>)
-    ).toEqual(true);
-    expect(wrapper.find('Alert').contains(<div>Error with url</div>)).toEqual(
-      true
-    );
   });
 });

--- a/awx/ui_next/src/components/FormField/sortErrorMessages.js
+++ b/awx/ui_next/src/components/FormField/sortErrorMessages.js
@@ -1,0 +1,35 @@
+export default function sortErrorMessages(error, formValues = {}) {
+  if (!error) {
+    return {};
+  }
+
+  const fieldErrors = {};
+  let formErrors = [];
+  if (
+    error?.response?.data &&
+    typeof error.response.data === 'object' &&
+    Object.keys(error.response.data).length > 0
+  ) {
+    Object.keys(error.response.data).forEach(fieldName => {
+      const errors = error.response.data[fieldName];
+      if (!errors) {
+        return;
+      }
+      const errorsArray = Array.isArray(errors) ? errors : [errors];
+      if (typeof formValues[fieldName] === 'undefined') {
+        formErrors = [...formErrors, ...errorsArray];
+      } else {
+        fieldErrors[fieldName] = errorsArray.join('; ');
+      }
+    });
+  } else {
+    /* eslint-disable-next-line no-console */
+    console.error(error);
+    formErrors.push(error.message);
+  }
+
+  return {
+    formError: formErrors.join('; '),
+    fieldErrors: Object.keys(fieldErrors).length ? fieldErrors : null,
+  };
+}

--- a/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
+++ b/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
@@ -79,4 +79,68 @@ describe('sortErrorMessages', () => {
       },
     });
   });
+
+  test('should give nested field error messages', () => {
+    const error = {
+      response: {
+        data: {
+          inputs: {
+            url: ['URL Error'],
+            other: {
+              stuff: ['Other stuff error'],
+            },
+          },
+        },
+      },
+    };
+    const formValues = {
+      inputs: {
+        url: '',
+        other: {
+          stuff: '',
+        },
+      },
+    };
+    const parsed = sortErrorMessages(error, formValues);
+    expect(parsed).toEqual({
+      formError: '',
+      fieldErrors: {
+        inputs: {
+          url: 'URL Error',
+          other: {
+            stuff: 'Other stuff error',
+          },
+        },
+      },
+    });
+  });
+
+  test('should give unknown nested field error as form error', () => {
+    const error = {
+      response: {
+        data: {
+          inputs: {
+            url: ['URL Error'],
+            other: {
+              stuff: ['Other stuff error'],
+            },
+          },
+        },
+      },
+    };
+    const formValues = {
+      inputs: {
+        url: '',
+      },
+    };
+    const parsed = sortErrorMessages(error, formValues);
+    expect(parsed).toEqual({
+      formError: 'Other stuff error',
+      fieldErrors: {
+        inputs: {
+          url: 'URL Error',
+        },
+      },
+    });
+  });
 });

--- a/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
+++ b/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
@@ -1,0 +1,81 @@
+import sortErrorMessages from './sortErrorMessages';
+
+describe('sortErrorMessages', () => {
+  let consoleError;
+  beforeEach(() => {
+    consoleError = global.console.error;
+    global.console.error = () => {};
+  });
+
+  afterEach(() => {
+    global.console.error = consoleError;
+  });
+
+  test('should give general error message', () => {
+    const error = {
+      message: 'An error occurred',
+    };
+    const parsed = sortErrorMessages(error);
+
+    expect(parsed).toEqual({
+      formError: 'An error occurred',
+      fieldErrors: null,
+    });
+  });
+
+  test('should give field error messages', () => {
+    const error = {
+      response: {
+        data: {
+          foo: 'bar',
+          baz: 'bam',
+        },
+      },
+    };
+    const parsed = sortErrorMessages(error, { foo: '', baz: '' });
+    expect(parsed).toEqual({
+      formError: '',
+      fieldErrors: {
+        foo: 'bar',
+        baz: 'bam',
+      },
+    });
+  });
+
+  test('should give form error for nonexistent field', () => {
+    const error = {
+      response: {
+        data: {
+          alpha: 'oopsie',
+          baz: 'bam',
+        },
+      },
+    };
+    const parsed = sortErrorMessages(error, { foo: '', baz: '' });
+    expect(parsed).toEqual({
+      formError: 'oopsie',
+      fieldErrors: {
+        baz: 'bam',
+      },
+    });
+  });
+
+  test('should join multiple field error messages', () => {
+    const error = {
+      response: {
+        data: {
+          foo: ['bar', 'bar2'],
+          baz: 'bam',
+        },
+      },
+    };
+    const parsed = sortErrorMessages(error, { foo: '', baz: '' });
+    expect(parsed).toEqual({
+      formError: '',
+      fieldErrors: {
+        foo: 'bar; bar2',
+        baz: 'bam',
+      },
+    });
+  });
+});

--- a/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
+++ b/awx/ui_next/src/components/FormField/sortErrorMessages.test.js
@@ -3,6 +3,7 @@ import sortErrorMessages from './sortErrorMessages';
 describe('sortErrorMessages', () => {
   let consoleError;
   beforeEach(() => {
+    // Component logs errors to console. Hide those during testing.
     consoleError = global.console.error;
     global.console.error = () => {};
   });


### PR DESCRIPTION
##### SUMMARY
Reworks how FormSubmitError parses error messages from an API response:

* parsing is now done entirely in a util function, which can be test-driven for any future changes
* No longer display field error messages both below the field and beneath the whole form
* If the API returns a field error for a field that Formik doesn't have a value for (e.g. `rrule` in the Schedules form), the error is not set on Formik and instead displays at the bottom of the form

addresses #7515 

This also addresses #7822, which was caused by sending errors to PatternFly form components as arrays rather than strings

##### ISSUE TYPE
 - Improvement

##### COMPONENT NAME
 - UI
