### PR TITLE
Removes the "path" property when using ClusterIP as the service type.…

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -554,10 +554,12 @@ spec:
   - host: {{ kubernetes_ingress_hostname }}
     http:
       paths:
-      - path: /
-        backend:
+      - backend:
           serviceName: {{ kubernetes_deployment_name }}-web-svc
           servicePort: 80
+{% if kubernetes_web_svc_type != "ClusterIP" %}
+        path: /
+{% endif %}
 {% else %}
   backend:
     serviceName: {{ kubernetes_deployment_name }}-web-svc


### PR DESCRIPTION
…  This allows the LoadBalancer to forward all calls (such as JS, CSS) to make it to the web service.

##### SUMMARY
Adds a condition to check if the `kubernetes_web_svc_type` variable is set to `ClusterIP`.  If it is set to this it will not write the `path` property on the deployment.  This fixes an issue we were facing where the ingress was serving the landing page of AWX but not serving any of the JavaScript, CSS, or any "child" file/path.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
awx: 15.0.1
```


##### ADDITIONAL INFORMATION

1. When deploying set the `kubernetes_web_svc_type` to ClusterIP.
2. Run the playbook.
2. Attempt to load the AWX landing page.
3. Only the landing page comes down, all other requests return a 503.
4. Apply patch.
5. Run the playbook again.
