### PR TITLE
Disable job templates in node modal that are missing inv or project

### DIFF
--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import {
   DataListItem,
   DataListItemRow,
@@ -8,6 +9,14 @@ import {
   Radio,
 } from '@patternfly/react-core';
 import DataListCell from '../DataListCell';
+
+const Label = styled.label`
+  ${({ isDisabled }) =>
+    isDisabled &&
+    `
+    opacity: 0.5;
+  `}
+`;
 
 const CheckboxListItem = ({
   isDisabled = false,
@@ -32,7 +41,7 @@ const CheckboxListItem = ({
           aria-label={`check-action-item-${itemId}`}
           aria-labelledby={`check-action-item-${itemId}`}
           checked={isSelected}
-          disabled={isDisabled}
+          isDisabled={isDisabled}
           id={`selected-${itemId}`}
           isChecked={isSelected}
           name={name}
@@ -42,13 +51,14 @@ const CheckboxListItem = ({
         <DataListItemCells
           dataListCells={[
             <DataListCell key="name">
-              <label
+              <Label
                 id={`check-action-item-${itemId}`}
                 htmlFor={`selected-${itemId}`}
                 className="check-action-item"
+                isDisabled={isDisabled}
               >
                 <b>{label}</b>
-              </label>
+              </Label>
             </DataListCell>,
           ]}
         />

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
@@ -94,6 +94,7 @@ const mockJobTemplate = {
   },
   related: { webhook_receiver: '' },
   inventory: 1,
+  project: 5,
 };
 
 describe('NodeModal', () => {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
@@ -16,6 +16,7 @@ const onUpdateNodeResource = jest.fn();
 describe('JobTemplatesList', () => {
   let wrapper;
   afterEach(() => {
+    jest.clearAllMocks();
     wrapper.unmount();
   });
   test('Row selected when nodeResource id matches row id and clicking new row makes expected callback', async () => {
@@ -28,12 +29,16 @@ describe('JobTemplatesList', () => {
             name: 'Test Job Template',
             type: 'job_template',
             url: '/api/v2/job_templates/1',
+            inventory: 1,
+            project: 2,
           },
           {
             id: 2,
             name: 'Test Job Template 2',
             type: 'job_template',
             url: '/api/v2/job_templates/2',
+            inventory: 1,
+            project: 2,
           },
         ],
       },
@@ -61,8 +66,16 @@ describe('JobTemplatesList', () => {
         .isSelected
     ).toBe(true);
     expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
+        .isDisabled
+    ).toBe(false);
+    expect(
       wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
         .isSelected
+    ).toBe(false);
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
+        .isDisabled
     ).toBe(false);
     wrapper
       .find('CheckboxListItem[name="Test Job Template 2"]')
@@ -72,7 +85,74 @@ describe('JobTemplatesList', () => {
       name: 'Test Job Template 2',
       type: 'job_template',
       url: '/api/v2/job_templates/2',
+      inventory: 1,
+      project: 2,
     });
+  });
+  test('Row disabled when job template missing inventory or project', async () => {
+    JobTemplatesAPI.read.mockResolvedValueOnce({
+      data: {
+        count: 2,
+        results: [
+          {
+            id: 1,
+            name: 'Test Job Template',
+            type: 'job_template',
+            url: '/api/v2/job_templates/1',
+            inventory: 1,
+            project: null,
+            ask_inventory_on_launch: false,
+          },
+          {
+            id: 2,
+            name: 'Test Job Template 2',
+            type: 'job_template',
+            url: '/api/v2/job_templates/2',
+            inventory: null,
+            project: 2,
+            ask_inventory_on_launch: false,
+          },
+        ],
+      },
+    });
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <JobTemplatesList
+          nodeResource={nodeResource}
+          onUpdateNodeResource={onUpdateNodeResource}
+        />
+      );
+    });
+    wrapper.update();
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
+        .isSelected
+    ).toBe(true);
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
+        .isDisabled
+    ).toBe(true);
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
+        .isSelected
+    ).toBe(false);
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
+        .isDisabled
+    ).toBe(true);
+    wrapper
+      .find('CheckboxListItem[name="Test Job Template 2"]')
+      .simulate('click');
+    expect(onUpdateNodeResource).not.toHaveBeenCalled();
   });
   test('Error shown when read() request errors', async () => {
     JobTemplatesAPI.read.mockRejectedValue(new Error());


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/9410

Editing an existing node:
<img width="1589" alt="Screen Shot 2021-03-01 at 11 46 17 AM" src="https://user-images.githubusercontent.com/9889020/109529796-0bf7e800-7a84-11eb-9ecd-0872d175afb5.png">

Adding a new node:
<img width="1200" alt="Screen Shot 2021-03-01 at 11 46 06 AM" src="https://user-images.githubusercontent.com/9889020/109529803-0d291500-7a84-11eb-83db-102f0663ad73.png">

Job template rows should be disabled if the job template is

1) Missing a project
or
2) Missing an inventory _and_ ask_inventory_on_launch is _false_.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
