### PR TITLE
avoid breaking upgrades from certain AWX versions

### DIFF
--- a/awx/main/migrations/0122_really_remove_cloudforms_inventory.py
+++ b/awx/main/migrations/0122_really_remove_cloudforms_inventory.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+from awx.main.migrations._inventory_source import delete_cloudforms_inv_source
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0121_delete_toweranalyticsstate'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_cloudforms_inv_source),
+    ]


### PR DESCRIPTION
the prior version of this migration was rewritten:

https://github.com/ansible/awx/commit/0b701b3b241d1387de87e037e30c777c39a9f572#diff-8f8976e361c136144961b9b565a9995688ffc739790a40c0aac1e5d72ff7c6b7

...so we should run the function again to really make sure that cleanup happens