### PR TITLE
make sure we use built in credential type

### DIFF
--- a/awxkit/awxkit/api/pages/credentials.py
+++ b/awxkit/awxkit/api/pages/credentials.py
@@ -82,6 +82,7 @@ def config_cred_from_kind(kind):
 
 credential_type_name_to_config_kind_map = {
     'amazon web services': 'aws',
+    'container registry': 'registry',
     'ansible galaxy/automation hub api token': 'galaxy',
     'ansible tower': 'tower',
     'google compute engine': 'gce',


### PR DESCRIPTION
this way we can pass kind="registry" to akit create method and
we get the correct built in type

@rebeccahhh @yagomarques 