### PR TITLE
Fixing get_one calls in tower_inventory_source_update

### DIFF
--- a/awx_collection/plugins/modules/tower_inventory_source_update.py
+++ b/awx_collection/plugins/modules/tower_inventory_source_update.py
@@ -107,17 +107,16 @@ def main():
     interval = module.params.get('interval')
     timeout = module.params.get('timeout')
 
-    lookup_data = {'name': inventory}
+    lookup_data = {}
     if organization:
         lookup_data['organization'] = module.resolve_name_to_id('organizations', organization)
-    inventory_object = module.get_one('inventories', data=lookup_data)
+    inventory_object = module.get_one('inventories', name_or_id=inventory, data=lookup_data)
 
     if not inventory_object:
         module.fail_json(msg='The specified inventory, {0}, was not found.'.format(lookup_data))
 
-    inventory_source_object = module.get_one('inventory_sources', **{
+    inventory_source_object = module.get_one('inventory_sources', name_or_id=inventory_source, **{
         'data': {
-            'name': inventory_source,
             'inventory': inventory_object['id'],
         }
     })


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The get_one calls in tower_inventory_source_update did not respect the name_or_id causing the module to fail if an id was passed for the inventory or the inventory_source.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
