### PR TITLE
fixed default location for docker_compose_dir variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -497,7 +497,7 @@ Before starting the install process, review the [inventory](./installer/inventor
 
 *docker_compose_dir*
 
-> When using docker-compose, the `docker-compose.yml` file will be created there (default `/tmp/awxcompose`).
+> When using docker-compose, the `docker-compose.yml` file will be created there (default `~/.awx/awxcompose`).
 
 *custom_venv_dir*
 


### PR DESCRIPTION
##### SUMMARY
Updated the default location of `docker_compose_dir`  in the install docs to reflect the default set in `installer/inventory`

##### ISSUE TYPE
 - Docs Pull Request

##### AWX VERSION
```
16.0.0
```

