### PR TITLE
Add empty child group to inventory groups before adding it to the parent group

### DIFF
--- a/awx_collection/plugins/inventory/tower.py
+++ b/awx_collection/plugins/inventory/tower.py
@@ -153,6 +153,8 @@ class InventoryModule(BaseInventoryPlugin):
                     self.inventory.add_host(host_name, group_name)
                 # Then add the parent-children group relationships.
                 for child_group_name in group_content.get('children', []):
+                    # add the child group to groups, if its already there it will just throw a warning
+                    self.inventory.add_group(child_group_name)
                     self.inventory.add_child(group_name, child_group_name)
             # Set the group vars. Note we should set group var for 'all', but not '_meta'.
             if group_name != '_meta':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #8459 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without this PR
```
[root@rhel75-2 ~]# ansible-inventory -i tower.yml --graph
[WARNING]: You are using the awx version of this collection but connecting to Red Hat Ansible Tower
[WARNING]:  * Failed to parse /root/tower.yml with auto plugin: test_group2 is not a known host nor group
[WARNING]:  * Failed to parse /root/tower.yml with yaml plugin: Plugin configuration YAML file, not YAML
inventory
[WARNING]:  * Failed to parse /root/tower.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending
in ':' is not allowed, this character is reserved to provide a port.
[WARNING]: Unable to parse /root/tower.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
@all:
  |--@ungrouped:
```
With this PR:

```
[root@rhel75-2 ~]# ansible-inventory -i tower.yml --graph
[WARNING]: You are using the awx version of this collection but connecting to Red Hat Ansible Tower
@all:
  |--@test_group1:
  |  |--@test_group2:
  |  |--test_host1
  |--@ungrouped:
  |  |--localhost

```