### PR TITLE
Fix nav console error

### DIFF
--- a/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
+++ b/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
@@ -7,12 +7,10 @@ class NavExpandableGroup extends Component {
   constructor(props) {
     super(props);
     const { routes } = this.props;
-    this.state = { isExpanded: true };
 
     // Extract a list of paths from the route params and store them for later. This creates
     // an array of url paths associated with any NavItem component rendered by this component.
     this.navItemPaths = routes.map(({ path }) => path);
-    this.handleExpand = this.handleExpand.bind(this);
     this.isActiveGroup = this.isActiveGroup.bind(this);
     this.isActivePath = this.isActivePath.bind(this);
   }
@@ -26,13 +24,8 @@ class NavExpandableGroup extends Component {
     return Boolean(matchPath(history.location.pathname, { path }));
   }
 
-  handleExpand(e, isExpanded) {
-    this.setState({ isExpanded });
-  }
-
   render() {
     const { groupId, groupTitle, routes } = this.props;
-    const { isExpanded } = this.state;
 
     if (routes.length === 1) {
       const [{ path }] = routes;
@@ -46,10 +39,9 @@ class NavExpandableGroup extends Component {
     return (
       <NavExpandable
         isActive={this.isActiveGroup()}
-        isExpanded={isExpanded}
+        isExpanded
         groupId={groupId}
         title={groupTitle}
-        onExpand={this.handleExpand}
       >
         {routes.map(({ path, title }) => (
           <NavItem


### PR DESCRIPTION
##### SUMMARY
```
index.js:1 Warning: Unknown event handler property `onExpand`. It will be ignored.
    in li (created by Context.Consumer)
    in NavExpandable (at NavExpandableGroup.jsx:47)
    in NavExpandableGroup (created by Context.Consumer)
    in withRouter(NavExpandableGroup) (at AppContainer.jsx:102)
    in ul (created by Context.Consumer)
    in NavList (at AppContainer.jsx:100)
    in nav (created by Nav)
    in Nav (at AppContainer.jsx:99)
    in div (created by Context.Consumer)
    in div (created by Context.Consumer)
    in PageSidebar (at AppContainer.jsx:96)
    in div (created by Page)
    in Page (at AppContainer.jsx:117)
    in AppContainer (created by Context.Consumer)
    in withRouter(AppContainer) (created by I18n)
    in I18n (created by WithI18n)
    in WithI18n (at App.jsx:53)
    in Route (at App.jsx:26)
    in ProtectedRoute (at App.jsx:52)
    in Switch (at App.jsx:42)
    in Unknown (at App.jsx:41)
    in I18n (at App.jsx:39)
    in I18nProvider (at App.jsx:38)
    in App (at App.jsx:80)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.jsx:79)
    in Unknown (at src/index.jsx:11)
    in StrictMode (at src/index.jsx:10)
```

I don't think we need the `onExpand` but we do need `isExpanded`.  That was the piece that was missing from #8535.
