### PR TITLE
Prompts on schedules

### DIFF
--- a/awx/ui_next/src/api/models/InventorySources.js
+++ b/awx/ui_next/src/api/models/InventorySources.js
@@ -10,6 +10,7 @@ class InventorySources extends LaunchUpdateMixin(
     super(http);
     this.baseUrl = '/api/v2/inventory_sources/';
 
+    this.createSchedule = this.createSchedule.bind(this);
     this.createSyncStart = this.createSyncStart.bind(this);
     this.destroyGroups = this.destroyGroups.bind(this);
     this.destroyHosts = this.destroyHosts.bind(this);

--- a/awx/ui_next/src/api/models/JobTemplates.js
+++ b/awx/ui_next/src/api/models/JobTemplates.js
@@ -10,6 +10,7 @@ class JobTemplates extends SchedulesMixin(
     super(http);
     this.baseUrl = '/api/v2/job_templates/';
 
+    this.createSchedule = this.createSchedule.bind(this);
     this.launch = this.launch.bind(this);
     this.readLaunch = this.readLaunch.bind(this);
     this.associateLabel = this.associateLabel.bind(this);

--- a/awx/ui_next/src/api/models/Projects.js
+++ b/awx/ui_next/src/api/models/Projects.js
@@ -16,6 +16,7 @@ class Projects extends SchedulesMixin(
     this.readPlaybooks = this.readPlaybooks.bind(this);
     this.readSync = this.readSync.bind(this);
     this.sync = this.sync.bind(this);
+    this.createSchedule = this.createSchedule.bind(this);
   }
 
   readAccessList(id, params) {

--- a/awx/ui_next/src/api/models/Schedules.js
+++ b/awx/ui_next/src/api/models/Schedules.js
@@ -14,6 +14,19 @@ class Schedules extends Base {
     return this.http.get(`${this.baseUrl}${resourceId}/credentials/`, params);
   }
 
+  associateCredential(resourceId, credentialId) {
+    return this.http.post(`${this.baseUrl}${resourceId}/credentials/`, {
+      id: credentialId,
+    });
+  }
+
+  disassociateCredential(resourceId, credentialId) {
+    return this.http.post(`${this.baseUrl}${resourceId}/credentials/`, {
+      id: credentialId,
+      disassociate: true,
+    });
+  }
+
   readZoneInfo() {
     return this.http.get(`${this.baseUrl}zoneinfo/`);
   }

--- a/awx/ui_next/src/api/models/WorkflowJobTemplates.js
+++ b/awx/ui_next/src/api/models/WorkflowJobTemplates.js
@@ -6,6 +6,7 @@ class WorkflowJobTemplates extends SchedulesMixin(NotificationsMixin(Base)) {
   constructor(http) {
     super(http);
     this.baseUrl = '/api/v2/workflow_job_templates/';
+    this.createSchedule = this.createSchedule.bind(this);
   }
 
   readWebhookKey(id) {

--- a/awx/ui_next/src/components/JobList/JobListItem.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.jsx
@@ -160,6 +160,14 @@ function JobListItem({
                   }
                 />
               )}
+
+              {job.job_explanation && (
+                <Detail
+                  fullWidth
+                  label={i18n._(t`Explanation`)}
+                  value={job.job_explanation}
+                />
+              )}
             </DetailList>
           </ExpandableRowContent>
         </Td>

--- a/awx/ui_next/src/components/LaunchPrompt/steps/usePreviewStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/usePreviewStep.jsx
@@ -11,7 +11,8 @@ export default function usePreviewStep(
   resource,
   surveyConfig,
   hasErrors,
-  showStep
+  showStep,
+  nextButtonText
 ) {
   return {
     step: showStep
@@ -31,7 +32,7 @@ export default function usePreviewStep(
             />
           ),
           enableNext: !hasErrors,
-          nextButtonText: i18n._(t`Launch`),
+          nextButtonText: nextButtonText || i18n._(t`Launch`),
         }
       : null,
     initialValues: {},

--- a/awx/ui_next/src/components/Schedule/Schedule.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.jsx
@@ -26,12 +26,7 @@ function Schedule({ i18n, setBreadcrumb, resource }) {
 
   const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
 
-  const {
-    isLoading: contentLoading,
-    error: contentError,
-    request: loadData,
-    result: schedule,
-  } = useRequest(
+  const { isLoading, error, request: loadData, result: schedule } = useRequest(
     useCallback(async () => {
       const { data } = await SchedulesAPI.readDetail(scheduleId);
 
@@ -68,7 +63,7 @@ function Schedule({ i18n, setBreadcrumb, resource }) {
     },
   ];
 
-  if (contentLoading) {
+  if (isLoading) {
     return <ContentLoading />;
   }
 
@@ -85,8 +80,8 @@ function Schedule({ i18n, setBreadcrumb, resource }) {
     );
   }
 
-  if (contentError) {
-    return <ContentError error={contentError} />;
+  if (error) {
+    return <ContentError error={error} />;
   }
 
   let showCardHeader = true;

--- a/awx/ui_next/src/components/Schedule/Schedule.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.jsx
@@ -19,7 +19,13 @@ import ScheduleEdit from './ScheduleEdit';
 import { SchedulesAPI } from '../../api';
 import useRequest from '../../util/useRequest';
 
-function Schedule({ i18n, setBreadcrumb, resource }) {
+function Schedule({
+  i18n,
+  setBreadcrumb,
+  resource,
+  launchConfig,
+  surveyConfig,
+}) {
   const { scheduleId } = useParams();
 
   const { pathname } = useLocation();
@@ -100,13 +106,18 @@ function Schedule({ i18n, setBreadcrumb, resource }) {
         />
         {schedule && [
           <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit schedule={schedule} resource={resource} />
+            <ScheduleEdit
+              schedule={schedule}
+              resource={resource}
+              launchConfig={launchConfig}
+              surveyConfig={surveyConfig}
+            />
           </Route>,
           <Route
             key="details"
             path={`${pathRoot}schedules/:scheduleId/details`}
           >
-            <ScheduleDetail schedule={schedule} />
+            <ScheduleDetail schedule={schedule} surveyConfig={surveyConfig} />
           </Route>,
         ]}
         <Route key="not-found" path="*">

--- a/awx/ui_next/src/components/Schedule/Schedule.test.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.test.jsx
@@ -93,10 +93,7 @@ describe('<Schedule />', () => {
         <Route
           path="/templates/job_template/:id/schedules"
           component={() => (
-            <Schedule
-              setBreadcrumb={() => {}}
-              unifiedJobTemplate={unifiedJobTemplate}
-            />
+            <Schedule setBreadcrumb={() => {}} resource={unifiedJobTemplate} />
           )}
         />,
         {

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
@@ -8,7 +8,7 @@ import { CardBody } from '../../Card';
 import buildRuleObj from '../shared/buildRuleObj';
 import ScheduleForm from '../shared/ScheduleForm';
 
-function ScheduleAdd({ i18n, createSchedule }) {
+function ScheduleAdd({ i18n, resource, apiModel }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const history = useHistory();
   const location = useLocation();
@@ -18,11 +18,8 @@ function ScheduleAdd({ i18n, createSchedule }) {
   const handleSubmit = async values => {
     try {
       const rule = new RRule(buildRuleObj(values, i18n));
-      const {
-        data: { id: scheduleId },
-      } = await createSchedule({
-        name: values.name,
-        description: values.description,
+
+      const { id: scheduleId } = await apiModel.createSchedule(resource.id, {
         rrule: rule.toString().replace(/\n/g, ' '),
       });
 
@@ -46,7 +43,7 @@ function ScheduleAdd({ i18n, createSchedule }) {
 }
 
 ScheduleAdd.propTypes = {
-  createSchedule: func.isRequired,
+  apiModel: shape({ createSchedule: func.isRequired }).isRequired,
 };
 
 ScheduleAdd.defaultProps = {};

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
@@ -15,14 +15,18 @@ import mergeExtraVars from '../../../util/prompt/mergeExtraVars';
 import getSurveyValues from '../../../util/prompt/getSurveyValues';
 import { getAddedAndRemoved } from '../../../util/lists';
 
-function ScheduleAdd({ i18n, resource, apiModel }) {
+function ScheduleAdd({ i18n, resource, apiModel, launchConfig, surveyConfig }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const history = useHistory();
   const location = useLocation();
   const { pathname } = location;
   const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
 
-  const handleSubmit = async (values, launchConfig, surveyConfig) => {
+  const handleSubmit = async (
+    values,
+    launchConfiguration,
+    surveyConfiguration
+  ) => {
     const {
       inventory,
       extra_vars,
@@ -51,8 +55,9 @@ function ScheduleAdd({ i18n, resource, apiModel }) {
     let extraVars;
     const surveyValues = getSurveyValues(values);
     const initialExtraVars =
-      launchConfig?.ask_variables_on_launch && (values.extra_vars || '---');
-    if (surveyConfig?.spec) {
+      launchConfiguration?.ask_variables_on_launch &&
+      (values.extra_vars || '---');
+    if (surveyConfiguration?.spec) {
       extraVars = yaml.safeDump(mergeExtraVars(initialExtraVars, surveyValues));
     } else {
       extraVars = yaml.safeDump(mergeExtraVars(initialExtraVars, {}));
@@ -92,6 +97,8 @@ function ScheduleAdd({ i18n, resource, apiModel }) {
           handleCancel={() => history.push(`${pathRoot}schedules`)}
           handleSubmit={handleSubmit}
           submitError={formSubmitError}
+          launchConfig={launchConfig}
+          surveyConfig={surveyConfig}
           resource={resource}
         />
       </CardBody>

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
@@ -19,45 +19,45 @@ SchedulesAPI.readZoneInfo.mockResolvedValue({
     },
   ],
 });
-JobTemplatesAPI.readLaunch.mockResolvedValue({
-  data: {
-    can_start_without_user_input: false,
-    passwords_needed_to_start: [],
-    ask_scm_branch_on_launch: false,
-    ask_variables_on_launch: false,
-    ask_tags_on_launch: false,
-    ask_diff_mode_on_launch: false,
-    ask_skip_tags_on_launch: false,
-    ask_job_type_on_launch: false,
-    ask_limit_on_launch: false,
-    ask_verbosity_on_launch: false,
-    ask_inventory_on_launch: true,
-    ask_credential_on_launch: false,
-    survey_enabled: false,
-    variables_needed_to_start: [],
-    credential_needed_to_start: false,
-    inventory_needed_to_start: true,
-    job_template_data: {
-      name: 'Demo Job Template',
-      id: 7,
-      description: '',
-    },
-    defaults: {
-      extra_vars: '---',
-      diff_mode: false,
-      limit: '',
-      job_tags: '',
-      skip_tags: '',
-      job_type: 'run',
-      verbosity: 0,
-      inventory: {
-        name: null,
-        id: null,
-      },
-      scm_branch: '',
-    },
+
+const launchConfig = {
+  can_start_without_user_input: false,
+  passwords_needed_to_start: [],
+  ask_scm_branch_on_launch: false,
+  ask_variables_on_launch: false,
+  ask_tags_on_launch: false,
+  ask_diff_mode_on_launch: false,
+  ask_skip_tags_on_launch: false,
+  ask_job_type_on_launch: false,
+  ask_limit_on_launch: false,
+  ask_verbosity_on_launch: false,
+  ask_inventory_on_launch: true,
+  ask_credential_on_launch: false,
+  survey_enabled: false,
+  variables_needed_to_start: [],
+  credential_needed_to_start: false,
+  inventory_needed_to_start: true,
+  job_template_data: {
+    name: 'Demo Job Template',
+    id: 7,
+    description: '',
   },
-});
+  defaults: {
+    extra_vars: '---',
+    diff_mode: false,
+    limit: '',
+    job_tags: '',
+    skip_tags: '',
+    job_type: 'run',
+    verbosity: 0,
+    inventory: {
+      name: null,
+      id: null,
+    },
+    scm_branch: '',
+  },
+};
+
 JobTemplatesAPI.createSchedule.mockResolvedValue({ data: { id: 3 } });
 
 let wrapper;
@@ -74,6 +74,7 @@ describe('<ScheduleAdd />', () => {
             inventory: 2,
             summary_fields: { credentials: [] },
           }}
+          launchConfig={launchConfig}
         />
       );
     });
@@ -377,7 +378,6 @@ describe('<ScheduleAdd />', () => {
     );
     wrapper.update();
     expect(wrapper.find('Wizard').length).toBe(0);
-    // console.log(wrapper.debug());
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
         name: 'Schedule',

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
@@ -5,10 +5,12 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
-import { SchedulesAPI } from '../../../api';
+import { SchedulesAPI, JobTemplatesAPI, InventoriesAPI } from '../../../api';
 import ScheduleAdd from './ScheduleAdd';
 
 jest.mock('../../../api/models/Schedules');
+jest.mock('../../../api/models/JobTemplates');
+jest.mock('../../../api/models/Inventories');
 
 SchedulesAPI.readZoneInfo.mockResolvedValue({
   data: [
@@ -17,22 +19,62 @@ SchedulesAPI.readZoneInfo.mockResolvedValue({
     },
   ],
 });
+JobTemplatesAPI.readLaunch.mockResolvedValue({
+  data: {
+    can_start_without_user_input: false,
+    passwords_needed_to_start: [],
+    ask_scm_branch_on_launch: false,
+    ask_variables_on_launch: false,
+    ask_tags_on_launch: false,
+    ask_diff_mode_on_launch: false,
+    ask_skip_tags_on_launch: false,
+    ask_job_type_on_launch: false,
+    ask_limit_on_launch: false,
+    ask_verbosity_on_launch: false,
+    ask_inventory_on_launch: true,
+    ask_credential_on_launch: false,
+    survey_enabled: false,
+    variables_needed_to_start: [],
+    credential_needed_to_start: false,
+    inventory_needed_to_start: true,
+    job_template_data: {
+      name: 'Demo Job Template',
+      id: 7,
+      description: '',
+    },
+    defaults: {
+      extra_vars: '---',
+      diff_mode: false,
+      limit: '',
+      job_tags: '',
+      skip_tags: '',
+      job_type: 'run',
+      verbosity: 0,
+      inventory: {
+        name: null,
+        id: null,
+      },
+      scm_branch: '',
+    },
+  },
+});
+JobTemplatesAPI.createSchedule.mockResolvedValue({ data: { id: 3 } });
 
 let wrapper;
-
-const createSchedule = jest.fn().mockImplementation(() => {
-  return {
-    data: {
-      id: 1,
-    },
-  };
-});
 
 describe('<ScheduleAdd />', () => {
   beforeAll(async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <ScheduleAdd createSchedule={createSchedule} />
+        <ScheduleAdd
+          apiModel={JobTemplatesAPI}
+          resource={{
+            id: 700,
+            type: 'job_template',
+            inventory: 2,
+            summary_fields: { credentials: [] },
+          }}
+        />
       );
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
@@ -42,7 +84,7 @@ describe('<ScheduleAdd />', () => {
   });
   test('Successfully creates a schedule with repeat frequency: None (run once)', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'none',
@@ -52,16 +94,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run once schedule',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T100000 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
   test('Successfully creates a schedule with 10 minute repeat frequency after 10 occurrences', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'after',
         frequency: 'minute',
@@ -72,16 +115,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run every 10 minutes 10 times',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T103000 RRULE:INTERVAL=10;FREQ=MINUTELY;COUNT=10',
     });
   });
   test('Successfully creates a schedule with hourly repeat frequency ending on a specific date/time', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'onDate',
         endDateTime: '2020-03-26T10:45:00',
@@ -92,16 +136,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run every hour until date',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=HOURLY;UNTIL=20200326T104500',
     });
   });
   test('Successfully creates a schedule with daily repeat frequency', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'day',
@@ -111,16 +156,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run daily',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=DAILY',
     });
   });
   test('Successfully creates a schedule with weekly repeat frequency on mon/wed/fri', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         daysOfWeek: [RRule.MO, RRule.WE, RRule.FR],
         description: 'test description',
         end: 'never',
@@ -132,15 +178,16 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run weekly on mon/wed/fri',
+      extra_data: {},
       rrule: `DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=${RRule.MO},${RRule.WE},${RRule.FR}`,
     });
   });
   test('Successfully creates a schedule with monthly repeat frequency on the first day of the month', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'month',
@@ -153,16 +200,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run on the first day of the month',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200401T104500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYMONTHDAY=1',
     });
   });
   test('Successfully creates a schedule with monthly repeat frequency on the last tuesday of the month', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         endDateTime: '2020-03-26T11:00:00',
@@ -177,16 +225,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Run monthly on the last Tuesday',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200331T110000 RRULE:INTERVAL=1;FREQ=MONTHLY;BYSETPOS=-1;BYDAY=TU',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the first day of March', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -200,16 +249,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Yearly on the first day of March',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200301T000000 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the second Friday in April', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -224,16 +274,17 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Yearly on the second Friday in April',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=2;BYDAY=FR;BYMONTH=4',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the first weekday in October', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -248,11 +299,119 @@ describe('<ScheduleAdd />', () => {
         timezone: 'America/New_York',
       });
     });
-    expect(createSchedule).toHaveBeenCalledWith({
+    expect(JobTemplatesAPI.createSchedule).toHaveBeenCalledWith(700, {
       description: 'test description',
       name: 'Yearly on the first weekday in October',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=1;BYDAY=MO,TU,WE,TH,FR;BYMONTH=10',
     });
+  });
+
+  test('should submit prompted data properly', async () => {
+    InventoriesAPI.read.mockResolvedValue({
+      data: {
+        count: 2,
+        results: [
+          {
+            name: 'Foo',
+            id: 1,
+            url: '',
+          },
+          {
+            name: 'Bar',
+            id: 2,
+            url: '',
+          },
+        ],
+      },
+    });
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: {
+        related_search_fields: [],
+        actions: {
+          GET: {
+            filterable: true,
+          },
+        },
+      },
+    });
+
+    await act(async () =>
+      wrapper.find('Button[aria-label="Prompt"]').prop('onClick')()
+    );
+    wrapper.update();
+    expect(
+      wrapper
+        .find('WizardNavItem')
+        .at(0)
+        .prop('isCurrent')
+    ).toBe(true);
+    await act(async () => {
+      wrapper
+        .find('input[aria-labelledby="check-action-item-1"]')
+        .simulate('change', {
+          target: {
+            checked: true,
+          },
+        });
+    });
+    wrapper.update();
+    expect(
+      wrapper
+        .find('input[aria-labelledby="check-action-item-1"]')
+        .prop('checked')
+    ).toBe(true);
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onNext')()
+    );
+    wrapper.update();
+    expect(
+      wrapper
+        .find('WizardNavItem')
+        .at(1)
+        .prop('isCurrent')
+    ).toBe(true);
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onNext')()
+    );
+    wrapper.update();
+    expect(wrapper.find('Wizard').length).toBe(0);
+    // console.log(wrapper.debug());
+    await act(async () => {
+      wrapper.find('Formik').invoke('onSubmit')({
+        name: 'Schedule',
+        end: 'never',
+        endDateTime: '2021-01-29T14:15:00',
+        frequency: 'none',
+        occurrences: 1,
+        runOn: 'day',
+        runOnDayMonth: 1,
+        runOnDayNumber: 1,
+        runOnTheDay: 'sunday',
+        runOnTheMonth: 1,
+        runOnTheOccurrence: 1,
+        skip_tags: '',
+        inventory: { name: 'inventory', id: 45 },
+        credentials: [
+          { name: 'cred 1', id: 10 },
+          { name: 'cred 2', id: 20 },
+        ],
+        startDateTime: '2021-01-28T14:15:00',
+        timezone: 'America/New_York',
+      });
+    });
+    wrapper.update();
+
+    expect(JobTemplatesAPI.createSchedule).toBeCalledWith(700, {
+      extra_data: {},
+      inventory: 45,
+      name: 'Schedule',
+      rrule:
+        'DTSTART;TZID=America/New_York:20210128T141500 RRULE:COUNT=1;FREQ=MINUTELY',
+      skip_tags: '',
+    });
+    expect(SchedulesAPI.associateCredential).toBeCalledWith(3, 10);
+    expect(SchedulesAPI.associateCredential).toBeCalledWith(3, 20);
   });
 });

--- a/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.jsx
@@ -189,6 +189,14 @@ function ScheduleDetail({ schedule, i18n }) {
     showVerbosityDetail ||
     showVariablesDetail;
 
+  const VERBOSITY = {
+    0: i18n._(t`0 (Normal)`),
+    1: i18n._(t`1 (Verbose)`),
+    2: i18n._(t`2 (More Verbose)`),
+    3: i18n._(t`3 (Debug)`),
+    4: i18n._(t`4 (Connection Debug)`),
+  };
+
   if (isLoading) {
     return <ContentLoading />;
   }
@@ -254,6 +262,12 @@ function ScheduleDetail({ schedule, i18n }) {
                     ' '
                   )
                 }
+              />
+            )}
+            {ask_verbosity_on_launch && (
+              <Detail
+                label={i18n._(t`Verbosity`)}
+                value={VERBOSITY[verbosity]}
               />
             )}
             {ask_scm_branch_on_launch && (

--- a/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.jsx
@@ -26,6 +26,7 @@ const allPrompts = {
     ask_variables_on_launch: true,
     ask_verbosity_on_launch: true,
     survey_enabled: true,
+    inventory_needed_to_start: true,
   },
 };
 
@@ -488,5 +489,40 @@ describe('<ScheduleDetail />', () => {
       el => el.length === 0
     );
     expect(SchedulesAPI.destroy).toHaveBeenCalledTimes(1);
+  });
+  test('should have disabled toggle', async () => {
+    SchedulesAPI.readCredentials.mockResolvedValueOnce({
+      data: {
+        count: 0,
+        results: [],
+      },
+    });
+    JobTemplatesAPI.readLaunch.mockResolvedValueOnce(allPrompts);
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Route
+          path="/templates/job_template/:id/schedules/:scheduleId"
+          component={() => (
+            <ScheduleDetail schedule={schedule} surveyConfig={{ spec: [] }} />
+          )}
+        />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: { params: { id: 1 } },
+              },
+            },
+          },
+        }
+      );
+    });
+    await waitForElement(
+      wrapper,
+      'ScheduleToggle',
+      el => el.prop('isDisabled') === true
+    );
   });
 });

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
@@ -9,7 +9,7 @@ import { SchedulesAPI } from '../../../api';
 import buildRuleObj from '../shared/buildRuleObj';
 import ScheduleForm from '../shared/ScheduleForm';
 
