### PR TITLE
Use literal quotation marks for Kubernetes annotations instead of quo…

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -4,10 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ kubernetes_serviceaccount_name }}
   namespace: {{ kubernetes_namespace }}
-{% if kubernetes_service_account_annotations is defined %}
+{% if kubernetes_service_account_is defined %}
   annotations:
 {% for key, value in kubernetes_service_account_annotations.items() %}
-    {{ key }}: {{ value | quote }}
+    {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
 {% if kubernetes_image_pull_secrets is defined %}
@@ -88,7 +88,7 @@ metadata:
 {% if kubernetes_deployment_annotations is defined %}
   annotations:
 {% for key, value in kubernetes_deployment_annotations.items() %}
-    {{ key }}: {{ value | quote }}
+    {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
 {% if openshift_host is defined %}
@@ -107,7 +107,7 @@ spec:
 {% if kubernetes_pod_annotations is defined %}
       annotations:
 {% for key, value in kubernetes_pod_annotations.items() %}
-        {{ key }}: {{ value | quote }}
+        {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
       labels:
@@ -521,7 +521,7 @@ metadata:
 {% if kubernetes_service_annotations is defined %}
   annotations:
 {% for key, value in kubernetes_service_annotations.items() %}
-    {{ key }}: {{ value | quote }}
+    {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
 spec:
@@ -546,7 +546,7 @@ metadata:
 {% if kubernetes_ingress_annotations is defined %}
   annotations:
 {% for key, value in kubernetes_ingress_annotations.items() %}
-    {{ key }}: {{ value | quote }}
+    {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
…te filter

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Looks like I was wrong about how the `| quote` filter works in ansible.

See: https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_filters.html#other-useful-filters

Instead we need to use literal quotation marks 🙄 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
15.0.1
```
