### PR TITLE
Fix Local Docker installer upgrade permission issues

### DIFF
--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -214,6 +214,7 @@ RUN for dir in \
       /var/run/awx-rsyslog \
       /var/log/tower \
       /var/log/nginx \
+      /var/lib/postgresql \
       /var/run/supervisor \
       /var/lib/nginx ; \
     do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp root $dir ; done && \

--- a/installer/roles/local_docker/defaults/main.yml
+++ b/installer/roles/local_docker/defaults/main.yml
@@ -8,3 +8,4 @@ postgresql_version: "12"
 postgresql_image: "postgres:{{postgresql_version}}"
 
 compose_start_containers: true
+upgrade_postgres: false

--- a/installer/roles/local_docker/tasks/upgrade_postgres.yml
+++ b/installer/roles/local_docker/tasks/upgrade_postgres.yml
@@ -1,26 +1,24 @@
 ---
-- name: Check for existing Postgres data
-  stat:
-    path: "{{ postgres_data_dir }}/pgdata/PG_VERSION"
+
+- name: Register temporary docker container
+  set_fact:
+    container_command: "docker run -v '{{ postgres_data_dir | realpath }}:/var/lib/postgresql' centos:8 bash "
+
+- name: Check for existing Postgres data (run from inside the container for access to file)
+  shell:
+    cmd: "{{ container_command }} [[ -f /var/lib/postgresql/10/data/PG_VERSION ]] && echo 'exists'"
   register: pg_version_file
+  ignore_errors: true
 
 - name: Record Postgres version
-  set_fact:
-    old_pg_version: "{{ lookup('file', postgres_data_dir + '/pgdata/PG_VERSION') }}"
-  when: pg_version_file.stat.exists
+  shell: "{{ container_command }} cat var/lib/postgresql/10/data/PG_VERSION"
+  register: old_pg_version
+  when: pg_version_file.stdout == 'exists'
 
 - name: Determine whether to upgrade postgres
   set_fact:
-    upgrade_postgres: "{{ old_pg_version is defined and old_pg_version == '9.6' }}"
-
-- name: Set up new postgres paths pre-upgrade
-  file:
-    state: directory
-    path: "{{ item }}"
-    recurse: true
-  when: upgrade_postgres | bool
-  with_items:
-    - "{{ postgres_data_dir }}/10/data"
+    upgrade_postgres: "{{ old_pg_version is defined and old_pg_version.stdout == '10' | bool }}"
+  when: not old_pg_version.skipped | bool
 
 - name: Stop AWX before upgrading postgres
   docker_service:
@@ -31,20 +29,15 @@
 - name: Upgrade Postgres
   shell: |
     docker run --rm \
-      -v {{ postgres_data_dir }}/10/data:/var/lib/postgresql/10/data \
-      -v {{ postgres_data_dir }}/12/data:/var/lib/postgresql/12/data \
+      -v {{ postgres_data_dir | realpath }}:/var/lib/postgresql \
       -e PGUSER={{ pg_username }} -e POSTGRES_INITDB_ARGS="-U {{ pg_username }}" \
       tianon/postgres-upgrade:10-to-12 --username={{ pg_username }}
   when: upgrade_postgres | bool
 
 - name: Copy old pg_hba.conf
-  copy:
-    src: "{{ postgres_data_dir + '/pgdata/pg_hba.conf' }}"
-    dest: "{{ postgres_data_dir + '/12/data/' }}"
+  shell: "{{ container_command }} cp /var/lib/postgresql/10/data/pg_hba.conf /var/lib/postgresql/12/data/pg_hba.conf"
   when: upgrade_postgres | bool
 
 - name: Remove old data directory
-  file:
-    path: "{{ postgres_data_dir + '/10/data' }}"
-    state: absent
+  shell: "{{ container_command }} rm -rf /var/lib/postgresql/10/data"
   when: compose_start_containers|bool

--- a/installer/roles/local_docker/templates/docker-compose.yml.j2
+++ b/installer/roles/local_docker/templates/docker-compose.yml.j2
@@ -177,7 +177,7 @@ services:
     container_name: awx_postgres
     restart: unless-stopped
     volumes:
-      - "{{ postgres_data_dir }}/10/data/:/var/lib/postgresql/data:Z"
+      - "{{ postgres_data_dir }}:/var/lib/postgresql:Z"
     environment:
       POSTGRES_USER: {{ pg_username }}
       POSTGRES_PASSWORD: {{ pg_password }}


### PR DESCRIPTION
##### SUMMARY

Issue: https://github.com/ansible/awx/issues/9066

**Problem:** The Local Docker installer puts the postgresql data dir in the `~/.awx/pgdocker` dir (by default).  Since we bind-mount this into the container without any precedent, docker defaults to restricting it to the root user.  Unfortunately, this means that the installer (which is not run as root) is not able to read the PG_VERSION or modify anything in the data dir as a result, which is an issue in a few places in the postgresql upgrade tasks.  


This error was seen, among other similar ones:

```
TASK [local_docker : Remove old data directory] **********************************************************************
task path: /home/chadams/awx/installer/roles/local_docker/tasks/upgrade_postgres.yml:46
fatal: [localhost]: FAILED! => {"changed": false, "msg": "rmtree failed: [Errno 13] Permission denied: '/home/chadams/.awx/pgdocker/10/data'"}
```

**Solution:** To get around this, I modified many of the postgresql upgrade tasks in the installer to be run from inside a temporary container with the pg data dir volume mounted.  

This PR also pre-creates the pg directory and makes the `awx` user own the /var/lib/postgresql directory inside the container, which allows us to simplify volume mounting when upgrading postgresql.  


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
16.0.0+
```


##### ADDITIONAL INFORMATION

> Note: It looks as though this has been a problem for a few releases.  Currently, users will still need to chown the pg data dir on the host machine in order to upgrade to whatever release this makes it in (probably AWX 17.0.0)

For example: 
```
chown -R ~/.awx/pgdocker
```

This will of course be different if you have set a custom `postgres_data_dir` in your inventory.  
