### PR TITLE
Add ansible requirement for dev env docs

### DIFF
--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -17,6 +17,7 @@ Notable files:
 - [docker-compose](https://pypi.org/project/docker-compose/) Python module.
     + This also installs the `docker` Python module, which is incompatible with [`docker-py`](https://pypi.org/project/docker-py/). If you have previously installed `docker-py`, please uninstall it.
 - [Docker Compose](https://docs.docker.com/compose/install/).
+- [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) will need to be installed as we use it to template files needed for the docker-compose.
 
 ## Configuration
 


### PR DESCRIPTION
##### SUMMARY
Ansible is required on the host system to run the dev environment because we use it to template out files used by the docker-compose.  This just makes that clear in our docs.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

