### PR TITLE
Improve handling of 0 and negative thresholds in the profile_sql command

### DIFF
--- a/awx/main/management/commands/profile_sql.py
+++ b/awx/main/management/commands/profile_sql.py
@@ -19,7 +19,9 @@ class Command(BaseCommand):
         profile_sql.delay(
             threshold=options['threshold'], minutes=options['minutes']
         )
-        print(f"Logging initiated with a threshold of {options['threshold']} second(s) and a duration of"
-              f" {options['minutes']} minute(s), any queries that meet criteria can"
-              f" be found in /var/log/tower/profile/."
-              )
+        if options['threshold'] > 0:
+            print(f"SQL profiling initiated with a threshold of {options['threshold']} second(s) and a"
+                  f" duration of {options['minutes']} minute(s), any queries that meet criteria can"
+                  f" be found in /var/log/tower/profile/.")
+        else:
+            print("SQL profiling disabled.")

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -313,7 +313,7 @@ def delete_project_files(project_path):
 
 @task(queue='tower_broadcast_all')
 def profile_sql(threshold=1, minutes=1):
-    if threshold == 0:
+    if threshold <= 0:
         cache.delete('awx-profile-sql-threshold')
         logger.error('SQL PROFILING DISABLED')
     else:


### PR DESCRIPTION
##### SUMMARY

- output a profiling disabled message when appropriate
- specify that we are doing SQL profiling in the enabled case
- treat negative thresholds the same as zero, disabling profiling

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 15.0.1
```

##### ADDITIONAL INFORMATION

before:
```
bash-4.4$ awx-manage profile_sql --threshold=0.2 --minutes=1
Logging initiated with a threshold of 0.2 second(s) and a duration of 1.0 minute(s), any queries that meet criteria can be found in /var/log/tower/profile/.
```

```
bash-4.4$ awx-manage profile_sql --threshold=0
Logging initiated with a threshold of 0.0 second(s) and a duration of 5 minute(s), any queries that meet criteria can be found in /var/log/tower/profile/.
```

after:
```
bash-4.4$ awx-manage profile_sql --threshold=0.2 --minutes=1
SQL profiling initiated with a threshold of 0.2 second(s) and a duration of 1.0 minute(s), any queries that meet criteria can be found in /var/log/tower/profile/.
```

```
bash-4.4$ awx-manage profile_sql --threshold=0
SQL profiling disabled.
```
