### PR TITLE
Adding option to use custom ansible-runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ awx/ui_next/instrumented
 rsyslog.pid
 tools/prometheus/data
 tools/docker-compose/Dockerfile
+tools/ansible-runner
 
 # Tower setup playbook testing
 setup/test/roles/postgresql

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,12 @@ If you're not using Docker for Mac, or Docker for Windows, you may need, or choo
 See [the ui development documentation](awx/ui_next/CONTRIBUTING.md).
 
 
+### Pre Build Steps
+
+AWX can be configured to use a development version of [ansible-runner](https://github.com/ansible/ansible-runner).
+To do this, place the source code in the folder `tools/ansible-runner`.
+The image builder step (make docker-compose-build) will replace the default version of ansible-runner with the version provided in this directory.
+
 ### Build the environment
 
 #### Fork and clone the AWX repo

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ COLLECTION_BASE ?= /var/lib/awx/vendor/awx_ansible_collections
 SCL_PREFIX ?=
 CELERY_SCHEDULE_FILE ?= /var/lib/awx/beat.db
 
+ANSIBLE_RUNNER_DIR ?= tools/ansible-runner
+
 DEV_DOCKER_TAG_BASE ?= gcr.io/ansible-tower-engineering
 # Python packages to install only from source (not from binary wheels)
 # Comma separated list
@@ -199,6 +201,11 @@ requirements_collections:
 	    ansible-galaxy collection install -r requirements/collections_requirements.yml -p $(COLLECTION_BASE) && break; \
 	    n=$$((n+1)); \
 	done
+
+requirements_runner:
+	if [ -f "$(ANSIBLE_RUNNER_DIR)/Makefile" ]; then \
+	    $(VENV_BASE)/awx/bin/pip install "${ANSIBLE_RUNNER_DIR}"; \
+	fi
 
 requirements: requirements_ansible requirements_awx requirements_collections
 

--- a/installer/roles/image_build/templates/Dockerfile.j2
+++ b/installer/roles/image_build/templates/Dockerfile.j2
@@ -67,6 +67,10 @@ ADD requirements/requirements_ansible.txt \
 RUN cd /tmp && make requirements_awx requirements_ansible_py3
 RUN cd /tmp && make requirements_collections
 
+COPY tools/ansible-runner /tmp/ansible-runner
+# This will simply do nothing if the Makefile is not in the directory
+RUN cd /tmp && make ANSIBLE_RUNNER_DIR=/tmp/ansible-runner requirements_runner
+
 {% if build_dev|bool %}
 ADD requirements/requirements_dev.txt /tmp/requirements
 RUN cd /tmp && make requirements_awx_dev requirements_ansible_dev


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In developing an AWX feature I needed to make modifications to ansible-runner. This PR allows me to place ansible-runner code in the tools directory which will be picked up and installed as part of the `make docker-compose-build` phase. If no source code is provided, the default version of ansible-runner will be installed from the existing requirements/requirements.txt.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 16.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
