### PR TITLE
fix the tower_user module to update the fields properly

### DIFF
--- a/awx_collection/plugins/modules/tower_user.py
+++ b/awx_collection/plugins/modules/tower_user.py
@@ -149,19 +149,19 @@ def main():
 
     # Create the data that gets sent for create and update
     new_fields = {}
-    if username:
+    if username is not None:
         new_fields['username'] = module.get_item_name(existing_item) if existing_item else username
-    if first_name:
+    if first_name is not None:
         new_fields['first_name'] = first_name
-    if last_name:
+    if last_name is not None:
         new_fields['last_name'] = last_name
-    if email:
+    if email is not None:
         new_fields['email'] = email
-    if is_superuser:
+    if is_superuser is not None:
         new_fields['is_superuser'] = is_superuser
-    if is_system_auditor:
+    if is_system_auditor is not None:
         new_fields['is_system_auditor'] = is_system_auditor
-    if password:
+    if password is not None:
         new_fields['password'] = password
 
     # If the state was present and we can let the module build or update the existing item, this will return on its own

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -62,18 +62,18 @@ def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
 @pytest.mark.django_db
 def test_update_user(run_module, admin_user, mock_auth_stuff):
     result = run_module('tower_user', dict(
-        username='Bob',
-        password='pass4word',
-        is_system_auditor=True
-    ), admin_user)
-    assert not result.get('failed', False), result.get('msg', result)
-    assert result.get('changed'), result
+        username='Bob',
+        password='pass4word',
+        is_system_auditor=True
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
 
     update_result = run_module('tower_user', dict(
-        username='Bob',
-        is_system_auditor=False
-    ), admin_user)
+        username='Bob',
+        is_system_auditor=False
+    ), admin_user)
 
-    assert update_result.get('changed')
-    user = User.objects.get(id=result['id'])
-    assert not user.is_system_auditor
+    assert update_result.get('changed')
+    user = User.objects.get(id=result['id'])
+    assert not user.is_system_auditor

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -57,3 +57,24 @@ def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
         assert not result.get('failed', False), result.get('msg', result)
 
     assert not result.get('changed')
+
+
+@pytest.mark.django_db
+def test_update_user(run_module, admin_user, mock_auth_stuff):
+    result = run_module('tower_user', dict(
+        username='Bob',
+        password='pass4word',
+        is_system_auditor=True
+    ), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+
+    update_result =     result = run_module('tower_user', dict(
+        username='Bob',
+        password='pass4word',
+        is_system_auditor=False
+    ), admin_user)
+
+    assert update_result.get('changed')
+    user = User.objects.get(id=result['id'])
+    assert not user.is_system_auditor

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -69,7 +69,7 @@ def test_update_user(run_module, admin_user, mock_auth_stuff):
     assert not result.get('failed', False), result.get('msg', result)
     assert result.get('changed'), result
 
-    update_result =     result = run_module('tower_user', dict(
+    update_result = run_module('tower_user', dict(
         username='Bob',
         password='pass4word',
         is_system_auditor=False

--- a/awx_collection/test/awx/test_user.py
+++ b/awx_collection/test/awx/test_user.py
@@ -61,7 +61,7 @@ def test_update_password_on_create(run_module, admin_user, mock_auth_stuff):
 
 @pytest.mark.django_db
 def test_update_user(run_module, admin_user, mock_auth_stuff):
-    result = run_module('tower_user', dict(
+    result = run_module('tower_user', dict(
         username='Bob',
         password='pass4word',
         is_system_auditor=True
@@ -69,9 +69,8 @@ def test_update_user(run_module, admin_user, mock_auth_stuff):
     assert not result.get('failed', False), result.get('msg', result)
     assert result.get('changed'), result
 
-    update_result = run_module('tower_user', dict(
+    update_result = run_module('tower_user', dict(
         username='Bob',
-        password='pass4word',
         is_system_auditor=False
     ), admin_user)
 


### PR DESCRIPTION
##### SUMMARY
tower_user module was not updating the fields properly, especially the boolean fields. Only True to False was happening but not False to True. This PR fixes that issue.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Following is the playbook:
```
- hosts: localhost
  gather_facts: false
  tasks:
    - name: tower user
      awx.awx.tower_user:
         username: test_admin
         is_system_auditor: False
```

Before the PR:

```
niks@rhel83 ~]$ ansible-playbook  test_user.yml -v
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [tower user] *************************************************************************************************************************************************************************************************
ok: [localhost] => {"changed": false, "id": 5}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

After the PR:
```
[niks@rhel83 ~]$ ansible-playbook  test_user.yml -v
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [tower user] *************************************************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "id": 5}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```