### PR TITLE
Default to lang in catalog when browser preference unavailable

### DIFF
--- a/awx/ui_next/src/App.jsx
+++ b/awx/ui_next/src/App.jsx
@@ -30,7 +30,12 @@ const ProtectedRoute = ({ children, ...rest }) =>
 
 function App() {
   const catalogs = { en, ja };
-  const language = getLanguageWithoutRegionCode(navigator);
+  let language = getLanguageWithoutRegionCode(navigator);
+  if (!Object.keys(catalogs).includes(language)) {
+    // If there isn't a string catalog available for the browser's
+    // preferred language, default to one that has strings.
+    language = 'en';
+  }
   const match = useRouteMatch();
   const { hash, search, pathname } = useLocation();
 


### PR DESCRIPTION
for https://github.com/ansible/awx/issues/8884
##### SUMMARY
When strings aren't available for the browser's preferred locale, default to one with strings to avoid displaying raw javascript
variables.
