### PR TITLE
Added GUID filters for k8s/OCP environment

### DIFF
--- a/installer/roles/kubernetes/templates/configmap.yml.j2
+++ b/installer/roles/kubernetes/templates/configmap.yml.j2
@@ -168,6 +168,7 @@ data:
         '()': 'logging.StreamHandler',
         'level': 'DEBUG',
         'formatter': 'simple',
+        'filters': ['guid'],
     }
 
     LOGGING['loggers']['django.request']['handlers'] = ['console']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For environments running on Kubernetes or OCP, we need a configure a proper filters to get the GUID messages logged in the console (stdout). 

This PR introduces the configuration required on the configmap. 

cc: @ryanpetrello 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
**Before**
```
[awx-85544f9b88-6z8sv awx-task] KeyError: 'guid' 
[awx-85544f9b88-6z8sv awx-task] Call stack: 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/bin/awx-manage", line 8, in <module> 
[awx-85544f9b88-6z8sv awx-task]     sys.exit(manage()) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/__init__.py", line 154, in manage 
[awx-85544f9b88-6z8sv awx-task]     execute_from_command_line(sys.argv) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line 
[awx-85544f9b88-6z8sv awx-task]     utility.execute() 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute 
[awx-85544f9b88-6z8sv awx-task]     self.fetch_command(subcommand).run_from_argv(self.argv) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv 
[awx-85544f9b88-6z8sv awx-task]     self.execute(*args, **cmd_options) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/django/core/management/base.py", line 364, in execute 
[awx-85544f9b88-6z8sv awx-task]     output = self.handle(*args, **options) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/main/management/commands/run_callback_receiver.py", line 32, in handle 
[awx-85544f9b88-6z8sv awx-task]     queues=[getattr(settings, 'CALLBACK_QUEUE', '')], 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/main/dispatch/worker/base.py", line 59, in __init__ 
[awx-85544f9b88-6z8sv awx-task]     self.pool.init_workers(self.worker.work_loop) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/main/dispatch/pool.py", line 242, in init_workers 
[awx-85544f9b88-6z8sv awx-task]     self.up() 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/main/dispatch/pool.py", line 258, in up 
[awx-85544f9b88-6z8sv awx-task]     logger.warn('scaling up worker pid:{}'.format(worker.pid)) 
[awx-85544f9b88-6z8sv awx-task] Message: 'scaling up worker pid:103' 
[awx-85544f9b88-6z8sv awx-task] Arguments: () 
[awx-85544f9b88-6z8sv awx-task] --- Logging error --- 
[awx-85544f9b88-6z8sv awx-task] Traceback (most recent call last): 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/lib64/python3.6/logging/__init__.py", line 994, in emit 
[awx-85544f9b88-6z8sv awx-task]     msg = self.format(record) 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/lib64/python3.6/logging/__init__.py", line 840, in format 
[awx-85544f9b88-6z8sv awx-task]     return fmt.format(record) 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/lib64/python3.6/logging/__init__.py", line 580, in format 
[awx-85544f9b88-6z8sv awx-task]     s = self.formatMessage(record) 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/lib64/python3.6/logging/__init__.py", line 549, in formatMessage 
[awx-85544f9b88-6z8sv awx-task]     return self._style.format(record) 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/lib64/python3.6/logging/__init__.py", line 391, in format 
[awx-85544f9b88-6z8sv awx-task]     return self._fmt % record.__dict__ 
[awx-85544f9b88-6z8sv awx-task] KeyError: 'guid' 
[awx-85544f9b88-6z8sv awx-task] Call stack: 
[awx-85544f9b88-6z8sv awx-task]   File "/usr/bin/awx-manage", line 8, in <module> 
[awx-85544f9b88-6z8sv awx-task]     sys.exit(manage()) 
[awx-85544f9b88-6z8sv awx-task]   File "/var/lib/awx/venv/awx/lib/python3.6/site-packages/awx/__init__.py",
```

**After**

```
$ kubectl edit configmap awx-config -n awx-nightly 
configmap/awx-config edited

$ kubectl get configmap awx-config -n awx-nightly -o yaml | grep 'guid' -A1 -B2             09:07:28
        'level': 'DEBUG',
        'formatter': 'simple',
        'filters': ['guid'],
    }

$ kubectl rollout restart deploy/awx -n awx-nightly

[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:16:59,863 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.dispatch task ad7cfd0a-e5a9-405a-9c27-2174a368bea0 starting awx.main.tasks.cluster_node_heartbeat(*[]) 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:16:59,964 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.tasks Cluster node heartbeat task. 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:16:59,908 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.dispatch task f3a5b3e2-3e55-4b63-9340-7e73d138e56d starting awx.main.tasks.awx_k8s_reaper(*[]) 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:16:59,907 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.dispatch task ef421b28-043a-4c76-b566-db5439c11a70 starting awx.main.scheduler.tasks.run_task_manager(*[]) 
[awx-85544f9b88-7ckzf awx-task] RESULT 2 
[awx-85544f9b88-7ckzf awx-task] OKREADY 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:16:59,908 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.dispatch task d1c95d2f-3fd9-40ee-b921-199ff9de62ca starting awx.main.tasks.awx_periodic_scheduler(*[]) 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:00,012 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.scheduler Running Tower task manager. 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:00,014 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.tasks Starting periodic scheduler 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:00,015 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.scheduler Starting Scheduler 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:00,017 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.tasks Last scheduler run was: 2021-02-22 14:16:29.788253+00:00 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:00,070 DEBUG    [570eca4a94d144ac9c2e1c3a4ffb15fc] awx.main.scheduler Finishing Scheduler 
[awx-85544f9b88-7ckzf awx-web] RESULT 2 
[awx-85544f9b88-7ckzf awx-web] OKREADY 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:19,891 DEBUG    [6687cd06d9c04ef5b00e715a631c3775] awx.main.dispatch task 9e6dcffa-cd81-46ac-a5f9-c531ad9270fb starting awx.main.scheduler.tasks.run_task_manager(*[]) 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:19,893 DEBUG    [6687cd06d9c04ef5b00e715a631c3775] awx.main.scheduler Running Tower task manager. 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:19,940 DEBUG    [6687cd06d9c04ef5b00e715a631c3775] awx.main.scheduler Starting Scheduler 
[awx-85544f9b88-7ckzf awx-task] 2021-02-22 14:17:20,014 DEBUG    [6687cd06d9c04ef5b00e715a631c3775] awx.main.scheduler Finishing Scheduler 
```
