### PR TITLE
Update virtualenv init container image to centos:8

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -122,7 +122,7 @@ spec:
 {% if custom_venvs is defined %}
 {% set trusted_hosts = "" %}
       initContainers:
-        - image: 'centos:7'
+        - image: 'centos:8'
           name: init-custom-venvs
 {% if http_proxy is defined or https_proxy is defined %}
 {% set trusted_hosts = "--trusted-host pypi.org --trusted-host files.pythonhosted.org --trusted-host pypi.python.org" %}
@@ -143,10 +143,10 @@ spec:
           command:
             - sh
             - '-c'
-            - >-
-              yum install -y ansible curl python-setuptools epel-release \
-                openssl openssl-devel gcc python-devel &&
-              yum install -y python-virtualenv python36 python36-devel &&
+            - >
+              yum install -y centos-release-ansible29 curl python3-setuptools
+              epel-release openssl openssl-devel gcc platform-python-devel &&
+              yum install -y python3-virtualenv python38 python38-devel &&
               mkdir -p {{ custom_venvs_path }} &&
 {% for custom_venv in custom_venvs %}
               virtualenv -p {{ custom_venv.python | default(custom_venvs_python) }} \


### PR DESCRIPTION
Signed-off-by: Sergio David Morel <smorel86@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update the base image used when creating custom virtual environments from CentOS 7 to CentOS 8
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
