### PR TITLE
making the cli use AWXKIT_CREDENTIAL_FILE

### DIFF
--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -5,6 +5,22 @@ from distutils.util import strtobool
 import yaml
 
 from awxkit.cli.utils import colored
+from awxkit import config
+
+
+def get_config_credentials():
+    """Load username and password from config.credentials.default.
+
+    In order to respect configurations from AWXKIT_CREDENTIAL_FILE.
+    """
+    default_username = 'admin'
+    default_password = 'password'
+
+    if not hasattr(config, 'credentials'):
+        return default_username, default_password
+
+    default = config.credentials.get('default', {})
+    return (default.get('username', default_username), default.get('password', default_password))
 
 
 def add_authentication_arguments(parser, env):
@@ -20,16 +36,20 @@ def add_authentication_arguments(parser, env):
         help='an OAuth2.0 token (get one by using `awx login`)',
         metavar='TEXT',
     )
+
+    config_username, config_password = get_config_credentials()
+    # options configured via cli args take higher precedence than those from the config
     auth.add_argument(
         '--conf.username',
-        default=env.get('CONTROLLER_USERNAME', env.get('TOWER_USERNAME', 'admin')),
+        default=env.get('CONTROLLER_USERNAME', env.get('TOWER_USERNAME', config_username)),
         metavar='TEXT',
     )
     auth.add_argument(
         '--conf.password',
-        default=env.get('CONTROLLER_PASSWORD', env.get('TOWER_PASSWORD', 'password')),
+        default=env.get('CONTROLLER_PASSWORD', env.get('TOWER_PASSWORD', config_password)),
         metavar='TEXT',
     )
+
     auth.add_argument(
         '-k',
         '--conf.insecure',

--- a/awxkit/test/cli/test_config.py
+++ b/awxkit/test/cli/test_config.py
@@ -1,3 +1,5 @@
+import os
+import json
 import pytest
 from requests.exceptions import ConnectionError
 
@@ -44,6 +46,61 @@ def test_username_and_password_argv():
 def test_config_precedence():
     cli = CLI()
     cli.parse_args(['awx', '--conf.username', 'mary', '--conf.password', 'secret'], env={'CONTROLLER_USERNAME': 'IGNORE', 'CONTROLLER_PASSWORD': 'IGNORE'})
+    with pytest.raises(ConnectionError):
+        cli.connect()
+
+    assert config.credentials.default.username == 'mary'
+    assert config.credentials.default.password == 'secret'
+
+
+def test_config_file_precedence():
+    """Ignores AWXKIT_CREDENTIAL_FILE if cli args are set"""
+    os.makedirs('/tmp/awx-test/', exist_ok=True)
+    with open('/tmp/awx-test/config.json', 'w') as f:
+        json.dump({'default': {'username': 'IGNORE', 'password': 'IGNORE'}}, f)
+
+    cli = CLI()
+    cli.parse_args(
+        ['awx', '--conf.username', 'mary', '--conf.password', 'secret'],
+        env={
+            'AWXKIT_CREDENTIAL_FILE': '/tmp/awx-test/config.json',
+        },
+    )
+    with pytest.raises(ConnectionError):
+        cli.connect()
+
+    assert config.credentials.default.username == 'mary'
+    assert config.credentials.default.password == 'secret'
+
+
+def test_config_file_precedence_2():
+    """Ignores AWXKIT_CREDENTIAL_FILE if TOWER_* vars are set."""
+    os.makedirs('/tmp/awx-test/', exist_ok=True)
+    with open('/tmp/awx-test/config.json', 'w') as f:
+        json.dump({'default': {'username': 'IGNORE', 'password': 'IGNORE'}}, f)
+
+    cli = CLI()
+    cli.parse_args(['awx'], env={'AWXKIT_CREDENTIAL_FILE': '/tmp/awx-test/config.json', 'TOWER_USERNAME': 'mary', 'TOWER_PASSWORD': 'secret'})
+    with pytest.raises(ConnectionError):
+        cli.connect()
+
+    assert config.credentials.default.username == 'mary'
+    assert config.credentials.default.password == 'secret'
+
+
+def test_config_file():
+    """Reads username and password from AWXKIT_CREDENTIAL_FILE."""
+    os.makedirs('/tmp/awx-test/', exist_ok=True)
+    with open('/tmp/awx-test/config.json', 'w') as f:
+        json.dump({'default': {'username': 'mary', 'password': 'secret'}}, f)
+
+    cli = CLI()
+    cli.parse_args(
+        ['awx'],
+        env={
+            'AWXKIT_CREDENTIAL_FILE': '/tmp/awx-test/config.json',
+        },
+    )
     with pytest.raises(ConnectionError):
         cli.connect()
 


### PR DESCRIPTION
##### SUMMARY
- https://github.com/ansible/awx/blob/devel/awxkit/awxkit/config.py loads AWXKIT_CREDENTIAL_FILE, which modifies config.credentials
- https://github.com/ansible/awx/blob/devel/awxkit/awxkit/cli/format.py ignores that, it only looks at the cli args, TOWER_USERNAME and TOWER_PASSWORD
- config.credentials might not be defined, so hasattr is used to check if it exists
- cli args > TOWER_USERNAME and TOWER_PASSWORD > AWXKIT_CREDENTIAL_FILE
- added 3 tests

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - CLI
 
##### AWX VERSION
```
awx: 17.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

setup:
```
> nano /awx_credentials.json
> export AWXKIT_CREDENTIAL_FILE=/awx_credentials.json
> cat /awx_credentials.json 
{
  "default": {
    "username": "testuser",
    "password": "testpassword"
  }
}
```

before:
```
> awx login
...
Error retrieving an OAuth2.0 token (<class 'awxkit.exceptions.Unauthorized'>).
```

after:
```
> awx login
{
     "token": "***"
}
```

