### PR TITLE
Expose the SCM Branch name in the playbook environment

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -799,6 +799,9 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
             for name in ('awx', 'tower'):
                 r['{}_project_revision'.format(name)] = self.project.scm_revision
                 r['{}_project_scm_branch'.format(name)] = self.project.scm_branch
+        if self.scm_branch:
+            for name in ('awx', 'tower'):
+                r['{}_job_scm_branch'.format(name)] = self.scm_branch
         if self.job_template:
             for name in ('awx', 'tower'):
                 r['{}_job_template_id'.format(name)] = self.job_template.pk

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -798,6 +798,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         if self.project:
             for name in ('awx', 'tower'):
                 r['{}_project_revision'.format(name)] = self.project.scm_revision
+                r['{}_project_scm_branch'.format(name)] = self.project.scm_branch
         if self.job_template:
             for name in ('awx', 'tower'):
                 r['{}_job_template_id'.format(name)] = self.job_template.pk


### PR DESCRIPTION
##### SUMMARY
Expose more job setting variables in the playbook environment.

related #8429

A playbook wanting to know the branch or tag name it is deployed from has currently no way to do so.

With this change, any configured default project SCM branch is exposed as `{awx,tower}_project_scm_branch`.
If the SCM Branch is overwritten in the job, the related value is exposed as `{awx,tower}_job_scm_branch`.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 15.0.1
```


