### PR TITLE
Handle error state with traceback and no stdout

### DIFF
--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -347,7 +347,7 @@ class JobOutput extends Component {
           let countOffset = 1;
           if (job?.result_traceback) {
             const tracebackEvent = {
-              counter: -1,
+              counter: 1,
               created: null,
               event: null,
               type: null,
@@ -357,7 +357,7 @@ class JobOutput extends Component {
             const firstIndex = newResults.findIndex(
               jobEvent => jobEvent.counter === 1
             );
-            if (firstIndex) {
+            if (firstIndex && newResults[firstIndex]?.stdout) {
               const stdoutLines = newResults[firstIndex].stdout.split('\r\n');
               stdoutLines[0] = tracebackEvent.stdout;
               newResults[firstIndex].stdout = stdoutLines.join('\r\n');


### PR DESCRIPTION
##### SUMMARY
Note: For reproducing this bug, launch a job with  an `error` (not `failed`) state, a `result_traceback`, and no stdout.

