### PR TITLE
Point installer to community.general.docker_image

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,6 +79,7 @@ Before you can run a deployment, you'll need the following installed in your loc
     + This is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
     + We use this module instead of `docker-py` because it is what the `docker-compose` Python module requires.
 - [community.general.docker_image collection](https://docs.ansible.com/ansible/latest/collections/community/general/docker_image_module.html)
+    + This is only required if you are using Ansible >= 2.10
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Git](https://git-scm.com/) Requires Version 1.8.4+
 - Python 3.6+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,6 +78,7 @@ Before you can run a deployment, you'll need the following installed in your loc
 - [docker](https://pypi.org/project/docker/) Python module
     + This is incompatible with `docker-py`. If you have previously installed `docker-py`, please uninstall it.
     + We use this module instead of `docker-py` because it is what the `docker-compose` Python module requires.
+- [community.general.docker_image collection](https://docs.ansible.com/ansible/latest/collections/community/general/docker_image_module.html)
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Git](https://git-scm.com/) Requires Version 1.8.4+
 - Python 3.6+

--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -42,7 +42,7 @@
   delegate_to: localhost
 
 - name: Build sdist builder image
-  community.general.docker_image:
+  docker_image:
     build:
       path: "{{ role_path }}/files"
       dockerfile: Dockerfile.sdist

--- a/installer/roles/image_build/tasks/main.yml
+++ b/installer/roles/image_build/tasks/main.yml
@@ -42,7 +42,7 @@
   delegate_to: localhost
 
 - name: Build sdist builder image
-  docker_image:
+  community.general.docker_image:
     build:
       path: "{{ role_path }}/files"
       dockerfile: Dockerfile.sdist


### PR DESCRIPTION
Fixes issue in Ansible 2.10.2 where docker_image command is not found.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue #8407 in my environment. The change to the `main.yml` tasks file is not strictly necessary, but I figured it might make sense to do as well?
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
