### PR TITLE
Avoid invalid group characters in default inventory script factory

### DIFF
--- a/awxkit/awxkit/api/pages/inventory.py
+++ b/awxkit/awxkit/api/pages/inventory.py
@@ -231,7 +231,7 @@ class InventoryScript(HasCopy, HasCreate, base.Base):
             'inventory["{0}"]["vars"] = dict(ansible_host="127.0.0.1", ansible_connection="local")',
             'print(json.dumps(inventory))'
         ])
-        group_name = re.sub(r"[\']", "", "group-{}".format(random_utf8()))
+        group_name = re.sub(r"[\']", "", "group_{}".format(random_title(non_ascii=False)))
         host_names = [
             re.sub(
                 r"[\':]",


### PR DESCRIPTION
##### SUMMARY
This avoids the warning:

> [WARNING]: Invalid characters were found in group names but not replaced, use

When this script is used.

Pretty soon, we need to kill off this script, but we also need to silence this warning to clean up some tests right now.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

