### PR TITLE
Add Kubernetes Service support for annotations

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -518,6 +518,12 @@ metadata:
   namespace: {{ kubernetes_namespace }}
   labels:
     name: {{ kubernetes_deployment_name }}-web-svc
+{% if kubernetes_service_annotations is defined %}
+  annotations:
+{% for key, value in kubernetes_service_annotations.items() %}
+    {{ key }}: {{ value | quote }}
+{% endfor %}
+{% endif %}
 spec:
   type: {{ kubernetes_web_svc_type }}
   ports:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Annotations support was missed for Services.
This PR will allow you now to specify annotations for Kubernetes Service
resources by defining `kubernetes_service_annotations` var list

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
15.0.1
```