### PR TITLE
Avoid copies made from failed updates

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2417,9 +2417,10 @@ class RunProjectUpdate(BaseTask):
                 shutil.rmtree(stage_path)  # cannot trust content update produced
 
             if self.job_private_data_dir:
-                # copy project folder before resetting to default branch
-                # because some git-tree-specific resources (like submodules) might matter
-                self.make_local_copy(instance, self.job_private_data_dir)
+                if status == 'successful':
+                    # copy project folder before resetting to default branch
+                    # because some git-tree-specific resources (like submodules) might matter
+                    self.make_local_copy(instance, self.job_private_data_dir)
                 if self.original_branch:
                     # for git project syncs, non-default branches can be problems
                     # restore to branch the repo was on before this run


### PR DESCRIPTION
This is a bit of a log cleanup, although you could maybe come up with some extremely oddball situations where it might do the wrong thing.

Situations will produce the very weird dual-log:

```
2020-11-24 18:19:15,968 ERROR    awx.main.tasks project_update 1295 (running) Post run hook errored.
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1529, in run
    self.post_run_hook(self.instance, status)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 2434, in post_run_hook
    self.make_local_copy(instance, self.job_private_data_dir)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 2373, in make_local_copy
    raise RuntimeError('Unexpectedly could not determine a revision to run from project.')
RuntimeError: Unexpectedly could not determine a revision to run from project.
2020-11-24 18:19:16,056 ERROR    awx.main.tasks job 1293 (running) Exception occurred while running task
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1382, in run
    self.pre_run_hook(self.instance, private_data_dir)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1941, in pre_run_hook
    sync_task.run(local_project_sync.id)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 813, in _wrapped
    return f(self, *args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/awx/main/tasks.py", line 1554, in run
    raise AwxTaskError.TaskError(self.instance, rc)
Exception: project_update 1295 (failed) encountered an error (rc=2), please see task stdout for details.
```

The 2nd exception is okay(-ish), but the first exception puts us into the wrong code path. It was never expected that `make_local_copy` would be passed a failed update. How are you going to make a copy when it failed to update? If we want to run offline, thus not pulling new source, then the update task should not run to begin with.

This patch should avoid hitting the first error, and will allow the logic to continue doing the intended post-update things.