### PR TITLE
Adds warning message to inventory step when launching wfjt or creating node with wfjt

### DIFF
--- a/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
@@ -17,7 +17,7 @@ const QS_CONFIG = getQSConfig('inventory', {
   order_by: 'name',
 });
 
-function InventoryStep({ i18n }) {
+function InventoryStep({ i18n, warningMessage = null }) {
   const [field, meta, helpers] = useField({
     name: 'inventory',
   });
@@ -68,6 +68,7 @@ function InventoryStep({ i18n }) {
 
   return (
     <>
+      {warningMessage}
       <OptionsList
         value={field.value ? [field.value] : []}
         options={inventories}

--- a/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.test.jsx
@@ -47,4 +47,20 @@ describe('InventoryStep', () => {
     expect(InventoriesAPI.read).toHaveBeenCalled();
     expect(wrapper.find('OptionsList').prop('options')).toEqual(inventories);
   });
+
+  test('should show warning message when one is passed in', async () => {
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik>
+          <InventoryStep
+            warningMessage={<div id="test-warning-message">TEST</div>}
+          />
+        </Formik>
+      );
+    });
+    wrapper.update();
+
+    expect(wrapper.find('div#test-warning-message').length).toBe(1);
+  });
 });

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { t } from '@lingui/macro';
 import { useField } from 'formik';
+import styled from 'styled-components';
 import { Alert } from '@patternfly/react-core';
 import InventoryStep from './InventoryStep';
 import StepName from './StepName';
+
+const InventoryAlert = styled(Alert)`
+  margin-bottom: 16px;
+`;
 
 const STEP_ID = 'inventory';
 
@@ -53,11 +58,11 @@ function getStep(launchConfig, i18n, formError, resource) {
         i18n={i18n}
         warningMessage={
           resource.type === 'workflow_job_template' ? (
-            <Alert
+            <InventoryAlert
               variant="warning"
               isInline
               title={i18n._(
-                t`This inventory is applied to all job template nodes within this workflow that prompt for an inventory.`
+                t`This inventory is applied to all job template nodes within this workflow (${resource.name}) that prompt for an inventory.`
               )}
             />
           ) : null

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
@@ -59,6 +59,7 @@ function getStep(launchConfig, i18n, formError, resource) {
         warningMessage={
           resource.type === 'workflow_job_template' ? (
             <InventoryAlert
+              ouiaId="InventoryStep-alert"
               variant="warning"
               isInline
               title={i18n._(

--- a/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/useInventoryStep.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { t } from '@lingui/macro';
 import { useField } from 'formik';
+import { Alert } from '@patternfly/react-core';
 import InventoryStep from './InventoryStep';
 import StepName from './StepName';
 
@@ -21,7 +22,7 @@ export default function useInventoryStep(
         !meta.value;
 
   return {
-    step: getStep(launchConfig, i18n, formError),
+    step: getStep(launchConfig, i18n, formError, resource),
     initialValues: getInitialValues(launchConfig, resource),
     isReady: true,
     contentError: null,
@@ -36,7 +37,7 @@ export default function useInventoryStep(
     },
   };
 }
-function getStep(launchConfig, i18n, formError) {
+function getStep(launchConfig, i18n, formError, resource) {
   if (!launchConfig.ask_inventory_on_launch) {
     return null;
   }
@@ -47,7 +48,22 @@ function getStep(launchConfig, i18n, formError) {
         {i18n._(t`Inventory`)}
       </StepName>
     ),
-    component: <InventoryStep i18n={i18n} />,
+    component: (
+      <InventoryStep
+        i18n={i18n}
+        warningMessage={
+          resource.type === 'workflow_job_template' ? (
+            <Alert
+              variant="warning"
+              isInline
+              title={i18n._(
+                t`This inventory is applied to all job template nodes within this workflow that prompt for an inventory.`
+              )}
+            />
+          ) : null
+        }
+      />
+    ),
     enableNext: true,
   };
 }


### PR DESCRIPTION
##### SUMMARY
link #8789 

<img width="1677" alt="Screen Shot 2021-03-03 at 1 34 13 PM" src="https://user-images.githubusercontent.com/9889020/109854579-3503ae80-7c25-11eb-906c-a6ebc432afce.png">
<img width="1664" alt="Screen Shot 2021-03-03 at 1 33 48 PM" src="https://user-images.githubusercontent.com/9889020/109854581-3503ae80-7c25-11eb-8752-565d7ec37d58.png">

This message should not be present on the inventory step when launching a JT or when creating a JT node in a workflow.

Here's the ouiaId on this new alert:

<img width="1435" alt="Screen Shot 2021-03-03 at 1 38 27 PM" src="https://user-images.githubusercontent.com/9889020/109855027-c83ce400-7c25-11eb-822b-ce6e035bc41f.png">

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI