### PR TITLE
Make workflow_job.assert_successful() give specifics

### DIFF
--- a/awxkit/awxkit/api/mixins/has_status.py
+++ b/awxkit/awxkit/api/mixins/has_status.py
@@ -47,6 +47,13 @@ class HasStatus(object):
     def wait_until_started(self, interval=1, timeout=60):
         return self.wait_until_status(self.started_statuses, interval=interval, timeout=timeout)
 
+    def failure_output_details(self):
+        if getattr(self, 'result_stdout', ''):
+            output = bytes_to_str(self.result_stdout)
+            if output:
+                return '\nstdout:\n{}'.format(output)
+        return ''
+
     def assert_status(self, status_list, msg=None):
         if isinstance(status_list, str):
             status_list = [status_list]
@@ -65,10 +72,9 @@ class HasStatus(object):
             msg += '\njob_explanation: {}'.format(bytes_to_str(self.job_explanation))
         if getattr(self, 'result_traceback', ''):
             msg += '\nresult_traceback:\n{}'.format(bytes_to_str(self.result_traceback))
-        if getattr(self, 'result_stdout', ''):
-            output = bytes_to_str(self.result_stdout)
-            if output:
-                msg = msg + '\nstdout:\n{}'.format(output)
+
+        msg += self.failure_output_details()
+
         if getattr(self, 'job_explanation', '').startswith('Previous Task Failed'):
             try:
                 data = json.loads(self.job_explanation.replace('Previous Task Failed: ', ''))

--- a/awxkit/awxkit/api/pages/workflow_jobs.py
+++ b/awxkit/awxkit/api/pages/workflow_jobs.py
@@ -21,11 +21,7 @@ class WorkflowJob(UnifiedJob):
         node_list = self.related.workflow_nodes.get().results
 
         for node in node_list:
-            msg += '\n{}:'.format(node.id)
-            if node.job:
-                msg += ' {}'.format(node.summary_fields.job)
-            else:
-                msg += ' None'
+            msg += '\n{}: {}'.format(node.id, node.summary_fields.get('job'))
             for rel in ('failure_nodes', 'always_nodes', 'success_nodes'):
                 val = getattr(node, rel, [])
                 if val:

--- a/awxkit/awxkit/api/pages/workflow_jobs.py
+++ b/awxkit/awxkit/api/pages/workflow_jobs.py
@@ -13,11 +13,37 @@ class WorkflowJob(UnifiedJob):
         result = self.related.relaunch.post(payload)
         return self.walk(result.url)
 
+    def failure_output_details(self):
+        """Special implementation of this part of assert_status so that
+        workflow_job.assert_successful() will give a breakdown of failure
+        """
+        msg = '\nNode summary:'
+        node_list = self.related.workflow_nodes.get().results
+
+        for node in node_list:
+            msg += '\n{}:'.format(node.id)
+            if node.job:
+                msg += ' {}'.format(node.summary_fields.job)
+            else:
+                msg += ' None'
+            for rel in ('failure_nodes', 'always_nodes', 'success_nodes'):
+                val = getattr(node, rel, [])
+                if val:
+                    msg += ' {} {}'.format(rel, val)
+
+        msg += '\n\nUnhandled individual job failures:\n'
+        for node in node_list:
+            if node.job and not (node.failure_nodes or node.always_nodes):
+                job = node.related.job.get()
+                try:
+                    job.assert_successful()
+                except Exception as e:
+                    msg += str(e)
+        return msg
+
     @property
     def result_stdout(self):
         # workflow jobs do not have result_stdout
-        # which is problematic for the UnifiedJob.is_successful reliance on
-        # related stdout endpoint.
         if 'result_stdout' not in self.json:
             return 'Unprovided AWX field.'
         else:

--- a/awxkit/awxkit/api/pages/workflow_jobs.py
+++ b/awxkit/awxkit/api/pages/workflow_jobs.py
@@ -17,9 +17,9 @@ class WorkflowJob(UnifiedJob):
         """Special implementation of this part of assert_status so that
         workflow_job.assert_successful() will give a breakdown of failure
         """
-        msg = '\nNode summary:'
         node_list = self.related.workflow_nodes.get().results
 
+        msg = '\nNode summary:'
         for node in node_list:
             msg += '\n{}: {}'.format(node.id, node.summary_fields.get('job'))
             for rel in ('failure_nodes', 'always_nodes', 'success_nodes'):
@@ -29,12 +29,14 @@ class WorkflowJob(UnifiedJob):
 
         msg += '\n\nUnhandled individual job failures:\n'
         for node in node_list:
+            # nodes without always or failure paths consider failures unhandled
             if node.job and not (node.failure_nodes or node.always_nodes):
                 job = node.related.job.get()
                 try:
                     job.assert_successful()
                 except Exception as e:
                     msg += str(e)
+
         return msg
 
     @property


### PR DESCRIPTION
##### SUMMARY
On many occasions my efforts to address test failures have dead-ended at:

