### PR TITLE
default cluster node count env var to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,7 @@ awx/projects:
 	@mkdir -p $@
 
 COMPOSE_UP_OPTS ?=
-CLUSER_NODE_COUNT ?= 1
+CLUSTER_NODE_COUNT ?= 1
 
 docker-compose-sources:
 	ansible-playbook -i tools/docker-compose/inventory tools/docker-compose/ansible/sources.yml \

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -5,4 +5,4 @@ awx_image: 'quay.io/ansible/awx_devel'
 pg_port: 5432
 pg_username: 'awx'
 pg_database: 'awx'
-cluster_node_count: "{{ lookup('env', 'CLUSTER_COUNT') | default(1, True) }}"
+cluster_node_count: 1


### PR DESCRIPTION
Without this, `cluster_node_count` was getting set to an empty string because the env var was node defined yet we were passing in `-e cluster_node_count=`