### PR TITLE
Explicitly set table column widths

### DIFF
--- a/awx/ui_next/src/components/PaginatedTable/HeaderRow.jsx
+++ b/awx/ui_next/src/components/PaginatedTable/HeaderRow.jsx
@@ -1,3 +1,4 @@
+import 'styled-components/macro';
 import React from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Thead, Tr, Th as PFTh } from '@patternfly/react-table';
@@ -54,7 +55,14 @@ export default function HeaderRow({ qsConfig, children }) {
   );
 }
 
-export function HeaderCell({ sortKey, onSort, sortBy, columnIndex, children }) {
+export function HeaderCell({
+  sortKey,
+  onSort,
+  sortBy,
+  columnIndex,
+  width,
+  children,
+}) {
   const sort = sortKey
     ? {
         onSort: (event, key, order) => onSort(sortKey, order),
@@ -62,5 +70,18 @@ export function HeaderCell({ sortKey, onSort, sortBy, columnIndex, children }) {
         columnIndex,
       }
     : null;
-  return <Th sort={sort}>{children}</Th>;
+  return (
+    <Th
+      sort={sort}
+      css={
+        width
+          ? `
+        --pf-c-table--cell--Width: ${width};
+      `
+          : null
+      }
+    >
+      {children}
+    </Th>
+  );
 }

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -191,10 +191,12 @@ function InventoryList({ i18n }) {
           toolbarRelatedSearchableKeys={relatedSearchableKeys}
           headerRow={
             <HeaderRow qsConfig={QS_CONFIG}>
-              <HeaderCell sortKey="name">{i18n._(t`Name`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Status`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Type`)}</HeaderCell>
-              <HeaderCell>{i18n._(t`Organization`)}</HeaderCell>
+              <HeaderCell sortKey="name" width="30%">
+                {i18n._(t`Name`)}
+              </HeaderCell>
+              <HeaderCell width="10%">{i18n._(t`Status`)}</HeaderCell>
+              <HeaderCell width="10%">{i18n._(t`Type`)}</HeaderCell>
+              <HeaderCell width="20%">{i18n._(t`Organization`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Groups`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Hosts`)}</HeaderCell>
               <HeaderCell>{i18n._(t`Sources`)}</HeaderCell>

--- a/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationList/OrganizationList.jsx
@@ -1,3 +1,4 @@
+import 'styled-components/macro';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation, useRouteMatch } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
@@ -151,9 +152,11 @@ function OrganizationsList({ i18n }) {
             toolbarRelatedSearchableKeys={relatedSearchableKeys}
             headerRow={
               <HeaderRow qsConfig={QS_CONFIG}>
-                <HeaderCell sortKey="name">{i18n._(t`Name`)}</HeaderCell>
-                <HeaderCell>{i18n._(t`Members`)}</HeaderCell>
-                <HeaderCell>{i18n._(t`Teams`)}</HeaderCell>
+                <HeaderCell sortKey="name" width="50%">
+                  {i18n._(t`Name`)}
+                </HeaderCell>
+                <HeaderCell width="20%">{i18n._(t`Members`)}</HeaderCell>
+                <HeaderCell width="20%">{i18n._(t`Teams`)}</HeaderCell>
                 <HeaderCell>{i18n._(t`Actions`)}</HeaderCell>
               </HeaderRow>
             }


### PR DESCRIPTION
##### SUMMARY
Adds `width` prop to HeaderCell component for list tables, to minimize column shifting when changing pagination. Updates Org and Inventories lists with some specified widths.

Note this is not 100% foolproof, as columns will still shrink to fit when the browser width is constrained — but IMO this is the preferred behavior for that case, since fitting the data on screen is more important than preventing shift.

Adresses #9010 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI