### PR TITLE
Add typeahead component for playbook select

### DIFF
--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -148,10 +148,10 @@ function CredentialFormFields({ i18n, credentialTypes }) {
         label={i18n._(t`Credential Type`)}
       >
         <Select
+          ouiaId="CredentialForm-credential_type"
           aria-label={i18n._(t`Credential Type`)}
           isOpen={isSelectOpen}
           variant={SelectVariant.typeahead}
-          ouiaId="credential-select"
           onToggle={setIsSelectOpen}
           onSelect={(event, value) => {
             credTypeHelpers.setValue(value);

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.jsx
@@ -42,6 +42,7 @@ function BecomeMethodField({ fieldOptions, isRequired }) {
       validated={!(meta.touched && meta.error) ? 'default' : 'error'}
     >
       <Select
+        ouiaId={`CredentialForm-${fieldOptions.id}`}
         maxHeight={200}
         variant={SelectVariant.typeahead}
         onToggle={setIsOpen}

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx
@@ -109,6 +109,7 @@ const SCMSubForm = ({ autoPopulateProject, i18n }) => {
         }
       >
         <Select
+          ouiaId="InventorySourceForm-source_path"
           variant={SelectVariant.typeahead}
           onToggle={setIsOpen}
           isOpen={isOpen}

--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -147,7 +147,7 @@ function JobTemplateForm({
 
   const handleProjectUpdate = useCallback(
     value => {
-      setFieldValue('playbook', 0);
+      setFieldValue('playbook', '');
       setFieldValue('scm_branch', '');
       setFieldValue('project', value);
     },
@@ -307,12 +307,13 @@ function JobTemplateForm({
           }
         >
           <PlaybookSelect
-            onChange={playbookHelpers.setValue}
             projectId={projectField.value?.id}
             isValid={!playbookMeta.touched || !playbookMeta.error}
             selected={playbookField.value}
             onBlur={() => playbookHelpers.setTouched()}
             onError={setContentError}
+            helpers={playbookHelpers}
+            onChange={selection => playbookHelpers.setValue(selection)}
           />
         </FormGroup>
         <FormFullWidthLayout>

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.jsx
@@ -2,10 +2,25 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { number, string, oneOfType } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import { SelectVariant, Select, SelectOption } from '@patternfly/react-core';
+import styled from 'styled-components';
+import {
+  Select as PFSelect,
+  SelectVariant,
+  SelectOption as PFSelectOption,
+} from '@patternfly/react-core';
 import { ProjectsAPI } from '../../../api';
 import useRequest from '../../../util/useRequest';
 
+const Select = styled(PFSelect)`
+  ul {
+    max-width: 495px;
+  }
+`;
+const SelectOption = styled(PFSelectOption)`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
 function PlaybookSelect({
   projectId,
   isValid,
@@ -14,6 +29,7 @@ function PlaybookSelect({
   onError,
   onChange,
   i18n,
+  helpers,
 }) {
   const [isDisabled, setIsDisabled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -50,18 +66,28 @@ function PlaybookSelect({
 
   return (
     <Select
+      ouiaId="JobTemplateForm-playbook"
       isOpen={isOpen}
+      maxHeight="100vh"
+      noResultsFoundText={i18n._(t`No results found`)}
       variant={SelectVariant.typeahead}
       selections={selected}
-      onToggle={setIsOpen}
+      onToggle={() => {
+        helpers.setTouched();
+        setIsOpen(!isOpen);
+      }}
       placeholderText={i18n._(t`Select a playbook`)}
-      isCreateable={false}
-      onSelect={(event, value) => {
-        onChange(value);
+      onSelect={(event, selection) => {
+        setIsOpen(false);
+        onChange(selection);
       }}
       id="template-playbook"
       isValid={isValid}
       onBlur={onBlur}
+      onClear={() => {
+        helpers.setTouched();
+        onChange('');
+      }}
       isDisabled={isLoading || isDisabled}
     >
       {options.map(opt => (

--- a/awx/ui_next/src/screens/Template/shared/PlaybookSelect.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/PlaybookSelect.test.jsx
@@ -1,36 +1,43 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import {
+  mountWithContexts,
+  waitForElement,
+} from '../../../../testUtils/enzymeHelpers';
 import PlaybookSelect from './PlaybookSelect';
 import { ProjectsAPI } from '../../../api';
 
 jest.mock('../../../api');
 
 describe('<PlaybookSelect />', () => {
-  beforeEach(() => {
+  let wrapper;
+  const onChange = jest.fn();
+  beforeEach(async () => {
     ProjectsAPI.readPlaybooks.mockReturnValue({
-      data: ['debug.yml'],
+      data: ['debug.yml', 'chatty.yml', 'tasks.yml'],
     });
-  });
 
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
-  test('should reload playbooks when project value changes', async () => {
-    let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
         <PlaybookSelect
           projectId={1}
           isValid
           form={{}}
-          field={{ onChange: () => {}, value: '' }}
+          field={{ value: '' }}
+          helpers={{ setTouched: () => {} }}
           onError={() => {}}
+          onChange={onChange}
         />
       );
     });
+  });
 
+  afterEach(() => {
+    wrapper.unmount();
+    jest.clearAllMocks();
+  });
+
+  test('should reload playbooks when project value changes', async () => {
     expect(ProjectsAPI.readPlaybooks).toHaveBeenCalledWith(1);
     await act(async () => {
       wrapper.setProps({ projectId: 15 });
@@ -38,5 +45,81 @@ describe('<PlaybookSelect />', () => {
 
     expect(ProjectsAPI.readPlaybooks).toHaveBeenCalledTimes(2);
     expect(ProjectsAPI.readPlaybooks).toHaveBeenCalledWith(15);
+  });
+
+  test('should filter results properly', async () => {
+    await act(async () => {
+      wrapper.find('SelectToggle').prop('onToggle')();
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper
+        .find('input[placeholder="Select a playbook"]')
+        .simulate('change', {
+          target: { value: 'chatty', name: 'playbook' },
+        });
+    });
+    wrapper.update();
+
+    expect(wrapper.find('SelectOption[value="chatty.yml"]').length).toBe(1);
+  });
+
+  test('should select playbook', async () => {
+    act(() => wrapper.find('SelectToggle').prop('onToggle')());
+
+    wrapper.update();
+    act(() => {
+      wrapper.find('Select').invoke('onSelect')({}, 'chatty.yml');
+    });
+
+    wrapper.update();
+    expect(onChange).toBeCalledWith('chatty.yml');
+  });
+
+  test('should disable', async () => {
+    ProjectsAPI.readPlaybooks.mockRejectedValue({
+      response: { status: 403 },
+    });
+    let newWrapper;
+    await act(async () => {
+      newWrapper = mountWithContexts(
+        <PlaybookSelect
+          projectId={1}
+          isValid
+          form={{}}
+          field={{ value: '' }}
+          helpers={{ setTouched: () => {} }}
+          onError={() => {}}
+          onChange={onChange}
+        />
+      );
+    });
+    await waitForElement(
+      newWrapper,
+      'Select',
+      el => el.prop('isDisabled') === true
+    );
+  });
+
+  test('should show content error', async () => {
+    ProjectsAPI.readPlaybooks.mockRejectedValue({
+      response: { status: 400 },
+    });
+
+    const onError = jest.fn();
+    await act(async () => {
+      mountWithContexts(
+        <PlaybookSelect
+          projectId={1}
+          isValid
+          form={{}}
+          field={{ value: '' }}
+          helpers={{ setTouched: () => {} }}
+          onError={onError}
+          onChange={onChange}
+        />
+      );
+    });
+    expect(onError).toBeCalled();
   });
 });


### PR DESCRIPTION
##### SUMMARY
This resolved #8473 and #8378

It adds the type ahead select component to the playbook select on the Job Template form.  It also updates test related to that form, and it adds additional tests to the `PlaybookSelect.test.jsx` component

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

##### ADDITIONAL INFORMATION
![Screen Shot 2020-11-12 at 6 59 54 PM](https://user-images.githubusercontent.com/39280967/99011089-49f2ef80-2519-11eb-9e7d-aa28b4c48c17.png)

