### PR TITLE
Hide instance group for Inventory Details if the data is not available

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.jsx
@@ -80,19 +80,21 @@ function InventoryDetail({ inventory, i18n }) {
             </Link>
           }
         />
-        <Detail
-          fullWidth
-          label={i18n._(t`Instance Groups`)}
-          value={
-            <ChipGroup numChips={5} totalChips={instanceGroups.length}>
-              {instanceGroups.map(ig => (
-                <Chip key={ig.id} isReadOnly>
-                  {ig.name}
-                </Chip>
-              ))}
-            </ChipGroup>
-          }
-        />
+        {instanceGroups && instanceGroups.length > 0 && (
+          <Detail
+            fullWidth
+            label={i18n._(t`Instance Groups`)}
+            value={
+              <ChipGroup numChips={5} totalChips={instanceGroups.length}>
+                {instanceGroups.map(ig => (
+                  <Chip key={ig.id} isReadOnly>
+                    {ig.name}
+                  </Chip>
+                ))}
+              </ChipGroup>
+            }
+          />
+        )}
         <VariablesDetail
           label={i18n._(t`Variables`)}
           value={inventory.variables}

--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
@@ -63,11 +63,6 @@ const associatedInstanceGroups = [
     name: 'Foo',
   },
 ];
-InventoriesAPI.readInstanceGroups.mockResolvedValue({
-  data: {
-    results: associatedInstanceGroups,
-  },
-});
 
 function expectDetailToMatch(wrapper, label, value) {
   const detail = wrapper.find(`Detail[label="${label}"]`);
@@ -77,6 +72,12 @@ function expectDetailToMatch(wrapper, label, value) {
 
 describe('<InventoryDetail />', () => {
   test('should render details', async () => {
+    InventoriesAPI.readInstanceGroups.mockResolvedValue({
+      data: {
+        results: associatedInstanceGroups,
+      },
+    });
+
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
@@ -105,6 +106,12 @@ describe('<InventoryDetail />', () => {
   });
 
   test('should load instance groups', async () => {
+    InventoriesAPI.readInstanceGroups.mockResolvedValue({
+      data: {
+        results: associatedInstanceGroups,
+      },
+    });
+
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
@@ -118,5 +125,25 @@ describe('<InventoryDetail />', () => {
     const chip = wrapper.find('Chip').at(0);
     expect(chip.prop('isReadOnly')).toEqual(true);
     expect(chip.prop('children')).toEqual('Foo');
+  });
+
+  test('should not load instance groups', async () => {
+    InventoriesAPI.readInstanceGroups.mockResolvedValue({
+      data: {
+        results: [],
+      },
+    });
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <InventoryDetail inventory={mockInventory} />
+      );
+    });
+    wrapper.update();
+    expect(InventoriesAPI.readInstanceGroups).toHaveBeenCalledWith(
+      mockInventory.id
+    );
+    expect(wrapper.find(`Detail[label="Instance Groups"]`)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Hide instance group for Inventory Details if the data is not available.
This is the the same approach used in other details screens.


![image](https://user-images.githubusercontent.com/9053044/99560842-51d8e680-2994-11eb-9908-dbfd3d6f85c1.png)


See: https://github.com/ansible/awx/issues/8620

