### PR TITLE
Remove launch script config mapping for k8s and ocp

### DIFF
--- a/installer/roles/kubernetes/templates/deployment.yml.j2
+++ b/installer/roles/kubernetes/templates/deployment.yml.j2
@@ -448,22 +448,6 @@ spec:
               - key: environment_sh
                 path: 'environment.sh'
 
-        - name: {{ kubernetes_deployment_name }}-launch-awx-web
-          configMap:
-            name: {{ kubernetes_deployment_name }}-launch-awx
-            items:
-              - key: launch-awx-web
-                path: 'launch_awx.sh'
-            defaultMode: 0755
-
-        - name: {{ kubernetes_deployment_name }}-launch-awx-task
-          configMap:
-            name: {{ kubernetes_deployment_name }}-launch-awx
-            items:
-              - key: launch-awx-task
-                path: 'launch_awx_task.sh'
-            defaultMode: 0755
-
         - name: {{ kubernetes_deployment_name }}-supervisor-web-config
           configMap:
             name: {{ kubernetes_deployment_name }}-supervisor-config


### PR DESCRIPTION
  * Related to https://github.com/ansible/awx/pull/8968

##### SUMMARY

We no longer need these configmaps in the deployment.yml now that [this](https://github.com/ansible/awx/pull/8968) has merged.  In fact, it causes the installer to fail when an OCP/k8 cluster is configured in the inventory file.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
