### PR TITLE
Linter fixes for Execution Environments module

### DIFF
--- a/awx_collection/plugins/modules/tower_ad_hoc_command.py
+++ b/awx_collection/plugins/modules/tower_ad_hoc_command.py
@@ -132,6 +132,7 @@ def main():
         wait=dict(default=False, type='bool'),
         interval=dict(default=1.0, type='float'),
         timeout=dict(default=None, type='int'),
+        execution_environment=dict(),
     )
 
     # Create a module for ourselves

--- a/awx_collection/plugins/modules/tower_execution_environment.py
+++ b/awx_collection/plugins/modules/tower_execution_environment.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: tower_execution_environment
-author: "Shane McDonald"
+author: "Shane McDonald (@shanemcd)"
 short_description: create, update, or destroy Execution Environments in Ansible Tower.
 description:
     - Create, update, or destroy Execution Environments in Ansible Tower. See
@@ -54,7 +54,7 @@ options:
       description:
         - determine image pull behavior
       choices: ["always", "missing", "never"]
-      default: ''
+      default: 'missing'
       type: str
 extends_documentation_fragment: awx.awx.auth
 '''
@@ -108,7 +108,7 @@ def main():
 
     if pull:
         new_fields['pull'] = pull
-        
+
     # Attempt to look up the related items the user specified (these will fail the module if not found)
     organization = module.params.get('organization')
     if organization:

--- a/awx_collection/plugins/modules/tower_export.py
+++ b/awx_collection/plugins/modules/tower_export.py
@@ -47,6 +47,10 @@ options:
       description:
         - credential name to export
       type: str
+    execution_environments:
+      description:
+        - execution environment name to export
+      type: str
     notification_templates:
       description:
         - notification template name to export


### PR DESCRIPTION
Fix linter for the recently added Execution Environments module

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 17.0.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Fixes for 

```
$ ansible-test sanity --test pep8

plugins/modules/tower_execution_environment.py:111:0: trailing-whitespace: Trailing whitespace
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-test sanity --test validate-modules
plugins/modules/tower_ad_hoc_command.py:0:0: nonexistent-parameter-documented: Argument 'execution_environment' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec 
plugins/modules/tower_execution_environment.py:0:0: doc-default-does-not-match-spec: Argument 'pull' in argument_spec defines default as ('missing') but documentation defines default as (None) 
plugins/modules/tower_execution_environment.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got 'Shane McDonald' 
plugins/modules/tower_export.py:0:0: parameter-type-not-in-doc: Argument 'execution_environments' in argument_spec defines type as 'str' but documentation doesn't define type 
plugins/modules/tower_export.py:0:0: undocumented-parameter: Argument 'execution_environments' is listed in the argument_spec, but not documented in the module documentation
```
