### PR TITLE
Remove Type from ScheduleList Sort

### DIFF
--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.jsx
@@ -18,7 +18,7 @@ import ScheduleListItem from './ScheduleListItem';
 const QS_CONFIG = getQSConfig('schedule', {
   page: 1,
   page_size: 20,
-  order_by: 'unified_job_template__polymorphic_ctype__model',
+  order_by: 'name',
 });
 
 function ScheduleList({
@@ -161,10 +161,6 @@ function ScheduleList({
           {
             name: i18n._(t`Next Run`),
             key: 'next_run',
-          },
-          {
-            name: i18n._(t`Type`),
-            key: 'unified_job_template__polymorphic_ctype__model',
           },
         ]}
         toolbarSearchableKeys={searchableKeys}


### PR DESCRIPTION
Remove Type from ScheduleList Sort, and make `name` as default sort.

![image](https://user-images.githubusercontent.com/9053044/97630826-7b8e9580-1a06-11eb-827e-26f89ae898b2.png)

See: https://github.com/ansible/awx/issues/7706

