### PR TITLE
Add inventory source and project links to details view of Jobs list

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -124,7 +124,7 @@ SUMMARIZABLE_FK_FIELDS = {
     'last_update': DEFAULT_SUMMARY_FIELDS + ('status', 'failed', 'license_error'),
     'current_update': DEFAULT_SUMMARY_FIELDS + ('status', 'failed', 'license_error'),
     'current_job': DEFAULT_SUMMARY_FIELDS + ('status', 'failed', 'license_error'),
-    'inventory_source': ('source', 'last_updated', 'status'),
+    'inventory_source': ('id', 'name', 'source', 'last_updated', 'status'),
     'custom_inventory_script': DEFAULT_SUMMARY_FIELDS,
     'source_script': DEFAULT_SUMMARY_FIELDS,
     'role': ('id', 'role_field'),

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -61,6 +61,8 @@ function JobDetail({ job, i18n }) {
     credentials,
     instance_group: instanceGroup,
     inventory,
+    inventory_source,
+    source_project,
     job_template: jobTemplate,
     workflow_job_template: workflowJobTemplate,
     labels,
@@ -200,6 +202,33 @@ function JobDetail({ job, i18n }) {
               >
                 {inventory.name}
               </Link>
+            }
+          />
+        )}
+        {inventory_source && (
+          <Detail
+            label={i18n._(t`Inventory Source`)}
+            value={
+              <Link
+                to={`/inventories/inventory/${inventory.id}/sources/${inventory_source.id}`}
+              >
+                {inventory_source.name}
+              </Link>
+            }
+          />
+        )}
+        {inventory_source && inventory_source.source === 'scm' && (
+          <Detail
+            label={i18n._(t`Project`)}
+            value={
+              <StatusDetailValue>
+                {source_project.status && (
+                  <StatusIcon status={source_project.status} />
+                )}
+                <Link to={`/projects/${source_project.id}`}>
+                  {source_project.name}
+                </Link>
+              </StatusDetailValue>
             }
           />
         )}


### PR DESCRIPTION
##### SUMMARY
Add links to inventory source and project to inventory update details view of Jobs list
* Addresses #8839

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
- Added inventory source and project links to the job details(Jobs -> Choose an Inventory Sync Job > Press Details tab)
![JobDetails](https://user-images.githubusercontent.com/7360578/103478127-daf29280-4e07-11eb-85fa-4ccf4ce704c9.png)
