### PR TITLE
Wrap functions in useCallback to avoid extra requests

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventorySource/InventorySource.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySource/InventorySource.jsx
@@ -62,14 +62,19 @@ function InventorySource({ i18n, inventory, setBreadcrumb, me }) {
     }
   }, [inventory, source, setBreadcrumb]);
 
-  const loadSchedules = params =>
-    InventorySourcesAPI.readSchedules(source?.id, params);
+  const loadSchedules = useCallback(
+    params => {
+      return InventorySourcesAPI.readSchedules(source?.id, params);
+    },
+    [source]
+  );
 
   const createSchedule = data =>
     InventorySourcesAPI.createSchedule(source?.id, data);
 
-  const loadScheduleOptions = () =>
-    InventorySourcesAPI.readScheduleOptions(source?.id);
+  const loadScheduleOptions = useCallback(() => {
+    return InventorySourcesAPI.readScheduleOptions(source?.id);
+  }, [source]);
 
   const tabsArray = [
     {

--- a/awx/ui_next/src/screens/Project/Project.jsx
+++ b/awx/ui_next/src/screens/Project/Project.jsx
@@ -69,13 +69,16 @@ function Project({ i18n, setBreadcrumb }) {
     return ProjectsAPI.createSchedule(project.id, data);
   }
 
-  function loadScheduleOptions() {
+  const loadScheduleOptions = useCallback(() => {
     return ProjectsAPI.readScheduleOptions(project.id);
-  }
+  }, [project]);
 
-  function loadSchedules(params) {
-    return ProjectsAPI.readSchedules(project.id, params);
-  }
+  const loadSchedules = useCallback(
+    params => {
+      return ProjectsAPI.readSchedules(project.id, params);
+    },
+    [project]
+  );
 
   const canSeeNotificationsTab = me.is_system_auditor || isNotifAdmin;
   const canToggleNotifications = isNotifAdmin;

--- a/awx/ui_next/src/screens/Schedule/AllSchedules.jsx
+++ b/awx/ui_next/src/screens/Schedule/AllSchedules.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
@@ -9,13 +9,13 @@ import { ScheduleList } from '../../components/Schedule';
 import { SchedulesAPI } from '../../api';
 
 function AllSchedules({ i18n }) {
-  const loadScheduleOptions = () => {
+  const loadScheduleOptions = useCallback(() => {
     return SchedulesAPI.readOptions();
-  };
+  }, []);
 
-  const loadSchedules = params => {
+  const loadSchedules = useCallback(params => {
     return SchedulesAPI.read(params);
-  };
+  }, []);
 
   return (
     <>

--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -71,13 +71,16 @@ function Template({ i18n, me, setBreadcrumb }) {
     return JobTemplatesAPI.createSchedule(templateId, data);
   };
 
-  const loadScheduleOptions = () => {
+  const loadScheduleOptions = useCallback(() => {
     return JobTemplatesAPI.readScheduleOptions(templateId);
-  };
+  }, [templateId]);
 
-  const loadSchedules = params => {
-    return JobTemplatesAPI.readSchedules(templateId, params);
-  };
+  const loadSchedules = useCallback(
+    params => {
+      return JobTemplatesAPI.readSchedules(templateId, params);
+    },
+    [templateId]
+  );
 
   const canSeeNotificationsTab = me.is_system_auditor || isNotifAdmin;
   const canAddAndEditSurvey =

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
@@ -74,13 +74,16 @@ function WorkflowJobTemplate({ i18n, me, setBreadcrumb }) {
     return WorkflowJobTemplatesAPI.createSchedule(templateId, data);
   };
 
-  const loadScheduleOptions = () => {
+  const loadScheduleOptions = useCallback(() => {
     return WorkflowJobTemplatesAPI.readScheduleOptions(templateId);
-  };
+  }, [templateId]);
 
-  const loadSchedules = params => {
-    return WorkflowJobTemplatesAPI.readSchedules(templateId, params);
-  };
+  const loadSchedules = useCallback(
+    params => {
+      return WorkflowJobTemplatesAPI.readSchedules(templateId, params);
+    },
+    [templateId]
+  );
 
   const canSeeNotificationsTab = me.is_system_auditor || isNotifAdmin;
   const canAddAndEditSurvey =


### PR DESCRIPTION
Wrap functions in useCallback to avoid extra requests.

`make ui-devel` I noticed a few extra requests with the build.

with useCallback.

![image](https://user-images.githubusercontent.com/9053044/101927519-97a75a00-3ba2-11eb-86e8-903c634280ef.png)

without useCallback.

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/9053044/101928230-53688980-3ba3-11eb-8b91-30e9c0f0f897.png">