```
Traceback (most recent call last):
  File "/home/ec2-user/tower-qa/tests/api/external_jobs/test_container_groups.py", line 204, in test_container_group_workflow_job
    wf_job.assert_successful()
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/mixins/has_status.py", line 90, in assert_successful
    return self.assert_status('successful', msg=msg)
  File "/home/ec2-user/venvs/venv/lib64/python3.6/site-packages/awxkit/api/mixins/has_status.py", line 87, in assert_status
    raise AssertionError(msg)
AssertionError: Workflow_Job-3334 has status of failed, which is not in ['successful'].
job_explanation: No error handling paths found, marking workflow as failed
stdout:
Unprovided AWX field.
TIME WHEN STATUS WAS FOUND: 2021-01-04 17:55:40.081762 (UTC)
```

I don't get any more information. The _only_ thing this tells me is that the workflow job in that test failed. For long iteration cycles, this delays progress.

This PR proposes detailed information for workflow failures, in a way congruent to `job.assert_successful()`. Of course, the volume of text will scale with the size of the workflow.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
16.0.0
```


##### ADDITIONAL INFORMATION
Here is a test script to create a workflow which will fail:

```python
        fail = factories.job_template(playbook='fail.yml', allow_simultaneous=True)
        jt = factories.job_template(allow_simultaneous=True)
        wfjt = factories.workflow_job_template()

        # this branch will not fail the workflow
        n1 = factories.workflow_job_template_node(
            workflow_job_template=wfjt,
            unified_job_template=fail
        )
        n2 = factories.workflow_job_template_node(
            workflow_job_template=wfjt,
            unified_job_template=jt
        )
        try:
            n1.related.failure_nodes.post(dict(id=n2.id))
        except NoContent:
            pass

        # this branch will fail the workflow with a new root node
        factories.workflow_job_template_node(
            workflow_job_template=wfjt,
            unified_job_template=fail
        )

        # this branch will fail the workflow with a new root node
        factories.workflow_job_template_node(
            workflow_job_template=wfjt,
            unified_job_template=fail
        )

        wfj = wfjt.launch().wait_until_completed()
        wfj.assert_successful()
```

This has a mix of a few things - multiple un-handled failure paths. Failure that _are_ handled, and successes.

The output this change gives is:

```
Traceback (most recent call last):
  File "/home/alancoding/repos/tower-qa/tests/api/workflows/test_workflow_job_templates.py", line 81, in test_alan
    wfj.assert_successful()
  File "/home/alancoding/repos/awx/awxkit/awxkit/api/mixins/has_status.py", line 96, in assert_successful
    return self.assert_status('successful', msg=msg)
  File "/home/alancoding/repos/awx/awxkit/awxkit/api/mixins/has_status.py", line 93, in assert_status
    raise AssertionError(msg)
AssertionError: Workflow_Job-59 has status of failed, which is not in ['successful'].
job_explanation: No error handling paths found, marking workflow as failed
Node summary:
19: {'id': 62, 'name': 'JobTemplate - NetBat�', 'description': 'VarietyBlankTrainingGuardWingRegisterFruitStrategyDressTrick�', 'status': 'failed', 'failed': True, 'elapsed': 2.715, 'type': 'job'}
20: {'id': 61, 'name': 'JobTemplate - NetBat�', 'description': 'VarietyBlankTrainingGuardWingRegisterFruitStrategyDressTrick�', 'status': 'failed', 'failed': True, 'elapsed': 2.698, 'type': 'job'}
21: {'id': 63, 'name': 'JobTemplate - PeaceEquipment打', 'description': 'SupportFamilyMarkFatLogCityBoneAssignmentLocalArt�', 'status': 'successful', 'failed': False, 'elapsed': 1.3, 'type': 'job'}
22: {'id': 60, 'name': 'JobTemplate - NetBat�', 'description': 'VarietyBlankTrainingGuardWingRegisterFruitStrategyDressTrick�', 'status': 'failed', 'failed': True, 'elapsed': 2.65, 'type': 'job'} failure_nodes [21]

Unhandled individual job failures:
Job-62 has status of failed, which is not in ['successful'].
stdout:
Identity added: /tmp/awx_62_75h8f3cd/artifacts/62/ssh_key_data (/tmp/awx_62_75h8f3cd/artifacts/62/ssh_key_data)
SSH password: 
BECOME password[defaults to SSH password]: 
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [fail] ********************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Sorry, unless you tell me otherwise, this task will fail"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


TIME WHEN STATUS WAS FOUND: 2021-01-05 15:09:31.915780 (UTC)
Job-61 has status of failed, which is not in ['successful'].
stdout:
Identity added: /tmp/awx_61_mdt6dx4x/artifacts/61/ssh_key_data (/tmp/awx_61_mdt6dx4x/artifacts/61/ssh_key_data)
SSH password: 
BECOME password[defaults to SSH password]: 
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [fail] ********************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Sorry, unless you tell me otherwise, this task will fail"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


TIME WHEN STATUS WAS FOUND: 2021-01-05 15:09:32.233026 (UTC)

TIME WHEN STATUS WAS FOUND: 2021-01-05 15:09:32.357197 (UTC)
```

I don't love the "TIME WHEN STATUS WAS FOUND", but it's out of scope here. I just want workflows to give enough output to pursue the failure in the same way that this method does for jobs.
