### PR TITLE
Fix Pylint Error

### DIFF
--- a/awx_collection/test/awx/test_notification_template.py
+++ b/awx_collection/test/awx/test_notification_template.py
@@ -136,5 +136,5 @@ def test_build_notification_message_undefined(run_module, admin_user, organizati
     ), admin_user)
     nt = NotificationTemplate.objects.get(id=result['id'])
 
-    _, body = job.build_notification_message(nt, 'running')
-    assert '{"started_by": "My Placeholder"}' in body
+    body = job.build_notification_message(nt, 'running')
+    assert '{"started_by": "My Placeholder"}' in body[1]


### PR DESCRIPTION
##### SUMMARY
`pylint` doesn't like throwaway variables; this PR replaces the `_` in `test_build_notification_message_undefined` with a tuple index so that the string `'running'` can still be accessed without throwing an error.

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
17.0.0
```
