### PR TITLE
consolidate conditional pytest sqlite3 db settings

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -21,13 +21,6 @@ from split_settings.tools import optional, include
 # Load default settings.
 from .defaults import *  # NOQA
 
-if "pytest" in sys.modules:
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'unique-{}'.format(str(uuid.uuid4())),
-        },
-    }
 
 # awx-manage shell_plus --notebook
 NOTEBOOK_ARGUMENTS = [
@@ -165,6 +158,27 @@ try:
 except ImportError:
     traceback.print_exc()
     sys.exit(1)
+
+# Use SQLite for unit tests instead of PostgreSQL.  If the lines below are
+# commented out, Django will create the test_awx-dev database in PostgreSQL to
+# run unit tests.
+if "pytest" in sys.modules:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'unique-{}'.format(str(uuid.uuid4())),
+        },
+    }
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'awx.sqlite3'), # noqa
+            'TEST': {
+                # Test database cannot be :memory: for inventory tests.
+                'NAME': os.path.join(BASE_DIR, 'awx_test.sqlite3'), # noqa
+            },
+        }
+    }
 
 
 CELERYBEAT_SCHEDULE.update({  # noqa

--- a/tools/docker-compose/ansible/roles/sources/files/local_settings.py
+++ b/tools/docker-compose/ansible/roles/sources/files/local_settings.py
@@ -11,29 +11,12 @@
 ###############################################################################
 # MISC PROJECT SETTINGS
 ###############################################################################
-import os
-import sys
 
 # Enable the following lines and install the browser extension to use Django debug toolbar
 # if your deployment method is not VMWare of Docker-for-Mac you may
 # need a different IP address from request.META['REMOTE_ADDR']
 # INTERNAL_IPS = ('172.19.0.1', '172.18.0.1', '192.168.100.1')
 # ALLOWED_HOSTS = ['*']
-
-# Use SQLite for unit tests instead of PostgreSQL.  If the lines below are
-# commented out, Django will create the test_awx-dev database in PostgreSQL to
-# run unit tests.
-if "pytest" in sys.modules:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': os.path.join(BASE_DIR, 'awx.sqlite3'),
-            'TEST': {
-                # Test database cannot be :memory: for inventory tests.
-                'NAME': os.path.join(BASE_DIR, 'awx_test.sqlite3'),
-            },
-        }
-    }
 
 # Location for cross-development of inventory plugins
 AWX_ANSIBLE_COLLECTIONS_PATHS = '/var/lib/awx/vendor/awx_ansible_collections'


### PR DESCRIPTION
##### SUMMARY
@jbradberry noticed that the unit & functional tests are failing because they are being inadvertently pointed at the postgres db instead of sqlite.  

This is because of an import order issue cause by the introduction of `/etc/tower/conf.d/database.py` from the sources role.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
