### PR TITLE
Fixes missing credential types and makes credential type field a type ahead

### DIFF
--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
@@ -14,6 +14,12 @@ import {
 import CredentialEdit from './CredentialEdit';
 
 jest.mock('../../../api');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    id: 3,
+  }),
+}));
 
 const mockCredential = {
   id: 3,

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -8,10 +8,11 @@ import {
   Button,
   Form,
   FormGroup,
-  Select,
-  SelectOption,
+  Select as PFSelect,
+  SelectOption as PFSelectOption,
   SelectVariant,
 } from '@patternfly/react-core';
+import styled from 'styled-components';
 import FormField, { FormSubmitError } from '../../../components/FormField';
 import {
   FormColumnLayout,
@@ -21,6 +22,18 @@ import { required } from '../../../util/validators';
 import OrganizationLookup from '../../../components/Lookup/OrganizationLookup';
 import TypeInputsSubForm from './TypeInputsSubForm';
 import ExternalTestModal from './ExternalTestModal';
+
+const Select = styled(PFSelect)`
+  ul {
+    max-width: 495px;
+  }
+`;
+
+const SelectOption = styled(PFSelectOption)`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
 
 function CredentialFormFields({ i18n, credentialTypes }) {
   const { setFieldValue, initialValues, setFieldTouched } = useFormikContext();
@@ -142,11 +155,13 @@ function CredentialFormFields({ i18n, credentialTypes }) {
           onSelect={(event, value) => {
             credTypeHelpers.setValue(value);
             resetSubFormFields(value);
+            setIsSelectOpen(false);
           }}
           selections={credTypeField.value}
           placeholder={i18n._(t`Select a credential Type`)}
           isCreatable={false}
           maxHeight="300px"
+          width="100%"
         >
           {credentialTypeOptions.map(credType => (
             <SelectOption key={credType.value} value={credType.value}>

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -3,26 +3,28 @@ import { Formik, useField, useFormikContext } from 'formik';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { arrayOf, func, object, shape } from 'prop-types';
-import { ActionGroup, Button, Form, FormGroup } from '@patternfly/react-core';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core';
 import FormField, { FormSubmitError } from '../../../components/FormField';
 import {
   FormColumnLayout,
   FormFullWidthLayout,
 } from '../../../components/FormLayout';
-import AnsibleSelect from '../../../components/AnsibleSelect';
 import { required } from '../../../util/validators';
 import OrganizationLookup from '../../../components/Lookup/OrganizationLookup';
 import TypeInputsSubForm from './TypeInputsSubForm';
 import ExternalTestModal from './ExternalTestModal';
 
-function CredentialFormFields({
-  i18n,
-  credentialTypes,
-  formik,
-  initialValues,
-}) {
-  const { setFieldValue } = useFormikContext();
-
+function CredentialFormFields({ i18n, credentialTypes }) {
+  const { setFieldValue, initialValues, setFieldTouched } = useFormikContext();
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [credTypeField, credTypeMeta, credTypeHelpers] = useField({
     name: 'credential_type',
     validate: required(i18n._(t`Select a value for this field`), i18n),
@@ -30,7 +32,7 @@ function CredentialFormFields({
 
   const isGalaxyCredential =
     !!credTypeField.value &&
-    credentialTypes[credTypeField.value].kind === 'galaxy';
+    credentialTypes[credTypeField.value]?.kind === 'galaxy';
 
   const [orgField, orgMeta, orgHelpers] = useField({
     name: 'organization',
@@ -52,16 +54,14 @@ function CredentialFormFields({
     })
     .sort((a, b) => (a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1));
 
-  const resetSubFormFields = (newCredentialType, form) => {
+  const resetSubFormFields = newCredentialType => {
     const fields = credentialTypes[newCredentialType].inputs.fields || [];
     fields.forEach(
       ({ ask_at_runtime, type, id, choices, default: defaultValue }) => {
-        if (
-          parseInt(newCredentialType, 10) === form.initialValues.credential_type
-        ) {
-          form.setFieldValue(`inputs.${id}`, initialValues.inputs[id]);
+        if (parseInt(newCredentialType, 10) === initialValues.credential_type) {
+          setFieldValue(`inputs.${id}`, initialValues.inputs[id]);
           if (ask_at_runtime) {
-            form.setFieldValue(
+            setFieldValue(
               `passwordPrompts.${id}`,
               initialValues.passwordPrompts[id]
             );
@@ -69,24 +69,24 @@ function CredentialFormFields({
         } else {
           switch (type) {
             case 'string':
-              form.setFieldValue(`inputs.${id}`, defaultValue || '');
+              setFieldValue(`inputs.${id}`, defaultValue || '');
               break;
             case 'boolean':
-              form.setFieldValue(`inputs.${id}`, defaultValue || false);
+              setFieldValue(`inputs.${id}`, defaultValue || false);
               break;
             default:
               break;
           }
 
           if (choices) {
-            form.setFieldValue(`inputs.${id}`, defaultValue);
+            setFieldValue(`inputs.${id}`, defaultValue);
           }
 
           if (ask_at_runtime) {
-            form.setFieldValue(`passwordPrompts.${id}`, false);
+            setFieldValue(`passwordPrompts.${id}`, false);
           }
         }
-        form.setFieldTouched(`inputs.${id}`, false);
+        setFieldTouched(`inputs.${id}`, false);
       }
     );
   };
@@ -133,23 +133,27 @@ function CredentialFormFields({
         }
         label={i18n._(t`Credential Type`)}
       >
-        <AnsibleSelect
-          {...credTypeField}
+        <Select
+          aria-label={i18n._(t`Credential Type`)}
+          isOpen={isSelectOpen}
+          variant={SelectVariant.typeahead}
           id="credential-type"
-          data={[
-            {
-              value: '',
-              key: '',
-              label: i18n._(t`Choose a Credential Type`),
-              isDisabled: true,
-            },
-            ...credentialTypeOptions,
-          ]}
-          onChange={(event, value) => {
+          onToggle={setIsSelectOpen}
+          onSelect={(event, value) => {
             credTypeHelpers.setValue(value);
-            resetSubFormFields(value, formik);
+            resetSubFormFields(value);
           }}
-        />
+          selections={credTypeField.value}
+          placeholder={i18n._(t`Select a credential Type`)}
+          isCreatable={false}
+          maxHeight="300px"
+        >
+          {credentialTypeOptions.map(credType => (
+            <SelectOption key={credType.value} value={credType.value}>
+              {credType.label}
+            </SelectOption>
+          ))}
+        </Select>
       </FormGroup>
       {credTypeField.value !== undefined &&
         credTypeField.value !== '' &&
@@ -177,7 +181,7 @@ function CredentialForm({
     name: credential.name || '',
     description: credential.description || '',
     organization: credential?.summary_fields?.organization || null,
-    credential_type: credential.credential_type || '',
+    credential_type: credential?.credential_type || '',
     inputs: {},
     passwordPrompts: {},
   };
@@ -235,8 +239,6 @@ function CredentialForm({
           <Form autoComplete="off" onSubmit={formik.handleSubmit}>
             <FormColumnLayout>
               <CredentialFormFields
-                formik={formik}
-                initialValues={initialValues}
                 credentialTypes={credentialTypes}
                 i18n={i18n}
                 {...rest}

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -137,7 +137,7 @@ function CredentialFormFields({ i18n, credentialTypes }) {
           aria-label={i18n._(t`Credential Type`)}
           isOpen={isSelectOpen}
           variant={SelectVariant.typeahead}
-          id="credential-type"
+          ouiaId="credential-select"
           onToggle={setIsSelectOpen}
           onSelect={(event, value) => {
             credTypeHelpers.setValue(value);

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
@@ -137,15 +137,28 @@ describe('<CredentialForm />', () => {
     test('should display cred type subform when scm type select has a value', async () => {
       await act(async () => {
         await wrapper
-          .find('AnsibleSelect[id="credential-type"]')
-          .invoke('onChange')(null, 1);
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onToggle')();
       });
       wrapper.update();
+      await act(async () => {
+        await wrapper
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onSelect')(null, 1);
+      });
+      wrapper.update();
+
       machineFieldExpects();
       await act(async () => {
         await wrapper
-          .find('AnsibleSelect[id="credential-type"]')
-          .invoke('onChange')(null, 2);
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onToggle')();
+      });
+      wrapper.update();
+      await act(async () => {
+        await wrapper
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onSelect')(null, 2);
       });
       wrapper.update();
       sourceFieldExpects();
@@ -154,8 +167,14 @@ describe('<CredentialForm />', () => {
     test('should update expected fields when gce service account json file uploaded', async () => {
       await act(async () => {
         await wrapper
-          .find('AnsibleSelect[id="credential-type"]')
-          .invoke('onChange')(null, 10);
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onToggle')();
+      });
+      wrapper.update();
+      await act(async () => {
+        await wrapper
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onSelect')(null, 10);
       });
       wrapper.update();
       gceFieldExpects();
@@ -215,8 +234,14 @@ describe('<CredentialForm />', () => {
     test('should show error when error thrown parsing JSON', async () => {
       await act(async () => {
         await wrapper
-          .find('AnsibleSelect[id="credential-type"]')
-          .invoke('onChange')(null, 10);
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onToggle')();
+      });
+      wrapper.update();
+      await act(async () => {
+        await wrapper
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onSelect')(null, 10);
       });
       wrapper.update();
       expect(wrapper.find('#credential-gce-file-helper').text()).toBe(
@@ -246,8 +271,14 @@ describe('<CredentialForm />', () => {
     test('should show Test button when external credential type is selected', async () => {
       await act(async () => {
         await wrapper
-          .find('AnsibleSelect[id="credential-type"]')
-          .invoke('onChange')(null, 21);
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onToggle')();
+      });
+      wrapper.update();
+      await act(async () => {
+        await wrapper
+          .find('Select[aria-label="Credential Type"]')
+          .invoke('onSelect')(null, 21);
       });
       wrapper.update();
       expect(wrapper.find('Button[children="Test"]').length).toBe(1);


### PR DESCRIPTION


##### SUMMARY
This resolves #8944.  It calls the api to get up to 400 credential types and turns the credential type field into a drop down.  The mock ups call for the credential type field to be a look up, but prior to this PR it was a drop down and I believe continuing with the drop down, and adding typeahead functionality is the right direction to go instead of using a look up.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
##### ADDITIONAL INFORMATION
![Screen Shot 2021-01-20 at 11 02 22 AM](https://user-images.githubusercontent.com/39280967/105201555-061af880-5b0f-11eb-989f-cd50ca631c58.png)
