### PR TITLE
Add helm installation (#8551)

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -146,6 +146,10 @@ RUN dnf -y update && \
 RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.8/bin/linux/{{ kubectl_architecture | default('amd64') }}/kubectl && \
     chmod a+x /usr/bin/kubectl
 
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh
+
 # Install tini
 RUN curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-{{ tini_architecture | default('amd64') }} && \
     chmod +x /usr/bin/tini


### PR DESCRIPTION
Update to address https://github.com/ansible/awx/issues/8551
Install `helm` binaries along with `kubectl`

##### SUMMARY
Add helm install RUN step
#8551

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION

Due to access restrictions there is no way to install extra rpm or OS packages, therefore limiting the use of running Ansible jobs from Tower.

AWX `kubectl` comes with `kubectl` already installed, adding `helm` pre-installed users can run Ansible playbooks that depend on `helm` from AWX as well.

