### PR TITLE
cast create_preload_data to boolean with `create_preload_data | bool` in launch_awx_task.sh.j2

### DIFF
--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -24,7 +24,7 @@ fi
 
 if [ ! -z "$AWX_ADMIN_USER" ]&&[ ! -z "$AWX_ADMIN_PASSWORD" ]; then
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('$AWX_ADMIN_USER', 'root@localhost', '$AWX_ADMIN_PASSWORD')" | awx-manage shell
-    {% if create_preload_data %}
+    {% if create_preload_data | bool %}
     awx-manage create_preload_data
     {% endif %}
 fi


### PR DESCRIPTION
##### SUMMARY

The `create_preload_data` var from the installer inventory file is a string, and currently always evaluates to `True` in the `launch_awx_task.sh.j2` Jinja template.  This results in the preload data always being populated, regardless of setting in the inventory file.  This was tested using the docker-compose deployment method and discussed in #ansible-awx.  Also, piping to the `bool` filter is used for all the other boolean type vars in the inventory when used in jinja templates as part of the installation process.

##### ISSUE TYPE

Bugfix Pull Request


##### COMPONENT NAME

Installer

##### AWX VERSION

```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
