### PR TITLE
Fix the handling of wrong survey spec in awx collection

### DIFF
--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -151,7 +151,15 @@ import json
 
 def update_survey(module, last_request):
     spec_endpoint = last_request.get('related', {}).get('survey_spec')
-    module.post_endpoint(spec_endpoint, **{'data': module.params.get('survey_spec')})
+    if module.params.get('survey_spec') == {}:
+        response = module.delete_endpoint(spec_endpoint)
+        if response['status_code'] != 200:
+            # Not sure how to make this actually return a non 200 to test what to dump in the respinse
+            module.fail_json(msg="Failed to delete survey: {0}".format(response['json']))
+    else:
+        response = module.post_endpoint(spec_endpoint, **{'data': module.params.get('survey_spec')})
+        if response['status_code'] != 200:
+            module.fail_json(msg="Failed to update survey: {0}".format(response['json']['error']))
     module.exit_json(**module.json_output)
 
 

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -178,6 +178,38 @@ def test_job_template_with_survey_spec(run_module, admin_user, project, inventor
 
 
 @pytest.mark.django_db
+def test_job_template_with_wrong_survey_spec(run_module, admin_user, project, inventory, survey_spec):
+    result = run_module('tower_job_template', dict(
+        name='foo',
+        playbook='helloworld.yml',
+        project=project.name,
+        inventory=inventory.name,
+        survey_spec=survey_spec,
+        survey_enabled=True
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed', False), result
+    jt = JobTemplate.objects.get(pk=result['id'])
+
+    assert jt.survey_spec == survey_spec
+
+    prior_ct = ActivityStream.objects.count()
+
+    del survey_spec['description']
+
+    result = run_module('tower_job_template', dict(
+        name='foo',
+        playbook='helloworld.yml',
+        project=project.name,
+        inventory=inventory.name,
+        survey_spec=survey_spec,
+        survey_enabled=True
+    ), admin_user)
+    assert result.get('failed', True)
+    assert result.get('msg') == "Failed to update survey: Field 'description' is missing from survey spec."
+
+
+@pytest.mark.django_db
 def test_job_template_with_survey_encrypted_default(run_module, admin_user, project, inventory, silence_warning):
     spec = {
         "spec": [

--- a/awx_collection/test/awx/test_workflow_job_template.py
+++ b/awx_collection/test/awx/test_workflow_job_template.py
@@ -82,6 +82,34 @@ def test_survey_spec_only_changed(run_module, admin_user, organization, survey_s
 
 
 @pytest.mark.django_db
+def test_survey_spec_only_changed(run_module, admin_user, organization, survey_spec):
+    wfjt = WorkflowJobTemplate.objects.create(
+        organization=organization, name='foo-workflow',
+        survey_enabled=True, survey_spec=survey_spec
+    )
+    result = run_module('tower_workflow_job_template', {
+        'name': 'foo-workflow',
+        'organization': organization.name,
+        'state': 'present'
+    }, admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert not result.get('changed', True), result
+    wfjt.refresh_from_db()
+    assert wfjt.survey_spec == survey_spec
+
+    del survey_spec['description']
+
+    result = run_module('tower_workflow_job_template', {
+        'name': 'foo-workflow',
+        'organization': organization.name,
+        'survey_spec': survey_spec,
+        'state': 'present'
+    }, admin_user)
+    assert result.get('failed', True)
+    assert result.get('msg') == "Failed to update survey: Field 'description' is missing from survey spec."
+
+
+@pytest.mark.django_db
 def test_associate_only_on_success(run_module, admin_user, organization, project):
     wfjt = WorkflowJobTemplate.objects.create(
         organization=organization, name='foo-workflow',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes https://github.com/ansible/awx/issues/8986
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
With the above PR following is what we get with a wrong survey spec in wfjt and jt

1.) Task with wrong survey spec for workflow_job_template (missing description):
```
tasks:
  - name: Create Workflow Job Templates
    awx.awx.tower_workflow_job_template:
      name: My AutoWFtest
      description: This is my autowftest
      organization: Default
      survey_enabled: yes
      survey: {
            "question_name": "How do you feel?",
            "question_description": "",
            "required": false,
            "type": "textarea",
            "variable": "current_feelings",
            "min": 0,
            "max": 4096,
            "default": "",
            "choices": "",
            "new_question": true
        }
      state: present
```
Playbook Output:
```
TASK [Create Workflow Job Templates] ******************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to update survey: Field 'description' is missing from survey spec."}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

2.) Task with wrong survey spec for job_template (missing description):
```
tasks:
  - name: Create Job Templates
    awx.awx.tower_job_template:
      name: My AutoJTtest
      project: galaxy
      playbook: "test.yml"
      inventory: Demo Inventory
      description: This is my autowftest
      organization: Default
      survey_enabled: yes
      survey_spec:
         spec: [
           {
             "question_name": "How do you feel?",
             "question_description": "",
             "required": false,
             "type": "textarea",
             "variable": "current_feelings",
             "min": 0,
             "max": 4096,
             "default": "",
             "choices": "",
             "new_question": true
           }
         ]
      state: present
```

Playbook output:
```
TASK [Create Job Templates] ***************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to update survey: Field 'description' is missing from survey spec."}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```