### PR TITLE
Add Git-LFS to build image

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -121,6 +121,7 @@ RUN dnf -y update && \
     ansible \
     bubblewrap \
     git-core \
+    git-lfs \
     glibc-langpack-en \
     krb5-workstation \
     libcgroup-tools \


### PR DESCRIPTION
##### SUMMARY
For background, see: #8278 

Install git-lfs inside the awx image to allow repositories with lfs files to be downloaded correctly. Nowadays without git lfs installed deploying software lead to issues hard do detect until you check that the size of those files differs.

To mannually solve this issue the installation inside the awx_task containers is needed and then force the cleanup of the repositories to allow the correct download of lfs files.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
