### PR TITLE
[feature] Keep pod_spec_override-provided pod labels

### DIFF
--- a/awx/main/scheduler/kubernetes.py
+++ b/awx/main/scheduler/kubernetes.py
@@ -14,10 +14,12 @@ logger = logging.getLogger('awx.main.scheduler')
 
 def deepmerge(a, b):
     """
-    >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
-    >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
-    >>> deepmerge(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
-    True
+    Merge dict structures and return the result.
+
+    >>> a = {'first': {'all_rows': {'pass': 'dog', 'number': '1'}}}
+    >>> b = {'first': {'all_rows': {'fail': 'cat', 'number': '5'}}}
+    >>> import pprint; pprint.pprint(deepmerge(a, b))
+    {'first': {'all_rows': {'fail': 'cat', 'number': '5', 'pass': 'dog'}}}
     """
     if isinstance(a, dict) and isinstance(b, dict):
         return dict([(k, deepmerge(a.get(k), b.get(k)))

--- a/awx/main/scheduler/kubernetes.py
+++ b/awx/main/scheduler/kubernetes.py
@@ -21,7 +21,7 @@ def deepmerge(a, b):
     """
     if isinstance(a, dict) and isinstance(b, dict):
         return dict([(k, deepmerge(a.get(k), b.get(k)))
-                      for k in set(a.keys()).union(b.keys())])
+                     for k in set(a.keys()).union(b.keys())])
     elif b is None:
         return a
     else:
@@ -150,7 +150,7 @@ class PodManager(object):
                      labels={
                          'ansible-awx': settings.INSTALL_UUID,
                          'ansible-awx-job-id': str(self.task.id)
-                         }))
+                     }))
             pod_spec['spec']['containers'][0]['name'] = self.pod_name
 
         return pod_spec


### PR DESCRIPTION
Fixes #8486 

##### SUMMARY

related #8486

- Write a deepmerge() implementation, keeping only the test suite of
https://stackoverflow.com/a/20666342/435004

- Use it to deep-merge pod['metadata'] with user input,
instead of replacing fields in it wholesale (in particular, `.labels`)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

- Kubernetes scheduler

##### AWX VERSION

```
awx: 15.0.1
```

##### ADDITIONAL INFORMATION

N/A
