### PR TITLE
added guid filter for docker settings.py

### DIFF
--- a/installer/roles/dockerfile/files/settings.py
+++ b/installer/roles/dockerfile/files/settings.py
@@ -50,6 +50,7 @@ LOGGING['handlers']['console'] = {
     '()': 'logging.StreamHandler',
     'level': 'DEBUG',
     'formatter': 'simple',
+    'filters': ['guid'],
 }
 
 LOGGING['loggers']['django.request']['handlers'] = ['console']


### PR DESCRIPTION
Signed-off-by: Mohamed Elhouderi <7518186+rokat@users.noreply.github.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Same as #9378 but missing guid filter for docker settings.py
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### Before
```
awx-manage: --- Logging error ---
awx-manage: Traceback (most recent call last):
awx-manage: File "/usr/lib64/python3.6/logging/__init__.py", line 994, in emit
awx-manage: msg = self.format(record)
awx-manage: File "/usr/lib64/python3.6/logging/__init__.py", line 840, in format
awx-manage: return fmt.format(record)
awx-manage: File "/usr/lib64/python3.6/logging/__init__.py", line 580, in format
awx-manage: s = self.formatMessage(record)
awx-manage: File "/usr/lib64/python3.6/logging/__init__.py", line 549, in formatMessage
awx-manage: return self._style.format(record)
awx-manage: File "/usr/lib64/python3.6/logging/__init__.py", line 391, in format
awx-manage: return self._fmt % record.__dict__
awx-manage: KeyError: 'guid'
awx-manage: Call stack:
awx-manage: File "/usr/bin/awx-manage", line 11, in <module>
awx-manage: sys.exit(manage())
awx-manage: File "/usr/lib/python3.6/site-packages/awx/__init__.py", line 154, in manage
```
##### After
```
awx-manage: 2021-02-22 21:25:56,831 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.models.inventory Going to update inventory computed fields, pk=1
awx-manage: 2021-02-22 21:25:56,848 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.models.inventory Finished updating inventory computed fields, pk=1, in 0.014 seconds
awx-manage: 2021-02-22 21:25:56,983 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.dispatch task c2a9a588-7200-42d3-9bd1-0073ee1c31bf starting awx.main.scheduler.tasks.run_task_manager(*[])
awx-manage: 2021-02-22 21:25:56,984 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Running Tower task manager.
awx-manage: 2021-02-22 21:25:56,989 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Starting Scheduler
awx-manage: 2021-02-22 21:25:57,057 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.analytics.job_lifecycle job-7 acknowledged
awx-manage: 2021-02-22 21:25:57,087 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.analytics.job_lifecycle projectupdate-8 created
awx-manage: 2021-02-22 21:25:57,144 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Spawned project_update 8 (pending) as dependency of job 7 (pending)
awx-manage: 2021-02-22 21:25:57,173 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Starting project_update 8 (pending) in group tower instance atw02.lab.momo (remaining_capacity=35)
awx-manage: 2021-02-22 21:25:57,185 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Submitting project_update 8 (waiting) to <instance group, instance> <1,atw02.lab.momo>.
awx-manage: 2021-02-22 21:25:57,218 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.analytics.job_lifecycle projectupdate-8 waiting
awx-manage: 2021-02-22 21:25:57,219 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler project_update 8 (waiting) consumed 1 capacity units from tower with prior total of 0
awx-manage: 2021-02-22 21:25:57,222 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.analytics.job_lifecycle job-7 blocked by projectupdate-8
awx-manage: 2021-02-22 21:25:57,222 DEBUG    [4f6fc9d7d9514892b64fe18c7e199cc6] awx.main.scheduler Finishing Scheduler
```