### PR TITLE
Aggregate quantity per sub allocation, not exported

### DIFF
--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -183,10 +183,7 @@ class Licenser(object):
             currentEndDate = datetime.fromtimestamp(int(currentEndDateStr), timezone.utc)
             if endDate < currentEndDate:
                 license['license_date'] = endDate.strftime('%s')
-            try:
-                instances = sub['pool']['exported']
-            except KeyError:
-                instances = sub['pool']['quantity']
+            instances = sub['quantity']
             license['instance_count'] = license.get('instance_count', 0) + instances
             license['subscription_name'] = re.sub(r'[\d]* Managed Nodes', '%d Managed Nodes' % license['instance_count'], license['subscription_name'])
 


### PR DESCRIPTION
  * The exported field shows total quantity exported to a manifest for a given sub.  We want to sum the quantities of each sub allocation in a manifest instead.

##### SUMMARY
Correct issue in aggregating subscription quantity.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

