### PR TITLE
Remove activity from inventory details page

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
@@ -70,7 +70,6 @@ function InventoryDetail({ inventory, i18n }) {
           value={inventory.name}
           dataCy="inventory-detail-name"
         />
-        <Detail label={i18n._(t`Activity`)} value="Coming soon" />
         <Detail label={i18n._(t`Description`)} value={inventory.description} />
         <Detail label={i18n._(t`Type`)} value={i18n._(t`Inventory`)} />
         <Detail

--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
@@ -85,7 +85,6 @@ describe('<InventoryDetail />', () => {
     });
     wrapper.update();
     expectDetailToMatch(wrapper, 'Name', mockInventory.name);
-    expectDetailToMatch(wrapper, 'Activity', 'Coming soon');
     expectDetailToMatch(wrapper, 'Description', mockInventory.description);
     expectDetailToMatch(wrapper, 'Type', 'Inventory');
     const org = wrapper.find('Detail[label="Organization"]');


### PR DESCRIPTION
Remove activity from inventory details page

This information is already present on the `Complete jobs` tab.

See: https://github.com/ansible/awx/issues/8467
