### PR TITLE
No longer delete local_settings.py

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -45,11 +45,6 @@
     - "database.py"
     - "websocket_secret.py"
 
-- name: Delete old local_settings.py
-  file:
-    path: "{{ playbook_dir }}/../../../awx/settings/local_settings.py"
-    state: absent
-
 - name: Copy local_settings.py
   copy:
     src: "local_settings.py"


### PR DESCRIPTION
##### SUMMARY
Removes task in docker-compose sources role that removes the old local_settings.py file. 

If you want to add custom dev settings, create a file called `local_whatever.py` in `awx/settings/`, then put your custom settings there.  

 * this assumes people have already migrated from the old dev env.
 * new custom dev settings can be set in /etc/tower/conf.d/local_settings.py
 * this new settings file is bind-mounted from tools/docker-compose/_sources/local_settings.py

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - dev
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
