### PR TITLE
Swap underscores for hyphens in qs namespace strings

### DIFF
--- a/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/InstanceGroupsLookup.jsx
@@ -13,7 +13,7 @@ import useRequest from '../../util/useRequest';
 import Lookup from './Lookup';
 import LookupErrorMessage from './shared/LookupErrorMessage';
 
-const QS_CONFIG = getQSConfig('instance_groups', {
+const QS_CONFIG = getQSConfig('instance-groups', {
   page: 1,
   page_size: 5,
   order_by: 'name',

--- a/awx/ui_next/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx
+++ b/awx/ui_next/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx
@@ -18,7 +18,7 @@ import DatalistToolbar from '../../../components/DataListToolbar';
 
 import CredentialTypeListItem from './CredentialTypeListItem';
 
-const QS_CONFIG = getQSConfig('credential_type', {
+const QS_CONFIG = getQSConfig('credential-type', {
   page: 1,
   page_size: 20,
   managed_by_tower: false,

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx
@@ -18,7 +18,7 @@ import AddDropDownButton from '../../../components/AddDropDownButton';
 
 import InstanceGroupListItem from './InstanceGroupListItem';
 
-const QS_CONFIG = getQSConfig('instance_group', {
+const QS_CONFIG = getQSConfig('instance-group', {
   page: 1,
   page_size: 20,
 });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx
@@ -10,7 +10,7 @@ import PaginatedDataList from '../../../../../../components/PaginatedDataList';
 import DataListToolbar from '../../../../../../components/DataListToolbar';
 import CheckboxListItem from '../../../../../../components/CheckboxListItem';
 
-const QS_CONFIG = getQSConfig('inventory_sources', {
+const QS_CONFIG = getQSConfig('inventory-sources', {
   page: 1,
   page_size: 5,
   order_by: 'name',

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
@@ -10,7 +10,7 @@ import PaginatedDataList from '../../../../../../components/PaginatedDataList';
 import DataListToolbar from '../../../../../../components/DataListToolbar';
 import CheckboxListItem from '../../../../../../components/CheckboxListItem';
 
-const QS_CONFIG = getQSConfig('job_templates', {
+const QS_CONFIG = getQSConfig('job-templates', {
   page: 1,
   page_size: 5,
   order_by: 'name',

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.jsx
@@ -10,7 +10,7 @@ import PaginatedDataList from '../../../../../../components/PaginatedDataList';
 import DataListToolbar from '../../../../../../components/DataListToolbar';
 import CheckboxListItem from '../../../../../../components/CheckboxListItem';
 
-const QS_CONFIG = getQSConfig('workflow_job_templates', {
+const QS_CONFIG = getQSConfig('workflow-job-templates', {
   page: 1,
   page_size: 5,
   order_by: 'name',


### PR DESCRIPTION
##### SUMMARY
link #8530 

We currently have both patterns (underscores and hyphens) being used in these strings.  While I feel like the underscores make sense for display in the url, they don't look great in our element id's.

Since this string is used in both of those places it's going to look funny somewhere.  At least this way they're all consistent.

Example of hyphen already being used: https://github.com/ansible/awx/blob/devel/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx#L19