### PR TITLE
 Make display type unique for different job types and consistent between job list and details

### DIFF
--- a/awx/ui_next/src/components/JobList/JobListItem.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.jsx
@@ -39,7 +39,7 @@ function JobListItem({
     project_update: i18n._(t`Source Control Update`),
     inventory_update: i18n._(t`Inventory Sync`),
     job: i18n._(t`Playbook Run`),
-    command: i18n._(t`Command`),
+    ad_hoc_command: i18n._(t`Command`),
     management_job: i18n._(t`Management Job`),
     workflow_job: i18n._(t`Workflow Job`),
   };

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -92,6 +92,15 @@ function JobDetail({ job, i18n }) {
   const [errorMsg, setErrorMsg] = useState();
   const history = useHistory();
 
+  const jobTypes = {
+    project_update: i18n._(t`Source Control Update`),
+    inventory_update: i18n._(t`Inventory Sync`),
+    job: i18n._(t`Playbook Run`),
+    ad_hoc_command: i18n._(t`Command`),
+    management_job: i18n._(t`Management Job`),
+    workflow_job: i18n._(t`Workflow Job`),
+  };
+
   const { value: launchedByValue, link: launchedByLink } =
     getLaunchedByDetails(job) || {};
 
@@ -181,7 +190,7 @@ function JobDetail({ job, i18n }) {
             }
           />
         )}
-        <Detail label={i18n._(t`Job Type`)} value={toTitleCase(job.type)} />
+        <Detail label={i18n._(t`Job Type`)} value={jobTypes[job.type]} />
         <Detail
           label={i18n._(t`Launched By`)}
           value={

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -181,7 +181,7 @@ function JobDetail({ job, i18n }) {
             }
           />
         )}
-        <Detail label={i18n._(t`Job Type`)} value={toTitleCase(job.job_type)} />
+        <Detail label={i18n._(t`Job Type`)} value={toTitleCase(job.type)} />
         <Detail
           label={i18n._(t`Launched By`)}
           value={

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -45,7 +45,7 @@ describe('<JobDetail />', () => {
     assertDetail('Started', '8/8/2019, 7:24:18 PM');
     assertDetail('Finished', '8/8/2019, 7:24:50 PM');
     assertDetail('Job Template', mockJobData.summary_fields.job_template.name);
-    assertDetail('Job Type', 'Run');
+    assertDetail('Job Type', 'Playbook Run');
     assertDetail('Launched By', mockJobData.summary_fields.created_by.username);
     assertDetail('Inventory', mockJobData.summary_fields.inventory.name);
     assertDetail(


### PR DESCRIPTION
##### SUMMARY
for #8856 

Make display type unique for different job types and consistent between job list and details:

- Fix key for adhoc command display type in job list item
- Use `type` field as key for job display type on job details
- Match displayed type text for job list and details