-function ScheduleEdit({ i18n, schedule }) {
+function ScheduleEdit({ i18n, schedule, resource }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const history = useHistory();
   const location = useLocation();

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
@@ -4,10 +4,16 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { RRule } from 'rrule';
 import { shape } from 'prop-types';
 import { Card } from '@patternfly/react-core';
+import yaml from 'js-yaml';
 import { CardBody } from '../../Card';
 import { SchedulesAPI } from '../../../api';
 import buildRuleObj from '../shared/buildRuleObj';
 import ScheduleForm from '../shared/ScheduleForm';
+import { getAddedAndRemoved } from '../../../util/lists';
+
+import { parseVariableField } from '../../../util/yaml';
+import mergeExtraVars from '../../../util/prompt/mergeExtraVars';
+import getSurveyValues from '../../../util/prompt/getSurveyValues';
 
 function ScheduleEdit({ i18n, schedule, resource }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
@@ -16,16 +22,69 @@ function ScheduleEdit({ i18n, schedule, resource }) {
   const { pathname } = location;
   const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
 
-  const handleSubmit = async values => {
+  const handleSubmit = async (
+    values,
+    launchConfig,
+    surveyConfig,
+    scheduleCredentials = []
+  ) => {
+    const {
+      inventory,
+      credentials = [],
+      end,
+      frequency,
+      interval,
+      startDateTime,
+      timezone,
+      occurrences,
+      runOn,
+      runOnTheDay,
+      runOnTheMonth,
+      runOnDayMonth,
+      runOnDayNumber,
+      endDateTime,
+      runOnTheOccurrence,
+      daysOfWeek,
+      ...submitValues
+    } = values;
+    const { added, removed } = getAddedAndRemoved(
+      [...resource?.summary_fields.credentials, ...scheduleCredentials],
+      credentials
+    );
+
+    let extraVars;
+    const surveyValues = getSurveyValues(values);
+    const initialExtraVars =
+      launchConfig?.ask_variables_on_launch && (values.extra_vars || '---');
+    if (surveyConfig?.spec) {
+      extraVars = yaml.safeDump(mergeExtraVars(initialExtraVars, surveyValues));
+    } else {
+      extraVars = yaml.safeDump(mergeExtraVars(initialExtraVars, {}));
+    }
+    submitValues.extra_data = extraVars && parseVariableField(extraVars);
+    delete values.extra_vars;
+    if (inventory) {
+      submitValues.inventory = inventory.id;
+    }
+
     try {
       const rule = new RRule(buildRuleObj(values, i18n));
       const {
         data: { id: scheduleId },
       } = await SchedulesAPI.update(schedule.id, {
-        name: values.name,
-        description: values.description,
+        ...submitValues,
         rrule: rule.toString().replace(/\n/g, ' '),
       });
+      if (values.credentials?.length > 0) {
+        await Promise.all([
+          ...removed.map(({ id }) =>
+            SchedulesAPI.disassociateCredential(scheduleId, id)
+          ),
+          ...added.map(({ id }) =>
+            SchedulesAPI.associateCredential(scheduleId, id)
+          ),
+        ]);
+      }
 
       history.push(`${pathRoot}schedules/${scheduleId}/details`);
     } catch (err) {
@@ -43,6 +102,7 @@ function ScheduleEdit({ i18n, schedule, resource }) {
           }
           handleSubmit={handleSubmit}
           submitError={formSubmitError}
+          resource={resource}
         />
       </CardBody>
     </Card>

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
@@ -5,10 +5,20 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
-import { SchedulesAPI } from '../../../api';
+import {
+  SchedulesAPI,
+  JobTemplatesAPI,
+  InventoriesAPI,
+  CredentialsAPI,
+  CredentialTypesAPI,
+} from '../../../api';
 import ScheduleEdit from './ScheduleEdit';
 
 jest.mock('../../../api/models/Schedules');
+jest.mock('../../../api/models/JobTemplates');
+jest.mock('../../../api/models/Inventories');
+jest.mock('../../../api/models/Credentials');
+jest.mock('../../../api/models/CredentialTypes');
 
 SchedulesAPI.readZoneInfo.mockResolvedValue({
   data: [
@@ -16,6 +26,75 @@ SchedulesAPI.readZoneInfo.mockResolvedValue({
       name: 'America/New_York',
     },
   ],
+});
+
+JobTemplatesAPI.readLaunch.mockResolvedValue({
+  data: {
+    can_start_without_user_input: false,
+    passwords_needed_to_start: [],
+    ask_scm_branch_on_launch: false,
+    ask_variables_on_launch: false,
+    ask_tags_on_launch: false,
+    ask_diff_mode_on_launch: false,
+    ask_skip_tags_on_launch: false,
+    ask_job_type_on_launch: false,
+    ask_limit_on_launch: false,
+    ask_verbosity_on_launch: false,
+    ask_inventory_on_launch: true,
+    ask_credential_on_launch: true,
+    survey_enabled: false,
+    variables_needed_to_start: [],
+    credential_needed_to_start: true,
+    inventory_needed_to_start: true,
+    job_template_data: {
+      name: 'Demo Job Template',
+      id: 7,
+      description: '',
+    },
+    defaults: {
+      extra_vars: '---',
+      diff_mode: false,
+      limit: '',
+      job_tags: '',
+      skip_tags: '',
+      job_type: 'run',
+      verbosity: 0,
+      inventory: {
+        name: null,
+        id: null,
+      },
+      scm_branch: '',
+    },
+  },
+});
+
+SchedulesAPI.readCredentials.mockResolvedValue({
+  data: {
+    results: [
+      { name: 'schedule credential 1', id: 1, kind: 'vault' },
+      { name: 'schedule credential 2', id: 2, kind: 'aws' },
+    ],
+    count: 2,
+  },
+});
+
+CredentialTypesAPI.loadAllTypes.mockResolvedValue([
+  { id: 1, name: 'ssh', kind: 'ssh' },
+]);
+
+CredentialsAPI.read.mockResolvedValue({
+  data: {
+    count: 3,
+    results: [
+      { id: 1, name: 'Credential 1', kind: 'ssh', url: '' },
+      { id: 2, name: 'Credential 2', kind: 'ssh', url: '' },
+      { id: 3, name: 'Credential 3', kind: 'ssh', url: '' },
+    ],
+  },
+});
+
+CredentialsAPI.readOptions.mockResolvedValue({
+  data: { related_search_fields: [], actions: { GET: { filterabled: true } } },
 });
 
 SchedulesAPI.update.mockResolvedValue({
@@ -37,13 +116,14 @@ const mockSchedule = {
       edit: true,
       delete: true,
     },
+    inventory: { id: 702, name: 'Inventory' },
   },
   created: '2020-04-02T18:43:12.664142Z',
   modified: '2020-04-02T18:43:12.664185Z',
   name: 'mock schedule',
   description: '',
   extra_data: {},
-  inventory: null,
+  inventory: 1,
   scm_branch: null,
   job_type: null,
   job_tags: null,
@@ -61,18 +141,33 @@ const mockSchedule = {
 };
 
 describe('<ScheduleEdit />', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await act(async () => {
-      wrapper = mountWithContexts(<ScheduleEdit schedule={mockSchedule} />);
+      wrapper = mountWithContexts(
+        <ScheduleEdit
+          schedule={mockSchedule}
+          resource={{
+            id: 700,
+            type: 'job_template',
+            iventory: 1,
+            summary_fields: {
+              credentials: [
+                { name: 'job template credential', id: 75, kind: 'ssh' },
+              ],
+            },
+          }}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
   });
   afterEach(() => {
+    wrapper.unmount();
     jest.clearAllMocks();
   });
   test('Successfully creates a schedule with repeat frequency: None (run once)', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'none',
@@ -85,13 +180,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run once schedule',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T100000 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
   test('Successfully creates a schedule with 10 minute repeat frequency after 10 occurrences', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'after',
         frequency: 'minute',
@@ -105,13 +201,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run every 10 minutes 10 times',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T103000 RRULE:INTERVAL=10;FREQ=MINUTELY;COUNT=10',
     });
   });
   test('Successfully creates a schedule with hourly repeat frequency ending on a specific date/time', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'onDate',
         endDateTime: '2020-03-26T10:45:00',
@@ -125,13 +222,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run every hour until date',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=HOURLY;UNTIL=20200326T104500',
     });
   });
   test('Successfully creates a schedule with daily repeat frequency', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'day',
@@ -144,13 +242,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run daily',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=DAILY',
     });
   });
   test('Successfully creates a schedule with weekly repeat frequency on mon/wed/fri', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         daysOfWeek: [RRule.MO, RRule.WE, RRule.FR],
         description: 'test description',
         end: 'never',
@@ -165,12 +264,13 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run weekly on mon/wed/fri',
+      extra_data: {},
       rrule: `DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=${RRule.MO},${RRule.WE},${RRule.FR}`,
     });
   });
   test('Successfully creates a schedule with monthly repeat frequency on the first day of the month', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'month',
@@ -186,13 +286,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run on the first day of the month',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200401T104500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYMONTHDAY=1',
     });
   });
   test('Successfully creates a schedule with monthly repeat frequency on the last tuesday of the month', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         endDateTime: '2020-03-26T11:00:00',
@@ -210,13 +311,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run monthly on the last Tuesday',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200331T110000 RRULE:INTERVAL=1;FREQ=MONTHLY;BYSETPOS=-1;BYDAY=TU',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the first day of March', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -233,13 +335,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Yearly on the first day of March',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200301T000000 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the second Friday in April', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -257,13 +360,14 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Yearly on the second Friday in April',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=2;BYDAY=FR;BYMONTH=4',
     });
   });
   test('Successfully creates a schedule with yearly repeat frequency on the first weekday in October', async () => {
     await act(async () => {
-      wrapper.find('ScheduleForm').invoke('handleSubmit')({
+      wrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
         end: 'never',
         frequency: 'year',
@@ -281,8 +385,215 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Yearly on the first weekday in October',
+      extra_data: {},
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=1;BYDAY=MO,TU,WE,TH,FR;BYMONTH=10',
+    });
+  });
+
+  test('should open with correct values and navigate through the Promptable fields properly', async () => {
+    InventoriesAPI.read.mockResolvedValue({
+      data: {
+        count: 2,
+        results: [
+          {
+            name: 'Foo',
+            id: 1,
+            url: '',
+          },
+          {
+            name: 'Bar',
+            id: 2,
+            url: '',
+          },
+        ],
+      },
+    });
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: {
+        related_search_fields: [],
+        actions: {
+          GET: {
+            filterable: true,
+          },
+        },
+      },
+    });
+
+    await act(async () =>
+      wrapper.find('Button[aria-label="Prompt"]').prop('onClick')()
+    );
+    wrapper.update();
+    expect(wrapper.find('WizardNavItem').length).toBe(3);
+    expect(
+      wrapper
+        .find('WizardNavItem')
+        .at(0)
+        .prop('isCurrent')
+    ).toBe(true);
+
+    await act(async () => {
+      wrapper
+        .find('input[aria-labelledby="check-action-item-1"]')
+        .simulate('change', {
+          target: {
+            checked: true,
+          },
+        });
+    });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find('input[aria-labelledby="check-action-item-1"]')
+        .prop('checked')
+    ).toBe(true);
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onNext')()
+    );
+    wrapper.update();
+    expect(
+      wrapper
+        .find('WizardNavItem')
+        .at(1)
+        .prop('isCurrent')
+    ).toBe(true);
+
+    expect(wrapper.find('CredentialChip').length).toBe(3);
+
+    wrapper.update();
+
+    await act(async () => {
+      wrapper
+        .find('input[aria-labelledby="check-action-item-3"]')
+        .simulate('change', {
+          target: {
+            checked: true,
+          },
+        });
+    });
+    wrapper.update();
+    expect(
+      wrapper
+        .find('input[aria-labelledby="check-action-item-3"]')
+        .prop('checked')
+    ).toBe(true);
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onNext')()
+    );
+    wrapper.update();
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onNext')()
+    );
+    wrapper.update();
+    expect(wrapper.find('Wizard').length).toBe(0);
+    await act(async () => {
+      wrapper.find('Formik').invoke('onSubmit')({
+        name: mockSchedule.name,
+        end: 'never',
+        endDateTime: '2021-01-29T14:15:00',
+        frequency: 'none',
+        occurrences: 1,
+        runOn: 'day',
+        runOnDayMonth: 1,
+        runOnDayNumber: 1,
+        runOnTheDay: 'sunday',
+        runOnTheMonth: 1,
+        runOnTheOccurrence: 1,
+        skip_tags: '',
+        startDateTime: '2021-01-28T14:15:00',
+        timezone: 'America/New_York',
+        credentials: [
+          { id: 3, name: 'Credential 3', kind: 'ssh', url: '' },
+          { name: 'schedule credential 1', id: 1, kind: 'vault' },
+          { name: 'schedule credential 2', id: 2, kind: 'aws' },
+        ],
+      });
+    });
+    wrapper.update();
+
+    expect(SchedulesAPI.update).toBeCalledWith(27, {
+      extra_data: {},
+      name: 'mock schedule',
+      rrule:
+        'DTSTART;TZID=America/New_York:20210128T141500 RRULE:COUNT=1;FREQ=MINUTELY',
+      skip_tags: '',
+    });
+    expect(SchedulesAPI.disassociateCredential).toBeCalledWith(27, 75);
+
+    expect(SchedulesAPI.associateCredential).toBeCalledWith(27, 3);
+  });
+
+  test('should submit updated static form values, but original prompt form values', async () => {
+    InventoriesAPI.read.mockResolvedValue({
+      data: {
+        count: 2,
+        results: [
+          {
+            name: 'Foo',
+            id: 1,
+            url: '',
+          },
+          {
+            name: 'Bar',
+            id: 2,
+            url: '',
+          },
+        ],
+      },
+    });
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: {
+        related_search_fields: [],
+        actions: {
+          GET: {
+            filterable: true,
+          },
+        },
+      },
+    });
+    await act(async () =>
+      wrapper.find('input#schedule-name').simulate('change', {
+        target: { value: 'foo', name: 'name' },
+      })
+    );
+    wrapper.update();
+    await act(async () =>
+      wrapper.find('Button[aria-label="Prompt"]').prop('onClick')()
+    );
+    wrapper.update();
+    await act(async () => {
+      wrapper
+        .find('input[aria-labelledby="check-action-item-2"]')
+        .simulate('change', {
+          target: {
+            checked: true,
+          },
+        });
+    });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find('input[aria-labelledby="check-action-item-2"]')
+        .prop('checked')
+    ).toBe(true);
+    await act(async () =>
+      wrapper.find('WizardFooterInternal').prop('onClose')()
+    );
+    wrapper.update();
+    expect(wrapper.find('Wizard').length).toBe(0);
+
+    await act(async () =>
+      wrapper.find('Button[aria-label="Save"]').prop('onClick')()
+    );
+    expect(SchedulesAPI.update).toBeCalledWith(27, {
+      description: '',
+      extra_data: {},
+      inventory: 702,
+      name: 'foo',
+      rrule:
+        'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
 });

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
@@ -7,7 +7,6 @@ import {
 } from '../../../../testUtils/enzymeHelpers';
 import {
   SchedulesAPI,
-  JobTemplatesAPI,
   InventoriesAPI,
   CredentialsAPI,
   CredentialTypesAPI,
@@ -26,46 +25,6 @@ SchedulesAPI.readZoneInfo.mockResolvedValue({
       name: 'America/New_York',
     },
   ],
-});
-
-JobTemplatesAPI.readLaunch.mockResolvedValue({
-  data: {
-    can_start_without_user_input: false,
-    passwords_needed_to_start: [],
-    ask_scm_branch_on_launch: false,
-    ask_variables_on_launch: false,
-    ask_tags_on_launch: false,
-    ask_diff_mode_on_launch: false,
-    ask_skip_tags_on_launch: false,
-    ask_job_type_on_launch: false,
-    ask_limit_on_launch: false,
-    ask_verbosity_on_launch: false,
-    ask_inventory_on_launch: true,
-    ask_credential_on_launch: true,
-    survey_enabled: false,
-    variables_needed_to_start: [],
-    credential_needed_to_start: true,
-    inventory_needed_to_start: true,
-    job_template_data: {
-      name: 'Demo Job Template',
-      id: 7,
-      description: '',
-    },
-    defaults: {
-      extra_vars: '---',
-      diff_mode: false,
-      limit: '',
-      job_tags: '',
-      skip_tags: '',
-      job_type: 'run',
-      verbosity: 0,
-      inventory: {
-        name: null,
-        id: null,
-      },
-      scm_branch: '',
-    },
-  },
 });
 
 SchedulesAPI.readCredentials.mockResolvedValue({
@@ -156,6 +115,44 @@ describe('<ScheduleEdit />', () => {
               ],
             },
           }}
