### PR TITLE
Add Kubernetes Deployment support for annotations

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -85,6 +85,12 @@ kind: Deployment
 metadata:
   name: {{ kubernetes_deployment_name }}
   namespace: {{ kubernetes_namespace }}
+{% if kubernetes_deployment_annotations is defined %}
+  annotations:
+{% for key, value in kubernetes_deployment_annotations.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
+{% endif %}
 {% if openshift_host is defined %}
   labels:
     app: {{ kubernetes_deployment_name }}


### PR DESCRIPTION

##### SUMMARY
Annotations are only supported for ingress and service accounts
This PR will allow you now to specify annotations for Kubernetes Deployment
resources by defining `kubernetes_deployment_annotations` var list

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 15.0.0
```