### PR TITLE
Don't build job redirect until data available

### DIFF
--- a/awx/ui_next/src/screens/Job/JobTypeRedirect.jsx
+++ b/awx/ui_next/src/screens/Job/JobTypeRedirect.jsx
@@ -18,8 +18,11 @@ function JobTypeRedirect({ id, path, view, i18n }) {
     request: loadJob,
   } = useRequest(
     useCallback(async () => {
-      const { data } = await UnifiedJobsAPI.read({ id });
-      return { job: data };
+      const {
+        data: { results },
+      } = await UnifiedJobsAPI.read({ id });
+      const [item] = results;
+      return { job: item };
     }, [id]),
     { job: {} }
   );
@@ -42,7 +45,7 @@ function JobTypeRedirect({ id, path, view, i18n }) {
       </PageSection>
     );
   }
-  if (isLoading) {
+  if (isLoading || !job?.id) {
     // TODO show loading state
     return <div>Loading...</div>;
   }

--- a/awx/ui_next/src/screens/Template/Templates.jsx
+++ b/awx/ui_next/src/screens/Template/Templates.jsx
@@ -35,7 +35,7 @@ function Templates({ i18n }) {
         [`${templatePath}/notifications`]: i18n._(t`Notifications`),
         [`${templatePath}/completed_jobs`]: i18n._(t`Completed Jobs`),
         [surveyPath]: i18n._(t`Survey`),
-        [`${surveyPath}add`]: i18n._(t`Add Question`),
+        [`${surveyPath}/add`]: i18n._(t`Add Question`),
         [`${surveyPath}/edit`]: i18n._(t`Edit Question`),
         [schedulesPath]: i18n._(t`Schedules`),
         [`${schedulesPath}/add`]: i18n._(t`Create New Schedule`),


### PR DESCRIPTION
##### SUMMARY
Job and template route cleanup, addresses #8936 

- Add missing slash to templates routing key
- In job redirect, don't build redirect until data available