### PR TITLE
fix for issue 4696(tower) , Upstream commit for tower PR 4840

### DIFF
--- a/awx/sso/views.py
+++ b/awx/sso/views.py
@@ -58,12 +58,12 @@ class MetadataView(View):
     def get(self, request, *args, **kwargs):
         from social_django.utils import load_backend, load_strategy
         complete_url = reverse('social:complete', args=('saml', ))
-        saml_backend = load_backend(
-            load_strategy(request),
-            'saml',
-            redirect_uri=complete_url,
-        )
         try:
+            saml_backend = load_backend(
+                load_strategy(request),
+                'saml',
+                redirect_uri=complete_url,
+            )
             metadata, errors = saml_backend.generate_metadata_xml()
         except Exception as e:
             logger.exception('unable to generate SAML metadata')


### PR DESCRIPTION
Fix : tower issue 4696, 500 is not returned if SOCIAL_AUTH_SAML_SUPPORT_CONTACT is not entered in the UI


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The issue was that error 500 is returned in certain cases. This PR fixes that. 
The following line was creating an exception that was not being catched. 
``` saml_backend = load_backend( ```
I have modified the ```try:``` statement to include that exception.
Error 500 is no longer returned by the endpoint. A page is rendered describing the error. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 17.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
