### PR TITLE
Reduce the log level for some of the more spammy sources

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -53,6 +53,10 @@ LOGGING['loggers']['awx.isolated.manager.playbooks']['propagate'] = True  # noqa
 
 # celery is annoyingly loud when docker containers start
 LOGGING['loggers'].pop('celery', None)  # noqa
+# avoid awx.main.dispatch WARNING-level scaling worker up/down messages
+LOGGING['loggers']['awx.main.dispatch']['level'] = 'ERROR'  # noqa
+# suppress the spamminess of the awx.main.scheduler and .tasks loggers
+LOGGING['loggers']['awx']['level'] = 'INFO'  # noqa
 
 ALLOWED_HOSTS = ['*']
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -5,13 +5,13 @@ Django Debug Toolbar (DDT)
 ----------------
 This is a useful tool for examining SQL queries, performance, headers, requests, signals, cache, logging, and more.  
 
-To enable DDT, you need to set your `INTERNAL_IPS` to the IP address of your load balancer.  This can be overriden in `local_settings`.  
+To enable DDT, you need to set your `INTERNAL_IPS` to the IP address of your load balancer.  This can be overridden by creating a new settings file beginning with `local_` in `awx/settings/` (e.g. `local_overrides.py`).
 This IP address can be found by making a GET to any page on the browsable API and looking for a like this in the standard output:
 ```
 awx_1        | 14:42:08 uwsgi.1     | 172.18.0.1 GET /api/v2/tokens/ - HTTP/1.1 200
 ```
 
-Allow this IP address by adding it to the `INTERNAL_IPS` variable in `local_settings`, then navigate to the API and you should see DDT on the
+Allow this IP address by adding it to the `INTERNAL_IPS` variable in your new override local settings file, then navigate to the API and you should see DDT on the
 right side.  If you don't see it, make sure to set `DEBUG=True`.  
 > Note that enabling DDT is detrimental to the performance of AWX and adds overhead to every API request.  It is
 recommended to keep this turned off when you are not using it.  

--- a/tools/docker-compose-cluster/awx-1-receptor.conf
+++ b/tools/docker-compose-cluster/awx-1-receptor.conf
@@ -1,5 +1,5 @@
 ---
-- log-level: debug
+- log-level: info
 
 - control-service:
     service: control

--- a/tools/docker-compose-cluster/awx-2-receptor.conf
+++ b/tools/docker-compose-cluster/awx-2-receptor.conf
@@ -1,5 +1,5 @@
 ---
-- log-level: debug
+- log-level: info
 
 - control-service:
     service: control

--- a/tools/docker-compose-cluster/awx-3-receptor.conf
+++ b/tools/docker-compose-cluster/awx-3-receptor.conf
@@ -1,5 +1,5 @@
 ---
-- log-level: debug
+- log-level: info
 
 - control-service:
     service: control

--- a/tools/docker-compose/receptor.conf
+++ b/tools/docker-compose/receptor.conf
@@ -1,5 +1,5 @@
 ---
-- log-level: debug
+- log-level: info
 
 - control-service:
     service: control


### PR DESCRIPTION
##### SUMMARY
The log levels for certain things cause the docker terminal logs to be filled with lots of messages about the scheduler and task workers, potentially pushing out of view error log messages that the developer should pay attention to.

Also, let's put in the setting change that allows Django Debug Toolbar to work properly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - Installer

##### AWX VERSION
```
awx: 17.0.1
```