### PR TITLE
clean stale dispatcher connections closer to post-fork

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -352,7 +352,6 @@ class SettingsWrapper(UserSettingsHolder):
         self.cache.set_many(settings_to_cache, timeout=SETTING_CACHE_TIMEOUT)
 
     def _get_local(self, name, validate=True):
-        self.__clean_on_fork__()
         self._preload_cache()
         cache_key = Setting.get_cache_key(name)
         try:

--- a/awx/main/dispatch/worker/task.py
+++ b/awx/main/dispatch/worker/task.py
@@ -6,6 +6,7 @@ import traceback
 
 from kubernetes.config import kube_config
 
+from django.conf import settings
 from django_guid.middleware import GuidMiddleware
 
 from awx.main.tasks import dispatch_startup, inform_cluster_of_shutdown
@@ -85,6 +86,7 @@ class TaskWorker(BaseWorker):
             'task': u'awx.main.tasks.RunProjectUpdate'
         }
         '''
+        settings.__clean_on_fork__()
         result = None
         try:
             result = self.run_callable(body)


### PR DESCRIPTION
Note that relocating the post-fork cleanup code *here* is actually the *top frame* of the stack post-fork (this function is the actual `multiprocessing.Process` target we point at):

```python
awx_1_1     | Traceback (most recent call last):
awx_1_1     |   File "/awx_devel/awx/main/dispatch/worker/task.py", line 90, in perform_work
awx_1_1     |     result = self.run_callable(body)  <--------------------------
awx_1_1     |   File "/awx_devel/awx/main/dispatch/worker/task.py", line 66, in run_callable
awx_1_1     |     return _call(*args, **kwargs)
awx_1_1     |   File "/awx_devel/awx/main/tasks.py", line 824, in _wrapped
awx_1_1     |     return f(self, *args, **kwargs)
```

see: https://github.com/ansible/awx/issues/9559