### PR TITLE
Change import/export Collections Module to Detect Errors vs Warnings

### DIFF
--- a/awx_collection/plugins/modules/tower_export.py
+++ b/awx_collection/plugins/modules/tower_export.py
@@ -82,9 +82,11 @@ EXAMPLES = '''
 - name: Export all tower assets
   tower_export:
     all: True
+
 - name: Export all inventories
   tower_export:
     inventory: 'all'
+
 - name: Export a job template named "My Template" and all Credentials
   tower_export:
     job_template: "My Template"
@@ -135,27 +137,27 @@ def main():
             # Otherwise we take either the string or None (if the parameter was not passed) to get one or no items
             export_args[resource] = module.params.get(resource)
 
-    # Currently the import process does not return anything on error
-    # It simply just logs to pythons logger
-    # Setup a log gobbler to get error messages from import_assets
+    # Currently the export process does not return anything on error
+    # It simply just logs to Python's logger
+    # Set up a log gobbler to get error messages from export_assets
     log_capture_string = StringIO()
     ch = logging.StreamHandler(log_capture_string)
     for logger_name in ['awxkit.api.pages.api', 'awxkit.api.pages.page']:
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.WARNING)
-        ch.setLevel(logging.WARNING)
+        logger.setLevel(logging.ERROR)
+        ch.setLevel(logging.ERROR)
 
     logger.addHandler(ch)
     log_contents = ''
 
-    # Run the import process
+    # Run the export process
     try:
         module.json_output['assets'] = module.get_api_v2_object().export_assets(**export_args)
         module.exit_json(**module.json_output)
     except Exception as e:
         module.fail_json(msg="Failed to export assets {0}".format(e))
     finally:
-        # Finally consume the logs incase there were any errors and die if there were
+        # Finally, consume the logs in case there were any errors and die if there were
         log_contents = log_capture_string.getvalue()
         log_capture_string.close()
         if log_contents != '':

--- a/awx_collection/plugins/modules/tower_import.py
+++ b/awx_collection/plugins/modules/tower_import.py
@@ -38,7 +38,7 @@ EXAMPLES = '''
 - name: Export all assets
   tower_export:
     all: True
-  registeR: export_output
+  register: export_output
 
 - name: Import all tower assets from our export
   tower_import:
@@ -51,7 +51,7 @@ EXAMPLES = '''
 
 from ..module_utils.tower_awxkit import TowerAWXKitModule
 
-# These two lines are not needed if awxkit changes to do progamatic notifications on issues
+# These two lines are not needed if awxkit changes to do programatic notifications on issues
 from ansible.module_utils.six.moves import StringIO
 import logging
 
@@ -76,13 +76,15 @@ def main():
         module.fail_json(msg="Your version of awxkit does not appear to have import/export")
 
     # Currently the import process does not return anything on error
-    # It simply just logs to pythons logger
-    # Setup a log gobbler to get error messages from import_assets
+    # It simply just logs to Python's logger
+    # Set up a log gobbler to get error messages from import_assets
     logger = logging.getLogger('awxkit.api.pages.api')
-    logger.setLevel(logging.WARNING)
+    logger.setLevel(logging.ERROR)
+
     log_capture_string = StringIO()
     ch = logging.StreamHandler(log_capture_string)
-    ch.setLevel(logging.WARNING)
+    ch.setLevel(logging.ERROR)
+
     logger.addHandler(ch)
     log_contents = ''
 
@@ -92,7 +94,7 @@ def main():
     except Exception as e:
         module.fail_json(msg="Failed to import assets {0}".format(e))
     finally:
-        # Finally consume the logs incase there were any errors and die if there were
+        # Finally, consume the logs in case there were any errors and die if there were
         log_contents = log_capture_string.getvalue()
         log_capture_string.close()
         if log_contents != '':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `log_contents` error detection was picking up on `WARNING` level logs vs `ERROR` and above.   If an unprivileged user tries to import/export assets that they don't have permissions to, they get a warning; it is not necessary in this case to make the module fail out completely, since other assets will still get imported/exported.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Collections Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.1
```
