### PR TITLE
log galaxy token message as warning

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2163,7 +2163,7 @@ class RunProjectUpdate(BaseTask):
         if not galaxy_creds_are_defined and (
             settings.AWX_ROLES_ENABLED or settings.AWX_COLLECTIONS_ENABLED
         ):
-            logger.debug(
+            logger.warning(
                 'Galaxy role/collection syncing is enabled, but no '
                 f'credentials are configured for {project_update.project.organization}.'
             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Some users leave the default logging level which does not expose if they've not configured an org level galaxy credential.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION 
awx: 15.0.1

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
