### PR TITLE
Adds toast to notification template list whenever test notification finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a list of high-level changes for each release of AWX. A full list of com
 - Added ability to relaunch against failed hosts: https://github.com/ansible/awx/pull/9225
 - Added pending workflow approval count to the application header https://github.com/ansible/awx/pull/9334
 - Added user interface for management jobs: https://github.com/ansible/awx/pull/9224
+- Added toast message to show notification template test result to notification templates list https://github.com/ansible/awx/pull/9318
 
 # 17.0.1 (January 26, 2021)
 - Fixed pgdocker directory permissions issue with Local Docker installer: https://github.com/ansible/awx/pull/9152

--- a/awx/ui_next/src/components/CopyButton/CopyButton.jsx
+++ b/awx/ui_next/src/components/CopyButton/CopyButton.jsx
@@ -17,6 +17,7 @@ function CopyButton({
   onCopyFinish,
   errorMessage,
   i18n,
+  ouiaId,
 }) {
   const { isLoading, error: copyError, request: copyItemToAPI } = useRequest(
     copyItem
@@ -35,6 +36,7 @@ function CopyButton({
     <>
       <Button
         id={id}
+        ouiaId={ouiaId}
         isDisabled={isLoading || isDisabled}
         aria-label={i18n._(t`Copy`)}
         variant="plain"
@@ -62,10 +64,12 @@ CopyButton.propTypes = {
   onCopyFinish: PropTypes.func.isRequired,
   errorMessage: PropTypes.string.isRequired,
   isDisabled: PropTypes.bool,
+  ouiaId: PropTypes.string,
 };
 
 CopyButton.defaultProps = {
   isDisabled: false,
+  ouiaId: null,
 };
 
 export default withI18n()(CopyButton);

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx
@@ -227,7 +227,7 @@ function NotificationTemplatesList({ i18n }) {
         {i18n._(t`Failed to delete one or more notification template.`)}
         <ErrorDetail error={deletionError} />
       </AlertModal>
-      <AlertGroup isToast>
+      <AlertGroup ouiaId="notification-template-alerts" isToast>
         {testToasts
           .filter(notification => notification.status !== 'pending')
           .map(notification => (

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx
@@ -114,7 +114,9 @@ function NotificationTemplatesList({ i18n }) {
   }, []);
 
   const removeTestToast = notificationId => {
-    setTestToasts(testToasts.filter(toast => toast.id !== notificationId));
+    setTestToasts(oldToasts =>
+      oldToasts.filter(toast => toast.id !== notificationId)
+    );
   };
 
   const canAdd = actions && actions.POST;

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx
@@ -119,6 +119,7 @@ function NotificationTemplateListItem({
         <ActionsTd dataLabel={i18n._(t`Actions`)}>
           <ActionItem visible tooltip={i18n._(t`Test notification`)}>
             <Button
+              ouiaId={`notification-test-button-${template.id}`}
               aria-label={i18n._(t`Test Notification`)}
               variant="plain"
               onClick={sendTestNotification}
@@ -132,6 +133,7 @@ function NotificationTemplateListItem({
             tooltip={i18n._(t`Edit`)}
           >
             <Button
+              ouiaId={`notification-edit-button-${template.id}`}
               aria-label={i18n._(t`Edit Notification Template`)}
               variant="plain"
               component={Link}
@@ -145,6 +147,7 @@ function NotificationTemplateListItem({
             tooltip={i18n._(t`Copy Notification Template`)}
           >
             <CopyButton
+              ouiaId={`notification-copy-button-${template.id}`}
               copyItem={copyTemplate}
               isCopyDisabled={isCopyDisabled}
               onCopyStart={handleCopyStart}


### PR DESCRIPTION
##### SUMMARY
link #9223 

![toast_notif](https://user-images.githubusercontent.com/9889020/107991738-3dad8100-6fa5-11eb-8b3c-51f279655f17.gif)

I decided to make the success toasts disappear on a timer but the failure toasts are sticky.  This is slightly different from the UX of the old app where all toasts would disappear on a timer.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI