### PR TITLE
Update EE breadcrumb to use name instead of image

### DIFF
--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironments.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironments.jsx
@@ -22,7 +22,7 @@ function ExecutionEnvironments({ i18n }) {
       setBreadcrumbConfig({
         '/execution_environments': i18n._(t`Execution environments`),
         '/execution_environments/add': i18n._(t`Create Execution environments`),
-        [`/execution_environments/${executionEnvironments.id}`]: `${executionEnvironments.image}`,
+        [`/execution_environments/${executionEnvironments.id}`]: `${executionEnvironments.name}`,
         [`/execution_environments/${executionEnvironments.id}/edit`]: i18n._(
           t`Edit details`
         ),


### PR DESCRIPTION
Update EE breadcrumb to use name instead of image to be consistent with
the other screens.

See: https://github.com/ansible/awx/issues/9087
