### PR TITLE
NodeJS: Bump to actively maintained LTS 14.15.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ Before you can run a deployment, you'll need the following installed in your loc
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Git](https://git-scm.com/) Requires Version 1.8.4+
 - Python 3.6+
-- [Node 10.x LTS version](https://nodejs.org/en/download/)
+- [Node 14.x LTS version](https://nodejs.org/en/download/)
     + This is only required if you're [building your own container images](#official-vs-building-images) with `use_container_for_build=false`
 - [NPM 6.x LTS](https://docs.npmjs.com/)
     + This is only required if you're [building your own container images](#official-vs-building-images) with `use_container_for_build=false`

--- a/awx/ui_next/Dockerfile
+++ b/awx/ui_next/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 ARG NPMRC_FILE=.npmrc
 ENV NPMRC_FILE=${NPMRC_FILE}
 ARG TARGET='https://awx:8043'

--- a/awx/ui_next/package.json
+++ b/awx/ui_next/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "10.x"
+    "node": "14.x"
   },
   "dependencies": {
     "@lingui/react": "^2.9.1",

--- a/installer/roles/image_build/files/Dockerfile.sdist
+++ b/installer/roles/image_build/files/Dockerfile.sdist
@@ -11,9 +11,9 @@ RUN dnf -y update && dnf -y install epel-release && \
     python3-setuptools
 
 # Use the distro provided npm to bootstrap our required version of node
-RUN npm install -g n && n 10.15.0 && dnf remove -y nodejs
+RUN npm install -g n && n 14.15.1 && dnf remove -y nodejs
 
-ENV PATH=/usr/local/n/versions/node/10.15.0/bin:$PATH
+ENV PATH=/usr/local/n/versions/node/14.15.1/bin:$PATH
 
 WORKDIR "/awx"
 

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -109,7 +109,7 @@ RUN dnf -y install \
     wget \
     diffutils \
     unzip && \
-    npm install -g n && n 10.15.0 && dnf remove -y nodejs
+    npm install -g n && n 14.15.1 && dnf remove -y nodejs
 {% endif %}
 
 # Install runtime requirements


### PR DESCRIPTION
##### SUMMARY

This change aims to bump the version of NodeJS being used in the `ansible/awx` project.

Current version used, NodeJS 10 is soon getting to EOL.

![Screenshot_2020-12-07 Releases Node js](https://user-images.githubusercontent.com/1191411/101333473-f1dcae00-3876-11eb-850b-a19fb9459f0f.png)

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

 - UI

##### AWX VERSION

 - devel


##### ADDITIONAL INFORMATION

  - N/A
