### PR TITLE
Mark start node for translation

### DIFF
--- a/awx/ui_next/.eslintrc
+++ b/awx/ui_next/.eslintrc
@@ -79,7 +79,7 @@
           "theme",
           "gridColumns"
         ],
-        "ignore": ["Ansible", "Tower", "JSON", "YAML", "lg", "START"],
+        "ignore": ["Ansible", "Tower", "JSON", "YAML", "lg"],
         "ignoreComponent": [
           "code",
           "Omit",

--- a/awx/ui_next/src/components/Workflow/WorkflowStartNode.jsx
+++ b/awx/ui_next/src/components/Workflow/WorkflowStartNode.jsx
@@ -8,7 +8,6 @@ import {
   WorkflowDispatchContext,
   WorkflowStateContext,
 } from '../../contexts/Workflow';
-import { constants as wfConstants } from './WorkflowUtils';
 import WorkflowActionTooltip from './WorkflowActionTooltip';
 import WorkflowActionTooltipItem from './WorkflowActionTooltipItem';
 
@@ -16,8 +15,25 @@ const StartG = styled.g`
   pointer-events: ${props => (props.ignorePointerEvents ? 'none' : 'auto')};
 `;
 
+const StartForeignObject = styled.foreignObject`
+  overflow: visible;
+`;
+
+const StartDiv = styled.div`
+  background-color: #0279bc;
+  color: white;
+  width: max-content;
+  min-width: 80px;
+  height: 40px;
+  border-radius: 0.35em;
+  text-align: center;
+  line-height: 40px;
+  padding: 0px 10px;
+`;
+
 function WorkflowStartNode({ i18n, onUpdateHelpText, showActionTooltip }) {
   const ref = useRef(null);
+  const startNodeRef = useRef(null);
   const [hovering, setHovering] = useState(false);
   const dispatch = useContext(WorkflowDispatchContext);
   const { addingLink, nodePositions } = useContext(WorkflowStateContext);
@@ -36,18 +52,14 @@ function WorkflowStartNode({ i18n, onUpdateHelpText, showActionTooltip }) {
       ref={ref}
       transform={`translate(${nodePositions[1].x},0)`}
     >
-      <rect
-        fill="#0279BC"
-        height={wfConstants.rootH}
-        rx="2"
-        ry="2"
-        width={wfConstants.rootW}
+      <StartForeignObject
+        height="1"
+        width="1"
         y="10"
-      />
-      {/* TODO: We need to be able to handle translated text here */}
-      <text x="13" y="30" dy=".35em" fill="white">
-        START
-      </text>
+        style={{ overflow: 'visible' }}
+      >
+        <StartDiv ref={startNodeRef}>{i18n._(t`START`)}</StartDiv>
+      </StartForeignObject>
       {showActionTooltip && hovering && (
         <WorkflowActionTooltip
           actions={[
@@ -65,8 +77,8 @@ function WorkflowStartNode({ i18n, onUpdateHelpText, showActionTooltip }) {
               <PlusIcon />
             </WorkflowActionTooltipItem>,
           ]}
-          pointX={wfConstants.rootW}
-          pointY={wfConstants.rootH / 2 + 10}
+          pointX={startNodeRef.current.offsetWidth}
+          pointY={startNodeRef.current.offsetHeight / 2 + 10}
         />
       )}
     </StartG>

--- a/awx/ui_next/src/components/Workflow/WorkflowStartNode.test.jsx
+++ b/awx/ui_next/src/components/Workflow/WorkflowStartNode.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import { WorkflowStateContext } from '../../contexts/Workflow';
 import WorkflowStartNode from './WorkflowStartNode';
 
@@ -12,7 +12,7 @@ const nodePositions = {
 
 describe('WorkflowStartNode', () => {
   test('mounts successfully', () => {
-    const wrapper = mount(
+    const wrapper = mountWithContexts(
       <svg>
         <WorkflowStateContext.Provider value={{ nodePositions }}>
           <WorkflowStartNode
@@ -25,7 +25,7 @@ describe('WorkflowStartNode', () => {
     expect(wrapper).toHaveLength(1);
   });
   test('tooltip shown on hover', () => {
-    const wrapper = mount(
+    const wrapper = mountWithContexts(
       <svg>
         <WorkflowStateContext.Provider value={{ nodePositions }}>
           <WorkflowStartNode nodePositions={nodePositions} showActionTooltip />

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.jsx
@@ -250,7 +250,7 @@ function VisualizerGraph({ i18n, readOnly }) {
         </defs>
         <rect
           height="100%"
-          id="workflow-backround"
+          id="workflow-background"
           opacity="0"
           width="100%"
           {...(addingLink && {
@@ -267,12 +267,6 @@ function VisualizerGraph({ i18n, readOnly }) {
         />
         <g id="workflow-g" ref={gRef}>
           {nodePositions && [
-            <WorkflowStartNode
-              key="start"
-              showActionTooltip={!readOnly}
-              onUpdateHelpText={setHelpText}
-              readOnly={readOnly}
-            />,
             links.map(link => {
               if (
                 nodePositions[link.source.id] &&
@@ -307,6 +301,12 @@ function VisualizerGraph({ i18n, readOnly }) {
               }
               return null;
             }),
+            <WorkflowStartNode
+              key="start"
+              showActionTooltip={!readOnly}
+              onUpdateHelpText={setHelpText}
+              readOnly={readOnly}
+            />,
           ]}
           {addingLink && (
             <PotentialLink

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.jsx
@@ -94,7 +94,8 @@ function VisualizerLink({
         ];
 
   const handleLinkMouseEnter = () => {
-    ref.current.parentNode.appendChild(ref.current);
+    const startNode = document.getElementById('node-1');
+    ref.current.parentNode.insertBefore(ref.current, startNode);
     setHovering(true);
   };
 


### PR DESCRIPTION
##### SUMMARY
link #5990 

Start node with various text lengths:

<img width="1110" alt="Screen Shot 2021-02-17 at 2 38 22 PM" src="https://user-images.githubusercontent.com/9889020/108262233-a70eca80-7132-11eb-8e34-55c4cdaacae9.png">
<img width="1051" alt="Screen Shot 2021-02-17 at 2 37 53 PM" src="https://user-images.githubusercontent.com/9889020/108262235-a7a76100-7132-11eb-95c8-1d834922bfa1.png">
<img width="1089" alt="Screen Shot 2021-02-17 at 2 37 18 PM" src="https://user-images.githubusercontent.com/9889020/108262236-a7a76100-7132-11eb-8d60-bac45c4a788c.png">

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI