### PR TITLE
When deleting a job sometimes we get this error

### DIFF
--- a/awxkit/awxkit/api/pages/base.py
+++ b/awxkit/awxkit/api/pages/base.py
@@ -25,6 +25,11 @@ class Base(Page):
                 return self.delete()
         except (exc.NoContent, exc.NotFound, exc.Forbidden):
             pass
+        except exc.BadRequest as e:
+            if 'Job has not finished processing events' in e.msg:
+                pass
+            else:
+                raise e
 
     def get_object_role(self, role, by_name=False):
         """Lookup and return a related object role by its role field or name.


### PR DESCRIPTION
For the silent delete method, we should let this one slide
because it is an expected error that may occur if there are still
events processing.