### PR TITLE
Fix the broken paths to the favicon and logo in the API browser

### DIFF
--- a/awx/templates/error.html
+++ b/awx/templates/error.html
@@ -18,7 +18,7 @@ div.response-info span.meta {
     <div class="container">
       <div class="navbar-header">
         <a class="navbar-brand" href="/">
-          <img class="logo" src="{% static 'assets/logo-header.svg' %}">
+          <img class="logo" src="{% static 'media/logo-header.svg' %}">
         </a>
         <a class="navbar-title" href="{{ request.get_full_path }}">
           <span>&nbsp;&mdash; {{name}}</span>

--- a/awx/templates/rest_framework/api.html
+++ b/awx/templates/rest_framework/api.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block style %}
-<link href="{% static 'assets/favicon.ico' %}?v={{tower_version}}" rel="shortcut icon" />
+<link href="{% static 'favicon.ico' %}?v={{tower_version}}" rel="shortcut icon" />
 {{ block.super }}
 {% endblock %}
 
@@ -24,7 +24,7 @@
           <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="{% url 'api:api_root_view' %}">
-          <img class="logo" src="{% static 'assets/logo-header.svg' %}">
+          <img class="logo" src="{% static 'media/logo-header.svg' %}">
           <span>{% trans 'REST API' %}</span>
         </a>
         <a class="navbar-title" href="{{ request.get_full_path }}">


### PR DESCRIPTION
##### SUMMARY

When making use of the browseable API recently, I noticed that the logo in the top left and the favicon urls were broken.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 17.0.1
```
