### PR TITLE
Fixed link to Content Hub in Tower module documentation

### DIFF
--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -31,7 +31,7 @@ with the current AWX version, for example: `awx_collection/awx-awx-9.2.0.tar.gz`
 Installing the `tar.gz` involves no special instructions.
 
 {% else %}
-This collection should be installed from [Content Hub][https://cloud.redhat.com/ansible/automation-hub/ansible/tower/]
+This collection should be installed from [Content Hub](https://cloud.redhat.com/ansible/automation-hub/ansible/tower/)
 
 {% endif %}
 ## Running


### PR DESCRIPTION
Signed-off-by: David Roble <droble@redhat.com>

##### SUMMARY

Fixed link to Content Hub in Tower collection documentation

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- awx.awx.tower_license

##### AWX VERSION

16.0.0
