### PR TITLE
pin pip-tools for now

### DIFF
--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -21,7 +21,7 @@ _cleanup() {
 
 install_deps() {
   pip install pip --upgrade
-  pip install pip-tools
+  pip install "pip-tools==5.4.0"  # see https://github.com/jazzband/pip-tools/pull/1237
 }
 
 generate_requirements_v3() {


### PR DESCRIPTION
a new version of pip-tools changed the format of dependency annotations
in generated requirements.txt files

e.g.,

```
daphne==x.y.z    # via autobahn, and something else, and something else
```

becomes:

```
daphne==x.y.z
  # via autobahn
  # and something else
  # and something else
```

we should probably change to the new format at some point, but maybe
*after* we merge a few of our long-running branches that touch these
files (otherwise, managing conflicts could be pretty hellish)