### PR TITLE
Create uuid per node, allow clustering with docker_compose

### DIFF
--- a/installer/roles/local_docker/tasks/compose.yml
+++ b/installer/roles/local_docker/tasks/compose.yml
@@ -4,6 +4,20 @@
     path: "{{ docker_compose_dir }}"
     state: directory
 
+- name: Create uuid
+  shell: "uuidgen > {{ docker_compose_dir }}/uuid"
+  args:
+    creates: "{{ docker_compose_dir }}/uuid"
+
+- name: Load uuid
+  shell: "cat {{ docker_compose_dir }}/uuid"
+  register: uuid_out
+
+- name: Set uuid
+  set_fact:
+    uuid: "{{ uuid_out.stdout_lines.0 }}"
+  when: uuid is not defined
+
 - name: Create Redis socket directory
   file:
     path: "{{ docker_compose_dir }}/redis_socket"

--- a/installer/roles/local_docker/templates/credentials.py.j2
+++ b/installer/roles/local_docker/templates/credentials.py.j2
@@ -11,3 +11,6 @@ DATABASES = {
 }
 
 BROADCAST_WEBSOCKET_SECRET = "{{ broadcast_websocket_secret | b64encode }}"
+
+SYSTEM_UUID = "{{ uuid }}"
+CLUSTER_HOST_ID = "{{ awx_task_hostname | default('awx') }}"


### PR DESCRIPTION
Signed-off-by: Sascha Spreitzer <sascha@spreitzer.ch>

##### SUMMARY
This change will allow the docker_compose installer to set a per node uuid,
ultimately enabling clustering capability.

Steps to create a cluster:
* Install postgresql somewhere
* Set pg_* variables in inventory
* Add only first instance to the installer inventory and run installer (this will migrate the DB and other nodes won't run into race conditions, note: might enhance later)
* Add remaining instances, use `awx_task_hostname` variable per node for the instance name (note: might add documentation later)


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
```
16.0.0
```
