### PR TITLE
fix issue where adding a search tag could cause an error

### DIFF
--- a/awx/ui_next/src/components/Search/Search.jsx
+++ b/awx/ui_next/src/components/Search/Search.jsx
@@ -107,7 +107,7 @@ function Search({
     } else if (currentSearchColumn?.booleanLabels) {
       label = currentSearchColumn.booleanLabels[value];
     }
-    return label.toString();
+    return (label || colKey).toString();
   };
 
   const getChipsByKey = () => {


### PR DESCRIPTION
Fixes https://github.com/ansible/awx/issues/8477

On the jobs list, if you tried to add a search filter for id through the advanced search interface, a traceback would cause the page to stop working.  This is a simple fix for that.