### PR TITLE
Add all github category setting edit forms

### DIFF
--- a/awx/ui_next/src/screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx
@@ -86,6 +86,7 @@ function ActivityStreamDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/activity_stream/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx
@@ -78,6 +78,7 @@ function AzureADDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/azure/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHub.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHub.jsx
@@ -6,6 +6,8 @@ import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from '../../../components/ContentError';
 import GitHubDetail from './GitHubDetail';
 import GitHubEdit from './GitHubEdit';
+import GitHubOrgEdit from './GitHubOrgEdit';
+import GitHubTeamEdit from './GitHubTeamEdit';
 
 function GitHub({ i18n }) {
   const baseURL = '/settings/github';
@@ -29,8 +31,14 @@ function GitHub({ i18n }) {
           <Route path={`${baseURL}/:category/details`}>
             <GitHubDetail />
           </Route>
-          <Route path={`${baseURL}/:category/edit`}>
+          <Route path={`${baseURL}/default/edit`}>
             <GitHubEdit />
+          </Route>
+          <Route path={`${baseURL}/organization/edit`}>
+            <GitHubOrgEdit />
+          </Route>
+          <Route path={`${baseURL}/team/edit`}>
+            <GitHubTeamEdit />
           </Route>
           <Route key="not-found" path={`${baseURL}/*`}>
             <ContentError isNotFound>

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHub.test.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHub.test.jsx
@@ -5,33 +5,94 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
-import GitHub from './GitHub';
 import { SettingsAPI } from '../../../api';
+import { SettingsProvider } from '../../../contexts/Settings';
+import mockAllOptions from '../shared/data.allSettingOptions.json';
+import GitHub from './GitHub';
 
 jest.mock('../../../api/models/Settings');
-SettingsAPI.readCategory.mockResolvedValue({
-  data: {},
-});
 
 describe('<GitHub />', () => {
   let wrapper;
+
+  beforeEach(() => {
+    SettingsAPI.readCategory.mockResolvedValueOnce({
+      data: {
+        SOCIAL_AUTH_GITHUB_CALLBACK_URL:
+          'https://towerhost/sso/complete/github/',
+        SOCIAL_AUTH_GITHUB_KEY: 'mock github key',
+        SOCIAL_AUTH_GITHUB_SECRET: '$encrypted$',
+        SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: null,
+        SOCIAL_AUTH_GITHUB_TEAM_MAP: null,
+      },
+    });
+    SettingsAPI.readCategory.mockResolvedValueOnce({
+      data: {
+        SOCIAL_AUTH_GITHUB_ORG_CALLBACK_URL:
+          'https://towerhost/sso/complete/github-org/',
+        SOCIAL_AUTH_GITHUB_ORG_KEY: '',
+        SOCIAL_AUTH_GITHUB_ORG_SECRET: '$encrypted$',
+        SOCIAL_AUTH_GITHUB_ORG_NAME: '',
+        SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP: null,
+        SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP: null,
+      },
+    });
+    SettingsAPI.readCategory.mockResolvedValueOnce({
+      data: {
+        SOCIAL_AUTH_GITHUB_TEAM_CALLBACK_URL:
+          'https://towerhost/sso/complete/github-team/',
+        SOCIAL_AUTH_GITHUB_TEAM_KEY: 'OAuth2 key (Client ID)',
+        SOCIAL_AUTH_GITHUB_TEAM_SECRET: '$encrypted$',
+        SOCIAL_AUTH_GITHUB_TEAM_ID: 'team_id',
+        SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP: {},
+        SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP: {},
+      },
+    });
+  });
 
   afterEach(() => {
     wrapper.unmount();
     jest.clearAllMocks();
   });
 
-  test('should render github details', async () => {
+  test('should render github default details', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/settings/github/'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<GitHub />, {
-        context: { router: { history } },
-      });
+      wrapper = mountWithContexts(
+        <SettingsProvider value={mockAllOptions.actions}>
+          <GitHub />
+        </SettingsProvider>,
+        {
+          context: { router: { history } },
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('GitHubDetail').length).toBe(1);
+    expect(wrapper.find('Detail[label="GitHub OAuth2 Key"]').length).toBe(1);
+  });
+
+  test('should redirect to github organization category details', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/settings/github/organization'],
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <SettingsProvider value={mockAllOptions.actions}>
+          <GitHub />
+        </SettingsProvider>,
+        {
+          context: { router: { history } },
+        }
+      );
+    });
+    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
+    expect(wrapper.find('GitHubDetail').length).toBe(1);
+    expect(
+      wrapper.find('Detail[label="GitHub Organization OAuth2 Key"]').length
+    ).toBe(1);
   });
 
   test('should render github edit', async () => {
@@ -39,9 +100,14 @@ describe('<GitHub />', () => {
       initialEntries: ['/settings/github/default/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<GitHub />, {
-        context: { router: { history } },
-      });
+      wrapper = mountWithContexts(
+        <SettingsProvider value={mockAllOptions.actions}>
+          <GitHub />
+        </SettingsProvider>,
+        {
+          context: { router: { history } },
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('GitHubEdit').length).toBe(1);
@@ -52,9 +118,14 @@ describe('<GitHub />', () => {
       initialEntries: ['/settings/github/foo/bar'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<GitHub />, {
-        context: { router: { history } },
-      });
+      wrapper = mountWithContexts(
+        <SettingsProvider value={mockAllOptions.actions}>
+          <GitHub />
+        </SettingsProvider>,
+        {
+          context: { router: { history } },
+        }
+      );
     });
     expect(wrapper.find('ContentError').length).toBe(1);
   });

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx
@@ -114,6 +114,7 @@ function GitHubDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to={`${baseURL}/${category}/edit`}
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubOrgEdit/GitHubOrgEdit.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubOrgEdit/GitHubOrgEdit.jsx
@@ -19,14 +19,14 @@ import useModal from '../../../../util/useModal';
 import useRequest from '../../../../util/useRequest';
 import { SettingsAPI } from '../../../../api';
 
-function GitHubEdit() {
+function GitHubOrgEdit() {
   const history = useHistory();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
   const { isLoading, error, request: fetchGithub, result: github } = useRequest(
     useCallback(async () => {
-      const { data } = await SettingsAPI.readCategory('github');
+      const { data } = await SettingsAPI.readCategory('github-org');
       const mergedData = {};
       Object.keys(data).forEach(key => {
         if (!options[key]) {
@@ -48,7 +48,7 @@ function GitHubEdit() {
     useCallback(
       async values => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/details');
+        history.push('/settings/github/organization/details');
       },
       [history]
     ),
@@ -58,10 +58,12 @@ function GitHubEdit() {
   const handleSubmit = async form => {
     await submitForm({
       ...form,
-      SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: formatJson(
-        form.SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP
+      SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP: formatJson(
+        form.SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP
       ),
-      SOCIAL_AUTH_GITHUB_TEAM_MAP: formatJson(form.SOCIAL_AUTH_GITHUB_TEAM_MAP),
+      SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP: formatJson(
+        form.SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP
+      ),
     });
   };
 
@@ -76,7 +78,7 @@ function GitHubEdit() {
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/details');
+    history.push('/settings/github/organization/details');
   };
 
   const initialValues = fields =>
@@ -102,20 +104,24 @@ function GitHubEdit() {
             <Form autoComplete="off" onSubmit={formik.handleSubmit}>
               <FormColumnLayout>
                 <InputField
-                  name="SOCIAL_AUTH_GITHUB_KEY"
-                  config={github.SOCIAL_AUTH_GITHUB_KEY}
+                  name="SOCIAL_AUTH_GITHUB_ORG_KEY"
+                  config={github.SOCIAL_AUTH_GITHUB_ORG_KEY}
                 />
                 <EncryptedField
-                  name="SOCIAL_AUTH_GITHUB_SECRET"
-                  config={github.SOCIAL_AUTH_GITHUB_SECRET}
+                  name="SOCIAL_AUTH_GITHUB_ORG_SECRET"
+                  config={github.SOCIAL_AUTH_GITHUB_ORG_SECRET}
+                />
+                <InputField
+                  name="SOCIAL_AUTH_GITHUB_ORG_NAME"
+                  config={github.SOCIAL_AUTH_GITHUB_ORG_NAME}
                 />
                 <ObjectField
-                  name="SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP"
-                  config={github.SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP}
+                  name="SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP"
+                  config={github.SOCIAL_AUTH_GITHUB_ORG_ORGANIZATION_MAP}
                 />
                 <ObjectField
-                  name="SOCIAL_AUTH_GITHUB_TEAM_MAP"
-                  config={github.SOCIAL_AUTH_GITHUB_TEAM_MAP}
+                  name="SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP"
+                  config={github.SOCIAL_AUTH_GITHUB_ORG_TEAM_MAP}
                 />
                 {submitError && <FormSubmitError error={submitError} />}
               </FormColumnLayout>
@@ -138,4 +144,4 @@ function GitHubEdit() {
   );
 }
 
-export default GitHubEdit;
+export default GitHubOrgEdit;

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubOrgEdit/index.js
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubOrgEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from './GitHubOrgEdit';

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.jsx
@@ -19,14 +19,14 @@ import useModal from '../../../../util/useModal';
 import useRequest from '../../../../util/useRequest';
 import { SettingsAPI } from '../../../../api';
 
-function GitHubEdit() {
+function GitHubTeamEdit() {
   const history = useHistory();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
   const { isLoading, error, request: fetchGithub, result: github } = useRequest(
     useCallback(async () => {
-      const { data } = await SettingsAPI.readCategory('github');
+      const { data } = await SettingsAPI.readCategory('github-team');
       const mergedData = {};
       Object.keys(data).forEach(key => {
         if (!options[key]) {
@@ -48,7 +48,7 @@ function GitHubEdit() {
     useCallback(
       async values => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/details');
+        history.push('/settings/github/team/details');
       },
       [history]
     ),
@@ -58,10 +58,12 @@ function GitHubEdit() {
   const handleSubmit = async form => {
     await submitForm({
       ...form,
-      SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: formatJson(
-        form.SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP
+      SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP: formatJson(
+        form.SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP
       ),
-      SOCIAL_AUTH_GITHUB_TEAM_MAP: formatJson(form.SOCIAL_AUTH_GITHUB_TEAM_MAP),
+      SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP: formatJson(
+        form.SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP
+      ),
     });
   };
 
@@ -76,7 +78,7 @@ function GitHubEdit() {
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/details');
+    history.push('/settings/github/team/details');
   };
 
   const initialValues = fields =>
@@ -102,20 +104,24 @@ function GitHubEdit() {
             <Form autoComplete="off" onSubmit={formik.handleSubmit}>
               <FormColumnLayout>
                 <InputField
-                  name="SOCIAL_AUTH_GITHUB_KEY"
-                  config={github.SOCIAL_AUTH_GITHUB_KEY}
+                  name="SOCIAL_AUTH_GITHUB_TEAM_KEY"
+                  config={github.SOCIAL_AUTH_GITHUB_TEAM_KEY}
                 />
                 <EncryptedField
-                  name="SOCIAL_AUTH_GITHUB_SECRET"
-                  config={github.SOCIAL_AUTH_GITHUB_SECRET}
+                  name="SOCIAL_AUTH_GITHUB_TEAM_SECRET"
+                  config={github.SOCIAL_AUTH_GITHUB_TEAM_SECRET}
+                />
+                <InputField
+                  name="SOCIAL_AUTH_GITHUB_TEAM_ID"
+                  config={github.SOCIAL_AUTH_GITHUB_TEAM_ID}
                 />
                 <ObjectField
-                  name="SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP"
-                  config={github.SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP}
+                  name="SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP"
+                  config={github.SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP}
                 />
                 <ObjectField
-                  name="SOCIAL_AUTH_GITHUB_TEAM_MAP"
-                  config={github.SOCIAL_AUTH_GITHUB_TEAM_MAP}
+                  name="SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP"
+                  config={github.SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP}
                 />
                 {submitError && <FormSubmitError error={submitError} />}
               </FormColumnLayout>
@@ -138,4 +144,4 @@ function GitHubEdit() {
   );
 }
 
-export default GitHubEdit;
+export default GitHubTeamEdit;

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.test.jsx
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.test.jsx
@@ -8,25 +8,23 @@ import {
 import mockAllOptions from '../../shared/data.allSettingOptions.json';
 import { SettingsProvider } from '../../../../contexts/Settings';
 import { SettingsAPI } from '../../../../api';
-import GitHubEdit from './GitHubEdit';
+import GitHubTeamEdit from './GitHubTeamEdit';
 
 jest.mock('../../../../api/models/Settings');
 SettingsAPI.updateAll.mockResolvedValue({});
 SettingsAPI.readCategory.mockResolvedValue({
   data: {
-    SOCIAL_AUTH_GITHUB_CALLBACK_URL: 'https://foo/complete/github/',
-    SOCIAL_AUTH_GITHUB_KEY: 'mock github key',
-    SOCIAL_AUTH_GITHUB_SECRET: '$encrypted$',
-    SOCIAL_AUTH_GITHUB_TEAM_MAP: {},
-    SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: {
-      Default: {
-        users: true,
-      },
-    },
+    SOCIAL_AUTH_GITHUB_TEAM_CALLBACK_URL:
+      'https://towerhost/sso/complete/github-team/',
+    SOCIAL_AUTH_GITHUB_TEAM_KEY: 'OAuth2 key (Client ID)',
+    SOCIAL_AUTH_GITHUB_TEAM_SECRET: '$encrypted$',
+    SOCIAL_AUTH_GITHUB_TEAM_ID: 'team_id',
+    SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP: {},
+    SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP: {},
   },
 });
 
-describe('<GitHubEdit />', () => {
+describe('<GitHubTeamEdit />', () => {
   let wrapper;
   let history;
 
@@ -37,12 +35,12 @@ describe('<GitHubEdit />', () => {
 
   beforeEach(async () => {
     history = createMemoryHistory({
-      initialEntries: ['/settings/github/edit'],
+      initialEntries: ['/settings/github/team/edit'],
     });
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHubEdit />
+          <GitHubTeamEdit />
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -53,19 +51,23 @@ describe('<GitHubEdit />', () => {
   });
 
   test('initially renders without crashing', () => {
-    expect(wrapper.find('GitHubEdit').length).toBe(1);
+    expect(wrapper.find('GitHubTeamEdit').length).toBe(1);
   });
 
   test('should display expected form fields', async () => {
-    expect(wrapper.find('FormGroup[label="GitHub OAuth2 Key"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="GitHub OAuth2 Secret"]').length).toBe(
-      1
-    );
     expect(
-      wrapper.find('FormGroup[label="GitHub OAuth2 Organization Map"]').length
+      wrapper.find('FormGroup[label="GitHub Team OAuth2 Key"]').length
     ).toBe(1);
     expect(
-      wrapper.find('FormGroup[label="GitHub OAuth2 Team Map"]').length
+      wrapper.find('FormGroup[label="GitHub Team OAuth2 Secret"]').length
+    ).toBe(1);
+    expect(wrapper.find('FormGroup[label="GitHub Team ID"]').length).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="GitHub Team OAuth2 Organization Map"]')
+        .length
+    ).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="GitHub Team OAuth2 Team Map"]').length
     ).toBe(1);
   });
 
@@ -87,10 +89,11 @@ describe('<GitHubEdit />', () => {
     wrapper.update();
     expect(SettingsAPI.updateAll).toHaveBeenCalledTimes(1);
     expect(SettingsAPI.updateAll).toHaveBeenCalledWith({
-      SOCIAL_AUTH_GITHUB_KEY: '',
-      SOCIAL_AUTH_GITHUB_SECRET: '',
-      SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: null,
-      SOCIAL_AUTH_GITHUB_TEAM_MAP: null,
+      SOCIAL_AUTH_GITHUB_TEAM_KEY: '',
+      SOCIAL_AUTH_GITHUB_TEAM_SECRET: '',
+      SOCIAL_AUTH_GITHUB_TEAM_ID: '',
+      SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP: null,
+      SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP: null,
     });
   });
 
@@ -98,15 +101,15 @@ describe('<GitHubEdit />', () => {
     act(() => {
       wrapper
         .find(
-          'FormGroup[fieldId="SOCIAL_AUTH_GITHUB_SECRET"] button[aria-label="Revert"]'
+          'FormGroup[fieldId="SOCIAL_AUTH_GITHUB_TEAM_SECRET"] button[aria-label="Revert"]'
         )
         .invoke('onClick')();
-      wrapper.find('input#SOCIAL_AUTH_GITHUB_KEY').simulate('change', {
-        target: { value: 'new key', name: 'SOCIAL_AUTH_GITHUB_KEY' },
+      wrapper.find('input#SOCIAL_AUTH_GITHUB_TEAM_ID').simulate('change', {
+        target: { value: '12345', name: 'SOCIAL_AUTH_GITHUB_TEAM_ID' },
       });
       wrapper
-        .find('CodeMirrorInput#SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP')
-        .invoke('onChange')('{\n"Default":{\n"users":\nfalse\n}\n}');
+        .find('CodeMirrorInput#SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP')
+        .invoke('onChange')('{\n"Default":{\n"users":\ntrue\n}\n}');
     });
     wrapper.update();
     await act(async () => {
@@ -114,29 +117,30 @@ describe('<GitHubEdit />', () => {
     });
     expect(SettingsAPI.updateAll).toHaveBeenCalledTimes(1);
     expect(SettingsAPI.updateAll).toHaveBeenCalledWith({
-      SOCIAL_AUTH_GITHUB_KEY: 'new key',
-      SOCIAL_AUTH_GITHUB_SECRET: '',
-      SOCIAL_AUTH_GITHUB_TEAM_MAP: {},
-      SOCIAL_AUTH_GITHUB_ORGANIZATION_MAP: {
+      SOCIAL_AUTH_GITHUB_TEAM_KEY: 'OAuth2 key (Client ID)',
+      SOCIAL_AUTH_GITHUB_TEAM_SECRET: '',
+      SOCIAL_AUTH_GITHUB_TEAM_ID: '12345',
+      SOCIAL_AUTH_GITHUB_TEAM_TEAM_MAP: {},
+      SOCIAL_AUTH_GITHUB_TEAM_ORGANIZATION_MAP: {
         Default: {
-          users: false,
+          users: true,
         },
       },
     });
   });
 
-  test('should navigate to github default detail on successful submission', async () => {
+  test('should navigate to github team detail on successful submission', async () => {
     await act(async () => {
       wrapper.find('Form').invoke('onSubmit')();
     });
-    expect(history.location.pathname).toEqual('/settings/github/details');
+    expect(history.location.pathname).toEqual('/settings/github/team/details');
   });
 
-  test('should navigate to github default detail when cancel is clicked', async () => {
+  test('should navigate to github team detail when cancel is clicked', async () => {
     await act(async () => {
       wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
     });
-    expect(history.location.pathname).toEqual('/settings/github/details');
+    expect(history.location.pathname).toEqual('/settings/github/team/details');
   });
 
   test('should display error message on unsuccessful submission', async () => {
@@ -163,7 +167,7 @@ describe('<GitHubEdit />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHubEdit />
+          <GitHubTeamEdit />
         </SettingsProvider>
       );
     });

--- a/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/index.js
+++ b/awx/ui_next/src/screens/Setting/GitHub/GitHubTeamEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from './GitHubTeamEdit';

--- a/awx/ui_next/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx
+++ b/awx/ui_next/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx
@@ -78,6 +78,7 @@ function GoogleOAuth2Detail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/google_oauth2/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/Jobs/JobsDetail/JobsDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/Jobs/JobsDetail/JobsDetail.jsx
@@ -95,6 +95,7 @@ function JobsDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/jobs/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx
@@ -159,6 +159,7 @@ function LDAPDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to={`${baseURL}/${category}/edit`}
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/License/LicenseDetail/LicenseDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/License/LicenseDetail/LicenseDetail.jsx
@@ -13,6 +13,7 @@ function LicenseDetail({ i18n }) {
         <Button
           aria-label={i18n._(t`Edit`)}
           component={Link}
+          ouiaId="edit-button"
           to="/settings/license/edit"
         >
           {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx
@@ -99,6 +99,7 @@ function LoggingDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/logging/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/Logging/LoggingEdit/LoggingEdit.jsx
+++ b/awx/ui_next/src/screens/Setting/Logging/LoggingEdit/LoggingEdit.jsx
@@ -246,6 +246,7 @@ function LoggingEdit({ i18n }) {
                       <div>
                         <Button
                           aria-label={i18n._(t`Test logging`)}
+                          ouiaId="test-logging-button"
                           variant="secondary"
                           type="button"
                           onClick={handleTest}

--- a/awx/ui_next/src/screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx
@@ -140,6 +140,7 @@ function MiscSystemDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/miscellaneous_system/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx
@@ -78,6 +78,7 @@ function RADIUSDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/radius/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.jsx
@@ -78,6 +78,7 @@ function SAMLDetail({ i18n }) {
             <Button
               aria-label={i18n._(t`Edit`)}
               component={Link}
+              ouiaId="edit-button"
               to="/settings/saml/edit"
             >
               {i18n._(t`Edit`)}

--- a/awx/ui_next/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.jsx
@@ -79,6 +79,7 @@ function TACACSDetail({ i18n }) {
               aria-label={i18n._(t`Edit`)}
               component={Link}
               to="/settings/tacacs/edit"
+              ouiaId="edit-button"
             >
               {i18n._(t`Edit`)}
             </Button>

--- a/awx/ui_next/src/screens/Setting/UI/UIDetail/UIDetail.jsx
+++ b/awx/ui_next/src/screens/Setting/UI/UIDetail/UIDetail.jsx
@@ -94,6 +94,7 @@ function UIDetail({ i18n }) {
               aria-label={i18n._(t`Edit`)}
               component={Link}
               to="/settings/ui/edit"
+              ouiaId="edit-button"
             >
               {i18n._(t`Edit`)}
             </Button>

--- a/awx/ui_next/src/screens/Setting/shared/LoggingTestAlert.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/LoggingTestAlert.jsx
@@ -33,6 +33,7 @@ function LoggingTestAlert({ i18n, successResponse, errorResponse, onClose }) {
       {testMessage && (
         <Alert
           actionClose={<AlertActionCloseButton onClose={onClose} />}
+          ouiaId="logging-test-alert"
           title={successResponse ? i18n._(t`Success`) : i18n._(t`Error`)}
           variant={successResponse ? 'success' : 'danger'}
         >

--- a/awx/ui_next/src/screens/Setting/shared/RevertAllAlert.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/RevertAllAlert.jsx
@@ -11,12 +11,14 @@ function RevertAllAlert({ i18n, onClose, onRevertAll }) {
       title={i18n._(t`Revert settings`)}
       variant="info"
       onClose={onClose}
+      ouiaId="revert-all-modal"
       actions={[
         <Button
           key="revert"
           variant="primary"
           aria-label={i18n._(t`Confirm revert all`)}
           onClick={onRevertAll}
+          ouiaId="confirm-revert-all-button"
         >
           {i18n._(t`Revert all`)}
         </Button>,
@@ -25,6 +27,7 @@ function RevertAllAlert({ i18n, onClose, onRevertAll }) {
           variant="secondary"
           aria-label={i18n._(t`Cancel revert`)}
           onClick={onClose}
+          ouiaId="cancel-revert-all-button"
         >
           {i18n._(t`Cancel`)}
         </Button>,

--- a/awx/ui_next/src/screens/Setting/shared/RevertFormActionGroup.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/RevertFormActionGroup.jsx
@@ -20,6 +20,7 @@ const RevertFormActionGroup = ({
           variant="primary"
           type="button"
           onClick={onSubmit}
+          ouiaId="save-button"
         >
           {i18n._(t`Save`)}
         </Button>
@@ -28,6 +29,7 @@ const RevertFormActionGroup = ({
           variant="secondary"
           type="button"
           onClick={onRevert}
+          ouiaId="revert-all-button"
         >
           {i18n._(t`Revert all to default`)}
         </Button>
@@ -37,6 +39,7 @@ const RevertFormActionGroup = ({
           variant="secondary"
           type="button"
           onClick={onCancel}
+          ouiaId="cancel-button"
         >
           {i18n._(t`Cancel`)}
         </Button>

--- a/awx/ui_next/src/screens/Setting/shared/SharedFields.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/SharedFields.jsx
@@ -90,6 +90,7 @@ const BooleanField = withI18n()(
           labelOff={i18n._(t`Off`)}
           onChange={checked => helpers.setValue(checked)}
           aria-label={ariaLabel || config.label}
+          ouiaId={ariaLabel || config.label}
         />
       </SettingGroup>
     ) : null;


### PR DESCRIPTION
##### SUMMARY
Issue: #8288
This PR adds the following github category forms:
* Default `/settings/github/default/edit`
* Organization `/settings/github/organization/edit`
* Team `/settings/github/team/edit`
<img width="729" alt="Screen Shot 2020-12-04 at 3 55 47 PM" src="https://user-images.githubusercontent.com/15881645/101214524-2881b100-364a-11eb-8c92-ae7d93db15a6.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
