### PR TITLE
Fix issue with broken survey question edit breadcrumb by altering the url scheme

### DIFF
--- a/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
@@ -94,7 +94,7 @@ function SurveyListItem({
           dataListCells={[
             <DataListCell key="name">
               <>
-                <Link to={`survey/edit/${question.variable}`}>
+                <Link to={`survey/edit?question_variable=${question.variable}`}>
                   {question.question_name}
                 </Link>
                 {question.required && (

--- a/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.jsx
@@ -1,5 +1,10 @@
 import React, { useState } from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import {
+  Redirect,
+  useHistory,
+  useLocation,
+  useRouteMatch,
+} from 'react-router-dom';
 import ContentLoading from '../../../components/ContentLoading';
 import { CardBody } from '../../../components/Card';
 import SurveyQuestionForm from './SurveyQuestionForm';
@@ -8,12 +13,23 @@ export default function SurveyQuestionEdit({ survey, updateSurvey }) {
   const [formError, setFormError] = useState(null);
   const history = useHistory();
   const match = useRouteMatch();
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+  const questionVariable = queryParams.get('question_variable');
 
   if (!survey) {
     return <ContentLoading />;
   }
 
-  const question = survey.spec.find(q => q.variable === match.params.variable);
+  const question = survey.spec.find(q => q.variable === questionVariable);
+
+  if (!question) {
+    return (
+      <Redirect
+        to={`/templates/${match.params.templateType}/${match.params.id}/survey`}
+      />
+    );
+  }
 
   const navigateToList = () => {
     const index = match.url.indexOf('/edit');
@@ -34,7 +50,7 @@ export default function SurveyQuestionEdit({ survey, updateSurvey }) {
         return;
       }
       const questionIndex = survey.spec.findIndex(
-        q => q.variable === match.params.variable
+        q => q.variable === questionVariable
       );
       if (questionIndex === -1) {
         throw new Error('Question not found in spec');

--- a/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.test.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.test.jsx
@@ -33,87 +33,124 @@ describe('<SurveyQuestionEdit />', () => {
   let history;
   let wrapper;
 
-  beforeEach(() => {
-    history = createMemoryHistory({
-      initialEntries: ['/templates/job_templates/1/survey/edit/foo'],
+  describe('with question_variable present', () => {
+    beforeEach(() => {
+      history = createMemoryHistory({
+        initialEntries: [
+          '/templates/job_templates/1/survey/edit?question_variable=foo',
+        ],
+      });
+      updateSurvey = jest.fn();
+      act(() => {
+        wrapper = mountWithContexts(
+          <Switch>
+            <Route path="/templates/:templateType/:id/survey/edit">
+              <SurveyQuestionEdit survey={survey} updateSurvey={updateSurvey} />
+            </Route>
+          </Switch>,
+          {
+            context: { router: { history } },
+          }
+        );
+      });
     });
-    updateSurvey = jest.fn();
-    act(() => {
-      wrapper = mountWithContexts(
-        <Switch>
-          <Route path="/templates/:templateType/:id/survey/edit/:variable">
-            <SurveyQuestionEdit survey={survey} updateSurvey={updateSurvey} />
-          </Route>
-        </Switch>,
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    test('should render form', () => {
+      expect(wrapper.find('SurveyQuestionForm')).toHaveLength(1);
+    });
+
+    test('should call updateSurvey', () => {
+      act(() => {
+        wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
+          question_name: 'new question',
+          variable: 'question',
+          type: 'text',
+        });
+      });
+      wrapper.update();
+
+      expect(updateSurvey).toHaveBeenCalledWith([
         {
-          context: { router: { history } },
-        }
+          question_name: 'new question',
+          variable: 'question',
+          type: 'text',
+        },
+        survey.spec[1],
+      ]);
+    });
+
+    test('should set formError', async () => {
+      const realConsoleError = global.console.error;
+      global.console.error = jest.fn();
+      const err = new Error('oops');
+      updateSurvey.mockImplementation(() => {
+        throw err;
+      });
+
+      act(() => {
+        wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
+          question_name: 'new question',
+          variable: 'question',
+          type: 'text',
+        });
+      });
+      wrapper.update();
+
+      expect(wrapper.find('SurveyQuestionForm').prop('submitError')).toEqual(
+        err
       );
+      global.console.error = realConsoleError;
     });
-  });
 
-  test('should render form', () => {
-    expect(wrapper.find('SurveyQuestionForm')).toHaveLength(1);
-  });
+    test('should generate error for duplicate variable names', async () => {
+      const realConsoleError = global.console.error;
+      global.console.error = jest.fn();
 
-  test('should call updateSurvey', () => {
-    act(() => {
-      wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
-        question_name: 'new question',
-        variable: 'question',
-        type: 'text',
+      act(() => {
+        wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
+          question_name: 'new question',
+          variable: 'bar',
+          type: 'text',
+        });
       });
-    });
-    wrapper.update();
+      wrapper.update();
 
-    expect(updateSurvey).toHaveBeenCalledWith([
-      {
-        question_name: 'new question',
-        variable: 'question',
-        type: 'text',
-      },
-      survey.spec[1],
-    ]);
+      const err = wrapper.find('SurveyQuestionForm').prop('submitError');
+      expect(err.message).toEqual(
+        'Survey already contains a question with variable named “bar”'
+      );
+      global.console.error = realConsoleError;
+    });
   });
 
-  test('should set formError', async () => {
-    const realConsoleError = global.console.error;
-    global.console.error = jest.fn();
-    const err = new Error('oops');
-    updateSurvey.mockImplementation(() => {
-      throw err;
-    });
-
-    act(() => {
-      wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
-        question_name: 'new question',
-        variable: 'question',
-        type: 'text',
+  describe('without question_variable present', () => {
+    test('should redirect back to the survey list', () => {
+      history = createMemoryHistory({
+        initialEntries: ['/templates/job_templates/1/survey/edit'],
       });
-    });
-    wrapper.update();
-
-    expect(wrapper.find('SurveyQuestionForm').prop('submitError')).toEqual(err);
-    global.console.error = realConsoleError;
-  });
-
-  test('should generate error for duplicate variable names', async () => {
-    const realConsoleError = global.console.error;
-    global.console.error = jest.fn();
-
-    act(() => {
-      wrapper.find('SurveyQuestionForm').invoke('handleSubmit')({
-        question_name: 'new question',
-        variable: 'bar',
-        type: 'text',
+      updateSurvey = jest.fn();
+      act(() => {
+        wrapper = mountWithContexts(
+          <Switch>
+            <Route path="/templates/:templateType/:id/survey/edit">
+              <SurveyQuestionEdit survey={survey} updateSurvey={updateSurvey} />
+            </Route>
+          </Switch>,
+          {
+            context: { router: { history } },
+          }
+        );
       });
-    });
-    wrapper.update();
 
-    const err = wrapper.find('SurveyQuestionForm').prop('submitError');
-    expect(err.message).toEqual(
-      'Survey already contains a question with variable named “bar”'
-    );
-    global.console.error = realConsoleError;
+      expect(history.location.pathname).toEqual(
+        '/templates/job_templates/1/survey'
+      );
+
+      wrapper.unmount();
+    });
   });
 });

--- a/awx/ui_next/src/screens/Template/Survey/SurveyQuestionForm.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyQuestionForm.jsx
@@ -30,7 +30,7 @@ function AnswerTypeField({ i18n }) {
 
   return (
     <FormGroup
-      label={i18n._(t`Answer Type`)}
+      label={i18n._(t`Answer type`)}
       labelIcon={
         <Popover
           content={i18n._(
@@ -91,6 +91,7 @@ function SurveyQuestionForm({
 
   return (
     <Formik
+      enableReinitialize
       initialValues={{
         question_name: question?.question_name || '',
         question_description: question?.question_description || '',
@@ -126,7 +127,7 @@ function SurveyQuestionForm({
               id="question-variable"
               name="variable"
               type="text"
-              label={i18n._(t`Answer Variable Name`)}
+              label={i18n._(t`Answer variable name`)}
               validate={combine([noWhiteSpace(i18n), required(null, i18n)])}
               isRequired
               tooltip={i18n._(

--- a/awx/ui_next/src/screens/Template/TemplateSurvey.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateSurvey.jsx
@@ -100,7 +100,7 @@ function TemplateSurvey({ template, canEdit, i18n }) {
           </Route>
         )}
         {canEdit && (
-          <Route path="/templates/:templateType/:id/survey/edit/:variable">
+          <Route path="/templates/:templateType/:id/survey/edit">
             <SurveyQuestionEdit
               survey={survey}
               updateSurvey={updateSurveySpec}


### PR DESCRIPTION
##### SUMMARY
link #7522 

I couldn't come up with a different way to solve this problem.  We define a static breadcrumb object with exact url's whenever the survey component is mounted.  At that point in time, we have no idea what all of the survey question variables are and therefore cannot generate static breadcrumb strings for all the possibilities.

To get around this, I removed the question variable from the route and instead put it in query params.

I also added some logic to redirect the user back out to the survey list when the query param was missing or the variable was not present in the survey spec.

<img width="1679" alt="Screen Shot 2020-11-24 at 12 44 31 PM" src="https://user-images.githubusercontent.com/9889020/100132351-4e8da100-2e53-11eb-9a8e-5e6fc1d7c200.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