+          launchConfig={{
+            can_start_without_user_input: false,
+            passwords_needed_to_start: [],
+            ask_scm_branch_on_launch: false,
+            ask_variables_on_launch: false,
+            ask_tags_on_launch: false,
+            ask_diff_mode_on_launch: false,
+            ask_skip_tags_on_launch: false,
+            ask_job_type_on_launch: false,
+            ask_limit_on_launch: false,
+            ask_verbosity_on_launch: false,
+            ask_inventory_on_launch: true,
+            ask_credential_on_launch: true,
+            survey_enabled: false,
+            variables_needed_to_start: [],
+            credential_needed_to_start: true,
+            inventory_needed_to_start: true,
+            job_template_data: {
+              name: 'Demo Job Template',
+              id: 7,
+              description: '',
+            },
+            defaults: {
+              extra_vars: '---',
+              diff_mode: false,
+              limit: '',
+              job_tags: '',
+              skip_tags: '',
+              job_type: 'run',
+              verbosity: 0,
+              inventory: {
+                name: null,
+                id: null,
+              },
+              scm_branch: '',
+            },
+          }}
+          surveyConfig={{}}
         />
       );
     });
@@ -202,6 +199,7 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Run every 10 minutes 10 times',
       extra_data: {},
+      occurrences: 10,
       rrule:
         'DTSTART;TZID=America/New_York:20200325T103000 RRULE:INTERVAL=10;FREQ=MINUTELY;COUNT=10',
     });
