### PR TITLE
related #7665 added 400 if user attempts an edit to local_path in a SCM project

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1333,6 +1333,8 @@ class ProjectOptionsSerializer(BaseSerializer):
             scm_type = attrs.get('scm_type', u'') or u''
         if self.instance and not scm_type:
             valid_local_paths.append(self.instance.local_path)
+        if scm_type and self.instance.local_path != attrs.get('local_path'):
+            errors['local_path'] = _(f'Cannot change local_path for {scm_type}-based projects')
         if scm_type:
             attrs.pop('local_path', None)
         if 'local_path' in attrs and attrs['local_path'] not in valid_local_paths:

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1333,7 +1333,7 @@ class ProjectOptionsSerializer(BaseSerializer):
             scm_type = attrs.get('scm_type', u'') or u''
         if self.instance and not scm_type:
             valid_local_paths.append(self.instance.local_path)
-        if scm_type and self.instance.local_path != attrs.get('local_path'):
+        if scm_type and "local_path" in attrs and self.instance.local_path != attrs['local_path']:
             errors['local_path'] = _(f'Cannot change local_path for {scm_type}-based projects')
         if scm_type:
             attrs.pop('local_path', None)

--- a/awx/main/tests/functional/api/test_project.py
+++ b/awx/main/tests/functional/api/test_project.py
@@ -99,3 +99,12 @@ def test_changing_overwrite_behavior_okay_if_not_used(post, patch, organization,
         expect=200
     )
     assert Project.objects.get(pk=r1.data['id']).allow_override is False
+
+
+@pytest.mark.django_db
+def test_scm_project_local_path_invalid(get, patch, project, admin):
+    url = reverse('api:project_detail', kwargs={'pk': project.id})
+    resp = patch(url, {'local_path': '/foo/bar'}, user=admin, expect=400)
+    assert resp.data['local_path'] == [
+        'Cannot change local_path for git-based projects'
+    ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix for #7665 to not accept changes to the local_path if its a non-manual project. Change is adding a logical comparison of the patch value of `local_path` to the instance (stored/current) value of `local_path` and if they differ, fail with a simple error stating that local_path cannot be edited for an SCM project. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
$ make VERSION
awx: 15.0.1

```


##### ADDITIONAL INFORMATION
<!---serializer
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Big thanks to @rebeccahhh for the "print testing" tips that can be done with the serializer 

