### PR TITLE
Add back the AWX upgrade docs for k8s and ocp

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,6 +122,24 @@ ansible-playbook tools/ansible/build.yml -e awx_version=test-build
 The resulting image will automatically be pushed to a registry if `docker_registry` is defined. 
 
 
+## Upgrading from previous versions
+
+Upgrading AWX involves rerunning the install playbook. Download a newer release from [https://github.com/ansible/awx/releases](https://github.com/ansible/awx/releases) and re-populate the inventory file with your customized variables.
+
+For convenience, you can create a file called `vars.yml`:
+
+```
+admin_password: 'adminpass'
+pg_password: 'pgpass'
+secret_key: 'mysupersecret'
+```
+
+And pass it to the installer:
+
+```
+$ ansible-playbook -i inventory install.yml -e @vars.yml
+```
+
 
 ## OpenShift
 


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/awx/issues/9476#issuecomment-790691005

As part of the Local Docker Removal, this doc section was mistakenly removed, it is still pertinent for the k8s and ocp installation methods.  

This PR adds that back.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

