### PR TITLE
Fixing stack trace from an error not having a detail

### DIFF
--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -393,7 +393,7 @@ class TowerAPIModule(TowerModule):
             if response['status_code'] == 204:
                 self.json_output['changed'] = True
             else:
-                self.fail_json(msg="Failed to disassociate item {0}".format(response['json']['detail']))
+                self.fail_json(msg="Failed to disassociate item {0}".format(response['json'].get('detail', response['json'])))
 
         # Associate anything that is in new_association_list but not in `association`
         for an_id in list(set(new_association_list) - set(existing_associated_ids)):
@@ -401,7 +401,7 @@ class TowerAPIModule(TowerModule):
             if response['status_code'] == 204:
                 self.json_output['changed'] = True
             else:
-                self.fail_json(msg="Failed to associate item {0}".format(response['json']['detail']))
+                self.fail_json(msg="Failed to associate item {0}".format(response['json'].get('detail', response['json'])))
 
     def create_if_needed(self, existing_item, new_item, endpoint, on_create=None, item_type='unknown', associations=None):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Was attempting to add an SCM credential to a job template and got a stack trace. The API was returning:
```
{'error': 'Cannot assign a Credential of kind `scm`.'}
```

Which did not contain a "detail" field. This change attempts to return 'detail' but if that DNE than just send back the entire json response instead of generating a stack. In the future I want to create a `get_error` method which would look for all sorts of things.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
