### PR TITLE
Pre-create pgdocker dir ahead of time with proper permissions

### DIFF
--- a/installer/roles/local_docker/tasks/upgrade_postgres.yml
+++ b/installer/roles/local_docker/tasks/upgrade_postgres.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Create {{ postgres_data_dir }} directory
+  file:
+    path: "{{ postgres_data_dir }}"
+    state: directory
+
 - name: Get full path of postgres data dir
   shell: "echo {{ postgres_data_dir }}"
   register: fq_postgres_data_dir


### PR DESCRIPTION
##### SUMMARY

Issue: https://github.com/ansible/awx/issues/9140

The temporary container I added creates the `.awx` directory as root upon running because that is the default behavior when bind-mounting a directory to a container.  This happened during the following task:

```
TASK [local_docker : Check for existing Postgres data (run from inside the container for access to file)]
```

To solve this, I added a task to pre-create the directory (if it didn't already exist) with permissions that will work.  The pre-existing permissions of the file being bind-mounted will be observed by Docker.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
17.0.0
```
