### PR TITLE
Allow jobs to run in the base ansible-runner image

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1131,7 +1131,7 @@ class BaseTask(object):
         fn = os.path.join(path, 'hosts')
         with open(fn, 'w') as f:
             os.chmod(fn, stat.S_IRUSR | stat.S_IXUSR | stat.S_IWUSR)
-            f.write('#! /usr/bin/env python\n# -*- coding: utf-8 -*-\nprint(%r)\n' % json_data)
+            f.write('#! /usr/bin/env python3\n# -*- coding: utf-8 -*-\nprint(%r)\n' % json_data)
         return fn
 
     def build_args(self, instance, private_data_dir, passwords):


### PR DESCRIPTION
This is kind of related to https://github.com/ansible/awx-ee/pull/14

That PR allows us to run inventory updates (like SCM inventory updates) where the shebang is `#! /usr/bin/env python` in the default execution environment. This is pretty reasonable, and if we didn't do it, it would break a lot of default behavior.

However, for running _jobs_, where it's _our_ auto-created inventory as opposed to the user's inventory, `python3` is a better bet, as the linked fix is in awx-ee, and `ansible/ansible-runner` itself has no global `python`. There is no chance that we are supporting python2 execution environments.