### PR TITLE
Improve the behavior of EE resolution for ad hoc commands

### DIFF
--- a/awx/main/models/ad_hoc_commands.py
+++ b/awx/main/models/ad_hoc_commands.py
@@ -209,6 +209,9 @@ class AdHocCommand(UnifiedJob, JobNotificationMixin):
             self.name = Truncator(u': '.join(filter(None, (self.module_name, self.module_args)))).chars(512)
             if 'name' not in update_fields:
                 update_fields.append('name')
+        if not self.execution_environment_id:
+            self.execution_environment = self.resolve_execution_environment()
+            update_fields.append('execution_environment')
         super(AdHocCommand, self).save(*args, **kwargs)
 
     @property

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -882,8 +882,11 @@ class BaseTask(object):
 
     def build_execution_environment_params(self, instance):
         if instance.execution_environment_id is None:
-            self.instance = instance = self.update_model(
-                instance.pk, execution_environment=instance.resolve_execution_environment())
+            from awx.main.signals import disable_activity_stream
+
+            with disable_activity_stream():
+                self.instance = instance = self.update_model(
+                    instance.pk, execution_environment=instance.resolve_execution_environment())
 
         image = instance.execution_environment.image
         params = {


### PR DESCRIPTION
##### SUMMARY
- call resolve_execution_environment during AdHocCommand.save()
- wrap the fallback call of the resolver in tasks.py in disable_activity_stream()

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 16.0.0
```