### PR TITLE
Show WFJT notification list approval toggle 

### DIFF
--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
@@ -210,6 +210,7 @@ function WorkflowJobTemplate({ i18n, me, setBreadcrumb }) {
                 id={Number(templateId)}
                 canToggleNotifications={isNotifAdmin}
                 apiModel={WorkflowJobTemplatesAPI}
+                showApprovalsToggle
               />
             </Route>
           )}


### PR DESCRIPTION
##### SUMMARY
Issue #8699
* Pass a flag to show the approval toggle when we render the workflow job template notifications list
* Add a test that checks that the expected toggles are rendered in workflow job template notifications 

<img width="741" alt="Screen Shot 2020-12-09 at 3 33 26 PM" src="https://user-images.githubusercontent.com/15881645/101684269-234ea880-3a34-11eb-8ecc-bd6e9bae31bb.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
