### PR TITLE
Fixed the Customized Notification returning incorrect values for host_status_counts

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -383,12 +383,17 @@ class JobNotificationMixin(object):
         and a url to the job run."""
         job_context = {'host_status_counts': {}}
         summary = None
-        if hasattr(self, 'job_host_summaries'):
-            summary = self.job_host_summaries.first()
-        if summary:
-            from awx.api.serializers import JobHostSummarySerializer
-            summary_data = JobHostSummarySerializer(summary).to_representation(summary)
-            job_context['host_status_counts'] = summary_data
+        try:
+            has_event_property = any([f for f in self.event_class._meta.fields if f.name == 'event'])
+        except NotImplementedError:
+            has_event_property = False
+        if has_event_property:
+            qs = self.get_event_queryset()
+            if qs:
+                event = qs.only('event_data').filter(event='playbook_on_stats').first()
+                if event:
+                    summary = event.get_host_status_counts()
+        job_context['host_status_counts'] = summary
         context = {
             'job': job_context,
             'job_friendly_name': self.get_notification_friendly_name(),


### PR DESCRIPTION
Fixed the customized notification returning incorrect values for host_status_counts. Summarizing the issue in the following

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When running a Job Template with a customized notification associated with it, it is returning incorrect values for **host_status_counts** in SLACK channel. I could see that in the code that we are taking the values for host_status_counts from **job_host_summaries** for the first rack than taking it from the **_/api/v2/jobs/ID._**

> https://github.com/ansible/tower/blob/370440f63d51f424009665edfd35b10322ddbd06/awx/main/models/notifications.py#L387

The values shows in **/api/v2/jobs/ID** look perfectly correct to me than what shows in /api/v2/jobs/ID/job_host_summaries. In the job_host_summaries we calculate the host_status_counts values for dark,ok, processed, etc. individually for different hosts. And right now we are taking host_status_counts from the first rack of the job_host_summaries rather than just taking it from /api/v2/jobs/ID host_status_counts which is calculated correctly. Looking at the **job_host_summaries** API output I think we are taking the values from the first rack of **job_host_summaries**
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description, but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
* Tower version: 3.8.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

With the PR, we could see the correct values are getting received in SLACK notifications. 

![slack_notification](https://user-images.githubusercontent.com/21283108/107121248-681d8100-68b7-11eb-93ca-993ae340365a.png)

Following data is from /api/v2/jobs/185 for host_status_counts
![host_status_counts](https://user-images.githubusercontent.com/21283108/107121276-88e5d680-68b7-11eb-9657-9153f6870b3f.png)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
