### PR TITLE
Relax client-side email validator

### DIFF
--- a/awx/ui_next/src/util/validators.jsx
+++ b/awx/ui_next/src/util/validators.jsx
@@ -50,10 +50,23 @@ export function requiredEmail(i18n) {
     if (!value) {
       return i18n._(t`This field must not be blank`);
     }
-    if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)) {
-      return i18n._(t`Invalid email address`);
+
+    // This isn't a perfect validator. It's likely to let a few
+    // invalid (though unlikely) email addresses through.
+
+    // This is ok, because the server will always do strict validation for us.
+
+    const splitVals = value.split('@');
+
+    if (splitVals.length >= 2) {
+      if (splitVals[0] && splitVals[1]) {
+        // We get here if the string has an '@' that is enclosed by
+        // non-empty substrings
+        return undefined;
+      }
     }
-    return undefined;
+
+    return i18n._(t`Invalid email address`);
   };
 }
 

--- a/awx/ui_next/src/util/validators.test.js
+++ b/awx/ui_next/src/util/validators.test.js
@@ -8,6 +8,7 @@ import {
   url,
   combine,
   regExp,
+  requiredEmail,
 } from './validators';
 
 const i18n = { _: val => val };
@@ -186,5 +187,15 @@ describe('validators', () => {
     expect(regExp(i18n)('')).toBeUndefined();
     expect(regExp(i18n)('ok')).toBeUndefined();
     expect(regExp(i18n)('[^a-zA-Z]')).toBeUndefined();
+  });
+
+  test('email validator rejects obviously invalid email ', () => {
+    expect(requiredEmail(i18n)('foobar321')).toEqual({
+      id: 'Invalid email address',
+    });
+  });
+
+  test('bob has email', () => {
+    expect(requiredEmail(i18n)('bob@localhost')).toBeUndefined();
   });
 });


### PR DESCRIPTION
##### SUMMARY
* The client-side email validator can reject _most_ obviously invalid email addresses, but it shouldn't overdo it. Strict data validation happens in the server. The definition of a saveable email address lives on the server.