@@ -265,6 +263,7 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Run weekly on mon/wed/fri',
       extra_data: {},
+      occurrences: 1,
       rrule: `DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=${RRule.MO},${RRule.WE},${RRule.FR}`,
     });
   });
@@ -287,6 +286,7 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Run on the first day of the month',
       extra_data: {},
+      occurrences: 1,
       rrule:
         'DTSTART;TZID=America/New_York:20200401T104500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYMONTHDAY=1',
     });
@@ -312,6 +312,8 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Run monthly on the last Tuesday',
       extra_data: {},
+      occurrences: 1,
+      runOnTheOccurrence: -1,
       rrule:
         'DTSTART;TZID=America/New_York:20200331T110000 RRULE:INTERVAL=1;FREQ=MONTHLY;BYSETPOS=-1;BYDAY=TU',
     });
@@ -336,6 +338,7 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Yearly on the first day of March',
       extra_data: {},
+      occurrences: 1,
       rrule:
         'DTSTART;TZID=America/New_York:20200301T000000 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1',
     });
@@ -361,6 +364,8 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Yearly on the second Friday in April',
       extra_data: {},
+      occurrences: 1,
+      runOnTheOccurrence: 2,
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=2;BYDAY=FR;BYMONTH=4',
     });
@@ -386,6 +391,8 @@ describe('<ScheduleEdit />', () => {
       description: 'test description',
       name: 'Yearly on the first weekday in October',
       extra_data: {},
+      occurrences: 1,
+      runOnTheOccurrence: 1,
       rrule:
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=1;BYDAY=MO,TU,WE,TH,FR;BYMONTH=10',
     });
