### PR TITLE
Apply more rigor to asserting text in stdout

### DIFF
--- a/awxkit/awxkit/api/pages/unified_jobs.py
+++ b/awxkit/awxkit/api/pages/unified_jobs.py
@@ -46,9 +46,11 @@ class UnifiedJob(HasStatus, base.Base):
         Additionally, you may replace any ' ' with another character (including ''). This is applied after the newline
         replacement. Default behavior is to not replace spaces.
         """
+        self.wait_until_completed()
         stdout = self.result_stdout
         if replace_newlines is not None:
-            stdout = stdout.replace('\n', replace_newlines)
+            # make text into string with no line breaks, but watch out for trailing whitespace
+            stdout = replace_newlines.join([line.strip() for line in stdout.split('\n')])
         if replace_spaces is not None:
             stdout = stdout.replace(' ', replace_spaces)
         if expected_text not in stdout:


### PR DESCRIPTION
##### SUMMARY
Lately, we have increasingly observed this pattern in test failures:

```
Traceback (most recent call last):
  File "/home/ec2-user/tower-qa/tests/api/inventories/test_scm_inventory_source.py", line 552, in test_failing_scm_inv_source_update_error_reporting
    inv_update.assert_text_in_stdout(expected_error, replace_newlines=' ')
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/pages/unified_jobs.py", line 57, in assert_text_in_stdout
    'Expected "{}", but it was not found in stdout. Full stdout:\n {}'.format(expected_text, pretty_stdout)
AssertionError: Expected "bad data for the host list", but it was not found in stdout. Full stdout:
 ''
```

See that last little part about "Full stdout:". The full standard out is an empty string. The reason is exactly what you're expecting - the assertions were ran prematurely, before all events made it in. This comes up in several places because it does `scm_inv_source.wait_until_completed()` on the _template_ and not the _unified job_. The method by the same name is implemented differently for jobs, and it will wait for all events to save before continuing. Obviously, if you're looking at the template, it doesn't have knowledge of what job is relevant, and thus only looks at status. If you wait for status but not events, you can get this empty stdout situation.

Why now? Maybe something changed in the dynamics of processing events. @ryanpetrello ? Anyway, I feel pretty confident this makes the code more correct than before, and I have confirmed the failure and then fix a few times locally.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
15.0.1
```


