### PR TITLE
Fix username as a required field

### DIFF
--- a/awx/ui_next/src/screens/User/shared/UserForm.jsx
+++ b/awx/ui_next/src/screens/User/shared/UserForm.jsx
@@ -68,11 +68,9 @@ function UserFormFields({ user, i18n }) {
         name="username"
         type="text"
         validate={
-          !ldapUser && externalAccount === null
-            ? required(null, i18n)
-            : () => undefined
+          !ldapUser && !externalAccount ? required(null, i18n) : () => undefined
         }
-        isRequired={!ldapUser && externalAccount === null}
+        isRequired={!ldapUser && !externalAccount}
       />
       <FormField
         id="user-email"

--- a/awx/ui_next/src/screens/User/shared/UserForm.test.jsx
+++ b/awx/ui_next/src/screens/User/shared/UserForm.test.jsx
@@ -93,7 +93,7 @@ describe('<UserForm />', () => {
     });
   });
 
-  test('password fields are required on add', async () => {
+  test('fields required on add', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <UserForm handleSubmit={jest.fn()} handleCancel={jest.fn()} />
@@ -105,6 +105,26 @@ describe('<UserForm />', () => {
     expect(passwordFields.length).toBe(2);
     expect(passwordFields.at(0).prop('isRequired')).toBe(true);
     expect(passwordFields.at(1).prop('isRequired')).toBe(true);
+
+    expect(wrapper.find('FormField[label="Username"]').prop('isRequired')).toBe(
+      true
+    );
+  });
+
+  test('username field is required on edit', async () => {
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <UserForm
+          user={{ ...mockData, external_account: '', auth: [] }}
+          handleSubmit={jest.fn()}
+          handleCancel={jest.fn()}
+        />
+      );
+    });
+
+    expect(wrapper.find('FormField[label="Username"]').prop('isRequired')).toBe(
+      true
+    );
   });
 
   test('password fields are not required on edit', async () => {
@@ -123,6 +143,40 @@ describe('<UserForm />', () => {
     expect(passwordFields.length).toBe(2);
     expect(passwordFields.at(0).prop('isRequired')).toBe(false);
     expect(passwordFields.at(1).prop('isRequired')).toBe(false);
+  });
+
+  test('username should not be required for external accounts', async () => {
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <UserForm
+          user={mockData}
+          handleSubmit={jest.fn()}
+          handleCancel={jest.fn()}
+        />
+      );
+    });
+    expect(wrapper.find('FormField[label="Username"]').prop('isRequired')).toBe(
+      false
+    );
+  });
+
+  test('username should not be required for ldap accounts', async () => {
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <UserForm
+          user={{
+            ...mockData,
+            ldap_dn:
+              'uid=binduser,cn=users,cn=accounts,dc=lan,dc=example,dc=com',
+          }}
+          handleSubmit={jest.fn()}
+          handleCancel={jest.fn()}
+        />
+      );
+    });
+    expect(wrapper.find('FormField[label="Username"]').prop('isRequired')).toBe(
+      false
+    );
   });
 
   test('password fields are not displayed for social/ldap login', async () => {


### PR DESCRIPTION
Fix username as a required field. `UserForm` is used for adding and
editing an user. When adding an user, the initial user value is a `{}`
update logic to cover this case.

Also, add unit-tests to cover this particular case.

See: https://github.com/ansible/awx/issues/8453

Add


![image](https://user-images.githubusercontent.com/9053044/97349977-86122900-1866-11eb-84ad-cb51899d5bfa.png)



Edit

![image](https://user-images.githubusercontent.com/9053044/97349888-6975f100-1866-11eb-9bf9-9a1fe7d65bde.png)


