### PR TITLE
Rename inventory_source param to name in tower_inventory_source_update

### DIFF
--- a/awx_collection/plugins/modules/tower_inventory_source_update.py
+++ b/awx_collection/plugins/modules/tower_inventory_source_update.py
@@ -90,7 +90,7 @@ from ..module_utils.tower_api import TowerAPIModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        name=dict(required=True),
+        name=dict(required=True, aliases=['inventory_source']),
         inventory=dict(required=True),
         organization=dict(),
         wait=dict(default=False, type='bool'),

--- a/awx_collection/plugins/modules/tower_inventory_source_update.py
+++ b/awx_collection/plugins/modules/tower_inventory_source_update.py
@@ -27,6 +27,8 @@ options:
         - The name or id of the inventory source to update.
       required: True
       type: str
+      aliases:
+        - inventory_source
     inventory:
       description:
         - Name or id of the inventory that contains the inventory source(s) to update.

--- a/awx_collection/tests/integration/targets/tower_inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source_update/tasks/main.yml
@@ -73,8 +73,8 @@
 
     - name: Test Inventory Source Update
       tower_inventory_source_update:
+        name: "{{ inv_source2 }}"
         inventory: "{{ inv_name }}"
-        inventory_source: "{{ inv_source2 }}"
         organization: Default
       register: result
 
@@ -84,8 +84,8 @@
 
     - name: Test Inventory Source Update for All Sources
       tower_inventory_source_update:
+        name: "{{ item.name }}"
         inventory: "{{ inv_name }}"
-        inventory_source: "{{ item.name }}"
         organization: Default
         wait: true
       loop: "{{ query('awx.awx.tower_api', 'inventory_sources', query_params={ 'inventory': created_inventory.id }, expect_objects=True, return_objects=True) }}"

--- a/awx_collection/tests/integration/targets/tower_inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source_update/tasks/main.yml
@@ -97,6 +97,21 @@
         that:
           - "result is changed"
 
+    - name: Test Inventory Source Update for All Sources (using inventory_source as alias for name)
+      tower_inventory_source_update:
+        inventory_source: "{{ item.name }}"
+        inventory: "{{ inv_name }}"
+        organization: Default
+        wait: true
+      loop: "{{ query('awx.awx.tower_api', 'inventory_sources', query_params={ 'inventory': created_inventory.id }, expect_objects=True, return_objects=True) }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
   always:
     - name: Delete Inventory
       tower_inventory:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
* fixes #8347
* Rename inventory_source to name in the tower_inventory_source_update
* Allow to specify both name or id for `name` and `inventory` params

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - tower_inventory_source_update

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
