### PR TITLE
Don't instrument for coverage by default unless CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,7 @@ ui-zuul-lint-and-test:
 	$(NPM_BIN) --prefix awx/ui_next install
 	$(NPM_BIN) run --prefix awx/ui_next lint
 	$(NPM_BIN) run --prefix awx/ui_next prettier-check
-	$(NPM_BIN) run --prefix awx/ui_next test
+	$(NPM_BIN) run --prefix awx/ui_next test -- --coverage --watchAll=false
 
 
 # Build a pip-installable package into dist/ with a timestamped version number.

--- a/awx/ui_next/README.md
+++ b/awx/ui_next/README.md
@@ -53,6 +53,9 @@ npm --prefix awx/ui_next test -- src/screens/Login/Login.test.jsx
 
 # start the test watcher and run tests on files that you've changed
 npm --prefix awx/ui_next run test-watch
+
+# start the tests and get the coverage report after the tests have completed
+npm --prefix awx/ui_next run test -- --coverage
 ```
 #### Note:
 - Once the test watcher is up and running you can hit `a` to run all the tests.

--- a/awx/ui_next/package.json
+++ b/awx/ui_next/package.json
@@ -58,7 +58,7 @@
     "start": "PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
     "start-instrumented": "DEBUG=instrument-cra PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts -r @cypress/instrument-cra start",
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
-    "test": "TZ='UTC' react-scripts test --coverage --watchAll=false",
+    "test": "TZ='UTC' react-scripts test --watchAll=false",
     "test-watch": "TZ='UTC' react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js --ext .jsx .",


### PR DESCRIPTION
##### SUMMARY
This removes the unit test command `--coverage` in package.json that generates the coverage report after test are completed.  Instead, we decided to generate that report in zuul when creating/updated PRs.  Also updates ReadME

##### ISSUE TYPE
 - tooling

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
