### PR TITLE
Update project_update.yml

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -39,6 +39,7 @@
             refspec: "{{scm_refspec|default(omit)}}"
             force: "{{scm_clean}}"
             accept_hostkey: "{{scm_accept_hostkey|default(omit)}}"
+            depth: 1
           register: git_result
 
         - name: Set the git repository version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In project_update.yml, Set the depth of the pull to 1 in order to save space and bandwidth in the SCM transactions.  Tower will not be taking advantage of all of the prior revisions.  

This issue impacts a customer whose repositories have outgrown the disks of their Tower VMs.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Project update functionality of UI
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
any I guess
```


##### ADDITIONAL INFORMATION
<!---

If unset the depth parameter is ignored.  1 is the minimum value.  

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/git_module.html#parameter-depth

  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
vim /var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/playbooks/project_update.yml

[1]+  Stopped                 vim /var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/playbooks/project_update.yml
[root@localhost projects]# du -sh *
148K	_6__demo_project
0	_6__demo_project.lock
508K	_8__splunk
0	_8__splunk.lock

## run update in the Tower UI

[root@localhost projects]# du -sh *
148K	_6__demo_project
0	_6__demo_project.lock
184K	_8__splunk
0	_8__splunk.lock
[root@localhost projects]# pwd
/var/lib/awx/projects

```
