### PR TITLE
Display 'System' for user role resource name when summary_fields.resource_name not present

### DIFF
--- a/awx/ui_next/src/screens/User/UserRoles/UserRolesListItem.jsx
+++ b/awx/ui_next/src/screens/User/UserRoles/UserRolesListItem.jsx
@@ -18,12 +18,16 @@ function UserRolesListItem({ role, i18n, detailUrl, onSelect }) {
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[
-            <DataListCell key="name" aria-label={i18n._(t`resource name`)}>
-              <Link to={`${detailUrl}`} id={labelId}>
-                <b>{role.summary_fields.resource_name}</b>
-              </Link>
+            <DataListCell key="name" aria-label={i18n._(t`Resource name`)}>
+              {role.summary_fields.resource_name ? (
+                <Link to={`${detailUrl}`} id={labelId}>
+                  <b>{role.summary_fields.resource_name}</b>
+                </Link>
+              ) : (
+                <b>{i18n._(t`System`)}</b>
+              )}
             </DataListCell>,
-            <DataListCell key="type" aria-label={i18n._(t`resource type`)}>
+            <DataListCell key="type" aria-label={i18n._(t`Resource type`)}>
               {role.summary_fields && (
                 <DetailList stacked>
                   <Detail
@@ -33,7 +37,7 @@ function UserRolesListItem({ role, i18n, detailUrl, onSelect }) {
                 </DetailList>
               )}
             </DataListCell>,
-            <DataListCell key="role" aria-label={i18n._(t`resource role`)}>
+            <DataListCell key="role" aria-label={i18n._(t`Resource role`)}>
               {role.name && (
                 <DetailList stacked>
                   <Detail

--- a/awx/ui_next/src/screens/User/UserRoles/UserRolesListItem.test.jsx
+++ b/awx/ui_next/src/screens/User/UserRoles/UserRolesListItem.test.jsx
@@ -35,13 +35,13 @@ describe('<UserRolesListItem/>', () => {
       />
     );
     expect(
-      wrapper.find('PFDataListCell[aria-label="resource name"]').text()
+      wrapper.find('PFDataListCell[aria-label="Resource name"]').text()
     ).toBe('template delete project');
     expect(
-      wrapper.find('PFDataListCell[aria-label="resource type"]').text()
+      wrapper.find('PFDataListCell[aria-label="Resource type"]').text()
     ).toContain('Job Template');
     expect(
-      wrapper.find('PFDataListCell[aria-label="resource role"]').text()
+      wrapper.find('PFDataListCell[aria-label="Resource role"]').text()
     ).toContain('Admin');
   });
   test('should render deletable chip', () => {
@@ -62,5 +62,20 @@ describe('<UserRolesListItem/>', () => {
       />
     );
     expect(wrapper.find('Chip').prop('isReadOnly')).toBe(true);
+  });
+  test('should display System as name when no resource_name is present in summary_fields', () => {
+    wrapper = mountWithContexts(
+      <UserRolesListItem
+        role={{
+          ...role,
+          summary_fields: {
+            user_capabilities: { unattach: false },
+          },
+        }}
+      />
+    );
+    expect(
+      wrapper.find('PFDataListCell[aria-label="Resource name"]').text()
+    ).toBe('System');
   });
 });


### PR DESCRIPTION
##### SUMMARY
link #7816 

<img width="1502" alt="Screen Shot 2020-11-23 at 12 32 04 PM" src="https://user-images.githubusercontent.com/9889020/99995223-12413e80-2d88-11eb-80c4-e701b0c2350e.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
