### PR TITLE
Update consumers.py

### DIFF
--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -75,7 +75,7 @@ class WebsocketSecretAuthHelper:
         nonce_diff = now - nonce_parsed
         if abs(nonce_diff) > nonce_tolerance:
             logger.warn(f"Potential replay attack or machine(s) time out of sync by {nonce_diff} seconds.")
-            raise ValueError("Potential replay attack or machine(s) time out of sync by {nonce_diff} seconds.")
+            raise ValueError(f"Potential replay attack or machine(s) time out of sync by {nonce_diff} seconds.")
 
         return True
 


### PR DESCRIPTION
Caught a syntax issue at line number 78, modified the syntax to return correct value of nonce_diff.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
  - Logging Error

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX version: 16.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
--- Logging error ---
    raise ValueError("Potential replay attack or machine(s) time out of sync by {nonce_diff} seconds.")
ValueError: Potential replay attack or machine(s) time out of sync by {nonce_diff} seconds.
BlockingIOError: [Errno 11] Resource temporarily unavailable
```
Above is what the code is returning as of now. We could see ValueError is not returning value of **nonce_diff** and instead its treating nonce_diff as a plain string in quotes.

So just modified line number 78 with correct syntax, which will return the value of nonce_diff