@@ -515,6 +522,8 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toBeCalledWith(27, {
       extra_data: {},
       name: 'mock schedule',
+      occurrences: 1,
+      runOnTheOccurrence: 1,
       rrule:
         'DTSTART;TZID=America/New_York:20210128T141500 RRULE:COUNT=1;FREQ=MINUTELY',
       skip_tags: '',
@@ -590,8 +599,10 @@ describe('<ScheduleEdit />', () => {
     expect(SchedulesAPI.update).toBeCalledWith(27, {
       description: '',
       extra_data: {},
-      inventory: 702,
+      occurrences: 1,
+      runOnTheOccurrence: 1,
       name: 'foo',
+      inventory: 702,
       rrule:
         'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.test.jsx
@@ -32,19 +32,22 @@ describe('ScheduleList', () => {
   });
 
   describe('read call successful', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       await act(async () => {
         wrapper = mountWithContexts(
           <ScheduleList
             loadSchedules={loadSchedules}
             loadScheduleOptions={loadScheduleOptions}
+            resource={{ type: 'job_template', inventory: 1 }}
+            launchConfig={{ survey_enabled: false }}
+            surveyConfig={{}}
           />
         );
       });
       wrapper.update();
     });
 
-    afterAll(() => {
+    afterEach(() => {
       wrapper.unmount();
     });
 
@@ -202,6 +205,60 @@ describe('ScheduleList', () => {
       });
       wrapper.update();
       expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    });
+    test('should show missing resource icon and disabled toggle', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleList
+            loadSchedules={loadSchedules}
+            loadScheduleOptions={loadScheduleOptions}
+            hideAddButton
+            resource={{ type: 'job_template', inventory: 1 }}
+            launchConfig={{ survey_enabled: true }}
+            surveyConfig={{ spec: [{ required: true, default: null }] }}
+          />
+        );
+      });
+      wrapper.update();
+      expect(
+        wrapper
+          .find('ScheduleListItem')
+          .at(4)
+          .prop('isMissingSurvey')
+      ).toBe('This schedule is missing required survey values');
+      expect(wrapper.find('ExclamationTriangleIcon').length).toBe(5);
+      expect(wrapper.find('Switch#schedule-5-toggle').prop('isDisabled')).toBe(
+        true
+      );
+    });
+    test('should show missing resource icon and disabled toggle', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleList
+            loadSchedules={loadSchedules}
+            loadScheduleOptions={loadScheduleOptions}
+            hideAddButton
+            resource={{ type: 'job_template' }}
+            launchConfig={{
+              survey_enabled: true,
+              inventory_needed_to_start: true,
+            }}
+            surveyConfig={{ spec: [] }}
+          />
+        );
+      });
+      wrapper.update();
+
+      expect(
+        wrapper
+          .find('ScheduleListItem')
+          .at(3)
+          .prop('isMissingInventory')
+      ).toBe('This schedule is missing an Inventory');
+      expect(wrapper.find('ExclamationTriangleIcon').length).toBe(4);
+      expect(wrapper.find('Switch#schedule-3-toggle').prop('isDisabled')).toBe(
+        true
+      );
     });
   });
 

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.jsx
@@ -4,16 +4,33 @@ import { bool, func } from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { PencilAltIcon } from '@patternfly/react-icons';
+import {
+  PencilAltIcon,
+  ExclamationTriangleIcon as PFExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+import styled from 'styled-components';
 import { DetailList, Detail } from '../../DetailList';
 import { ActionsTd, ActionItem } from '../../PaginatedTable';
 import { ScheduleToggle } from '..';
 import { Schedule } from '../../../types';
 import { formatDateString } from '../../../util/dates';
 
-function ScheduleListItem({ i18n, isSelected, onSelect, schedule, rowIndex }) {
+const ExclamationTriangleIcon = styled(PFExclamationTriangleIcon)`
+  color: #c9190b;
+  margin-left: 20px;
+`;
+
+function ScheduleListItem({
+  i18n,
+  rowIndex,
+  isSelected,
+  onSelect,
+  schedule,
+  isMissingInventory,
+  isMissingSurvey,
+}) {
   const labelId = `check-action-${schedule.id}`;
 
   const jobTypeLabels = {
@@ -45,6 +62,7 @@ function ScheduleListItem({ i18n, isSelected, onSelect, schedule, rowIndex }) {
     default:
       break;
   }
+  const isDisabled = Boolean(isMissingInventory || isMissingSurvey);
 
   return (
     <Tr id={`schedule-row-${schedule.id}`}>
@@ -61,6 +79,18 @@ function ScheduleListItem({ i18n, isSelected, onSelect, schedule, rowIndex }) {
         <Link to={`${scheduleBaseUrl}/details`}>
           <b>{schedule.name}</b>
         </Link>
+        {Boolean(isMissingInventory || isMissingSurvey) && (
+          <span>
+            <Tooltip
+              content={[isMissingInventory, isMissingSurvey].map(message => (
+                <div key={message}>{message}</div>
+              ))}
+              position="right"
+            >
+              <ExclamationTriangleIcon />
+            </Tooltip>
+          </span>
+        )}
       </Td>
       <Td dataLabel={i18n._(t`Type`)}>
         {
@@ -80,7 +110,7 @@ function ScheduleListItem({ i18n, isSelected, onSelect, schedule, rowIndex }) {
         )}
       </Td>
       <ActionsTd dataLabel={i18n._(t`Actions`)} gridColumns="auto 40px">
-        <ScheduleToggle schedule={schedule} />
+        <ScheduleToggle schedule={schedule} isDisabled={isDisabled} />
         <ActionItem
           visible={schedule.summary_fields.user_capabilities.edit}
           tooltip={i18n._(t`Edit Schedule`)}

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.test.jsx
@@ -50,15 +50,13 @@ describe('ScheduleListItem', () => {
   describe('User has edit permissions', () => {
     beforeAll(() => {
       wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ScheduleListItem
-              isSelected={false}
-              onSelect={onSelect}
-              schedule={mockSchedule}
-            />
-          </tbody>
-        </table>
+        <ScheduleListItem
+          isSelected={false}
+          onSelect={onSelect}
+          schedule={mockSchedule}
+          isMissingSurvey={false}
+          isMissingInventory={false}
+        />
       );
     });
 
@@ -117,6 +115,9 @@ describe('ScheduleListItem', () => {
         .find('input')
         .simulate('change');
       expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+    test('Toggle button is enabled', () => {
+      expect(wrapper.find('ScheduleToggle').prop('isDisabled')).toBe(false);
     });
   });
 
@@ -184,6 +185,37 @@ describe('ScheduleListItem', () => {
           .first()
           .props().isDisabled
       ).toBe(true);
+    });
+  });
+  describe('schedule has missing prompt data', () => {
+    beforeAll(() => {
+      wrapper = mountWithContexts(
+        <ScheduleListItem
+          isSelected={false}
+          onSelect={onSelect}
+          schedule={{
+            ...mockSchedule,
+            summary_fields: {
+              ...mockSchedule.summary_fields,
+              user_capabilities: {
+                edit: false,
+                delete: false,
+              },
+            },
+          }}
+          isMissingInventory="Inventory Error"
+          isMissingSurvey="Survey Error"
+        />
+      );
+    });
+
+    afterAll(() => {
+      wrapper.unmount();
+    });
+
+    test('should show missing resource icon', () => {
+      expect(wrapper.find('ExclamationTriangleIcon').length).toBe(1);
+      expect(wrapper.find('ScheduleToggle').prop('isDisabled')).toBe(true);
     });
   });
 });

--- a/awx/ui_next/src/components/Schedule/ScheduleToggle/ScheduleToggle.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleToggle/ScheduleToggle.jsx
@@ -8,7 +8,7 @@ import ErrorDetail from '../../ErrorDetail';
 import useRequest from '../../../util/useRequest';
 import { SchedulesAPI } from '../../../api';
 
-function ScheduleToggle({ schedule, onToggle, className, i18n }) {
+function ScheduleToggle({ schedule, onToggle, className, i18n, isDisabled }) {
   const [isEnabled, setIsEnabled] = useState(schedule.enabled);
   const [showError, setShowError] = useState(false);
 
@@ -55,7 +55,9 @@ function ScheduleToggle({ schedule, onToggle, className, i18n }) {
           labelOff={i18n._(t`Off`)}
           isChecked={isEnabled}
           isDisabled={
-            isLoading || !schedule.summary_fields.user_capabilities.edit
+            isLoading ||
+            !schedule.summary_fields.user_capabilities.edit ||
+            isDisabled
           }
           onChange={toggleSchedule}
           aria-label={i18n._(t`Toggle schedule`)}

--- a/awx/ui_next/src/components/Schedule/Schedules.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedules.jsx
@@ -10,6 +10,8 @@ function Schedules({
   loadScheduleOptions,
   loadSchedules,
   setBreadcrumb,
+  launchConfig,
+  surveyConfig,
   resource,
 }) {
   const match = useRouteMatch();
@@ -17,14 +19,27 @@ function Schedules({
   return (
     <Switch>
       <Route path={`${match.path}/add`}>
-        <ScheduleAdd apiModel={apiModel} resource={resource} />
+        <ScheduleAdd
+          apiModel={apiModel}
+          resource={resource}
+          launchConfig={launchConfig}
+          surveyConfig={surveyConfig}
+        />
       </Route>
       <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule setBreadcrumb={setBreadcrumb} resource={resource} />
+        <Schedule
+          setBreadcrumb={setBreadcrumb}
+          resource={resource}
+          launchConfig={launchConfig}
+          surveyConfig={surveyConfig}
+        />
       </Route>
       <Route key="list" path={`${match.path}`}>
         <ScheduleList
+          resource={resource}
           loadSchedules={loadSchedules}
+          launchConfig={launchConfig}
+          surveyConfig={surveyConfig}
           loadScheduleOptions={loadScheduleOptions}
         />
       </Route>

--- a/awx/ui_next/src/components/Schedule/Schedules.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedules.jsx
@@ -6,24 +6,21 @@ import ScheduleAdd from './ScheduleAdd';
 import ScheduleList from './ScheduleList';
 
 function Schedules({
-  createSchedule,
+  apiModel,
   loadScheduleOptions,
   loadSchedules,
   setBreadcrumb,
-  unifiedJobTemplate,
+  resource,
 }) {
   const match = useRouteMatch();
 
   return (
     <Switch>
       <Route path={`${match.path}/add`}>
-        <ScheduleAdd createSchedule={createSchedule} />
+        <ScheduleAdd apiModel={apiModel} resource={resource} />
       </Route>
       <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          unifiedJobTemplate={unifiedJobTemplate}
-          setBreadcrumb={setBreadcrumb}
-        />
+        <Schedule setBreadcrumb={setBreadcrumb} resource={resource} />
       </Route>
       <Route key="list" path={`${match.path}`}>
         <ScheduleList

--- a/awx/ui_next/src/components/Schedule/data.schedules.json
+++ b/awx/ui_next/src/components/Schedule/data.schedules.json
@@ -8,6 +8,7 @@
       "rrule":
         "DTSTART;TZID=America/New_York:20200220T000000 RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
       "id": 1,
+      "extra_data":{},
       "summary_fields": {
         "unified_job_template": {
           "id": 6,
@@ -27,6 +28,7 @@
       "rrule":
         "DTSTART;TZID=America/New_York:20200220T000000 RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
       "id": 2,
+      "extra_data":{},
       "summary_fields": {
         "unified_job_template": {
           "id": 7,
@@ -46,6 +48,7 @@
       "rrule":
         "DTSTART;TZID=America/New_York:20200220T000000 RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
       "id": 3,
+      "extra_data":{},
       "summary_fields": {
         "unified_job_template": {
           "id": 8,
@@ -65,6 +68,7 @@
       "rrule":
         "DTSTART;TZID=America/New_York:20200220T000000 RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
       "id": 4,
+      "extra_data":{},
       "summary_fields": {
         "unified_job_template": {
           "id": 9,
@@ -84,6 +88,7 @@
       "rrule":
         "DTSTART;TZID=America/New_York:20200220T000000 RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
       "id": 5,
+      "extra_data":{"novalue":null},
       "summary_fields": {
         "unified_job_template": {
           "id": 10,

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
@@ -1,11 +1,71 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
-import { SchedulesAPI } from '../../../api';
+
+import {
+  mountWithContexts,
+  waitForElement,
+} from '../../../../testUtils/enzymeHelpers';
+import { SchedulesAPI, JobTemplatesAPI, InventoriesAPI } from '../../../api';
 import ScheduleForm from './ScheduleForm';
 
 jest.mock('../../../api/models/Schedules');
+jest.mock('../../../api/models/JobTemplates');
+jest.mock('../../../api/models/Inventories');
 
+const survey = {
+  name: '',
+  description: '',
+  spec: [
+    {
+      question_name: 'new survey',
+      question_description: '',
+      required: true,
+      type: 'text',
+      variable: 'newsurveyquestion',
+      min: 0,
+      max: 1024,
+      default: '',
+      choices: '',
+      new_question: false,
+    },
+  ],
+};
+const credentials = {
+  data: {
+    results: [
+      { id: 1, kind: 'cloud', name: 'Cred 1', url: 'www.google.com' },
+      { id: 2, kind: 'ssh', name: 'Cred 2', url: 'www.google.com' },
+      { id: 3, kind: 'Ansible', name: 'Cred 3', url: 'www.google.com' },
+      { id: 4, kind: 'Machine', name: 'Cred 4', url: 'www.google.com' },
+      { id: 5, kind: 'Machine', name: 'Cred 5', url: 'www.google.com' },
+    ],
+  },
+};
+const launchData = {
+  data: {
+    can_start_without_user_input: false,
+    passwords_needed_to_start: [],
+    ask_scm_branch_on_launch: false,
+    ask_variables_on_launch: false,
+    ask_tags_on_launch: false,
+    ask_diff_mode_on_launch: false,
+    ask_skip_tags_on_launch: false,
+    ask_job_type_on_launch: false,
+    ask_limit_on_launch: false,
+    ask_verbosity_on_launch: false,
+    ask_inventory_on_launch: true,
+    ask_credential_on_launch: false,
+    survey_enabled: false,
+    variables_needed_to_start: [],
+    credential_needed_to_start: false,
+    inventory_needed_to_start: true,
+    job_template_data: {
+      name: 'Demo Job Template',
+      id: 7,
+      description: '',
+    },
+  },
+};
 const mockSchedule = {
   rrule:
     'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
@@ -23,7 +83,7 @@ const mockSchedule = {
   name: 'mock schedule',
   description: 'test description',
   extra_data: {},
-  inventory: null,
+  inventory: 1,
   scm_branch: null,
   job_type: null,
   job_tags: null,
@@ -82,7 +142,11 @@ describe('<ScheduleForm />', () => {
       );
       await act(async () => {
         wrapper = mountWithContexts(
-          <ScheduleForm handleSubmit={jest.fn()} handleCancel={jest.fn()} />
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{ id: 23, type: 'job_template' }}
+          />
         );
       });
       wrapper.update();
@@ -92,6 +156,10 @@ describe('<ScheduleForm />', () => {
   describe('Cancel', () => {
     test('should make the appropriate callback', async () => {
       const handleCancel = jest.fn();
+      JobTemplatesAPI.readLaunch.mockResolvedValue(launchData);
+
+      JobTemplatesAPI.readSurvey.mockResolvedValue(survey);
+      SchedulesAPI.readCredentials.mockResolvedValue(credentials);
       SchedulesAPI.readZoneInfo.mockResolvedValue({
         data: [
           {
@@ -101,7 +169,11 @@ describe('<ScheduleForm />', () => {
       });
       await act(async () => {
         wrapper = mountWithContexts(
-          <ScheduleForm handleSubmit={jest.fn()} handleCancel={handleCancel} />
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={handleCancel}
+            resource={{ id: 23, type: 'job_template' }}
+          />
         );
       });
       wrapper.update();
@@ -109,6 +181,173 @@ describe('<ScheduleForm />', () => {
         wrapper.find('button[aria-label="Cancel"]').simulate('click');
       });
       expect(handleCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('Prompted Schedule', () => {
+    let promptWrapper;
+    beforeEach(async () => {
+      JobTemplatesAPI.readLaunch.mockResolvedValue({
+        data: {
+          can_start_without_user_input: false,
+          passwords_needed_to_start: [],
+          ask_scm_branch_on_launch: false,
+          ask_variables_on_launch: false,
+          ask_tags_on_launch: false,
+          ask_diff_mode_on_launch: false,
+          ask_skip_tags_on_launch: false,
+          ask_job_type_on_launch: false,
+          ask_limit_on_launch: false,
+          ask_verbosity_on_launch: false,
+          ask_inventory_on_launch: true,
+          ask_credential_on_launch: false,
+          survey_enabled: false,
+          variables_needed_to_start: [],
+          credential_needed_to_start: false,
+          inventory_needed_to_start: true,
+          job_template_data: {
+            name: 'Demo Job Template',
+            id: 7,
+            description: '',
+          },
+        },
+      });
+      SchedulesAPI.readZoneInfo.mockResolvedValue({
+        data: [
+          {
+            name: 'America/New_York',
+          },
+        ],
+      });
+      await act(async () => {
+        promptWrapper = mountWithContexts(
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{
+              id: 23,
+              type: 'job_template',
+              inventory: 1,
+              summary_fields: {
+                credentials: [],
+              },
+            }}
+          />
+        );
+      });
+      waitForElement(
+        promptWrapper,
+        'Button[aria-label="Prompt"]',
+        el => el.length > 0
+      );
+    });
+    afterEach(() => {
+      promptWrapper.unmount();
+      jest.clearAllMocks();
+    });
+
+    test('should open prompt modal with proper steps and default values', async () => {
+      await act(async () =>
+        promptWrapper.find('Button[aria-label="Prompt"]').prop('onClick')()
+      );
+      promptWrapper.update();
+      waitForElement(promptWrapper, 'Wizard', el => el.length > 0);
+      expect(promptWrapper.find('Wizard').length).toBe(1);
+      expect(promptWrapper.find('StepName#inventory-step').length).toBe(2);
+      expect(promptWrapper.find('StepName#preview-step').length).toBe(1);
+      expect(promptWrapper.find('WizardNavItem').length).toBe(2);
+    });
+
+    test('should update prompt modal data', async () => {
+      InventoriesAPI.read.mockResolvedValue({
+        data: {
+          count: 2,
+          results: [
+            {
+              name: 'Foo',
+              id: 1,
+              url: '',
+            },
+            {
+              name: 'Bar',
+              id: 2,
+              url: '',
+            },
+          ],
+        },
+      });
+      InventoriesAPI.readOptions.mockResolvedValue({
+        data: {
+          related_search_fields: [],
+          actions: {
+            GET: {
+              filterable: true,
+            },
+          },
+        },
+      });
+
+      await act(async () =>
+        promptWrapper.find('Button[aria-label="Prompt"]').prop('onClick')()
+      );
+      promptWrapper.update();
+      expect(
+        promptWrapper
+          .find('WizardNavItem')
+          .at(0)
+          .prop('isCurrent')
+      ).toBe(true);
+      await act(async () => {
+        promptWrapper
+          .find('input[aria-labelledby="check-action-item-1"]')
+          .simulate('change', {
+            target: {
+              checked: true,
+            },
+          });
+      });
+      promptWrapper.update();
+      expect(
+        promptWrapper
+          .find('input[aria-labelledby="check-action-item-1"]')
+          .prop('checked')
+      ).toBe(true);
+      await act(async () =>
+        promptWrapper.find('WizardFooterInternal').prop('onNext')()
+      );
+      promptWrapper.update();
+      expect(
+        promptWrapper
+          .find('WizardNavItem')
+          .at(1)
+          .prop('isCurrent')
+      ).toBe(true);
+      await act(async () =>
+        promptWrapper.find('WizardFooterInternal').prop('onNext')()
+      );
+      promptWrapper.update();
+      expect(promptWrapper.find('Wizard').length).toBe(0);
+    });
+    test('should render prompt button with disabled save button', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{
+              id: 23,
+              type: 'job_template',
+            }}
+          />
+        );
+      });
+      waitForElement(
+        wrapper,
+        'Button[aria-label="Prompt"]',
+        el => el.length > 0
+      );
+      expect(wrapper.find('Button[aria-label="Save"]').prop('isDisabled')).toBe(
+        true
+      );
     });
   });
   describe('Add', () => {
@@ -120,9 +359,39 @@ describe('<ScheduleForm />', () => {
           },
         ],
       });
+      JobTemplatesAPI.readLaunch.mockResolvedValue({
+        data: {
+          can_start_without_user_input: true,
+          passwords_needed_to_start: [],
+          ask_scm_branch_on_launch: false,
+          ask_variables_on_launch: false,
+          ask_tags_on_launch: false,
+          ask_diff_mode_on_launch: false,
+          ask_skip_tags_on_launch: false,
+          ask_job_type_on_launch: false,
+          ask_limit_on_launch: false,
+          ask_verbosity_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_credential_on_launch: false,
+          survey_enabled: false,
+          variables_needed_to_start: [],
+          credential_needed_to_start: false,
+          inventory_needed_to_start: false,
+          job_template_data: {
+            name: 'Demo Job Template',
+            id: 7,
+            description: '',
+          },
+        },
+      });
+
       await act(async () => {
         wrapper = mountWithContexts(
-          <ScheduleForm handleSubmit={jest.fn()} handleCancel={jest.fn()} />
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{ id: 23, type: 'job_template', inventory: 1 }}
+          />
         );
       });
     });
@@ -313,6 +582,14 @@ describe('<ScheduleForm />', () => {
     });
     test('occurrences field properly shown when end after selection is made', async () => {
       await act(async () => {
+        wrapper
+          .find('FormGroup[label="Run frequency"] FormSelect')
+          .invoke('onChange')('minute', {
+          target: { value: 'minute', key: 'minute', label: 'Minute' },
+        });
+      });
+      wrapper.update();
+      await act(async () => {
         wrapper.find('Radio#end-after').invoke('onChange')('after', {
           target: { name: 'end' },
         });
@@ -331,6 +608,14 @@ describe('<ScheduleForm />', () => {
       wrapper.update();
     });
     test('error shown when end date/time comes before start date/time', async () => {
+      await act(async () => {
+        wrapper
+          .find('FormGroup[label="Run frequency"] FormSelect')
+          .invoke('onChange')('minute', {
+          target: { value: 'minute', key: 'minute', label: 'Minute' },
+        });
+      });
+      wrapper.update();
       expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
@@ -361,12 +646,27 @@ describe('<ScheduleForm />', () => {
       );
     });
     test('error shown when on day number is not between 1 and 31', async () => {
-      await act(async () => {
+      act(() => {
+        wrapper.find('select[id="schedule-frequency"]').invoke('onChange')(
+          {
+            currentTarget: { value: 'month', type: 'change' },
+            target: { name: 'frequency', value: 'month' },
+          },
+          'month'
+        );
+      });
+      wrapper.update();
+
+      act(() => {
         wrapper.find('input#schedule-run-on-day-number').simulate('change', {
           target: { value: 32, name: 'runOnDayNumber' },
         });
       });
       wrapper.update();
+
+      expect(
+        wrapper.find('input#schedule-run-on-day-number').prop('value')
+      ).toBe(32);
 
       await act(async () => {
         wrapper.find('button[aria-label="Save"]').simulate('click');
@@ -379,7 +679,7 @@ describe('<ScheduleForm />', () => {
     });
   });
   describe('Edit', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       SchedulesAPI.readZoneInfo.mockResolvedValue({
         data: [
           {
@@ -387,10 +687,94 @@ describe('<ScheduleForm />', () => {
           },
         ],
       });
+      JobTemplatesAPI.readLaunch.mockResolvedValue({
+        data: {
+          can_start_without_user_input: true,
+          passwords_needed_to_start: [],
+          ask_scm_branch_on_launch: false,
+          ask_variables_on_launch: false,
+          ask_tags_on_launch: false,
+          ask_diff_mode_on_launch: false,
+          ask_skip_tags_on_launch: false,
+          ask_job_type_on_launch: false,
+          ask_limit_on_launch: false,
+          ask_verbosity_on_launch: false,
+          ask_inventory_on_launch: false,
+          ask_credential_on_launch: false,
+          survey_enabled: false,
+          variables_needed_to_start: [],
+          credential_needed_to_start: false,
+          inventory_needed_to_start: false,
+          job_template_data: {
+            name: 'Demo Job Template',
+            id: 7,
+            description: '',
+          },
+        },
+      });
+      JobTemplatesAPI.readSurvey.mockResolvedValue({});
+      SchedulesAPI.readCredentials.mockResolvedValue(credentials);
     });
     afterEach(() => {
       wrapper.unmount();
+      jest.clearAllMocks();
     });
+
+    test('should  make API calls to fetch credentials, launch configuration, and survey configuration', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            schedule={{ inventory: null, ...mockSchedule }}
+            resource={{ id: 23, type: 'job_template' }}
+          />
+        );
+      });
+      expect(JobTemplatesAPI.readLaunch).toBeCalledWith(23);
+      expect(JobTemplatesAPI.readSurvey).toBeCalledWith(23);
+      expect(SchedulesAPI.readCredentials).toBeCalledWith(27);
+    });
+
+    test('should not  call API to get credentials ', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{ id: 23, type: 'job_template' }}
+          />
+        );
+      });
+
+      expect(SchedulesAPI.readCredentials).not.toBeCalled();
+    });
+
+    test('should render prompt button with enabled save button for project', async () => {
+      await act(async () => {
+        wrapper = mountWithContexts(
+          <ScheduleForm
+            handleSubmit={jest.fn()}
+            handleCancel={jest.fn()}
+            resource={{
+              id: 23,
+              type: 'project',
+              inventory: 2,
+            }}
+          />
+        );
+      });
+      waitForElement(
+        wrapper,
+        'Button[aria-label="Prompt"]',
+        el => el.length > 0
+      );
+
+      expect(wrapper.find('Button[aria-label="Save"]').prop('isDisabled')).toBe(
+        false
+      );
+    });
+
     test('initially renders expected fields and values with existing schedule that runs once', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -398,6 +782,7 @@ describe('<ScheduleForm />', () => {
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
             schedule={mockSchedule}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
       });
@@ -426,6 +811,7 @@ describe('<ScheduleForm />', () => {
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=10;FREQ=MINUTELY',
               dtend: null,
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
       });
@@ -459,6 +845,7 @@ describe('<ScheduleForm />', () => {
               dtend: '2020-04-03T03:45:00Z',
               until: '',
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
       });
@@ -493,6 +880,7 @@ describe('<ScheduleForm />', () => {
               dtend: null,
               until: '',
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
         expect(wrapper.find('ScheduleForm').length).toBe(1);
@@ -526,6 +914,7 @@ describe('<ScheduleForm />', () => {
               dtend: '2020-10-30T18:45:00Z',
               until: '2021-01-01T00:00:00',
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
       });
@@ -583,6 +972,7 @@ describe('<ScheduleForm />', () => {
               dtend: null,
               until: '',
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
         expect(wrapper.find('ScheduleForm').length).toBe(1);
@@ -628,6 +1018,7 @@ describe('<ScheduleForm />', () => {
               dtend: null,
               until: '',
             })}
+            resource={{ id: 23, type: 'job_template' }}
           />
         );
         expect(wrapper.find('ScheduleForm').length).toBe(1);

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
@@ -12,24 +12,6 @@ jest.mock('../../../api/models/Schedules');
 jest.mock('../../../api/models/JobTemplates');
 jest.mock('../../../api/models/Inventories');
 
-const survey = {
-  name: '',
-  description: '',
-  spec: [
-    {
-      question_name: 'new survey',
-      question_description: '',
-      required: true,
-      type: 'text',
-      variable: 'newsurveyquestion',
-      min: 0,
-      max: 1024,
-      default: '',
-      choices: '',
-      new_question: false,
-    },
-  ],
-};
 const credentials = {
   data: {
     results: [
@@ -145,6 +127,29 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{
+              can_start_without_user_input: false,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: true,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: true,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
             resource={{ id: 23, type: 'job_template' }}
           />
         );
@@ -158,7 +163,6 @@ describe('<ScheduleForm />', () => {
       const handleCancel = jest.fn();
       JobTemplatesAPI.readLaunch.mockResolvedValue(launchData);
 
-      JobTemplatesAPI.readSurvey.mockResolvedValue(survey);
       SchedulesAPI.readCredentials.mockResolvedValue(credentials);
       SchedulesAPI.readZoneInfo.mockResolvedValue({
         data: [
@@ -172,7 +176,30 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={handleCancel}
-            resource={{ id: 23, type: 'job_template' }}
+            launchConfig={{
+              can_start_without_user_input: false,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: true,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: true,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
+            resource={{ id: 23, type: 'job_template', inventory: 1 }}
           />
         );
       });
@@ -186,31 +213,6 @@ describe('<ScheduleForm />', () => {
   describe('Prompted Schedule', () => {
     let promptWrapper;
     beforeEach(async () => {
-      JobTemplatesAPI.readLaunch.mockResolvedValue({
-        data: {
-          can_start_without_user_input: false,
-          passwords_needed_to_start: [],
-          ask_scm_branch_on_launch: false,
-          ask_variables_on_launch: false,
-          ask_tags_on_launch: false,
-          ask_diff_mode_on_launch: false,
-          ask_skip_tags_on_launch: false,
-          ask_job_type_on_launch: false,
-          ask_limit_on_launch: false,
-          ask_verbosity_on_launch: false,
-          ask_inventory_on_launch: true,
-          ask_credential_on_launch: false,
-          survey_enabled: false,
-          variables_needed_to_start: [],
-          credential_needed_to_start: false,
-          inventory_needed_to_start: true,
-          job_template_data: {
-            name: 'Demo Job Template',
-            id: 7,
-            description: '',
-          },
-        },
-      });
       SchedulesAPI.readZoneInfo.mockResolvedValue({
         data: [
           {
@@ -231,6 +233,30 @@ describe('<ScheduleForm />', () => {
                 credentials: [],
               },
             }}
+            launchConfig={{
+              can_start_without_user_input: false,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: true,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: true,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
+            surveyConfig={{ spec: [{ required: true, default: '' }] }}
           />
         );
       });
@@ -255,6 +281,12 @@ describe('<ScheduleForm />', () => {
       expect(promptWrapper.find('StepName#inventory-step').length).toBe(2);
       expect(promptWrapper.find('StepName#preview-step').length).toBe(1);
       expect(promptWrapper.find('WizardNavItem').length).toBe(2);
+    });
+
+    test('should render disabled save button due to missing required surevy values', () => {
+      expect(
+        promptWrapper.find('Button[aria-label="Save"]').prop('isDisabled')
+      ).toBe(true);
     });
 
     test('should update prompt modal data', async () => {
@@ -337,6 +369,29 @@ describe('<ScheduleForm />', () => {
               id: 23,
               type: 'job_template',
             }}
+            launchConfig={{
+              can_start_without_user_input: false,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: true,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: true,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
           />
         );
       });
@@ -359,31 +414,6 @@ describe('<ScheduleForm />', () => {
           },
         ],
       });
-      JobTemplatesAPI.readLaunch.mockResolvedValue({
-        data: {
-          can_start_without_user_input: true,
-          passwords_needed_to_start: [],
-          ask_scm_branch_on_launch: false,
-          ask_variables_on_launch: false,
-          ask_tags_on_launch: false,
-          ask_diff_mode_on_launch: false,
-          ask_skip_tags_on_launch: false,
-          ask_job_type_on_launch: false,
-          ask_limit_on_launch: false,
-          ask_verbosity_on_launch: false,
-          ask_inventory_on_launch: false,
-          ask_credential_on_launch: false,
-          survey_enabled: false,
-          variables_needed_to_start: [],
-          credential_needed_to_start: false,
-          inventory_needed_to_start: false,
-          job_template_data: {
-            name: 'Demo Job Template',
-            id: 7,
-            description: '',
-          },
-        },
-      });
 
       await act(async () => {
         wrapper = mountWithContexts(
@@ -391,6 +421,29 @@ describe('<ScheduleForm />', () => {
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
             resource={{ id: 23, type: 'job_template', inventory: 1 }}
+            launchConfig={{
+              can_start_without_user_input: true,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: false,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: false,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
           />
         );
       });
@@ -687,32 +740,7 @@ describe('<ScheduleForm />', () => {
           },
         ],
       });
-      JobTemplatesAPI.readLaunch.mockResolvedValue({
-        data: {
-          can_start_without_user_input: true,
-          passwords_needed_to_start: [],
-          ask_scm_branch_on_launch: false,
-          ask_variables_on_launch: false,
-          ask_tags_on_launch: false,
-          ask_diff_mode_on_launch: false,
-          ask_skip_tags_on_launch: false,
-          ask_job_type_on_launch: false,
-          ask_limit_on_launch: false,
-          ask_verbosity_on_launch: false,
-          ask_inventory_on_launch: false,
-          ask_credential_on_launch: false,
-          survey_enabled: false,
-          variables_needed_to_start: [],
-          credential_needed_to_start: false,
-          inventory_needed_to_start: false,
-          job_template_data: {
-            name: 'Demo Job Template',
-            id: 7,
-            description: '',
-          },
-        },
-      });
-      JobTemplatesAPI.readSurvey.mockResolvedValue({});
+
       SchedulesAPI.readCredentials.mockResolvedValue(credentials);
     });
     afterEach(() => {
@@ -728,21 +756,65 @@ describe('<ScheduleForm />', () => {
             handleCancel={jest.fn()}
             schedule={{ inventory: null, ...mockSchedule }}
             resource={{ id: 23, type: 'job_template' }}
+            launchConfig={{
+              can_start_without_user_input: true,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: false,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: false,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
           />
         );
       });
-      expect(JobTemplatesAPI.readLaunch).toBeCalledWith(23);
-      expect(JobTemplatesAPI.readSurvey).toBeCalledWith(23);
       expect(SchedulesAPI.readCredentials).toBeCalledWith(27);
     });
 
-    test('should not  call API to get credentials ', async () => {
+    test('should not call API to get credentials ', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
             resource={{ id: 23, type: 'job_template' }}
+            launchConfig={{
+              can_start_without_user_input: true,
+              passwords_needed_to_start: [],
+              ask_scm_branch_on_launch: false,
+              ask_variables_on_launch: false,
+              ask_tags_on_launch: false,
+              ask_diff_mode_on_launch: false,
+              ask_skip_tags_on_launch: false,
+              ask_job_type_on_launch: false,
+              ask_limit_on_launch: false,
+              ask_verbosity_on_launch: false,
+              ask_inventory_on_launch: false,
+              ask_credential_on_launch: false,
+              survey_enabled: false,
+              variables_needed_to_start: [],
+              credential_needed_to_start: false,
+              inventory_needed_to_start: false,
+              job_template_data: {
+                name: 'Demo Job Template',
+                id: 7,
+                description: '',
+              },
+            }}
           />
         );
       });
@@ -782,6 +854,7 @@ describe('<ScheduleForm />', () => {
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
             schedule={mockSchedule}
+            launchConfig={{ inventory_needed_to_start: false }}
             resource={{ id: 23, type: 'job_template' }}
           />
         );
@@ -806,6 +879,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=10;FREQ=MINUTELY',
@@ -839,6 +913,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;FREQ=HOURLY;COUNT=10',
@@ -874,6 +949,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;FREQ=DAILY',
@@ -908,6 +984,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20210101T050000Z',
@@ -966,6 +1043,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR',
@@ -1012,6 +1090,7 @@ describe('<ScheduleForm />', () => {
           <ScheduleForm
             handleSubmit={jest.fn()}
             handleCancel={jest.fn()}
+            launchConfig={{ inventory_needed_to_start: false }}
             schedule={Object.assign(mockSchedule, {
               rrule:
                 'DTSTART;TZID=America/New_York:20200402T144500 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=6',

--- a/awx/ui_next/src/components/Schedule/shared/SchedulePromptableFields.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/SchedulePromptableFields.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Wizard } from '@patternfly/react-core';
+import { withI18n } from '@lingui/react';
+import { t } from '@lingui/macro';
+import { useFormikContext } from 'formik';
+import AlertModal from '../../AlertModal';
+import { useDismissableError } from '../../../util/useRequest';
+import ContentError from '../../ContentError';
+import ContentLoading from '../../ContentLoading';
+import useSchedulePromptSteps from './useSchedulePromptSteps';
+
+function SchedulePromptableFields({
+  schedule,
+  surveyConfig,
+  launchConfig,
+  onCloseWizard,
+  onSave,
+  credentials,
+  resource,
+  i18n,
+}) {
+  const {
+    validateForm,
+    setFieldTouched,
+    values,
+    initialValues,
+    resetForm,
+  } = useFormikContext();
+  const {
+    steps,
+    visitStep,
+    visitAllSteps,
+    validateStep,
+    contentError,
+    isReady,
+  } = useSchedulePromptSteps(
+    surveyConfig,
+    launchConfig,
+    schedule,
+    resource,
+    i18n,
+    credentials
+  );
+
+  const { error, dismissError } = useDismissableError(contentError);
+  const cancelPromptableValues = async () => {
+    const hasErrors = await validateForm();
+    resetForm({
+      values: {
+        ...initialValues,
+        daysOfWeek: values.daysOfWeek,
+        description: values.description,
+        end: values.end,
+        endDateTime: values.endDateTime,
+        frequency: values.frequency,
+        interval: values.interval,
+        name: values.name,
+        occurences: values.occurances,
+        runOn: values.runOn,
+        runOnDayMonth: values.runOnDayMonth,
+        runOnDayNumber: values.runOnDayNumber,
+        runOnTheDay: values.runOnTheDay,
+        runOnTheMonth: values.runOnTheMonth,
+        runOnTheOccurence: values.runOnTheOccurance,
+        startDateTime: values.startDateTime,
+        timezone: values.timezone,
+      },
+    });
+    onCloseWizard(Object.keys(hasErrors).length > 0);
+  };
+
+  if (error) {
+    return (
+      <AlertModal
+        isOpen={error}
+        variant="error"
+        title={i18n._(t`Error!`)}
+        onClose={() => {
+          dismissError();
+          onCloseWizard();
+        }}
+      >
+        <ContentError error={error} />
+      </AlertModal>
+    );
+  }
+  return (
+    <Wizard
+      isOpen
+      onClose={cancelPromptableValues}
+      onSave={onSave}
+      onNext={async (nextStep, prevStep) => {
+        if (nextStep.id === 'preview') {
+          visitAllSteps(setFieldTouched);
+        } else {
+          visitStep(prevStep.prevId, setFieldTouched);
+        }
+        await validateForm();
+      }}
+      onGoToStep={async (nextStep, prevStep) => {
+        if (nextStep.id === 'preview') {
+          visitAllSteps(setFieldTouched);
+        } else {
+          visitStep(prevStep.prevId, setFieldTouched);
+          validateStep(nextStep.id);
+        }
+        await validateForm();
+      }}
+      title={i18n._(t`Prompts`)}
+      steps={
+        isReady
+          ? steps
+          : [
+              {
+                name: i18n._(t`Content Loading`),
+                component: <ContentLoading />,
+              },
+            ]
+      }
+      backButtonText={i18n._(t`Back`)}
+      cancelButtonText={i18n._(t`Cancel`)}
+      nextButtonText={i18n._(t`Next`)}
+    />
+  );
+}
+
+export default withI18n()(SchedulePromptableFields);

--- a/awx/ui_next/src/components/Schedule/shared/useSchedulePromptSteps.js
+++ b/awx/ui_next/src/components/Schedule/shared/useSchedulePromptSteps.js
@@ -22,7 +22,7 @@ export default function useSchedulePromptSteps(
     (Object.keys(schedule).length > 0 && schedule) || resource;
 
   sourceOfValues.summary_fields = {
-    credentials: [...resourceCredentials, ...scheduleCredentials],
+    credentials: [...(resourceCredentials || []), ...scheduleCredentials],
     ...sourceOfValues.summary_fields,
   };
   const { resetForm, values } = useFormikContext();

--- a/awx/ui_next/src/components/Schedule/shared/useSchedulePromptSteps.js
+++ b/awx/ui_next/src/components/Schedule/shared/useSchedulePromptSteps.js
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react';
+import { useFormikContext } from 'formik';
+import { t } from '@lingui/macro';
+import useInventoryStep from '../../LaunchPrompt/steps/useInventoryStep';
+import useCredentialsStep from '../../LaunchPrompt/steps/useCredentialsStep';
+import useOtherPromptsStep from '../../LaunchPrompt/steps/useOtherPromptsStep';
+import useSurveyStep from '../../LaunchPrompt/steps/useSurveyStep';
+import usePreviewStep from '../../LaunchPrompt/steps/usePreviewStep';
+
+export default function useSchedulePromptSteps(
+  surveyConfig,
+  launchConfig,
+  schedule,
+  resource,
+  i18n,
+  scheduleCredentials
+) {
+  const {
+    summary_fields: { credentials: resourceCredentials },
+  } = resource;
+  const sourceOfValues =
+    (Object.keys(schedule).length > 0 && schedule) || resource;
+
+  sourceOfValues.summary_fields = {
+    credentials: [...resourceCredentials, ...scheduleCredentials],
+    ...sourceOfValues.summary_fields,
+  };
+  const { resetForm, values } = useFormikContext();
+  const [visited, setVisited] = useState({});
+
+  const steps = [
+    useInventoryStep(launchConfig, sourceOfValues, i18n, visited),
+    useCredentialsStep(launchConfig, sourceOfValues, i18n),
+    useOtherPromptsStep(launchConfig, sourceOfValues, i18n),
+    useSurveyStep(launchConfig, surveyConfig, sourceOfValues, i18n, visited),
+  ];
+
+  const hasErrors = steps.some(step => step.hasError);
+  steps.push(
+    usePreviewStep(
+      launchConfig,
+      i18n,
+      resource,
+      surveyConfig,
+      hasErrors,
+      true,
+      i18n._(t`Save`)
+    )
+  );
+
+  const pfSteps = steps.map(s => s.step).filter(s => s != null);
+  const isReady = !steps.some(s => !s.isReady);
+
+  useEffect(() => {
+    let initialValues = {};
+    if (launchConfig && surveyConfig && isReady) {
+      initialValues = steps.reduce((acc, cur) => {
+        return {
+          ...acc,
+          ...cur.initialValues,
+        };
+      }, {});
+    }
+    resetForm({
+      values: {
+        ...initialValues,
+        ...values,
+      },
+    });
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [launchConfig, surveyConfig, isReady]);
+
+  const stepWithError = steps.find(s => s.contentError);
+  const contentError = stepWithError ? stepWithError.contentError : null;
+
+  return {
+    isReady,
+    validateStep: stepId => {
+      steps.find(s => s?.step?.id === stepId).validate();
+    },
+    steps: pfSteps,
+    visitStep: (prevStepId, setFieldTouched) => {
+      setVisited({
+        ...visited,
+        [prevStepId]: true,
+      });
+      steps.find(s => s?.step?.id === prevStepId).setTouched(setFieldTouched);
+    },
+    visitAllSteps: setFieldTouched => {
+      setVisited({
+        inventory: true,
+        credentials: true,
+        other: true,
+        survey: true,
+        preview: true,
+      });
+      steps.forEach(s => s.setTouched(setFieldTouched));
+    },
+    contentError,
+  };
+}

--- a/awx/ui_next/src/screens/Inventory/InventorySource/InventorySource.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySource/InventorySource.jsx
@@ -69,9 +69,6 @@ function InventorySource({ i18n, inventory, setBreadcrumb, me }) {
     [source]
   );
 
-  const createSchedule = data =>
-    InventorySourcesAPI.createSchedule(source?.id, data);
-
   const loadScheduleOptions = useCallback(() => {
     return InventorySourcesAPI.readScheduleOptions(source?.id);
   }, [source]);
@@ -160,11 +157,11 @@ function InventorySource({ i18n, inventory, setBreadcrumb, me }) {
             path="/inventories/inventory/:id/sources/:sourceId/schedules"
           >
             <Schedules
-              createSchedule={createSchedule}
-              setBreadcrumb={(unifiedJobTemplate, schedule) =>
+              apiModel={InventorySourcesAPI}
+              setBreadcrumb={schedule =>
                 setBreadcrumb(inventory, source, schedule)
               }
-              unifiedJobTemplate={source}
+              resource={source}
               loadSchedules={loadSchedules}
               loadScheduleOptions={loadScheduleOptions}
             />

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -326,11 +326,6 @@ function JobDetail({ job, i18n }) {
           user={created_by}
         />
         <UserDateDetail label={i18n._(t`Last Modified`)} date={job.modified} />
-        <Detail
-          fullWidth
-          label={i18n._(t`Explanation`)}
-          value={job.job_explanation}
-        />
       </DetailList>
       {job.extra_vars && (
         <VariablesInput

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -326,6 +326,11 @@ function JobDetail({ job, i18n }) {
           user={created_by}
         />
         <UserDateDetail label={i18n._(t`Last Modified`)} date={job.modified} />
+        <Detail
+          fullWidth
+          label={i18n._(t`Explanation`)}
+          value={job.job_explanation}
+        />
       </DetailList>
       {job.extra_vars && (
         <VariablesInput

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -40,6 +40,7 @@ describe('<JobDetail />', () => {
               name: 'Test Source Workflow',
             },
           },
+          job_explanation: 'It failed, bummer!',
         }}
       />
     );
@@ -69,6 +70,7 @@ describe('<JobDetail />', () => {
     assertDetail('Job Slice', '0/1');
     assertDetail('Credentials', 'SSH: Demo Credential');
     assertDetail('Machine Credential', 'SSH: Machine cred');
+    assertDetail('Explanation', 'It failed, bummer!');
 
     const credentialChip = wrapper.find(
       `Detail[label="Credentials"] CredentialChip`

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -40,7 +40,6 @@ describe('<JobDetail />', () => {
               name: 'Test Source Workflow',
             },
           },
-          job_explanation: 'It failed, bummer!',
         }}
       />
     );
@@ -70,7 +69,6 @@ describe('<JobDetail />', () => {
     assertDetail('Job Slice', '0/1');
     assertDetail('Credentials', 'SSH: Demo Credential');
     assertDetail('Machine Credential', 'SSH: Machine cred');
-    assertDetail('Explanation', 'It failed, bummer!');
 
     const credentialChip = wrapper.find(
       `Detail[label="Credentials"] CredentialChip`

--- a/awx/ui_next/src/screens/Project/Project.jsx
+++ b/awx/ui_next/src/screens/Project/Project.jsx
@@ -78,10 +78,6 @@ function Project({ i18n, setBreadcrumb }) {
     }
   }, [project, setBreadcrumb]);
 
-  function createSchedule(data) {
-    return ProjectsAPI.createSchedule(project.id, data);
-  }
-
   const loadScheduleOptions = useCallback(() => {
     return ProjectsAPI.readScheduleOptions(project.id);
   }, [project]);
@@ -188,8 +184,8 @@ function Project({ i18n, setBreadcrumb }) {
               <Route path="/projects/:id/schedules">
                 <Schedules
                   setBreadcrumb={setBreadcrumb}
-                  unifiedJobTemplate={project}
-                  createSchedule={createSchedule}
+                  resource={project}
+                  apiModel={ProjectsAPI}
                   loadSchedules={loadSchedules}
                   loadScheduleOptions={loadScheduleOptions}
                 />

--- a/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyListItem.jsx
@@ -20,10 +20,12 @@ import DataListCell from '../../../components/DataListCell';
 import ChipGroup from '../../../components/ChipGroup';
 
 const DataListAction = styled(_DataListAction)`
-  margin-left: 0;
-  margin-right: 20px;
-  padding-top: 15px;
-  padding-bottom: 15px;
+  && {
+    margin-left: 0;
+    margin-right: 20px;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 `;
 const Button = styled(_Button)`
   padding-top: 0;

--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -86,10 +86,6 @@ function Template({ i18n, setBreadcrumb }) {
     }
   }, [template, setBreadcrumb]);
 
-  const createSchedule = data => {
-    return JobTemplatesAPI.createSchedule(template.id, data);
-  };
-
   const loadScheduleOptions = useCallback(() => {
     return JobTemplatesAPI.readScheduleOptions(templateId);
   }, [templateId]);
@@ -203,9 +199,9 @@ function Template({ i18n, setBreadcrumb }) {
               path="/templates/:templateType/:id/schedules"
             >
               <Schedules
-                createSchedule={createSchedule}
+                apiModel={JobTemplatesAPI}
                 setBreadcrumb={setBreadcrumb}
-                unifiedJobTemplate={template}
+                resource={template}
                 loadSchedules={loadSchedules}
                 loadScheduleOptions={loadScheduleOptions}
               />

--- a/awx/ui_next/src/screens/Template/Template.test.jsx
+++ b/awx/ui_next/src/screens/Template/Template.test.jsx
@@ -21,7 +21,7 @@ describe('<Template />', () => {
   let wrapper;
   beforeEach(() => {
     JobTemplatesAPI.readDetail.mockResolvedValue({
-      data: mockJobTemplateData,
+      data: { ...mockJobTemplateData, survey_enabled: false },
     });
     JobTemplatesAPI.readTemplateOptions.mockResolvedValue({
       data: {
@@ -56,6 +56,7 @@ describe('<Template />', () => {
         ],
       },
     });
+    JobTemplatesAPI.readLaunch.mockResolvedValue({ data: {} });
     JobTemplatesAPI.readWebhookKey.mockResolvedValue({
       data: {
         webhook_key: 'key',

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.jsx
@@ -73,10 +73,6 @@ function WorkflowJobTemplate({ i18n, setBreadcrumb }) {
     loadTemplateAndRoles();
   }, [loadTemplateAndRoles, location.pathname]);
 
-  const createSchedule = data => {
-    return WorkflowJobTemplatesAPI.createSchedule(templateId, data);
-  };
-
   const loadScheduleOptions = useCallback(() => {
     return WorkflowJobTemplatesAPI.readScheduleOptions(templateId);
   }, [templateId]);
@@ -206,9 +202,9 @@ function WorkflowJobTemplate({ i18n, setBreadcrumb }) {
               path="/templates/:templateType/:id/schedules"
             >
               <Schedules
-                createSchedule={createSchedule}
+                apiModel={WorkflowJobTemplatesAPI}
                 setBreadcrumb={setBreadcrumb}
-                unifiedJobTemplate={template}
+                resource={template}
                 loadSchedules={loadSchedules}
                 loadScheduleOptions={loadScheduleOptions}
               />

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.test.jsx
@@ -26,7 +26,7 @@ describe('<WorkflowJobTemplate />', () => {
   let wrapper;
   beforeEach(() => {
     WorkflowJobTemplatesAPI.readDetail.mockResolvedValue({
-      data: mockWorkflowJobTemplateData,
+      data: { ...mockWorkflowJobTemplateData, survey_enabled: false },
     });
     WorkflowJobTemplatesAPI.readWorkflowJobTemplateOptions.mockResolvedValue({
       data: {
@@ -45,6 +45,7 @@ describe('<WorkflowJobTemplate />', () => {
         ],
       },
     });
+    WorkflowJobTemplatesAPI.readLaunch.mockResolvedValue({ data: {} });
     WorkflowJobTemplatesAPI.readWebhookKey.mockResolvedValue({
       data: {
         webhook_key: 'key',


### PR DESCRIPTION
##### SUMMARY
This Addresses #7692.  Couple of unique items for this workflow because this is a form that uses both standard on screen form, and a wizard combo.
1)The save button should be disabled when the user must do some work inside the wizard because it is missing some required information like an inventory, or some survey values.
2) If the user cancels the modal in the middle of it, and then saves, it should not submit new values from the modal
3)Prompt button should not render for schedules that do not need it (ie. Inventory Source, Projects, and templates that do not have any prompt on launch values).



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![schedulePrompting](https://user-images.githubusercontent.com/39280967/106653797-46459680-6565-11eb-9e24-db9932d62b5b.gif)
