### PR TITLE
Pin cryptography to pre 3 release

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -140,6 +140,10 @@ The offline installer needs to have functionality confirmed before upgrading the
 Versions need to match the versions used in the pip bootstrapping step
 in the top-level Makefile.
 
+### cryptography
+
+The offline installer needs to have functionality confirmed before upgrading these.
+
 ## Library Notes
 
 ### pexpect

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,6 +6,7 @@ autobahn>=20.12.3  # CVE-2020-35678
 azure-keyvault==1.1.0  # see UPGRADE BLOCKERs
 channels
 channels-redis>=3.1.0  # https://github.com/django/channels_redis/issues/212
+cryptography<3.0.0
 daphne
 django==2.2.16  # see UPGRADE BLOCKERs
 django-auth-ldap

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ channels-redis==3.1.0     # via -r /awx_devel/requirements/requirements.in
 channels==2.4.0           # via -r /awx_devel/requirements/requirements.in, channels-redis
 chardet==3.0.4            # via aiohttp, requests
 constantly==15.1.0        # via twisted
-cryptography==3.3.1       # via adal, autobahn, azure-keyvault, pyopenssl, service-identity, social-auth-core
+cryptography==2.9.2       # via adal, autobahn, azure-keyvault, pyopenssl, service-identity, social-auth-core
 daphne==2.4.1             # via -r /awx_devel/requirements/requirements.in, channels
 defusedxml==0.6.0         # via python3-openid, python3-saml, social-auth-core
 dictdiffer==0.8.1         # via openshift


### PR DESCRIPTION
Pin cryptography to pre `2.9.2` release. The recent autobahn version allows it.