### PR TITLE
Fixes PostgreSQL deployment for k8s environment

### DIFF
--- a/installer/inventory
+++ b/installer/inventory
@@ -23,6 +23,8 @@ dockerhub_base=ansible
 # kubernetes_web_svc_type=NodePort
 # Optional Kubernetes Variables
 # pg_image_registry=docker.io
+# pg_image_repository=bitnami/postgresql
+# pg_image_version=12.5.0
 # pg_serviceaccount=awx
 # pg_volume_capacity=5
 # pg_persistence_storageClass=StorageClassName

--- a/installer/roles/kubernetes/templates/postgresql-values.yml.j2
+++ b/installer/roles/kubernetes/templates/postgresql-values.yml.j2
@@ -40,10 +40,20 @@ image:
   registry: {{ pg_image_registry }}
 {% endif %}
 {% if pg_image_registry is not defined %}
-  registry: docker.io/bitnami
+  registry: docker.io
 {% endif %}
-  repository: postgresql
+{% if pg_image_repository is defined %}
+  repository: {{ pg_image_repository }}
+{% endif %}
+{% if pg_image_repository is not defined %}
+  repository: bitnami/postgresql
+{% endif %}
+{% if pg_image_version is defined %}
+  tag: {{ pg_image_version }}
+{% endif %}
+{% if pg_image_version is not defined %}
   tag: '12.5.0'
+{% endif %}
 volumePermissions:
   image:
 {% if pg_image_registry is defined %}


### PR DESCRIPTION
##### SUMMARY
cc: @blomquisg @Spredzy 

Fixes: #9249

With the current `inventory` and `postgresql-values.yml` values, the user can be easily for mistakes when selecting the base image to deploy a PostgreSQL in the k8s cluster. 

With this patch, the user more explicitly determines which image will be used in the PostgreSQL `Statefulset`. 



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
17.0.1
```


##### ADDITIONAL INFORMATION
Please see https://github.com/ansible/awx/issues/9249#issuecomment-778408941 for a more verbose step-by-step. 
