### PR TITLE
Use credential_type for prompted multicred select categories

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.jsx
@@ -167,9 +167,10 @@ function CredentialsStep({ i18n }) {
             const hasSameVaultID = val =>
               val?.inputs?.vault_id !== undefined &&
               val?.inputs?.vault_id === item?.inputs?.vault_id;
-            const hasSameKind = val => val.kind === item.kind;
+            const hasSameCredentialType = val =>
+              val.credential_type === item.credential_type;
             const newItems = field.value.filter(i =>
-              isVault ? !hasSameVaultID(i) : !hasSameKind(i)
+              isVault ? !hasSameVaultID(i) : !hasSameCredentialType(i)
             );
             newItems.push(item);
             helpers.setValue(newItems);


### PR DESCRIPTION
##### SUMMARY
For #8878, #9230

For cred multiselect, we want to distinguish between selectable types using the credential_type id, not kind. The kind field is deprecated and less granular.