### PR TITLE
Related #5080 openstack region field missing

### DIFF
--- a/awx/locale/django.pot
+++ b/awx/locale/django.pot
@@ -3355,6 +3355,15 @@ msgid ""
 msgstr ""
 
 #: awx/main/models/credential/__init__.py:824
+msgid "Region Name"
+msgstr ""
+
+#: awx/main/models/credential/__init__.py:826
+msgid ""
+"For some cloud providers, like OVH, region must be specified."
+msgstr ""
+
+#: awx/main/models/credential/__init__.py:824
 #: awx/main/models/credential/__init__.py:1131
 #: awx/main/models/credential/__init__.py:1166
 msgid "Verify SSL"

--- a/awx/locale/en-us/LC_MESSAGES/django.po
+++ b/awx/locale/en-us/LC_MESSAGES/django.po
@@ -3355,6 +3355,15 @@ msgid ""
 msgstr ""
 
 #: awx/main/models/credential/__init__.py:824
+msgid "Region Name"
+msgstr ""
+
+#: awx/main/models/credential/__init__.py:826
+msgid ""
+"For some cloud providers, like OVH, region must be specified."
+msgstr ""
+
+#: awx/main/models/credential/__init__.py:824
 #: awx/main/models/credential/__init__.py:1131
 #: awx/main/models/credential/__init__.py:1166
 msgid "Verify SSL"

--- a/awx/locale/fr/LC_MESSAGES/django.po
+++ b/awx/locale/fr/LC_MESSAGES/django.po
@@ -3294,6 +3294,16 @@ msgid ""
 "common scenarios."
 msgstr "Les domaines OpenStack définissent les limites administratives. Ils sont nécessaires uniquement pour les URL d’authentification Keystone v3. Voir la documentation Ansible Tower pour les scénarios courants."
 
