### PR TITLE
Use Postgresql secret in openshift/k8s

### DIFF
--- a/installer/roles/kubernetes/tasks/main.yml
+++ b/installer/roles/kubernetes/tasks/main.yml
@@ -73,9 +73,6 @@
           -e MEMORY_LIMIT={{ pg_memory_limit|default('512') }}Mi \
           -e DATABASE_SERVICE_NAME=postgresql  \
           -e POSTGRESQL_MAX_CONNECTIONS={{ pg_max_connections|default(1024) }} \
-          -e POSTGRESQL_USER={{ pg_username }} \
-          -e POSTGRESQL_PASSWORD={{ pg_password | quote }} \
-          -e POSTGRESQL_DATABASE={{ pg_database | quote }} \
           -e POSTGRESQL_VERSION=12 \
           -n {{ kubernetes_namespace }}
       register: openshift_pg_activate

--- a/installer/roles/kubernetes/templates/postgresql-persistent.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-persistent.yml.j2
@@ -159,13 +159,13 @@ parameters:
 - description: Username for PostgreSQL user that will be used for accessing the
     database.
   displayName: PostgreSQL Connection Username
-  from: user[A-Z0-9]{3}
+  from: {{ pg_username }}
   generate: expression
   name: POSTGRESQL_USER
   required: true
 - description: Password for the PostgreSQL connection user.
   displayName: PostgreSQL Connection Password
-  from: '[a-zA-Z0-9]{16}'
+  from: '{{ pg_password }}'
   generate: expression
   name: POSTGRESQL_PASSWORD
   required: true
@@ -173,4 +173,4 @@ parameters:
   displayName: PostgreSQL Database Name
   name: POSTGRESQL_DATABASE
   required: true
-  value: sampledb
+  value: {{ pg_database }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removed plain text password from environment variables and added them to the secret that is created for postgresql. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
