### PR TITLE
Move jt/wfjt created/modified details to the end right before the full width details

### DIFF
--- a/awx/ui_next/src/screens/Application/ApplicationDetails/ApplicationDetails.jsx
+++ b/awx/ui_next/src/screens/Application/ApplicationDetails/ApplicationDetails.jsx
@@ -7,7 +7,11 @@ import { Button } from '@patternfly/react-core';
 import useRequest, { useDismissableError } from '../../../util/useRequest';
 import AlertModal from '../../../components/AlertModal';
 import { CardBody, CardActionsRow } from '../../../components/Card';
-import { Detail, DetailList } from '../../../components/DetailList';
+import {
+  Detail,
+  DetailList,
+  UserDateDetail,
+} from '../../../components/DetailList';
 import { ApplicationsAPI } from '../../../api';
 import DeleteButton from '../../../components/DeleteButton';
 import ErrorDetail from '../../../components/ErrorDetail';
@@ -97,6 +101,11 @@ function ApplicationDetails({
           label={i18n._(t`Client type`)}
           value={getClientType(application.client_type)}
           dataCy="app-detail-client-type"
+        />
+        <UserDateDetail label={i18n._(t`Created`)} date={application.created} />
+        <UserDateDetail
+          label={i18n._(t`Last Modified`)}
+          date={application.modified}
         />
       </DetailList>
       <CardActionsRow>

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -7,7 +7,11 @@ import { Button, Chip, Label } from '@patternfly/react-core';
 import styled from 'styled-components';
 
 import AlertModal from '../../../components/AlertModal';
-import { DetailList, Detail } from '../../../components/DetailList';
+import {
+  DetailList,
+  Detail,
+  UserDateDetail,
+} from '../../../components/DetailList';
 import { CardBody, CardActionsRow } from '../../../components/Card';
 import ChipGroup from '../../../components/ChipGroup';
 import CredentialChip from '../../../components/CredentialChip';
@@ -80,6 +84,7 @@ const getLaunchedByDetails = ({ summary_fields = {}, related = {} }) => {
 
 function JobDetail({ job, i18n }) {
   const {
+    created_by,
     credential,
     credentials,
     instance_group: instanceGroup,
@@ -289,6 +294,12 @@ function JobDetail({ job, i18n }) {
             }
           />
         )}
+        <UserDateDetail
+          label={i18n._(t`Created`)}
+          date={job.created}
+          user={created_by}
+        />
+        <UserDateDetail label={i18n._(t`Last Modified`)} date={job.modified} />
       </DetailList>
       {job.extra_vars && (
         <VariablesInput

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx
@@ -10,6 +10,7 @@ import {
   ArrayDetail,
   DetailList,
   DeletedDetail,
+  UserDateDetail,
 } from '../../../components/DetailList';
 import CodeDetail from '../../../components/DetailList/CodeDetail';
 import DeleteButton from '../../../components/DeleteButton';
@@ -23,6 +24,8 @@ function NotificationTemplateDetail({ i18n, template, defaultMessages }) {
   const history = useHistory();
 
   const {
+    created,
+    modified,
     notification_configuration: configuration,
     summary_fields,
     messages,
@@ -324,6 +327,16 @@ function NotificationTemplateDetail({ i18n, template, defaultMessages }) {
             />
           </>
         )}
+        <UserDateDetail
+          label={i18n._(t`Created`)}
+          date={created}
+          user={summary_fields?.created_by}
+        />
+        <UserDateDetail
+          label={i18n._(t`Last Modified`)}
+          date={modified}
+          user={summary_fields?.modified_by}
+        />
         {hasCustomMessages(messages, typeMessageDefaults) && (
           <CustomMessageDetails
             messages={messages}

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
@@ -219,16 +219,6 @@ function JobTemplateDetail({ i18n, template }) {
           value={verbosityDetails[0].details}
         />
         <Detail label={i18n._(t`Timeout`)} value={timeout || '0'} />
-        <UserDateDetail
-          label={i18n._(t`Created`)}
-          date={created}
-          user={summary_fields.created_by}
-        />
-        <UserDateDetail
-          label={i18n._(t`Last Modified`)}
-          date={modified}
-          user={summary_fields.modified_by}
-        />
         <Detail
           label={i18n._(t`Show Changes`)}
           value={diff_mode ? i18n._(t`On`) : i18n._(t`Off`)}
@@ -278,6 +268,16 @@ function JobTemplateDetail({ i18n, template }) {
         {renderOptionsField && (
           <Detail label={i18n._(t`Options`)} value={renderOptions} />
         )}
+        <UserDateDetail
+          label={i18n._(t`Created`)}
+          date={created}
+          user={summary_fields.created_by}
+        />
+        <UserDateDetail
+          label={i18n._(t`Last Modified`)}
+          date={modified}
+          user={summary_fields.modified_by}
+        />
         {summary_fields.credentials && summary_fields.credentials.length > 0 && (
           <Detail
             fullWidth

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx
@@ -135,9 +135,6 @@ function WorkflowJobTemplateDetail({ template, i18n }) {
             )}
           />
         )}
-        {renderOptionsField && (
-          <Detail label={i18n._(t`Options`)} value={renderOptions} />
-        )}
         <Detail
           label={i18n._(t`Webhook Service`)}
           value={toTitleCase(template.webhook_service)}
@@ -162,6 +159,19 @@ function WorkflowJobTemplateDetail({ template, i18n }) {
             }
           />
         )}
+        {renderOptionsField && (
+          <Detail label={i18n._(t`Options`)} value={renderOptions} />
+        )}
+        <UserDateDetail
+          label={i18n._(t`Created`)}
+          date={created}
+          user={summary_fields.created_by}
+        />
+        <UserDateDetail
+          label={i18n._(t`Modified`)}
+          date={modified}
+          user={summary_fields.modified_by}
+        />
         {summary_fields.labels?.results?.length > 0 && (
           <Detail
             fullWidth
@@ -184,16 +194,6 @@ function WorkflowJobTemplateDetail({ template, i18n }) {
           label={i18n._(t`Variables`)}
           value={extra_vars}
           rows={4}
-        />
-        <UserDateDetail
-          label={i18n._(t`Created`)}
-          date={created}
-          user={summary_fields.created_by}
-        />
-        <UserDateDetail
-          label={i18n._(t`Modified`)}
-          date={modified}
-          user={summary_fields.modified_by}
         />
       </DetailList>
       <CardActionsRow>


### PR DESCRIPTION
##### SUMMARY
link #5683 

<img width="1437" alt="Screen Shot 2020-11-23 at 2 37 42 PM" src="https://user-images.githubusercontent.com/9889020/100007310-e8911300-2d99-11eb-8417-cb0d6b5c5cbf.png">
<img width="1432" alt="Screen Shot 2020-11-23 at 2 20 57 PM" src="https://user-images.githubusercontent.com/9889020/100007314-e9c24000-2d99-11eb-9b8f-c86fbb0fbc34.png">

I also moved the Options detail in WorkflowJobTemplateDetail.jsx to come after the webhook details.  This makes it consistent with JobTemplateDetail.jsx.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

@unlikelyzero @tiagodread I assume this will cause a break in the visual tests
