### PR TITLE
add support for diff mode in tower_settings module

### DIFF
--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -133,7 +133,7 @@ def main():
     existing_settings = module.get_endpoint('settings/all')['json']
 
     # Begin a json response
-    json_output = {'changed': False, 'old_values': {}, 'new_values': {} }
+    json_output = {'changed': False, 'old_values': {}, 'new_values': {}}
 
     # Check any of the settings to see if anything needs to be updated
     needs_update = False
@@ -153,7 +153,7 @@ def main():
     # If nothing needs an update we can simply exit with the response (as not changed)
     if not needs_update:
         module.exit_json(**json_output)
-    
+
     if module.check_mode and module._diff:
         json_output['changed'] = True
         module.exit_json(**json_output)

--- a/awx_collection/plugins/modules/tower_settings.py
+++ b/awx_collection/plugins/modules/tower_settings.py
@@ -133,7 +133,7 @@ def main():
     existing_settings = module.get_endpoint('settings/all')['json']
 
     # Begin a json response
-    json_response = {'changed': False, 'old_values': {}}
+    json_output = {'changed': False, 'old_values': {}, 'new_values': {} }
 
     # Check any of the settings to see if anything needs to be updated
     needs_update = False
@@ -141,18 +141,29 @@ def main():
         if a_setting not in existing_settings or existing_settings[a_setting] != new_settings[a_setting]:
             # At least one thing is different so we need to patch
             needs_update = True
-            json_response['old_values'][a_setting] = existing_settings[a_setting]
+            json_output['old_values'][a_setting] = existing_settings[a_setting]
+            json_output['new_values'][a_setting] = new_settings[a_setting]
+
+    if module._diff:
+        json_output['diff'] = {
+            'before': json_output['old_values'],
+            'after': json_output['new_values']
+        }
 
     # If nothing needs an update we can simply exit with the response (as not changed)
     if not needs_update:
-        module.exit_json(**json_response)
+        module.exit_json(**json_output)
+    
+    if module.check_mode and module._diff:
+        json_output['changed'] = True
+        module.exit_json(**json_output)
 
     # Make the call to update the settings
     response = module.patch_endpoint('settings/all', **{'data': new_settings})
 
     if response['status_code'] == 200:
         # Set the changed response to True
-        json_response['changed'] = True
+        json_output['changed'] = True
 
         # To deal with the old style values we need to return 'value' in the response
         new_values = {}
@@ -161,11 +172,11 @@ def main():
 
         # If we were using a name we will just add a value of a string, otherwise we will return an array in values
         if name is not None:
-            json_response['value'] = new_values[name]
+            json_output['value'] = new_values[name]
         else:
-            json_response['values'] = new_values
+            json_output['values'] = new_values
 
-        module.exit_json(**json_response)
+        module.exit_json(**json_output)
     elif 'json' in response and '__all__' in response['json']:
         module.fail_json(msg=response['json']['__all__'])
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #8731
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
tower_settings


##### ADDITIONAL INFORMATION

Playbook:

```
  - name: Set LDAP
    awx.awx.tower_settings:
      settings:
        AUTH_LDAP_SERVER_URI: "ldap://ldap.example.com:123"
        AUTH_LDAP_BIND_DN: CN=user,DC=example,DC=com
      validate_certs: no
```
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Without the above PR:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[niks@rhel83 ~]$ ansible-playbook test_settings.yml -C --diff
PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Set LDAP] ***************************************************************************************************************************************************************************************************
[WARNING]: You are using the awx version of this collection but connecting to Red Hat Ansible Tower
changed: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

With the above PR:

```
[niks@rhel83 ~]$ ansible-playbook test_settings.yml -C --diff
PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Set LDAP] ***************************************************************************************************************************************************************************************************
--- before
+++ after
@@ -1,3 +1,3 @@
 {
-    "AUTH_LDAP_SERVER_URI": "ldap://ldap.example.com:389"
+    "AUTH_LDAP_SERVER_URI": "ldap://ldap.example.com:123"
 }

[WARNING]: You are using the awx version of this collection but connecting to Red Hat Ansible Tower
changed: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

