### PR TITLE
Update main.yml

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -101,7 +101,7 @@
 
     - name: Deploy and Activate Postgres (Kubernetes)
       shell: |
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com
+        helm repo add stable https://charts.helm.sh/stable
         helm repo update
         helm upgrade {{ postgresql_service_name }} \
           --install \


### PR DESCRIPTION
Updating helm repo

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
AWX installation on Kubernetes fails due to incorrect helm repo. Followed the instructions documented here - https://github.com/ansible/awx/blob/devel/INSTALL.md#kubernetes

Encountered the following error during installation.
```
TASK [kubernetes : Deploy and Activate Postgres (Kubernetes)] *********************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "helm repo add stable https://kubernetes-charts.storage.googleapis.com\nhelm repo update\nhelm upgrade awx-postgresql  --install  --namespace awx  --version=\"8.3.0\"  --values /var/folders/2f/3wzkqdxd4ss2fvr3gdtjq_740000gn/T/ansible.8jttg3o7.yml  stable/postgresql\n", "delta": "0:00:00.185554", "end": "2020-12-01 14:23:01.262520", "msg": "non-zero return code", "rc": 1, "start": "2020-12-01 14:23:01.076966", "stderr": "Error: repo \"https://kubernetes-charts.storage.googleapis.com\" is no longer available; try \"https://charts.helm.sh/stable\" instead\nError: no repositories found. You must add one before updating\nError: failed to download \"stable/postgresql\" at version \"8.3.0\" (hint: running `helm repo update` may help)", "stderr_lines": ["Error: repo \"https://kubernetes-charts.storage.googleapis.com\" is no longer available; try \"https://charts.helm.sh/stable\" instead", "Error: no repositories found. You must add one before updating", "Error: failed to download \"stable/postgresql\" at version \"8.3.0\" (hint: running `helm repo update` may help)"], "stdout": "Release \"awx-postgresql\" does not exist. Installing it now.", "stdout_lines": ["Release \"awx-postgresql\" does not exist. Installing it now."]}
```
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
As per Helm documentation, the location of helm repo has changed from "https://kubernetes-charts.storage.googleapis.com" to "https://charts.helm.sh/stable". The fix is to update helm repo in ansible playbook.

Fix for https://github.com/ansible/awx/issues/8715

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
15.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
