### PR TITLE
Add support for replace/revert on secret credential fields

### DIFF
--- a/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.jsx
@@ -127,7 +127,7 @@ function CredentialAdd({ me }) {
       </PageSection>
     );
   }
-  if (isLoading && !result) {
+  if (isLoading) {
     return (
       <PageSection>
         <Card>

--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.jsx
@@ -178,7 +178,7 @@ function CredentialEdit({ credential }) {
     return <ContentError error={error} />;
   }
 
-  if (isLoading && !credentialTypes) {
+  if (isLoading) {
     return <ContentLoading />;
   }
 

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { func, shape } from 'prop-types';
+import { shape } from 'prop-types';
 import { Formik, useField, useFormikContext } from 'formik';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
@@ -315,8 +315,6 @@ function CredentialForm({
 }
 
 CredentialForm.propTypes = {
-  handleSubmit: func.isRequired,
-  handleCancel: func.isRequired,
   credentialTypes: shape({}).isRequired,
   credential: shape({}),
   inputSources: shape({}),

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { mountWithContexts } from '../../../../../testUtils/enzymeHelpers';
+import credentialTypes from '../data.credentialTypes.json';
+import CredentialField from './CredentialField';
+
+const credentialType = credentialTypes.find(type => type.id === 5);
+const fieldOptions = {
+  id: 'password',
+  label: 'Secret Key',
+  type: 'string',
+  secret: true,
+};
+
+describe('<CredentialField />', () => {
+  let wrapper;
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  test('renders correctly without initial value', () => {
+    wrapper = mountWithContexts(
+      <Formik
+        initialValues={{
+          passwordPrompts: {},
+          inputs: {
+            password: '',
+          },
+        }}
+      >
+        {() => (
+          <CredentialField
+            fieldOptions={fieldOptions}
+            credentialType={credentialType}
+          />
+        )}
+      </Formik>
+    );
+    expect(wrapper.find('CredentialField').length).toBe(1);
+    expect(wrapper.find('PasswordInput').length).toBe(1);
+    expect(wrapper.find('TextInput').props().isDisabled).toBe(false);
+    expect(wrapper.find('KeyIcon').length).toBe(1);
+    expect(wrapper.find('PficonHistoryIcon').length).toBe(0);
+  });
+  test('renders correctly with initial value', () => {
+    wrapper = mountWithContexts(
+      <Formik
+        initialValues={{
+          passwordPrompts: {},
+          inputs: {
+            password: '$encrypted$',
+          },
+        }}
+      >
+        {() => (
+          <CredentialField
+            fieldOptions={fieldOptions}
+            credentialType={credentialType}
+          />
+        )}
+      </Formik>
+    );
+    expect(wrapper.find('CredentialField').length).toBe(1);
+    expect(wrapper.find('PasswordInput').length).toBe(1);
+    expect(wrapper.find('TextInput').props().isDisabled).toBe(true);
+    expect(wrapper.find('TextInput').props().value).toBe('');
+    expect(wrapper.find('TextInput').props().placeholder).toBe('ENCRYPTED');
+    expect(wrapper.find('KeyIcon').length).toBe(1);
+    expect(wrapper.find('PficonHistoryIcon').length).toBe(1);
+  });
+  test('replace/revert button behaves as expected', () => {
+    wrapper = mountWithContexts(
+      <Formik
+        initialValues={{
+          passwordPrompts: {},
+          inputs: {
+            password: '$encrypted$',
+          },
+        }}
+      >
+        {() => (
+          <CredentialField
+            fieldOptions={fieldOptions}
+            credentialType={credentialType}
+          />
+        )}
+      </Formik>
+    );
+    expect(
+      wrapper.find('Tooltip#credential-password-replace-tooltip').props()
+        .content
+    ).toBe('Replace');
+    expect(wrapper.find('TextInput').props().isDisabled).toBe(true);
+    expect(wrapper.find('PficonHistoryIcon').simulate('click'));
+    expect(
+      wrapper.find('Tooltip#credential-password-replace-tooltip').props()
+        .content
+    ).toBe('Revert');
+    expect(wrapper.find('TextInput').props().isDisabled).toBe(false);
+    expect(wrapper.find('TextInput').props().value).toBe('');
+    expect(wrapper.find('TextInput').props().placeholder).toBe(undefined);
+    expect(wrapper.find('PficonHistoryIcon').simulate('click'));
+    expect(
+      wrapper.find('Tooltip#credential-password-replace-tooltip').props()
+        .content
+    ).toBe('Replace');
+    expect(wrapper.find('TextInput').props().isDisabled).toBe(true);
+    expect(wrapper.find('TextInput').props().value).toBe('');
+    expect(wrapper.find('TextInput').props().placeholder).toBe('ENCRYPTED');
+  });
+});

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
@@ -27,8 +27,16 @@ function CredentialPluginInput(props) {
   } = props;
 
   const [showPluginWizard, setShowPluginWizard] = useState(false);
-  const [inputField, , helpers] = useField(`inputs.${fieldOptions.id}`);
+  const [inputField, meta, helpers] = useField(`inputs.${fieldOptions.id}`);
   const [passwordPromptField] = useField(`passwordPrompts.${fieldOptions.id}`);
+
+  const disableFieldAndButtons =
+    !!passwordPromptField.value ||
+    !!(
+      meta.initialValue &&
+      meta.initialValue !== '' &&
+      meta.value === meta.initialValue
+    );
 
   return (
     <>
@@ -44,7 +52,7 @@ function CredentialPluginInput(props) {
             ...inputField,
             isRequired,
             validated: isValid ? 'default' : 'error',
-            isDisabled: !!passwordPromptField.value,
+            isDisabled: disableFieldAndButtons,
             onChange: (_, event) => {
               inputField.onChange(event);
             },
@@ -61,7 +69,7 @@ function CredentialPluginInput(props) {
                 t`Populate field from an external secret management system`
               )}
               onClick={() => setShowPluginWizard(true)}
-              isDisabled={isDisabled || !!passwordPromptField.value}
+              isDisabled={isDisabled || disableFieldAndButtons}
             >
               <KeyIcon />
             </Button>


### PR DESCRIPTION
##### SUMMARY
link #7256 

Note that this only applies to editing an existing credential.  You should not see this button on fields when adding a new credential.

When editing an existing credential the replace button should show up on fields where `secret` is true _and_ the field has an existing value _that is not an external credential_.  Examples:

<img width="1352" alt="Screen Shot 2021-02-19 at 2 09 54 PM" src="https://user-images.githubusercontent.com/9889020/108550269-56c37400-72bc-11eb-87f7-aa3b0cd2f326.png">
<img width="1439" alt="Screen Shot 2021-02-19 at 2 10 43 PM" src="https://user-images.githubusercontent.com/9889020/108550271-575c0a80-72bc-11eb-8933-d392adde17d9.png">
<img width="1379" alt="Screen Shot 2021-02-19 at 2 12 07 PM" src="https://user-images.githubusercontent.com/9889020/108550410-86727c00-72bc-11eb-9b92-1705c2657f71.png">

Fields with external credentials should look the same:

<img width="1395" alt="Screen Shot 2021-02-19 at 2 12 59 PM" src="https://user-images.githubusercontent.com/9889020/108550470-9e4a0000-72bc-11eb-8303-85e9f2711a86.png">

Initially the button tooltip should say `Replace`.  Clicking `Replace` will clear out the previously saved value and enable the form field:

![replace_revert](https://user-images.githubusercontent.com/9889020/108550713-eec15d80-72bc-11eb-9479-3f9c0282147d.gif)

The tooltip will change to `Revert`.  Clicking `Revert` will take the field back to it's original state.

I also noticed a race condition which would result in the input fields (subform) not being populated due to the form rendering before the request(s) were completed.  I fixed this.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
