### PR TITLE
Revert "Kind" Choice from 'satellite' to 'satellite6'

### DIFF
--- a/awx_collection/plugins/modules/tower_credential.py
+++ b/awx_collection/plugins/modules/tower_credential.py
@@ -74,7 +74,7 @@ options:
         - Deprecated, please use credential_type
       required: False
       type: str
-      choices: ["aws", "tower", "gce", "azure_rm", "openstack", "cloudforms", "satellite", "rhv", "vmware", "aim", "conjur", "hashivault_kv", "hashivault_ssh",
+      choices: ["aws", "tower", "gce", "azure_rm", "openstack", "cloudforms", "satellite6", "rhv", "vmware", "aim", "conjur", "hashivault_kv", "hashivault_ssh",
                 "azure_kv", "insights", "kubernetes_bearer_token", "net", "scm", "ssh", "github_token", "gitlab_token", "vault"]
     host:
       description:
@@ -285,7 +285,7 @@ KIND_CHOICES = {
     'azure_rm': 'Microsoft Azure Resource Manager',
     'openstack': 'OpenStack',
     'cloudforms': 'Red Hat CloudForms',
-    'satellite': 'Red Hat Satellite 6',
+    'satellite6': 'Red Hat Satellite 6',
     'rhv': 'Red Hat Virtualization',
     'vmware': 'VMware vCenter',
     'aim': 'CyberArk AIM Central Credential Provider Lookup',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Missed the incorrect param choice from https://github.com/ansible/awx/pull/7976, reverting the change.  Below is a screenshot from the corresponding API endpoint:

<img width="148" alt="Screen Shot 2020-10-22 at 5 55 57 PM" src="https://user-images.githubusercontent.com/28930622/96934962-2516d980-1491-11eb-9382-5d2f160c524f.png">

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
15.0.1
```


