### PR TITLE
allow labelling docker web container

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -22,6 +22,16 @@ services:
     hostname: {{ awx_web_hostname }}
     user: root
     restart: unless-stopped
+    {% if (awx_web_container_labels is defined) and (',' in awx_web_container_labels) %}
+    {% set awx_web_container_labels_list = awx_web_container_labels.split(',') %}
+    labels:
+      {% for awx_web_container_label in awx_web_container_labels_list %}
+      - {{ awx_web_container_label }}
+      {% endfor %}
+    {% elif awx_web_container_labels is defined %}
+    labels:
+      - {{ awx_web_container_labels }}
+    {% endif %}
     volumes:
       - supervisor-socket:/var/run/supervisor
       - rsyslog-socket:/var/run/awx-rsyslog/


### PR DESCRIPTION
##### SUMMARY

for local docker installations, this pull request allows to [label](https://docs.docker.com/compose/compose-file/#labels-2) the awx_web container. this can be used to make container aware software e.g. automatically discover awx and route or generate ssl certs for it (one use case would be traefik which does both).

labels can be set in installer inventory via:

```
awx_web_container_labels="my.custom.label=foo"
```

and in a less contrived example (using traefik):

```
awx_web_container_lables="traefik.enable=true,traefik.http.routers.awx_web.rule=Host(`awx.example.com`),traefik.http.routers.awx_web.tls.certresolver=letsencrypt"
```

which is [picked up by traefik](https://doc.traefik.io/traefik/providers/docker/) when awx_web starts and routes access to `awx.example.com` to the awx_web container (without awx_web binding any port on the host interface) and also (optionally) requests an ssl cert via letsencrypt

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
