### PR TITLE
Remove old radius library from requirements

### DIFF
--- a/docs/licenses/python-radius.txt
+++ b/docs/licenses/python-radius.txt
@@ -1,9 +1,0 @@
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -34,7 +34,6 @@ prometheus_client
 psycopg2
 pygerduty
 pyparsing
-python-radius
 python3-saml
 python-ldap>=3.3.1 # https://github.com/python-ldap/python-ldap/issues/270
 pyyaml>=5.3.1  # minimum version to pull in new pyyaml for CVE-2017-18342

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -94,7 +94,6 @@ pyrsistent==0.15.7        # via jsonschema
 python-daemon==2.2.4      # via ansible-runner
 python-dateutil==2.8.1    # via adal, kubernetes
 python-ldap==3.3.1        # via -r /awx_devel/requirements/requirements.in, django-auth-ldap
-python-radius==1.0        # via -r /awx_devel/requirements/requirements.in
 python-string-utils==1.0.0  # via openshift
 python3-openid==3.1.0     # via social-auth-core
 python3-saml==1.9.0       # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
If it's not required by django-radius and not imported anywhere in AWX, we probably don't need it.
