### PR TITLE
make preload data optional again

### DIFF
--- a/installer/roles/image_build/templates/launch_awx_task.sh.j2
+++ b/installer/roles/image_build/templates/launch_awx_task.sh.j2
@@ -24,9 +24,6 @@ fi
 
 if [ ! -z "$AWX_ADMIN_USER" ]&&[ ! -z "$AWX_ADMIN_PASSWORD" ]; then
     echo "from django.contrib.auth.models import User; User.objects.create_superuser('$AWX_ADMIN_USER', 'root@localhost', '$AWX_ADMIN_PASSWORD')" | awx-manage shell
-    {% if create_preload_data | bool %}
-    awx-manage create_preload_data
-    {% endif %}
 fi
 echo 'from django.conf import settings; x = settings.AWX_TASK_ENV; x["HOME"] = "/var/lib/awx"; settings.AWX_TASK_ENV = x' | awx-manage shell
 

--- a/installer/roles/kubernetes/templates/launch_awx.yml.j2
+++ b/installer/roles/kubernetes/templates/launch_awx.yml.j2
@@ -24,10 +24,8 @@ data:
 
     if [ ! -z "$AWX_ADMIN_USER" ]&&[ ! -z "$AWX_ADMIN_PASSWORD" ]; then
         echo "from django.contrib.auth.models import User; User.objects.create_superuser('$AWX_ADMIN_USER', 'root@localhost', '$AWX_ADMIN_PASSWORD')" | awx-manage shell
-        awx-manage create_preload_data
     else
         echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'root@localhost', 'password')" | awx-manage shell
-        awx-manage create_preload_data
     fi
     echo 'from django.conf import settings; x = settings.AWX_TASK_ENV; x["HOME"] = "/var/lib/awx"; settings.AWX_TASK_ENV = x' | awx-manage shell
     awx-manage provision_instance --hostname=$(hostname)

--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -49,4 +49,10 @@
     - name: Update CA trust in awx_task container
       command: docker exec awx_task '/usr/bin/update-ca-trust'
       when: awx_compose_config.changed or awx_compose_start.changed
+
+    - name: Create Preload data
+      command: docker exec awx_task bash -c "/usr/bin/awx-manage create_preload_data"
+      when: create_preload_data|bool
+      register: cdo
+      changed_when: "'added' in cdo.stdout"
   when: compose_start_containers|bool


### PR DESCRIPTION
##### SUMMARY
Create the Demo preload data only if `create_preload_data` is set to `True` when running the installer.

While there is step in `kubernetes` role to create demo data only if the variable is set to `True` in `inventory`, it was useless since the command was defined in `lauch-awx-task` configMap and always run.
I am also adding this option to `local_docker` role to have the same user experience.

To make it work I have removed the command from Dockerfile template in `build_image` role.

Fixes https://github.com/ansible/awx/issues/2317

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer
