### PR TITLE
Fix inventory list responsive behavior

### DIFF
--- a/awx/ui_next/src/components/PaginatedTable/HeaderRow.jsx
+++ b/awx/ui_next/src/components/PaginatedTable/HeaderRow.jsx
@@ -71,6 +71,7 @@ export function HeaderCell({
   sortBy,
   columnIndex,
   idPrefix,
+  className,
   children,
 }) {
   const sort = sortKey
@@ -81,7 +82,11 @@ export function HeaderCell({
       }
     : null;
   return (
-    <Th sort={sort} id={sortKey ? `${idPrefix}-${sortKey}` : null}>
+    <Th
+      id={sortKey ? `${idPrefix}-${sortKey}` : null}
+      className={className}
+      sort={sort}
+    >
       {children}
     </Th>
   );

--- a/awx/ui_next/src/components/PaginatedTable/PaginatedTable.jsx
+++ b/awx/ui_next/src/components/PaginatedTable/PaginatedTable.jsx
@@ -1,3 +1,4 @@
+import 'styled-components/macro';
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { TableComposable, Tbody } from '@patternfly/react-table';
@@ -88,13 +89,13 @@ function PaginatedTable({
     );
   } else {
     Content = (
-      <>
+      <div css="overflow: scroll">
         {hasContentLoading && <LoadingSpinner />}
         <TableComposable aria-label={dataListLabel}>
           {headerRow}
           <Tbody>{items.map(renderRow)}</Tbody>
         </TableComposable>
-      </>
+      </div>
     );
   }
 

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useLocation, useRouteMatch, Link } from 'react-router-dom';
+import styled from 'styled-components';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Card, PageSection, DropdownItem } from '@patternfly/react-core';
@@ -17,6 +18,14 @@ import { getQSConfig, parseQueryString } from '../../../util/qs';
 import useWsInventories from './useWsInventories';
 import AddDropDownButton from '../../../components/AddDropDownButton';
 import InventoryListItem from './InventoryListItem';
+
+const ResponsiveHeaderCell = styled(HeaderCell)`
+  @media (max-width: 992px) {
+    && {
+      display: none;
+    }
+  }
+`;
 
 const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
@@ -195,9 +204,9 @@ function InventoryList({ i18n }) {
               <HeaderCell>{i18n._(t`Status`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Type`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Organization`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Groups`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Hosts`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Sources`)}</HeaderCell>
+              <ResponsiveHeaderCell>{i18n._(t`Groups`)}</ResponsiveHeaderCell>
+              <ResponsiveHeaderCell>{i18n._(t`Hosts`)}</ResponsiveHeaderCell>
+              <ResponsiveHeaderCell>{i18n._(t`Sources`)}</ResponsiveHeaderCell>
               <HeaderCell>{i18n._(t`Actions`)}</HeaderCell>
             </HeaderRow>
           }

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useLocation, useRouteMatch, Link } from 'react-router-dom';
-import styled from 'styled-components';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Card, PageSection, DropdownItem } from '@patternfly/react-core';
@@ -18,14 +17,6 @@ import { getQSConfig, parseQueryString } from '../../../util/qs';
 import useWsInventories from './useWsInventories';
 import AddDropDownButton from '../../../components/AddDropDownButton';
 import InventoryListItem from './InventoryListItem';
-
-const ResponsiveHeaderCell = styled(HeaderCell)`
-  @media (max-width: 992px) {
-    && {
-      display: none;
-    }
-  }
-`;
 
 const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
@@ -204,9 +195,6 @@ function InventoryList({ i18n }) {
               <HeaderCell>{i18n._(t`Status`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Type`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Organization`)}</HeaderCell>
-              <ResponsiveHeaderCell>{i18n._(t`Groups`)}</ResponsiveHeaderCell>
-              <ResponsiveHeaderCell>{i18n._(t`Hosts`)}</ResponsiveHeaderCell>
-              <ResponsiveHeaderCell>{i18n._(t`Sources`)}</ResponsiveHeaderCell>
               <HeaderCell>{i18n._(t`Actions`)}</HeaderCell>
             </HeaderRow>
           }

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
@@ -6,7 +6,6 @@ import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
 import { timeOfDay } from '../../../util/dates';
 import { InventoriesAPI } from '../../../api';
 import { Inventory } from '../../../types';

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
@@ -14,14 +14,6 @@ import { ActionsTd, ActionItem } from '../../../components/PaginatedTable';
 import CopyButton from '../../../components/CopyButton';
 import StatusLabel from '../../../components/StatusLabel';
 
-const ResponsiveTd = styled(Td)`
-  @media (max-width: 992px) {
-    && {
-      display: none;
-    }
-  }
-`;
-
 function InventoryListItem({
   inventory,
   rowIndex,
@@ -98,15 +90,6 @@ function InventoryListItem({
           {inventory?.summary_fields?.organization?.name}
         </Link>
       </Td>
-      <ResponsiveTd dataLabel={i18n._(t`Groups`)}>
-        {inventory.total_groups}
-      </ResponsiveTd>
-      <ResponsiveTd dataLabel={i18n._(t`Hosts`)}>
-        {inventory.total_hosts}
-      </ResponsiveTd>
-      <ResponsiveTd dataLabel={i18n._(t`Sources`)}>
-        {inventory.total_inventory_sources}
-      </ResponsiveTd>
       {inventory.pending_deletion ? (
         <Td dataLabel={i18n._(t`Groups`)}>
           <Label color="red">{i18n._(t`Pending delete`)}</Label>

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryListItem.jsx
@@ -6,12 +6,21 @@ import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import { timeOfDay } from '../../../util/dates';
 import { InventoriesAPI } from '../../../api';
 import { Inventory } from '../../../types';
 import { ActionsTd, ActionItem } from '../../../components/PaginatedTable';
 import CopyButton from '../../../components/CopyButton';
 import StatusLabel from '../../../components/StatusLabel';
+
+const ResponsiveTd = styled(Td)`
+  @media (max-width: 992px) {
+    && {
+      display: none;
+    }
+  }
+`;
 
 function InventoryListItem({
   inventory,
@@ -89,11 +98,15 @@ function InventoryListItem({
           {inventory?.summary_fields?.organization?.name}
         </Link>
       </Td>
-      <Td dataLabel={i18n._(t`Groups`)}>{inventory.total_groups}</Td>
-      <Td dataLabel={i18n._(t`Hosts`)}>{inventory.total_hosts}</Td>
-      <Td dataLabel={i18n._(t`Sources`)}>
+      <ResponsiveTd dataLabel={i18n._(t`Groups`)}>
+        {inventory.total_groups}
+      </ResponsiveTd>
+      <ResponsiveTd dataLabel={i18n._(t`Hosts`)}>
+        {inventory.total_hosts}
+      </ResponsiveTd>
+      <ResponsiveTd dataLabel={i18n._(t`Sources`)}>
         {inventory.total_inventory_sources}
-      </Td>
+      </ResponsiveTd>
       {inventory.pending_deletion ? (
         <Td dataLabel={i18n._(t`Groups`)}>
           <Label color="red">{i18n._(t`Pending delete`)}</Label>


### PR DESCRIPTION
##### SUMMARY

Hides Groups, Hosts, and Sources columns in Inventory List table when screen width is too narrow to show them.

Addresses #9049 

![Screen Shot 2021-01-11 at 9 49 04 AM](https://user-images.githubusercontent.com/410794/104223867-0faead00-53f9-11eb-8870-2ca623030f75.png)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
