### PR TITLE
Added module prefix to awx license module example documentation

### DIFF
--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -38,7 +38,7 @@ RETURN = ''' # '''
 
 EXAMPLES = '''
 - name: Set the license using a file
-  license:
+  tower_license:
     manifest: "/tmp/my_manifest.zip"
     eula_accepted: True
 '''


### PR DESCRIPTION
Signed-off-by: David Roble <droble@redhat.com>

##### SUMMARY

When following the example documentation for the [license module](https://docs.ansible.com/ansible/latest/collections/awx/awx/tower_license_module.html#examples) there is an issue which would cause the following error:

```ERROR! couldn't resolve module/action 'license'. This often indicates a misspelling, missing collection, or incorrect module path.```

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- awx.awx.tower_license

##### AWX VERSION
16.0.0


##### ADDITIONAL INFORMATION

To reproduce, add the following to a playbook, as copied from module documentation:

```
- name: Set the license using a file
  license:
    data: "{{ lookup('file', '/tmp/my_tower.license') }}"
    eula_accepted: True
```

Before change:
```
ERROR! couldn't resolve module/action 'license'. This often indicates a misspelling, missing collection, or incorrect module path.
```
After change, the module runs successfully.