+#: awx/main/models/credential/__init__.py:824
+msgid "Region Name"
+msgstr "Nom de la region"
+
+#: awx/main/models/credential/__init__.py:826
+msgid ""
+"For some cloud providers, like OVH, region must be specified."
+msgstr ""
+"Chez certains fournisseurs, comme OVH, vous devez spécifier le nom de la région"
+
 #: awx/main/models/credential/__init__.py:812
 #: awx/main/models/credential/__init__.py:1110
 #: awx/main/models/credential/__init__.py:1144

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -820,6 +820,11 @@ ManagedCredentialType(
                                        'URLs. Refer to Ansible Tower documentation for '
                                        'common scenarios.')
         }, {
+            'id': 'region',
+            'label': ugettext_noop('Region Name'),
+            'type': 'string',
+            'help_text': ugettext_noop('For some cloud providers, like OVH, region must be specified'),
+        }, {
             'id': 'verify_ssl',
             'label': ugettext_noop('Verify SSL'),
             'type': 'boolean',

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -83,17 +83,6 @@ def _openstack_data(cred):
         openstack_auth['domain_name'] = cred.get_input('domain', default='')
     verify_state = cred.get_input('verify_ssl', default=True)
 
-#    if cred.has_input('project_region_name'):
-#        openstack_data = {
-#            'clouds': {
-#                'devstack': {
-#                    'auth': openstack_auth,
-#                    'verify': verify_state,
-#                    'region_name': cred.get_input('project_region_name', default='')
-#                },
-#            },
-#        }
-#    else:
     openstack_data = {
         'clouds': {
             'devstack': {

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -87,7 +87,7 @@ def _openstack_data(cred):
         'clouds': {
             'devstack': {
                 'auth': openstack_auth,
-                'verify': verify_state
+                'verify': verify_state,
             },
         },
     }

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -82,14 +82,30 @@ def _openstack_data(cred):
     if cred.has_input('domain'):
         openstack_auth['domain_name'] = cred.get_input('domain', default='')
     verify_state = cred.get_input('verify_ssl', default=True)
+
+#    if cred.has_input('project_region_name'):
+#        openstack_data = {
+#            'clouds': {
+#                'devstack': {
+#                    'auth': openstack_auth,
+#                    'verify': verify_state,
+#                    'region_name': cred.get_input('project_region_name', default='')
+#                },
+#            },
+#        }
+#    else:
     openstack_data = {
         'clouds': {
             'devstack': {
                 'auth': openstack_auth,
-                'verify': verify_state,
+                'verify': verify_state
             },
         },
     }
+
+    if cred.has_input('project_region_name'):
+        openstack_data['clouds']['devstack']['region_name'] = cred.get_input('project_region_name', default='')
+
     return openstack_data
 
 

--- a/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
+++ b/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
@@ -9,4 +9,3 @@ clouds:
       username: fooo
     private: true
     verify: false
-    region_name: fooo

--- a/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
+++ b/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
@@ -9,3 +9,4 @@ clouds:
       username: fooo
     private: true
     verify: false
+    region_name: fooo

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -247,6 +247,52 @@ def test_openstack_client_config_generation_with_project_domain_name(mocker, sou
 
 
 @pytest.mark.parametrize("source,expected", [
+    (None, True), (False, False), (True, True)
+])
+def test_openstack_client_config_generation_with_project_region_name(mocker, source, expected, private_data_dir):
+    update = tasks.RunInventoryUpdate()
+    credential_type = CredentialType.defaults['openstack']()
+    inputs = {
+        'host': 'https://keystone.openstack.example.org',
+        'username': 'demo',
+        'password': 'secrete',
+        'project': 'demo-project',
+        'domain': 'my-demo-domain',
+        'project_domain_name': 'project-domain',
+        'project_region_name': 'region-name',
+    }
+    if source is not None:
+        inputs['verify_ssl'] = source
+    credential = Credential(pk=1, credential_type=credential_type, inputs=inputs)
+
+    inventory_update = mocker.Mock(**{
+        'source': 'openstack',
+        'source_vars_dict': {}, 
+        'get_cloud_credential': mocker.Mock(return_value=credential),
+        'get_extra_credentials': lambda x: [],
+        'ansible_virtualenv_path': '/venv/foo'
+    })
+    cloud_config = update.build_private_data(inventory_update, private_data_dir)
+    cloud_credential = yaml.safe_load(
+        cloud_config.get('credentials')[credential]
+    )
+    assert cloud_credential['clouds'] == {
+        'devstack': {
+            'auth': {
+                'auth_url': 'https://keystone.openstack.example.org',
+                'password': 'secrete',
+                'project_name': 'demo-project',
+                'username': 'demo',
+                'domain_name': 'my-demo-domain',
+                'project_domain_name': 'project-domain',
+            },
+            'verify': expected,
+            'private': True,
+            'region_name': 'region-name',
+        }
+    }
+
+@pytest.mark.parametrize("source,expected", [
     (False, False), (True, True)
 ])
 def test_openstack_client_config_generation_with_private_source_vars(mocker, source, expected, private_data_dir):

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -292,6 +292,7 @@ def test_openstack_client_config_generation_with_project_region_name(mocker, sou
         }
     }
 
+
 @pytest.mark.parametrize("source,expected", [
     (False, False), (True, True)
 ])

--- a/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
+++ b/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
@@ -276,6 +276,11 @@
           "help_text": "OpenStack domains define administrative boundaries. It is only needed for Keystone v3 authentication URLs. Refer to Ansible Tower documentation for common scenarios."
         },
         {
+          "id": "project_region_name",
+          "label": "Region Name",
+          "type": "string"
+        },
+        {
           "id": "verify_ssl",
           "label": "Verify SSL",
           "type": "boolean",


### PR DESCRIPTION
##### SUMMARY

- Add a 'Region Name' textfield for OpenStack credentials, as mentionned by [ansible-collections-openstack](https://github.com/openstack/ansible-collections-openstack/blob/8255ec4c80f186aa7851f023b85007a593b6f42f/scripts/inventory/openstack.yml#L14)
- Set English and French locales
- Add one specific test (test_openstack_client_config_generation_with_project_region_name)



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 16.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ make test && make ui-test-ci && echo "OK"
make: Nothing to be done for 'ui-test-ci'.
OK

```
