### PR TITLE
Change to manual instead of deleting hg projects

### DIFF
--- a/awx/main/migrations/_hg_removal.py
+++ b/awx/main/migrations/_hg_removal.py
@@ -10,10 +10,10 @@ def delete_hg_scm(apps, schema_editor):
     Project = apps.get_model('main', 'Project')
     ProjectUpdate = apps.get_model('main', 'ProjectUpdate')
 
-    ProjectUpdate.objects.filter(project__scm_type='hg').delete()
-    deleted_ct, deletion_summary = Project.objects.filter(scm_type='hg').delete()
+    ProjectUpdate.objects.filter(project__scm_type='hg').update(scm_type='')
+    update_ct = Project.objects.filter(scm_type='hg').update(scm_type='')
 
-    if deleted_ct:
-        logger.warn('Removed {} mercurial projects, deprecation period ended'.format(
-            deletion_summary.get('main.Project', '')
+    if update_ct:
+        logger.warn('Changed {} mercurial projects to manual, deprecation period ended'.format(
+            update_ct
         ))


### PR DESCRIPTION
##### SUMMARY
This is a change in migration behavior based on feedback I was getting.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
15.0.1
```


##### ADDITIONAL INFORMATION
Testing was done manually. There is a dearth of functional hg repos now that bitbucket has removed support. Thus... I go to:

https://www.mercurial-scm.org/wiki/TutorialClone

I made a project that uses:

http://www.selenic.com/repo/hello

That successfully updates (I had to use code from before my prior merge). Then I check out code from this branch and migrate. This leaves the project files in-place (this was already happening, so call it a bug).

This repo has no playbooks, so I had to fake it by putting in a debug playbook into the project files. From there, I could create a JT with the post-migration project and run a job.

![Screenshot from 2020-12-02 09-05-08](https://user-images.githubusercontent.com/1385596/100883746-aee99780-347e-11eb-85c4-88245a7b0276.png)

I can see how this is probably _better_ than before. Stuff will keep working in some cases, and when it doesn't, some artifacts will be left behind instead of leaving users in the cold. Old project updates cannot be relaunched, and the project cannot be updated.
