### PR TITLE
create performance logger to log api response time

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -45,7 +45,10 @@ class TimingMiddleware(threading.local, MiddlewareMixin):
         response['X-API-Total-Time'] = '%0.3fs' % total_time
         if settings.AWX_REQUEST_PROFILE:
             response['X-API-Profile-File'] = self.prof.stop()
-        perf_logger.info('api response times', extra=dict(python_objects=dict(request=request, response=response)))
+        perf_logger.info(
+            f'request: {request}, response_time: {response["X-API-Total-Time"]}',
+            extra=dict(python_objects=dict(request=request, response=response, X_API_TOTAL_TIME=response["X-API-Total-Time"]))
+        )
         return response
 
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1044,6 +1044,11 @@ LOGGING = {
             'level': 'INFO',
             'propagate': False
         },
+        'awx.analytics.performance': {
+            'handlers': ['console', 'file', 'tower_warnings', 'external_logger'],
+            'level': 'DEBUG',
+            'propagate': False
+        },
         'awx.analytics.job_lifecycle': {
             'handlers': ['console', 'job_lifecycle'],
             'level': 'DEBUG',


### PR DESCRIPTION
this middleware allready existed, and we were trying to log this
data but it was not working.

Hope is these logs will be able to be shipped via external logging
and we could use kibana to track response time of different endpoints

Just adding logger to `defaults.py` made it print out 
```
awx_1            | 2021-02-18 22:51:17,509 INFO     [2d049242] awx.analytics.performance api response times
``` 

so it seems the "Extra" keyword is just used by rsyslog (I know because i took it out, and rsyslog started throwing errors)

Now it prints this to console:

```
awx_1            | 2021-02-18 23:22:32,908 INFO     [540fd291] awx.analytics.performance request: <WSGIRequest: GET '/api/v2/job_events/'>, response_time: 0.593s
awx_1            | 172.18.0.1 GET /api/v2/job_events/ - HTTP/1.1 200
```

Still need to check if 

```
    "LOG_AGGREGATOR_LOGGERS": [
        "awx",
        "activity_stream",
        "job_events",
        "system_tracking",
        "performance"
    ],
    "LOG_AGGREGATOR_LEVEL": "DEBUG",
```

successfully causes this to get shipped to external logger