### PR TITLE
Fix typo for kubernetes_service_account_annotations variable

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ kubernetes_serviceaccount_name }}
   namespace: {{ kubernetes_namespace }}
-{% if kubernetes_service_account_is defined %}
+{% if kubernetes_service_account_annotations is defined %}
   annotations:
 {% for key, value in kubernetes_service_account_annotations.items() %}
     {{ key }}: {{ value | quote }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes: https://github.com/ansible/awx/commit/701deb2268f3258560d773c49331146555a6c89e#r44816248

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
15.0.1
```

@shanemcd I'm not sure how this got in there, but it did, and it was my fault, so here's a fix. Sorry about that 😬 
