### PR TITLE
add support for wait of project_updates jobs, inventory_update, and w…

### DIFF
--- a/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_wait/tasks/main.yml
@@ -135,3 +135,49 @@
     name: "{{ proj_name }}"
     organization: Default
     state: absent
+
+# tower workflow wait test
+- name: Generate a random string for test
+  set_fact:
+    test_id1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+  when: test_id1 is not defined
+
+- name: Generate names
+  set_fact:
+    wfjt_name2: "AWX-Collection-tests-tower_workflow_launch--wfjt1-{{ test_id1 }}"
+
+- name: Create our workflow
+  tower_workflow_job_template:
+    name: "{{ wfjt_name2 }}"
+    state: present
+
+- name: Add a node
+  tower_workflow_job_template_node:
+    workflow_job_template: "{{ wfjt_name2 }}"
+    unified_job_template: "Demo Job Template"
+    identifier: leaf
+  register: new_node
+
+- name: Kick off a workflow
+  tower_workflow_launch:
+    workflow_template: "{{ wfjt_name2 }}"
+  ignore_errors: true
+  register: workflow
+
+- name: Wait for the Workflow Job to finish
+  tower_job_wait:
+    job_id: "{{ workflow.job_info.id }}"
+    job_type: "workflow_jobs"
+  register: wait_workflow_results
+
+# Make sure it worked and that we have some data in our results
+- assert:
+    that:
+      - wait_workflow_results is successful
+      - "'elapsed' in wait_workflow_results"
+      - "'id' in wait_workflow_results"
+
+- name: Clean up test workflow
+  tower_workflow_job_template:
+    name: "{{ wfjt_name2 }}"
+    state: absent


### PR DESCRIPTION
…orkflow_job.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is an enhancement to allow the tower job wait module to support waiting for other similar jobs
Addtional "job" types allowed
- 'project_update'
- 'job'   # default
- 'inventory_update'
- 'workflow_job'

I wrote this some time ago and will need to rebase this to get it into this branch
My code is based off off commit 2e4e687d694c9b559189224e785ae7c104145bb4 - Commits on Feb 26, 2020

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related #8344

https://github.com/ansible/awx/issues/8344

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - tower_job_wait

##### AWX VERSION
```
awx: 9.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
