### PR TITLE
Use credential_type for multicred distinction

### DIFF
--- a/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.jsx
@@ -194,9 +194,10 @@ function MultiCredentialsLookup(props) {
                 const hasSameVaultID = val =>
                   val?.inputs?.vault_id !== undefined &&
                   val?.inputs?.vault_id === item?.inputs?.vault_id;
-                const hasSameKind = val => val.kind === item.kind;
+                const hasSameCredentialType = val =>
+                  val.credential_type === item.credential_type;
                 const selectedItems = state.selectedItems.filter(i =>
-                  isVault ? !hasSameVaultID(i) : !hasSameKind(i)
+                  isVault ? !hasSameVaultID(i) : !hasSameCredentialType(i)
                 );
                 selectedItems.push(item);
                 return dispatch({

--- a/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
@@ -13,11 +13,29 @@ describe('<MultiCredentialsLookup />', () => {
   let wrapper;
 
   const credentials = [
-    { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-    { id: 2, kind: 'ssh', name: 'Alex', url: 'www.google.com' },
-    { name: 'Gatsby', id: 21, kind: 'vault', inputs: { vault_id: '1' } },
-    { name: 'Gatsby 2', id: 23, kind: 'vault' },
-    { name: 'Gatsby', id: 8, kind: 'Machine' },
+    {
+      id: 1,
+      credential_type: 1,
+      kind: 'gce',
+      name: 'Foo',
+      url: 'www.google.com',
+    },
+    {
+      id: 2,
+      credential_type: 2,
+      kind: 'ssh',
+      name: 'Alex',
+      url: 'www.google.com',
+    },
+    {
+      id: 21,
+      credential_type: 3,
+      kind: 'vault',
+      inputs: { vault_id: '1' },
+      name: 'Gatsby',
+    },
+    { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+    { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
   ];
 
   beforeEach(() => {
@@ -34,11 +52,41 @@ describe('<MultiCredentialsLookup />', () => {
     CredentialsAPI.read.mockResolvedValueOnce({
       data: {
         results: [
-          { id: 1, kind: 'cloud', name: 'Cred 1', url: 'www.google.com' },
-          { id: 2, kind: 'ssh', name: 'Cred 2', url: 'www.google.com' },
-          { id: 3, kind: 'Ansible', name: 'Cred 3', url: 'www.google.com' },
-          { id: 4, kind: 'Machine', name: 'Cred 4', url: 'www.google.com' },
-          { id: 5, kind: 'Machine', name: 'Cred 5', url: 'www.google.com' },
+          {
+            id: 1,
+            credential_type: 1,
+            kind: 'gc2',
+            name: 'Cred 1',
+            url: 'www.google.com',
+          },
+          {
+            id: 2,
+            credential_type: 2,
+            kind: 'ssh',
+            name: 'Cred 2',
+            url: 'www.google.com',
+          },
+          {
+            id: 3,
+            credential_type: 5,
+            kind: 'Ansible',
+            name: 'Cred 3',
+            url: 'www.google.com',
+          },
+          {
+            id: 4,
+            credential_type: 4,
+            kind: 'Machine',
+            name: 'Cred 4',
+            url: 'www.google.com',
+          },
+          {
+            id: 5,
+            credential_type: 4,
+            kind: 'Machine',
+            name: 'Cred 5',
+            url: 'www.google.com',
+          },
         ],
         count: 3,
       },
@@ -95,10 +143,22 @@ describe('<MultiCredentialsLookup />', () => {
       button.invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
-      { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-      { id: 21, inputs: { vault_id: '1' }, kind: 'vault', name: 'Gatsby' },
-      { id: 23, kind: 'vault', name: 'Gatsby 2' },
-      { id: 8, kind: 'Machine', name: 'Gatsby' },
+      {
+        id: 1,
+        credential_type: 1,
+        kind: 'gce',
+        name: 'Foo',
+        url: 'www.google.com',
+      },
+      {
+        id: 21,
+        credential_type: 3,
+        kind: 'vault',
+        inputs: { vault_id: '1' },
+        name: 'Gatsby',
+      },
+      { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+      { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
     ]);
   });
 
@@ -165,6 +225,7 @@ describe('<MultiCredentialsLookup />', () => {
     act(() => {
       optionsList.invoke('selectItem')({
         id: 5,
+        credential_type: 4,
         kind: 'Machine',
         name: 'Cred 5',
         url: 'www.google.com',
@@ -175,11 +236,35 @@ describe('<MultiCredentialsLookup />', () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
-      { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-      { id: 2, kind: 'ssh', name: 'Alex', url: 'www.google.com' },
-      { id: 21, inputs: { vault_id: '1' }, kind: 'vault', name: 'Gatsby' },
-      { id: 23, kind: 'vault', name: 'Gatsby 2' },
-      { id: 5, kind: 'Machine', name: 'Cred 5', url: 'www.google.com' },
+      {
+        id: 1,
+        credential_type: 1,
+        kind: 'gce',
+        name: 'Foo',
+        url: 'www.google.com',
+      },
+      {
+        id: 2,
+        credential_type: 2,
+        kind: 'ssh',
+        name: 'Alex',
+        url: 'www.google.com',
+      },
+      {
+        id: 21,
+        credential_type: 3,
+        kind: 'vault',
+        inputs: { vault_id: '1' },
+        name: 'Gatsby',
+      },
+      { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+      {
+        id: 5,
+        credential_type: 4,
+        kind: 'Machine',
+        name: 'Cred 5',
+        url: 'www.google.com',
+      },
     ]);
   });
 
@@ -212,10 +297,10 @@ describe('<MultiCredentialsLookup />', () => {
     expect(optionsList.prop('multiple')).toEqual(true);
     act(() => {
       optionsList.invoke('selectItem')({
-        id: 5,
+        id: 11,
+        credential_type: 3,
         kind: 'vault',
-        name: 'Cred 5',
-        url: 'www.google.com',
+        name: 'Vault',
       });
     });
     wrapper.update();
@@ -223,12 +308,30 @@ describe('<MultiCredentialsLookup />', () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
-      { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-      { id: 2, kind: 'ssh', name: 'Alex', url: 'www.google.com' },
-      { id: 21, kind: 'vault', name: 'Gatsby', inputs: { vault_id: '1' } },
-      { id: 23, kind: 'vault', name: 'Gatsby 2' },
-      { id: 8, kind: 'Machine', name: 'Gatsby' },
-      { id: 5, kind: 'vault', name: 'Cred 5', url: 'www.google.com' },
+      {
+        id: 1,
+        credential_type: 1,
+        kind: 'gce',
+        name: 'Foo',
+        url: 'www.google.com',
+      },
+      {
+        id: 2,
+        credential_type: 2,
+        kind: 'ssh',
+        name: 'Alex',
+        url: 'www.google.com',
+      },
+      {
+        id: 21,
+        credential_type: 3,
+        kind: 'vault',
+        inputs: { vault_id: '1' },
+        name: 'Gatsby',
+      },
+      { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+      { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
+      { id: 11, credential_type: 3, kind: 'vault', name: 'Vault' },
     ]);
   });
 
@@ -261,11 +364,11 @@ describe('<MultiCredentialsLookup />', () => {
     expect(optionsList.prop('multiple')).toEqual(true);
     act(() => {
       optionsList.invoke('selectItem')({
-        id: 5,
+        id: 12,
+        credential_type: 3,
         kind: 'vault',
-        name: 'Cred 5',
-        url: 'www.google.com',
-        inputs: { vault_id: '2' },
+        name: 'Other Vault',
+        vault_id: '2',
       });
     });
     wrapper.update();
@@ -273,17 +376,35 @@ describe('<MultiCredentialsLookup />', () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
-      { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-      { id: 2, kind: 'ssh', name: 'Alex', url: 'www.google.com' },
-      { id: 21, kind: 'vault', name: 'Gatsby', inputs: { vault_id: '1' } },
-      { id: 23, kind: 'vault', name: 'Gatsby 2' },
-      { id: 8, kind: 'Machine', name: 'Gatsby' },
       {
-        id: 5,
-        kind: 'vault',
-        name: 'Cred 5',
+        id: 1,
+        credential_type: 1,
+        kind: 'gce',
+        name: 'Foo',
         url: 'www.google.com',
-        inputs: { vault_id: '2' },
+      },
+      {
+        id: 2,
+        credential_type: 2,
+        kind: 'ssh',
+        name: 'Alex',
+        url: 'www.google.com',
+      },
+      {
+        id: 21,
+        credential_type: 3,
+        kind: 'vault',
+        inputs: { vault_id: '1' },
+        name: 'Gatsby',
+      },
+      { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+      { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
+      {
+        id: 12,
+        credential_type: 3,
+        kind: 'vault',
+        name: 'Other Vault',
+        vault_id: '2',
       },
     ]);
   });
@@ -317,10 +438,10 @@ describe('<MultiCredentialsLookup />', () => {
     expect(optionsList.prop('multiple')).toEqual(true);
     act(() => {
       optionsList.invoke('selectItem')({
-        id: 24,
+        id: 13,
+        credential_type: 3,
         kind: 'vault',
-        name: 'Cred 5',
-        url: 'www.google.com',
+        name: 'Vault Cred with Same Vault Id',
         inputs: { vault_id: '1' },
       });
     });
@@ -329,15 +450,27 @@ describe('<MultiCredentialsLookup />', () => {
       wrapper.find('Button[variant="primary"]').invoke('onClick')();
     });
     expect(onChange).toBeCalledWith([
-      { id: 1, kind: 'cloud', name: 'Foo', url: 'www.google.com' },
-      { id: 2, kind: 'ssh', name: 'Alex', url: 'www.google.com' },
-      { id: 23, kind: 'vault', name: 'Gatsby 2' },
-      { id: 8, kind: 'Machine', name: 'Gatsby' },
       {
-        id: 24,
-        kind: 'vault',
-        name: 'Cred 5',
+        id: 1,
+        credential_type: 1,
+        kind: 'gce',
+        name: 'Foo',
         url: 'www.google.com',
+      },
+      {
+        id: 2,
+        credential_type: 2,
+        kind: 'ssh',
+        name: 'Alex',
+        url: 'www.google.com',
+      },
+      { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
+      { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
+      {
+        id: 13,
+        credential_type: 3,
+        kind: 'vault',
+        name: 'Vault Cred with Same Vault Id',
         inputs: { vault_id: '1' },
       },
     ]);


### PR DESCRIPTION
##### SUMMARY
for #8878 

For cred multiselect, we want to distinguish between selectable types using the `credential_type` id, not `kind`. The `kind` field is deprecated and less granular. 