### PR TITLE
extensions/v1beta1 has been deprecated

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -536,7 +536,7 @@ spec:
 
 {% if kubernetes_context is defined %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ kubernetes_deployment_name }}-web-svc


### PR DESCRIPTION
##### SUMMARY
extensions/v1beta1 has been deprecated and removed in version 1.16 in favour of networking.k8s.io/v1beta1

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
release 16.0.0

##### ADDITIONAL INFORMATION
getting the below error message when running ansible-playbook -i inventory install.yml     

```
 Internal error occurred: failed calling webhook \"validate.nginx.ingress.kubernetes.io\": an error on the server (\"\") has prevented the request from succeeding"]
```