### PR TITLE
use database application_name

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -88,26 +88,6 @@ def oauth2_getattribute(self, attr):
     return val
 
 
-class LazyApplicationName(str):
-    def __init__(self, cluster_host_id):
-        self.cluster_host_id = cluster_host_id
-
-    def __str__(self):
-        return f'{self.cluster_host_id}-{os.getpid()}-{" ".join(sys.argv)}'
-
-    def __repr__(self):
-        return str(self)
-
-
-def set_database_application_name(database_settings, cluster_host_id):
-    '''
-    Must wrap application_name value in a lazy evaluator to account ensure
-    pid is up-to-date when forking.
-    '''
-    options = database_settings.get('OPTIONS', {})
-    options.setdefault('application_name', LazyApplicationName(cluster_host_id))
-    database_settings['OPTIONS'] = options
-
 def prepare_env():
     # Update the default settings environment variable based on current mode.
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'awx.settings.%s' % MODE)
@@ -124,10 +104,6 @@ def prepare_env():
     # in django.conf settings each time, not just once during import
     import oauth2_provider.settings
     oauth2_provider.settings.OAuth2ProviderSettings.__getattribute__ = oauth2_getattribute
-
-    # Add application_name to database connection. Tracing from database
-    # will tell you the '<awx_hostname>-<pid>-<commandline_arguments>'
-    set_database_application_name(settings.DATABASES['default'], settings.CLUSTER_HOST_ID)
 
     # Use the AWX_TEST_DATABASE_* environment variables to specify the test
     # database settings to use when management command is run as an external

--- a/awx/main/management/commands/check_migrations.py
+++ b/awx/main/management/commands/check_migrations.py
@@ -8,5 +8,7 @@ class Command(MakeMigrations):
     def execute(self, *args, **options):
         settings = connections['default'].settings_dict.copy()
         settings['ENGINE'] = 'sqlite3'
+        if 'application_name' in settings['OPTIONS']:
+            del settings['OPTIONS']['application_name']
         connections['default'] = DatabaseWrapper(settings)
         return MakeMigrations().execute(*args, **options)

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -184,3 +184,6 @@ else:
         pass
 
 AWX_CALLBACK_PROFILE = True
+
+if 'sqlite3' not in DATABASES['default']['ENGINE']:
+    DATABASES['default'].setdefault('OPTIONS', dict()).setdefault('application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63]) # noqa

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -102,6 +102,7 @@ except IOError:
     else:
         raise
 
+# The below runs AFTER all of the custom settings are imported.
 
 CELERYBEAT_SCHEDULE.update({  # noqa
     'isolated_heartbeat': {
@@ -110,3 +111,5 @@ CELERYBEAT_SCHEDULE.update({  # noqa
         'options': {'expires': AWX_ISOLATED_PERIODIC_CHECK * 2},  # noqa
     }
 })
+
+DATABASES['default'].setdefault('OPTIONS', dict()).setdefault('application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63]) # noqa


### PR DESCRIPTION
* add `<hostname>-<pid>-<cmdline>` to application_name in database
* Makes it easier to find the process of a long running query or
long-held lock.
![image](https://user-images.githubusercontent.com/722880/95461283-0c141180-0944-11eb-82d5-5a6552ada0fd.png)

```
SELECT
  pid,
  client_addr,
  application_name,
  now() - pg_stat_activity.query_start AS duration,
  query,
  state
FROM pg_stat_activity;
```

![image](https://user-images.githubusercontent.com/722880/95461351-1fbf7800-0944-11eb-8f6e-faf66e75b019.png)


## TODO:
* truncate `application_name` to 63 characters otherwise when you first establish a connection to the database you will get `NOTICE:  identifier "tower010-vm10-towerperf.xxxxxxx.xxxxxxxx.com-4521-/usr/bin/awx-manage shell_plus" will be truncated to "tower010-vm10-towerperf.usersys.redhat.com-4521-/usr/bin/awx-ma"` To recreate, simply run `awx-manage shell_plus` and run a query, `jt=JobTemplate.objects.count()`
* This code might run too late. The database connection may already be established and we will not get our `application_name` injected. Note, saw this with Gabe and Mellow when debugging