### PR TITLE
Fix Openstack credential region implementation.

### DIFF
--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -92,8 +92,8 @@ def _openstack_data(cred):
         },
     }
 
-    if cred.has_input('project_region_name'):
-        openstack_data['clouds']['devstack']['region_name'] = cred.get_input('project_region_name', default='')
+    if cred.has_input('region'):
+        openstack_data['clouds']['devstack']['region_name'] = cred.get_input('region', default='')
 
     return openstack_data
 

--- a/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
+++ b/awx/main/tests/data/inventory/plugins/openstack/files/file_reference
@@ -8,4 +8,5 @@ clouds:
       project_name: fooo
       username: fooo
     private: true
+    region_name: fooo
     verify: false

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -249,7 +249,7 @@ def test_openstack_client_config_generation_with_project_domain_name(mocker, sou
 @pytest.mark.parametrize("source,expected", [
     (None, True), (False, False), (True, True)
 ])
-def test_openstack_client_config_generation_with_project_region_name(mocker, source, expected, private_data_dir):
+def test_openstack_client_config_generation_with_region(mocker, source, expected, private_data_dir):
     update = tasks.RunInventoryUpdate()
     credential_type = CredentialType.defaults['openstack']()
     inputs = {
@@ -259,7 +259,7 @@ def test_openstack_client_config_generation_with_project_region_name(mocker, sou
         'project': 'demo-project',
         'domain': 'my-demo-domain',
         'project_domain_name': 'project-domain',
-        'project_region_name': 'region-name',
+        'region': 'region-name',
     }
     if source is not None:
         inputs['verify_ssl'] = source

--- a/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
+++ b/awx/ui_next/src/screens/Credential/shared/data.credentialTypes.json
@@ -276,7 +276,7 @@
           "help_text": "OpenStack domains define administrative boundaries. It is only needed for Keystone v3 authentication URLs. Refer to Ansible Tower documentation for common scenarios."
         },
         {
-          "id": "project_region_name",
+          "id": "region",
           "label": "Region Name",
           "type": "string"
         },


### PR DESCRIPTION
See https://github.com/ansible/awx/issues/9165

This fixes a bug introduced in https://github.com/ansible/awx/pull/8880/files when this code was added.

Not tested yet, but I assert that the prior code can't possibly have worked, as the injector/tests/UI were not using the same credential field name as the model (see https://github.com/ansible/awx/blob/devel/awx/main/models/credential/__init__.py#L823).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
current
