### PR TITLE
Zedr wfjt inventories

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3438,6 +3438,12 @@ class WorkflowJobTemplateSerializer(JobTemplateMixin, LabelsListMixin, UnifiedJo
             res['organization'] = self.reverse('api:organization_detail',   kwargs={'pk': obj.organization.pk})
         if obj.webhook_credential_id:
             res['webhook_credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.webhook_credential_id})
+        if obj.inventory:
+            res['inventory'] = self.reverse(
+                'api:inventory_detail', kwargs={
+                    'pk': obj.inventory.pk
+                }
+            )
         return res
 
     def validate_extra_vars(self, value):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3438,10 +3438,10 @@ class WorkflowJobTemplateSerializer(JobTemplateMixin, LabelsListMixin, UnifiedJo
             res['organization'] = self.reverse('api:organization_detail',   kwargs={'pk': obj.organization.pk})
         if obj.webhook_credential_id:
             res['webhook_credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.webhook_credential_id})
-        if obj.inventory:
+        if obj.inventory_id:
             res['inventory'] = self.reverse(
                 'api:inventory_detail', kwargs={
-                    'pk': obj.inventory.pk
+                    'pk': obj.inventory_id
                 }
             )
         return res

--- a/awxkit/awxkit/api/pages/workflow_job_templates.py
+++ b/awxkit/awxkit/api/pages/workflow_job_templates.py
@@ -15,27 +15,6 @@ class WorkflowJobTemplate(HasCopy, HasCreate, HasNotifications, HasSurvey, Unifi
     optional_dependencies = [Organization]
     NATURAL_KEY = ('organization', 'name')
 
-    @property
-    def related(self):
-        """Augment the related namespace with the inventory.
-
-        This provides a workaround for API instances that do not provide
-        a reference to this workflow's associated inventory, if defined,
-        in the related namespace.
-
-        See issue #7798.
-        """
-        related_data = self.__getattr__('related')
-        if 'inventory' not in related_data:
-            inventory_id = self.json['inventory']
-            if inventory_id:
-                endpoint_url = '/api/v2/inventories/{}/'.format(inventory_id)
-                related_data['inventory'] = page.TentativePage(
-                    endpoint_url,
-                    self.connection
-                )
-        return related_data
-
     def launch(self, payload={}):
         """Launch using related->launch endpoint."""
         # get related->launch


### PR DESCRIPTION
##### SUMMARY
The current version of AWX fails to include the url to a non-null Inventory foreign key in the API results for a Workflow Job Template.  This PR finishes off work from @zedr to both add that link the the API output, but also attempt a reasonable fallback when using the awx-cli export function against a version of AWX that does not have this fix.

related #7798 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 15.0.0
```
