### PR TITLE
Fix setting toggle on click behavior

### DIFF
--- a/awx/ui_next/src/screens/Setting/shared/SharedFields.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/SharedFields.jsx
@@ -48,10 +48,10 @@ const SettingGroup = withI18n()(
     <FormGroup
       fieldId={fieldId}
       helperTextInvalid={helperTextInvalid}
+      id={`${fieldId}-field`}
       isRequired={isRequired}
       label={label}
       validated={validated}
-      id={fieldId}
       labelIcon={
         <>
           <Popover

--- a/awx/ui_next/src/screens/Setting/shared/SharedFields.test.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/SharedFields.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { mount } from 'enzyme';
 import { Formik } from 'formik';
+import { I18nProvider } from '@lingui/react';
 import { act } from 'react-dom/test-utils';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import {
@@ -12,28 +14,38 @@ import {
 
 describe('Setting form fields', () => {
   test('BooleanField renders the expected content', async () => {
-    const wrapper = mountWithContexts(
-      <Formik
-        initialValues={{
-          boolean: true,
-        }}
-      >
-        {() => (
-          <BooleanField
-            name="boolean"
-            config={{
-              label: 'test',
-              help_text: 'test',
-            }}
-          />
-        )}
-      </Formik>
+    const outerNode = document.createElement('div');
+    document.body.appendChild(outerNode);
+    const wrapper = mount(
+      <I18nProvider>
+        <Formik
+          initialValues={{
+            boolean: true,
+          }}
+        >
+          {() => (
+            <BooleanField
+              name="boolean"
+              config={{
+                label: 'test',
+                help_text: 'test',
+              }}
+            />
+          )}
+        </Formik>
+      </I18nProvider>,
+      {
+        attachTo: outerNode,
+      }
     );
     expect(wrapper.find('Switch')).toHaveLength(1);
     expect(wrapper.find('Switch').prop('isChecked')).toBe(true);
     expect(wrapper.find('Switch').prop('isDisabled')).toBe(false);
     await act(async () => {
-      wrapper.find('Switch').invoke('onChange')(false);
+      wrapper
+        .find('Switch label')
+        .instance()
+        .dispatchEvent(new Event('click'));
     });
     wrapper.update();
     expect(wrapper.find('Switch').prop('isChecked')).toBe(false);


### PR DESCRIPTION
##### SUMMARY
This PR fixes a bug where the setting toggle value did not change on click. The form group used the same `id` attr value as the form label and input which conflicted with the label control. To fix this, I updated the form group `id` to be different from the form label and input. 

![toggle bug](https://user-images.githubusercontent.com/15881645/104755604-a8f6ff80-5728-11eb-9f5f-852b3624e4c6.gif)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI