### PR TITLE
Flip the instance ID var for AWS to `instance_id`

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -662,7 +662,7 @@ INV_ENV_VARIABLE_BLOCKED = ("HOME", "USER", "_", "TERM")
 # ----------------
 EC2_ENABLED_VAR = 'ec2_state'
 EC2_ENABLED_VALUE = 'running'
-EC2_INSTANCE_ID_VAR = 'ec2_id'
+EC2_INSTANCE_ID_VAR = 'instance_id'
 EC2_EXCLUDE_EMPTY_GROUPS = True
 
 # ------------


### PR DESCRIPTION
This is always returned by the plugin, ec2_id was what the old script returned.

##### SUMMARY
See https://github.com/ansible/awx/issues/8741

Easiest way to check: without this, every time you sync it will recreate all the hosts (look at the "id" of the hosts to confirm)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

