### PR TITLE
openstacksdk up to update to latest

### DIFF
--- a/requirements/requirements_ansible.in
+++ b/requirements/requirements_ansible.in
@@ -61,7 +61,7 @@ pywinrm[kerberos]==0.3.0
 requests
 requests-credssp==1.0.2   # For windows authentication awx/issues/1144
 # OpenStack
-openstacksdk==0.37.0
+openstacksdk
 # Openshift/k8s
 openshift>=0.11.0  # minimum version to pull in new pyyaml for CVE-2017-18342
 pip==19.3.1  # see upgrade blockers


### PR DESCRIPTION
##### SUMMARY
Openstack.cloud collection modules require openstacksdk>0.37.
Example:
TASK [openstack.cloud.project] *****************************************
fatal: [192.168.89.5]: FAILED! => {"changed": false, "msg": "To utilize this module, the installed version of the openstacksdk library MUST be >=0.45.1."}

So just removed concrete version and let pip to instal latest from repo.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

