### PR TITLE
Disable cancel button on jobs list when one or more selected jobs is not running

### DIFF
--- a/awx/ui_next/src/components/JobList/JobListCancelButton.jsx
+++ b/awx/ui_next/src/components/JobList/JobListCancelButton.jsx
@@ -53,7 +53,7 @@ function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
       return (
         <div>
           {cannotCancelPermissions.length > 0 && (
-            <>
+            <div>
               {i18n._(
                 '{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}',
                 {
@@ -61,10 +61,10 @@ function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
                 }
               )}
               {' '.concat(cannotCancelPermissions.join(', '))}
-            </>
+            </div>
           )}
           {cannotCancelNotRunning.length > 0 && (
-            <>
+            <div>
               {i18n._(
                 '{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}',
                 {
@@ -72,7 +72,7 @@ function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
                 }
               )}
               {' '.concat(cannotCancelNotRunning.join(', '))}
-            </>
+            </div>
           )}
         </div>
       );

--- a/awx/ui_next/src/components/JobList/JobListCancelButton.jsx
+++ b/awx/ui_next/src/components/JobList/JobListCancelButton.jsx
@@ -7,8 +7,15 @@ import { KebabifiedContext } from '../../contexts/Kebabified';
 import AlertModal from '../AlertModal';
 import { Job } from '../../types';
 
-function cannotCancel(job) {
-  return !job.summary_fields.user_capabilities.start;
+function cannotCancelBecausePermissions(job) {
+  return (
+    !job.summary_fields.user_capabilities.start &&
+    ['pending', 'waiting', 'running'].includes(job.status)
+  );
+}
+
+function cannotCancelBecauseNotRunning(job) {
+  return !['pending', 'waiting', 'running'].includes(job.status);
 }
 
 function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
@@ -33,20 +40,40 @@ function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
   }, [isKebabified, isModalOpen, onKebabModalChange]);
 
   const renderTooltip = () => {
-    const jobsUnableToCancel = jobsToCancel
-      .filter(cannotCancel)
+    const cannotCancelPermissions = jobsToCancel
+      .filter(cannotCancelBecausePermissions)
       .map(job => job.name);
-    const numJobsUnableToCancel = jobsUnableToCancel.length;
+    const cannotCancelNotRunning = jobsToCancel
+      .filter(cannotCancelBecauseNotRunning)
+      .map(job => job.name);
+    const numJobsUnableToCancel = cannotCancelPermissions.concat(
+      cannotCancelNotRunning
+    ).length;
     if (numJobsUnableToCancel > 0) {
       return (
         <div>
-          {i18n._(
-            '{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}',
-            {
-              numJobsUnableToCancel,
-            }
+          {cannotCancelPermissions.length > 0 && (
+            <>
+              {i18n._(
+                '{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}',
+                {
+                  numJobsUnableToCancel: cannotCancelPermissions.length,
+                }
+              )}
+              {' '.concat(cannotCancelPermissions.join(', '))}
+            </>
           )}
-          {' '.concat(jobsUnableToCancel.join(', '))}
+          {cannotCancelNotRunning.length > 0 && (
+            <>
+              {i18n._(
+                '{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}',
+                {
+                  numJobsUnableToCancel: cannotCancelNotRunning.length,
+                }
+              )}
+              {' '.concat(cannotCancelNotRunning.join(', '))}
+            </>
+          )}
         </div>
       );
     }
@@ -62,7 +89,9 @@ function JobListCancelButton({ i18n, jobsToCancel, onCancel }) {
   };
 
   const isDisabled =
-    jobsToCancel.length === 0 || jobsToCancel.some(cannotCancel);
+    jobsToCancel.length === 0 ||
+    jobsToCancel.some(cannotCancelBecausePermissions) ||
+    jobsToCancel.some(cannotCancelBecauseNotRunning);
 
   const cancelJobText = i18n._(
     '{zeroOrOneJobSelected, plural, one {Cancel job} other {Cancel jobs}}',

--- a/awx/ui_next/src/components/JobList/JobListCancelButton.test.jsx
+++ b/awx/ui_next/src/components/JobList/JobListCancelButton.test.jsx
@@ -30,6 +30,29 @@ describe('<JobListCancelButton />', () => {
                 start: false,
               },
             },
+            status: 'running',
+          },
+        ]}
+      />
+    );
+    expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(
+      true
+    );
+  });
+  test('should be disabled when selected job is not running', () => {
+    wrapper = mountWithContexts(
+      <JobListCancelButton
+        jobsToCancel={[
+          {
+            id: 1,
+            name: 'some job',
+            summary_fields: {
+              user_capabilities: {
+                delete: false,
+                start: false,
+              },
+            },
+            status: 'successful',
           },
         ]}
       />
@@ -51,6 +74,7 @@ describe('<JobListCancelButton />', () => {
                 start: true,
               },
             },
+            status: 'running',
           },
         ]}
       />
@@ -73,6 +97,7 @@ describe('<JobListCancelButton />', () => {
                 start: true,
               },
             },
+            status: 'running',
           },
         ]}
         onCancel={onCancel}


### PR DESCRIPTION
##### SUMMARY
link #8207 

I also added separate messaging for jobs that you don't have permission to cancel v. jobs that cannot be canceled because they aren't running.

<img width="1680" alt="Screen Shot 2020-12-16 at 12 57 40 PM" src="https://user-images.githubusercontent.com/9889020/102387503-74afe800-3f9e-11eb-8812-0cc8a0ca6cbb.png">

<img width="1612" alt="Screen Shot 2020-12-16 at 12 53 35 PM" src="https://user-images.githubusercontent.com/9889020/102387526-7c6f8c80-3f9e-11eb-830b-5441833131c1.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI