### PR TITLE
Changed task to job in job timeout description, fixes #9016

### DIFF
--- a/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/JobTemplateForm.jsx
@@ -433,7 +433,7 @@ function JobTemplateForm({
               min="0"
               label={i18n._(t`Timeout`)}
               tooltip={i18n._(t`The amount of time (in seconds) to run
-                  before the task is canceled. Defaults to 0 for no job
+                  before the job is canceled. Defaults to 0 for no job
                   timeout.`)}
             />
             <FieldWithPrompt


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Current timeout description on TIMEOUT for job template uses the word task instead of job, thus leading to confusion on what it actually does
Fixes #9016
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Latest
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Changed to:
```
The amount of time (in seconds) to run
before the job is canceled. Defaults to 0 for no job
timeout.
```
Changed from:
```
The amount of time (in seconds) to run
before the task is canceled. Defaults to 0 for no job
timeout.
```
