### PR TITLE
Mark organization as a required field for Galaxy crendentials

### DIFF
--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -22,10 +22,24 @@ function CredentialFormFields({
   initialValues,
 }) {
   const { setFieldValue } = useFormikContext();
-  const [orgField, orgMeta, orgHelpers] = useField('organization');
+
   const [credTypeField, credTypeMeta, credTypeHelpers] = useField({
     name: 'credential_type',
     validate: required(i18n._(t`Select a value for this field`), i18n),
+  });
+
+  const isGalaxyCredential =
+    !!credTypeField.value &&
+    credentialTypes[credTypeField.value].kind === 'galaxy';
+
+  const [orgField, orgMeta, orgHelpers] = useField({
+    name: 'organization',
+    validate:
+      isGalaxyCredential &&
+      required(
+        i18n._(t`Galaxy credentials must be owned by an Organization.`),
+        i18n
+      ),
   });
 
   const credentialTypeOptions = Object.keys(credentialTypes)
@@ -108,6 +122,7 @@ function CredentialFormFields({
         value={orgField.value}
         touched={orgMeta.touched}
         error={orgMeta.error}
+        required={isGalaxyCredential}
       />
       <FormGroup
         fieldId="credential-Type"

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
@@ -4,6 +4,7 @@ import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import machineCredential from './data.machineCredential.json';
 import gceCredential from './data.gceCredential.json';
 import scmCredential from './data.scmCredential.json';
+import galaxyCredential from './data.galaxyCredential.json';
 import credentialTypesArr from './data.credentialTypes.json';
 import CredentialForm from './CredentialForm';
 
@@ -323,6 +324,26 @@ describe('<CredentialForm />', () => {
       });
 
       gceFieldExpects();
+    });
+
+    test('should display from fields for galaxy/automation hub credentials', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <CredentialForm
+            onCancel={onCancel}
+            onSubmit={onSubmit}
+            credential={galaxyCredential}
+            credentialTypes={credentialTypes}
+          />
+        );
+      });
+      expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Description"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Organization"]').length).toBe(1);
+      expect(
+        wrapper.find('FormGroup[label="Organization"]').prop('isRequired')
+      ).toBe(true);
+      expect(wrapper.find('FormGroup[label="Credential Type"]').length).toBe(1);
     });
   });
 });

--- a/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
+++ b/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
@@ -1269,5 +1269,54 @@
       "required": ["vault_password"]
     },
     "injectors": {}
-  }
+  },
+  {
+    "id": 42,
+    "type": "credential_type",
+    "url": "/api/v2/credential_types/42/",
+    "related": {
+        "credentials": "/api/v2/credential_types/42/credentials/",
+        "activity_stream": "/api/v2/credential_types/42/activity_stream/"
+    },
+    "summary_fields": {
+        "user_capabilities": {
+            "edit": true,
+            "delete": true
+        }
+    },
+    "created": "2020-11-11T00:18:31.928286Z",
+    "modified": "2020-11-11T00:19:00.851597Z",
+    "name": "Ansible Galaxy/Automation Hub API Token",
+    "description": "",
+    "kind": "galaxy",
+    "namespace": "galaxy_api_token",
+    "managed_by_tower": true,
+    "inputs": {
+        "fields": [
+            {
+                "id": "url",
+                "label": "Galaxy Server URL",
+                "type": "string",
+                "help_text": "The URL of the Galaxy instance to connect to."
+            },
+            {
+                "id": "auth_url",
+                "label": "Auth Server URL",
+                "type": "string",
+                "help_text": "The URL of a Keycloak server token_endpoint, if using SSO auth."
+            },
+            {
+                "id": "token",
+                "label": "API Token",
+                "type": "string",
+                "secret": true,
+                "help_text": "A token to use for authentication against the Galaxy instance."
+            }
+        ],
+        "required": [
+            "url"
+        ]
+    },
+    "injectors": {}
+}
 ]

--- a/awx/ui_next/src/screens/Credential/shared/data.galaxyCredential.json
+++ b/awx/ui_next/src/screens/Credential/shared/data.galaxyCredential.json
@@ -1,0 +1,89 @@
+{
+    "id": 5,
+    "type": "credential",
+    "url": "/api/v2/credentials/5/",
+    "related": {
+        "named_url": "/api/v2/credentials/Foo++Ansible Galaxy%2FAutomation Hub API Token+galaxy++Default/",
+        "created_by": "/api/v2/users/1/",
+        "modified_by": "/api/v2/users/1/",
+        "organization": "/api/v2/organizations/1/",
+        "activity_stream": "/api/v2/credentials/5/activity_stream/",
+        "access_list": "/api/v2/credentials/5/access_list/",
+        "object_roles": "/api/v2/credentials/5/object_roles/",
+        "owner_users": "/api/v2/credentials/5/owner_users/",
+        "owner_teams": "/api/v2/credentials/5/owner_teams/",
+        "copy": "/api/v2/credentials/5/copy/",
+        "input_sources": "/api/v2/credentials/5/input_sources/",
+        "credential_type": "/api/v2/credential_types/42/"
+    },
+    "summary_fields": {
+        "organization": {
+            "id": 1,
+            "name": "Baz",
+            "description": ""
+        },
+        "credential_type": {
+            "id": 42,
+            "name": "Ansible Galaxy/Automation Hub API Token",
+            "description": ""
+        },
+        "created_by": {
+            "id": 1,
+            "username": "admin",
+            "first_name": "",
+            "last_name": ""
+        },
+        "modified_by": {
+            "id": 1,
+            "username": "admin",
+            "first_name": "",
+            "last_name": ""
+        },
+        "object_roles": {
+            "admin_role": {
+                "description": "Can manage all aspects of the credential",
+                "name": "Admin",
+                "id": 109
+            },
+            "use_role": {
+                "description": "Can use the credential in a job template",
+                "name": "Use",
+                "id": 110
+            },
+            "read_role": {
+                "description": "May view settings for the credential",
+                "name": "Read",
+                "id": 111
+            }
+        },
+        "user_capabilities": {
+            "edit": true,
+            "delete": true,
+            "copy": true,
+            "use": true
+        },
+        "owners": [
+            {
+                "id": 1,
+                "type": "organization",
+                "name": "Default",
+                "description": "",
+                "url": "/api/v2/organizations/1/"
+            }
+        ]
+    },
+    "created": "2020-11-16T21:33:39.385284Z",
+    "modified": "2020-11-16T21:33:39.385311Z",
+    "name": "Foo",
+    "description": "Bar",
+    "organization": 1,
+    "credential_type": 42,
+    "managed_by_tower": false,
+    "inputs": {
+        "url": "https://localhost.com",
+        "auth_url": ""
+    },
+    "kind": "galaxy_api_token",
+    "cloud": false,
+    "kubernetes": false
+}


### PR DESCRIPTION
Mark organization as a required field for Galaxy credential type. 

See: https://github.com/ansible/awx/issues/8276

![image](https://user-images.githubusercontent.com/9053044/99318052-01974280-2835-11eb-9434-af11d5d42802.png)

Non required field.

![image](https://user-images.githubusercontent.com/9053044/99318103-196ec680-2835-11eb-846a-64deed4f46f8.png)

