### PR TITLE
Prevent url smashing from prompted inputs

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/steps/CredentialPasswordsStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/CredentialPasswordsStep.jsx
@@ -84,7 +84,11 @@ function CredentialPasswordsStep({ launchConfig, i18n }) {
   }
 
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+      }}
+    >
       {showcredentialPasswordSsh && (
         <PasswordField
           id="launch-ssh-password"

--- a/awx/ui_next/src/components/LaunchPrompt/steps/OtherPromptsStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/OtherPromptsStep.jsx
@@ -22,7 +22,11 @@ const FieldHeader = styled.div`
 
 function OtherPromptsStep({ launchConfig, i18n }) {
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+      }}
+    >
       {launchConfig.ask_job_type_on_launch && <JobTypeField i18n={i18n} />}
       {launchConfig.ask_limit_on_launch && (
         <FormField

--- a/awx/ui_next/src/components/LaunchPrompt/steps/SurveyStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/SurveyStep.jsx
@@ -33,7 +33,11 @@ function SurveyStep({ surveyConfig, i18n }) {
     float: NumberField,
   };
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+      }}
+    >
       {surveyConfig.spec.map(question => {
         const Field = fieldTypes[question.type];
         return (


### PR DESCRIPTION
##### SUMMARY
See: https://github.com/ansible/awx/issues/9229

The launch prompts use forms on several steps. By default, the forms attempt to handle all Enter key-press events as a form submission. The default method for a raw html form is a GET request, so user input to the prompt fields will be injected into the url as query params when handling the key-press.

User input is collected by the launch prompts on multiple forms across several steps, so we should disable the default event handlers on the intermediate steps.
