### PR TITLE
added survey_spec to JobTemplate API endpoints

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2921,8 +2921,8 @@ class JobTemplateSerializer(JobTemplateMixin, UnifiedJobTemplateSerializer, JobO
             'ask_variables_on_launch', 'ask_limit_on_launch', 'ask_tags_on_launch',
             'ask_skip_tags_on_launch', 'ask_job_type_on_launch', 'ask_verbosity_on_launch',
             'ask_inventory_on_launch', 'ask_credential_on_launch', 'survey_enabled',
-            'become_enabled', 'diff_mode', 'allow_simultaneous', 'custom_virtualenv',
-            'job_slice_count', 'webhook_service', 'webhook_credential',
+            'survey_spec', 'become_enabled', 'diff_mode', 'allow_simultaneous',
+            'custom_virtualenv', 'job_slice_count', 'webhook_service', 'webhook_credential',
         )
 
     def get_related(self, obj):
@@ -4064,7 +4064,7 @@ class JobLaunchSerializer(BaseSerializer):
                   'ask_scm_branch_on_launch', 'ask_variables_on_launch', 'ask_tags_on_launch',
                   'ask_diff_mode_on_launch', 'ask_skip_tags_on_launch', 'ask_job_type_on_launch', 'ask_limit_on_launch',
                   'ask_verbosity_on_launch', 'ask_inventory_on_launch', 'ask_credential_on_launch',
-                  'survey_enabled', 'variables_needed_to_start', 'credential_needed_to_start',
+                  'survey_enabled', 'survey_spec', 'variables_needed_to_start', 'credential_needed_to_start',
                   'inventory_needed_to_start', 'job_template_data', 'defaults', 'verbosity')
         read_only_fields = (
             'ask_scm_branch_on_launch',


### PR DESCRIPTION
##### SUMMARY
added "survey_spec" to the fields of the JobTemplate model, this enables the awx cli to be able to upload survey specs.

related #8464

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
17.0.1
```


##### ADDITIONAL INFORMATION
This is a PR to implement the change as mentioned in "CLI import of surveys does not work #8464", there was a request for a PR, so here it is.  I have tried it out my self and it seems to function as it should.