### PR TITLE
allow specifiying external networks for docker awx_web container

### DIFF
--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -31,6 +31,7 @@ services:
     {% elif awx_web_container_labels is defined %}
     labels:
       - {{ awx_web_container_labels }}
+    {% endif %}
     {% if (awx_web_container_networks is defined) and (',' in awx_web_container_networks) %}
     {% set awx_web_container_networks_list = awx_web_container_networks.split(',') %}
     networks:

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -31,6 +31,17 @@ services:
     {% elif awx_web_container_labels is defined %}
     labels:
       - {{ awx_web_container_labels }}
+    {% if (awx_web_container_networks is defined) and (',' in awx_web_container_networks) %}
+    {% set awx_web_container_networks_list = awx_web_container_networks.split(',') %}
+    networks:
+    {% for awx_web_container_network in awx_web_container_networks_list %}
+      - {{ awx_web_container_network }}
+    {% endfor %}
+      - default
+    {% elif awx_web_container_networks is defined %}
+    networks:
+      - {{ awx_web_container_networks }}
+      - default
     {% endif %}
     volumes:
       - supervisor-socket:/var/run/supervisor


### PR DESCRIPTION
##### SUMMARY

for local docker installations, this pull request allows to specify one or more external docker networks that the `awx_web` container will be connected to.

This is especially useful for setups with e.g. traefik being the only docker container with external port bindings to the host.
This way one can keep other awx containers in isolation while traefik can route (and provide ssl certs) just the web portion of awx.

Consider an existing external docker network named `ingress`:

```
docker network create ingress
```

and installer inventory variable:

```
awx_web_container_networks=ingress
```

now when you start e.g. another container via compose:

```
services:
  other:
    image: traefik
    networks:
      - ingress
networks:
  ingress:
    external:
      name: ingress
```

both, the "other" service and awx_web container can access each other via network connections (even though they are specified in different docker-compose files and awx_web does not bind ports on the host!)

To make the above example with traefik actually useful, see #8449 (which is now merged)

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 16.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This pull request should not interfere with the existing `docker_compose_subnet` which only alters the settings for the default network.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
