### PR TITLE
Assure that unit_id is always defined

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3015,6 +3015,7 @@ class AWXReceptorJob:
     def __init__(self, task, runner_params):
         self.task = task
         self.runner_params = runner_params
+        self.unit_id = None
 
         if not self.task.instance.is_container_group_task:
             execution_environment_params = self.task.build_execution_environment_params(self.task.instance)


### PR DESCRIPTION
I feel bad for letting this slip, I had a case where I was able to hit this:

```
Traceback (most recent call last):
  File "/awx_devel/awx/main/tasks.py", line 1425, in run
    res = receptor_job.run()
  File "/awx_devel/awx/main/tasks.py", line 3031, in run
    if self.unit_id is not None:
AttributeError: 'AWXReceptorJob' object has no attribute 'unit_id'
```