### PR TITLE
Remove groups/hosts when deleting inventory sources

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
@@ -105,8 +105,37 @@ function InventorySourceList({ i18n }) {
   );
   const { error: syncError, dismissError } = useDismissableError(syncAllError);
 
+  const deleteRelatedInventoryResources = resourceId => {
+    return [
+      InventorySourcesAPI.destroyHosts(resourceId),
+      InventorySourcesAPI.destroyGroups(resourceId),
+    ];
+  };
+
+  const {
+    isLoading: deleteRelatedResourcesLoading,
+    deletionError: deleteRelatedResourcesError,
+    deleteItems: handleDeleteRelatedResources,
+  } = useDeleteItems(
+    useCallback(async () => {
+      return (
+        Promise.all(
+          selected
+            .map(({ id: resourceId }) =>
+              deleteRelatedInventoryResources(resourceId)
+            )
+            .flat()
+        ),
+        []
+      );
+    }, [selected])
+  );
+
   const handleDelete = async () => {
-    await handleDeleteSources();
+    await handleDeleteRelatedResources();
+    if (!deleteRelatedResourcesError) {
+      await handleDeleteSources();
+    }
     setSelected([]);
   };
   const canAdd =
@@ -117,7 +146,12 @@ function InventorySourceList({ i18n }) {
     <>
       <PaginatedDataList
         contentError={fetchError}
-        hasContentLoading={isLoading || isDeleteLoading || isSyncAllLoading}
+        hasContentLoading={
+          isLoading ||
+          isDeleteLoading ||
+          isSyncAllLoading ||
+          deleteRelatedResourcesLoading
+        }
         items={sources}
         itemCount={sourceCount}
         pluralizedItemName={i18n._(t`Inventory Sources`)}
@@ -193,16 +227,16 @@ function InventorySourceList({ i18n }) {
         </AlertModal>
       )}
 
-      {deletionError && (
+      {(deletionError || deleteRelatedResourcesError) && (
         <AlertModal
           aria-label={i18n._(t`Delete error`)}
-          isOpen={deletionError}
+          isOpen={deletionError || deleteRelatedResourcesError}
           variant="error"
           title={i18n._(t`Error!`)}
           onClose={clearDeletionError}
         >
           {i18n._(t`Failed to delete one or more inventory sources.`)}
-          <ErrorDetail error={deletionError} />
+          <ErrorDetail error={deletionError || deleteRelatedResourcesError} />
         </AlertModal>
       )}
     </>

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.test.jsx
@@ -165,6 +165,8 @@ describe('<InventorySourceList />', () => {
       wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
     );
     expect(InventorySourcesAPI.destroy).toHaveBeenCalledWith(1);
+    expect(InventorySourcesAPI.destroyHosts).toHaveBeenCalledWith(1);
+    expect(InventorySourcesAPI.destroyGroups).toHaveBeenCalledWith(1);
   });
 
   test('should throw error after deletion failure', async () => {


### PR DESCRIPTION
Remove related resources groups/hosts when deleting inventory sources.

The current UI deletes `groups` and `hosts` once the inventory source is
deleted. Add this behavior to the new UI.

See: https://github.com/ansible/awx/issues/8098
