### PR TITLE
Make insights integration tests pass again

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1879,6 +1879,19 @@ class RunJob(BaseTask):
             return False
         return getattr(settings, 'AWX_PROOT_ENABLED', False)
 
+    def build_execution_environment_params(self, instance):
+        params = super(RunJob, self).build_execution_environment_params(instance)
+        # If this has an insights agent and it is not already mounted then show it
+        insights_dir = os.path.dirname(settings.INSIGHTS_SYSTEM_ID_FILE)
+        if instance.use_fact_cache and os.path.exists(insights_dir):
+            logger.info('not parent of others')
+            params.setdefault('container_volume_mounts', [])
+            params['container_volume_mounts'].extend([
+                f"{insights_dir}:{insights_dir}:Z",
+            ])
+
+        return params
+
     def pre_run_hook(self, job, private_data_dir):
         if job.inventory is None:
             error = _('Job could not start because it does not have a valid inventory.')

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -760,6 +760,8 @@ TOWER_URL_BASE = "https://towerhost"
 
 INSIGHTS_URL_BASE = "https://example.org"
 INSIGHTS_AGENT_MIME = 'application/example'
+# See https://github.com/ansible/awx-facts-playbooks
+INSIGHTS_SYSTEM_ID_FILE='/etc/redhat-access-insights/machine-id'
 
 TOWER_SETTINGS_MANIFEST = {}
 


### PR DESCRIPTION
This will come with a documentation note that the agent will need to be installed on both the node in the control plane and the node in the execution plane... just install the agent on all your nodes, okay?