### PR TITLE
make workflow approval creation return an HTTP 201, not 200 OK

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3043,7 +3043,7 @@ class WorkflowJobTemplateNodeCreateApproval(RetrieveAPIView):
             approval_template,
             context=self.get_serializer_context()
         ).data
-        return Response(data, status=status.HTTP_200_OK)
+        return Response(data, status=status.HTTP_201_CREATED)
 
     def check_permissions(self, request):
         obj = self.get_object().workflow_job_template

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -89,7 +89,7 @@ class TestApprovalNodes():
         url = reverse('api:workflow_job_template_node_create_approval',
                       kwargs={'pk': approval_node.pk, 'version': 'v2'})
         post(url, {'name': 'Test', 'description': 'Approval Node', 'timeout': 0},
-             user=admin_user, expect=200)
+             user=admin_user, expect=201)
 
         approval_node = WorkflowJobTemplateNode.objects.get(pk=approval_node.pk)
         assert isinstance(approval_node.unified_job_template, WorkflowApprovalTemplate)
@@ -108,9 +108,9 @@ class TestApprovalNodes():
         assert {'name': ['This field may not be blank.']} == json.loads(r.content)
 
     @pytest.mark.parametrize("is_admin, is_org_admin, status", [
-        [True, False, 200], # if they're a WFJT admin, they get a 200
+        [True, False, 201], # if they're a WFJT admin, they get a 201
         [False, False, 403], # if they're not a WFJT *nor* org admin, they get a 403
-        [False, True, 200], # if they're an organization admin, they get a 200
+        [False, True, 201], # if they're an organization admin, they get a 201
     ])
     def test_approval_node_creation_rbac(self, post, approval_node, alice, is_admin, is_org_admin, status):
         url = reverse('api:workflow_job_template_node_create_approval',
@@ -165,7 +165,7 @@ class TestApprovalNodes():
         url = reverse('api:workflow_job_template_node_create_approval',
                       kwargs={'pk': node.pk, 'version': 'v2'})
         post(url, {'name': 'Approve Test', 'description': '', 'timeout': 0},
-             user=admin_user, expect=200)
+             user=admin_user, expect=201)
         post(reverse('api:workflow_job_template_launch', kwargs={'pk': wfjt.pk}),
              user=admin_user, expect=201)
         wf_job = WorkflowJob.objects.first()
@@ -195,7 +195,7 @@ class TestApprovalNodes():
         url = reverse('api:workflow_job_template_node_create_approval',
                       kwargs={'pk': node.pk, 'version': 'v2'})
         post(url, {'name': 'Deny Test', 'description': '', 'timeout': 0},
-             user=admin_user, expect=200)
+             user=admin_user, expect=201)
         post(reverse('api:workflow_job_template_launch', kwargs={'pk': wfjt.pk}),
              user=admin_user, expect=201)
         wf_job = WorkflowJob.objects.first()


### PR DESCRIPTION
see: https://github.com/ansible/awx/pull/8364/files/e16a910062290674e19e7c2bf550d5e5a0e4ec99#diff-67c0fe4fc2a405ad611e42d1457e8aa5

cc @sean-m-sullivan 