### PR TITLE
log job lifecycle

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -828,6 +828,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         return self.inventory.hosts.only(*only)
 
     def start_job_fact_cache(self, destination, modification_times, timeout=None):
+        self.log_lifecycle("start_job_fact_cache")
         os.makedirs(destination, mode=0o700)
         hosts = self._get_inventory_hosts()
         if timeout is None:
@@ -852,6 +853,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
             modification_times[filepath] = os.path.getmtime(filepath)
 
     def finish_job_fact_cache(self, destination, modification_times):
+        self.log_lifecycle("finish_job_fact_cache")
         for host in self._get_inventory_hosts():
             filepath = os.sep.join(map(str, [destination, host.name]))
             if not os.path.realpath(filepath).startswith(destination):

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -348,11 +348,11 @@ def test_job_not_blocking_project_update(default_instance_group, job_template_fa
         project_update.instance_group = default_instance_group
         project_update.status = "pending"
         project_update.save()
-        assert not task_manager.is_job_blocked(project_update)
+        assert not task_manager.job_blocked_by(project_update)
 
-        dependency_graph = DependencyGraph(None)
+        dependency_graph = DependencyGraph()
         dependency_graph.add_job(job)
-        assert not dependency_graph.is_job_blocked(project_update)
+        assert not dependency_graph.task_blocked_by(project_update)
 
 
 @pytest.mark.django_db
@@ -378,11 +378,11 @@ def test_job_not_blocking_inventory_update(default_instance_group, job_template_
         inventory_update.status = "pending"
         inventory_update.save()
 
-        assert not task_manager.is_job_blocked(inventory_update)
+        assert not task_manager.job_blocked_by(inventory_update)
 
-        dependency_graph = DependencyGraph(None)
+        dependency_graph = DependencyGraph()
         dependency_graph.add_job(job)
-        assert not dependency_graph.is_job_blocked(inventory_update)
+        assert not dependency_graph.task_blocked_by(inventory_update)
 
 
 @pytest.mark.django_db

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -3,6 +3,7 @@
 
 from copy import copy
 import json
+import json_log_formatter
 import logging
 import traceback
 import socket
@@ -12,6 +13,15 @@ from dateutil.tz import tzutc
 from django.utils.timezone import now
 from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
+
+
+class JobLifeCycleFormatter(json_log_formatter.JSONFormatter):
+    def json_record(self, message: str, extra: dict, record: logging.LogRecord):
+        if 'time' not in extra:
+            extra['time'] = now()
+        if record.exc_info:
+            extra['exc_info'] = self.formatException(record.exc_info)
+        return extra
 
 
 class TimeFormatter(logging.Formatter):

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -103,6 +103,15 @@ if settings.COLOR_LOGS is True:
         from logutils.colorize import ColorizingStreamHandler
 
         class ColorHandler(ColorizingStreamHandler):
+            def colorize(self, line, record):
+                # comment out this method if you don't like the job_lifecycle
+                # logs rendered with cyan text
+                previous_level_map = self.level_map.copy()
+                if record.name == "awx.analytics.job_lifecycle":
+                    self.level_map[logging.DEBUG] = (None, 'cyan', True)
+                msg = super(ColorHandler, self).colorize(line, record)
+                self.level_map = previous_level_map
+                return msg
 
             def format(self, record):
                 message = logging.StreamHandler.format(self, record)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -842,6 +842,9 @@ LOGGING = {
         'dispatcher': {
             'format': '%(asctime)s %(levelname)-8s %(name)s PID:%(process)d %(message)s',
         },
+        'job_lifecycle': {
+            '()': 'awx.main.utils.formatters.JobLifeCycleFormatter',
+        },
     },
     'handlers': {
         'console': {
@@ -940,6 +943,12 @@ LOGGING = {
             'filename': os.path.join(LOG_ROOT, 'isolated_manager.log'),
             'formatter':'simple',
         },
+        'job_lifecycle': {
+            'level': 'DEBUG',
+            'class':'logging.handlers.WatchedFileHandler',
+            'filename': os.path.join(LOG_ROOT, 'job_lifecycle.log'),
+            'formatter': 'job_lifecycle',
+        },
     },
     'loggers': {
         'django': {
@@ -1027,6 +1036,11 @@ LOGGING = {
         'awx.analytics': {
             'handlers': ['external_logger'],
             'level': 'INFO',
+            'propagate': False
+        },
+        'awx.analytics.job_lifecycle': {
+            'handlers': ['console', 'job_lifecycle'],
+            'level': 'DEBUG',
             'propagate': False
         },
         'django_auth_ldap': {

--- a/docs/licenses/JSON-log-formatter.txt
+++ b/docs/licenses/JSON-log-formatter.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Marsel Mavletkulov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,6 +28,7 @@ djangorestframework-yaml
 GitPython>=3.1.1  # minimum to fix https://github.com/ansible/awx/issues/6119
 irc
 jinja2>=2.11.0  # required for ChainableUndefined
+JSON-log-formatter
 jsonschema
 Markdown  # used for formatting API help
 openshift>=0.11.0  # minimum version to pull in new pyyaml for CVE-2017-18342

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -61,6 +61,7 @@ jaraco.logging==3.0.0     # via irc
 jaraco.stream==3.0.0      # via irc
 jaraco.text==3.2.0        # via irc, jaraco.collections
 jinja2==2.11.2            # via -r /awx_devel/requirements/requirements.in, openshift
+JSON-log-formatter        # via -r /awx_devel/requirements/requirements.in
 jsonschema==3.2.0         # via -r /awx_devel/requirements/requirements.in
 kubernetes==11.0.0        # via openshift
 lockfile==0.12.2          # via python-daemon


### PR DESCRIPTION
feature issue https://github.com/ansible/awx/issues/8749

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
example output in `/var/log/tower/job_lifecycle.log`
```json
{"type": "job", "task_id": 353, "state": "created", "template_name": "sleep", "time": "2021-01-28T04:25:46.661029+00:00"}
{"type": "job", "task_id": 353, "state": "acknowledged", "template_name": "sleep", "time": "2021-01-28T04:25:47.125391+00:00"}
{"type": "job", "task_id": 350, "state": "blocked", "template_name": "sleep", "blocked_by": "projectupdate-351", "time": "2021-01-28T04:25:47.166337+00:00"}
{"type": "job", "task_id": 352, "state": "blocked", "template_name": "sleep", "blocked_by": "projectupdate-351", "time": "2021-01-28T04:25:47.176640+00:00"}
{"type": "job", "task_id": 353, "state": "blocked", "template_name": "sleep", "blocked_by": "projectupdate-351", "time": "2021-01-28T04:25:47.177712+00:00"}
```

these events also show up in the stdout log
`awx_1       | 2021-02-03 18:41:05,656 DEBUG    awx.analytics.job_lifecycle job-740 created`

##### Dependency Graph Changes

The `DependencyGraph` tells us _what_ is blocked, but doesn't tell us what is doing the blocking. I rewrote it to expose that information.

e.g. here is the new representation in `dependency_graph.data`
```python
{'inventory_source_ids': {},
 'inventory_source_updates': {},
 'inventory_updates': {},
 'job_template_jobs': {},
 'project_updates': {12: <ProjectUpdate: 2021-01-14 05:48:48.599418+00:00-2-pending>},
 'system_job': None,
 'workflow_job_template_jobs': {}}
```
now instead of `is_job_blocked` in the task manager, we have `job_blocked_by` which returns a `UnifiedJob` object, or `None` if it is not blocked.

##### Job Explanation Changes
We can also update `job_explanation` with some information about why a job is blocked.
e.g.
`waiting until the project update finishes`

To reduce performance loss with `task.save()`, we only update this `job_explanation` if it is different from the current job_explanation, and if more than 30 seconds have passed since `job.created`.

There is a PR open that will display job explanation in the UI, so this might be our mechanism of displaying information to the user.

https://github.com/ansible/awx/pull/8726/

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 16.0.0
```