### PR TITLE
Fix issues with prop types that were causing errors to be logged during tests

### DIFF
--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
@@ -134,7 +134,8 @@ const FormikApp = withFormik({
 
 FormikApp.propTypes = {
   onLaunch: PropTypes.func.isRequired,
-  moduleOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  moduleOptions: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
+    .isRequired,
   verbosityOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   onCloseWizard: PropTypes.func.isRequired,
   credentialTypeId: PropTypes.number.isRequired,

--- a/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocDetailsStep.jsx
@@ -316,7 +316,8 @@ function AdHocDetailsStep({ i18n, verbosityOptions, moduleOptions }) {
 }
 
 AdHocDetailsStep.propTypes = {
-  moduleOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  moduleOptions: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
+    .isRequired,
   verbosityOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.jsx
@@ -231,7 +231,7 @@ function InventoryHostList({ i18n }) {
           onClose={() => setIsAdHocCommandsOpen(false)}
           credentialTypeId={credentialTypeId}
           moduleOptions={moduleOptions}
-          itemId={id}
+          itemId={parseInt(id, 10)}
         />
       )}
       {deletionError && (

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -239,6 +239,7 @@ function JobTemplateForm({
           isRequired={!askInventoryOnLaunchField.value}
         >
           <InventoryLookup
+            fieldId="template-inventory"
             value={inventory}
             promptId="template-ask-inventory-on-launch"
             promptName="ask_inventory_on_launch"


### PR DESCRIPTION
##### SUMMARY
Noticed several errors being logged while the tests ran that had to do with prop types.  This PR should clean that up.

```
 PASS  src/screens/Template/shared/JobTemplateForm.test.jsx (23.988s)
  ● Console

    console.error node_modules/prop-types/checkPropTypes.js:20
      Warning: Failed prop type: The prop `fieldId` is marked as required in `FieldWithPrompt`, but its value is `undefined`.
          in FieldWithPrompt (created by I18n)
          in I18n (created by WithI18n)
          in WithI18n (at InventoryLookup.jsx:78)
          in InventoryLookup (created by Context.Consumer)
          in withRouter(InventoryLookup) (created by I18n)
          in I18n (created by WithI18n)
          in WithI18n (at JobTemplateForm.jsx:241)
          in div (created by FormGroup)
          in div (created by FormGroup)
          in FormGroup (at JobTemplateForm.jsx:230)
          in div (created by Context.Consumer)
          in StyledComponent (created by styled.div)
          in styled.div (at JobTemplateForm.jsx:194)
          in form (created by Form)
          in Form (at JobTemplateForm.jsx:193)
          in JobTemplateForm (created by Formik)
          in Formik (created by WithFormik(JobTemplateForm))
          in WithFormik(JobTemplateForm) (created by I18n)
          in I18n (created by WithI18n)
          in WithI18n (at JobTemplateForm.test.jsx:142)
          in Router (created by MemoryRouter)
          in MemoryRouter (at enzymeHelpers.jsx:96)
          in Wrap (created by WrapperComponent)
          in WrapperComponent
```

```
 PASS  src/components/AdHocCommands/AdHocDetailsStep.test.jsx
  ● Console

    console.error node_modules/prop-types/checkPropTypes.js:20
      Warning: Failed prop type: Invalid prop `moduleOptions[0]` of type `array` supplied to `AdHocDetailsStep`, expected `object`.
          in AdHocDetailsStep (created by I18n)
          in I18n (created by WithI18n)
          in WithI18n (at AdHocDetailsStep.test.jsx:44)
          in Formik (at AdHocDetailsStep.test.jsx:43)
          in Router (created by MemoryRouter)
          in MemoryRouter (at enzymeHelpers.jsx:96)
          in Wrap (created by WrapperComponent)
          in WrapperComponent
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI