### PR TITLE
Mount SECRET_KEY into dev env & document it

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
+import base64
 import os
 import re  # noqa
 import sys
@@ -148,7 +149,10 @@ SCHEDULE_MAX_JOBS = 10
 SITE_ID = 1
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = open('/etc/tower/SECRET_KEY', 'rb').read().strip()
+if os.path.exists('/etc/tower/SECRET_KEY'):
+    SECRET_KEY = open('/etc/tower/SECRET_KEY', 'rb').read().strip()
+else:
+    SECRET_KEY = base64.encodebytes(os.urandom(32)).decode().rstrip()
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -148,7 +148,7 @@ SCHEDULE_MAX_JOBS = 10
 SITE_ID = 1
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'p7z7g1ql4%6+(6nlebb6hdk7sd^&fnjpal308%n%+p^_e6vo1y'
+SECRET_KEY = open('/etc/tower/SECRET_KEY', 'rb').read().strip()
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -30,6 +30,12 @@
   when: not lookup('vars', item.item, default='')
   loop: "{{ secrets.results }}"
 
+- name: Write out SECRET_KEY
+  copy:
+    content: "{{ secret_key }}"
+    dest: "{{ sources_dest }}/SECRET_KEY"
+  no_log: true
+
 - name: Render configuration templates
   template:
     src: "{{ item }}.j2"

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -30,6 +30,7 @@ services:
       - "../../docker-compose/_sources/database.py:/etc/tower/conf.d/database.py"
       - "../../docker-compose/_sources/websocket_secret.py:/etc/tower/conf.d/websocket_secret.py"
       - "../../docker-compose/_sources/local_settings.py:/etc/tower/conf.d/local_settings.py"
+      - "../../docker-compose/_sources/SECRET_KEY:/etc/tower/SECRET_KEY"
       - "redis_socket:/var/run/redis/:rw"
     privileged: true
     tty: true

--- a/tools/docker-compose/docs/data_migration.md
+++ b/tools/docker-compose/docs/data_migration.md
@@ -13,7 +13,7 @@ If you had a custom pgdocker or awxcompose location, you will need to set the `p
 
 1. Run the [migrate playbook](./ansible/migrate.yml) to migrate your data to the new postgresql container and convert the data directory to a volume mount.
 ```bash
-$ ansible-playbook migrate.yml -e "migrate_local_docker=true" -e "postgres_data_dir=~/.awx/pgdocker" -e "old_docker_compose_dir=~/.awx/awxcompose"
+$ ansible-playbook  -i tools/docker-compose/inventory tools/docker-compose/migrate.yml -e "migrate_local_docker=true" -e "postgres_data_dir=~/.awx/pgdocker" -e "old_docker_compose_dir=~/.awx/awxcompose"
 ```
 
 2. Change directory to the top of your awx checkout and start your containers

--- a/tools/docker-compose/docs/data_migration.md
+++ b/tools/docker-compose/docs/data_migration.md
@@ -5,6 +5,8 @@ migrate your data to the development environment via the migrate.yml playbook, o
 
 > Note: This will also convert your postgresql bind-mount into a docker volume.
 
+First, in the  `inventory` file, set your `pg_password`, `broadcast_websocket_secret`, `secret_key`, and any other settings you need for your deployment.  **Make sure you use the same secret key value you had with your previous Local Docker deployment.**  
+
 ### Migrate data with migrate.yml
 
 If you had a custom pgdocker or awxcompose location, you will need to set the `postgres_data_dir` and `old_docker_compose_dir` variables. 


### PR DESCRIPTION
##### SUMMARY
As part of https://github.com/ansible/awx/pull/9289, we need to actually mount the SECRET_KEY file into the awx container to be able to use the migrated data.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
