### PR TITLE
analytics: a patch to track analytics collector data gathering and shipping duration

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('awx.main.analytics')
 
 def _valid_license():
     try:
-        if get_license().get('license_type', 'UNLICENSED') == 'open': 
+        if get_license().get('license_type', 'UNLICENSED') == 'open':
             return False
         access_registry[Job](None).check_license()
     except PermissionDenied:
@@ -91,7 +91,7 @@ def gather(dest=None, module=None, subset = None, since = None, until = now(), c
     :param module: the module to search for registered analytic collector
                     functions; defaults to awx.main.analytics.collectors
     """
-    logger.info("Start gather")
+    logger.debug("Start gather")
     start_gather = time.perf_counter()
     def _write_manifest(destdir, manifest):
         path = os.path.join(destdir, 'manifest.json')
@@ -224,7 +224,7 @@ def gather(dest=None, module=None, subset = None, since = None, until = now(), c
     finally:
         shutil.rmtree(dest, ignore_errors = True)
     stop_gather = time.perf_counter()
-    logger.info(f"Stop gather - duration: {stop_gather - start_gather}")
+    logger.debug(f"Stop gather - duration: {stop_gather - start_gather}")
     return tarfiles
 
 
@@ -232,7 +232,7 @@ def ship(path, skip_cleanup=False):
     """
     Ship gathered metrics to the Insights API
     """
-    logger.info("Start ship")
+    logger.debug("Start ship")
     start_ship = time.perf_counter()
     if not path:
         logger.error('Automation Analytics TAR not found')
@@ -276,4 +276,4 @@ def ship(path, skip_cleanup=False):
             if os.path.exists(path):
                 os.remove(path)
     stop_ship = time.perf_counter()
-    logger.info(f"Stop ship - duration: {stop_ship - start_ship}")
+    logger.debug(f"Stop ship - duration: {stop_ship - start_ship}")

--- a/awx/main/management/commands/gather_analytics.py
+++ b/awx/main/management/commands/gather_analytics.py
@@ -18,6 +18,8 @@ class Command(BaseCommand):
                             help='Gather analytics without shipping. Works even if analytics are disabled in settings.')
         parser.add_argument('--ship', dest='ship', action='store_true',
                             help='Enable to ship metrics to the Red Hat Cloud')
+        parser.add_argument('--skip-cleanup', dest='skip-cleanup', action='store_true',
+                            help='Do not delete metrics tarball after it was shipped to Red Hat Cloud')
         parser.add_argument('--since', dest='since', action='store',
                             help='Start date for collection')
         parser.add_argument('--until', dest='until', action='store',
@@ -34,6 +36,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.init_logging()
         opt_ship = options.get('ship')
+        opt_skip_cleanup = options.get('skip-cleanup')
         opt_dry_run = options.get('dry-run')
         opt_since = options.get('since') or None
         opt_until = options.get('until') or None
@@ -59,4 +62,4 @@ class Command(BaseCommand):
         if opt_ship:
             if tgzfiles:
                 for tgz in tgzfiles:
-                    ship(tgz)
+                    ship(tgz, opt_skip_cleanup)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Through this PR we can measure data gathering duration and shipping duration of `gather_analytics` commands. Its also includes optional argument `--skip-cleanup` to save archives after shipping. This helps to see what data is shipped to Red Hat Cloud.
```
  --skip-cleanup        Do not delete metrics tarball after it was shipped to
                        Red Hat Cloud
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request