### PR TITLE
specify isolated_manager.log path

### DIFF
--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -54,6 +54,7 @@ LOGGING['handlers']['task_system']['filename'] = '/var/log/tower/task_system.log
 LOGGING['handlers']['management_playbooks']['filename'] = '/var/log/tower/management_playbooks.log'  # noqa
 LOGGING['handlers']['system_tracking_migrations']['filename'] = '/var/log/tower/tower_system_tracking_migrations.log'  # noqa
 LOGGING['handlers']['rbac_migrations']['filename'] = '/var/log/tower/tower_rbac_migrations.log'  # noqa
+LOGGING['handlers']['isolated_manager']['filename'] = '/var/log/tower/isolated_manager.log'  # noqa
 
 # Store a snapshot of default settings at this point before loading any
 # customizable config files.


### PR DESCRIPTION
* By default, log files are created in the dir relative to the awx
source. For production, explicitly specify the log file path
