### PR TITLE
Fixes silent error on SCM subform

### DIFF
--- a/awx/ui_next/src/components/FormField/CheckboxField.jsx
+++ b/awx/ui_next/src/components/FormField/CheckboxField.jsx
@@ -22,7 +22,7 @@ function CheckboxField({
         <span>
           {label}
           &nbsp;
-          {tooltip && <Popover content={tooltip} />}
+          {tooltip && <Popover ouiaId="checkbox-tooltip" content={tooltip} />}
         </span>
       }
       id={id}

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.test.jsx
@@ -140,4 +140,63 @@ describe('<SCMSubForm />', () => {
     customWrapper.update();
     expect(customWrapper.find('Select').prop('selections')).toBe('newPath/');
   });
+  test('Update on project update should be disabled', async () => {
+    const customInitialValues = {
+      credential: { id: 1, name: 'Credential' },
+      custom_virtualenv: '',
+      overwrite: false,
+      overwrite_vars: false,
+      source_path: '/path',
+      source_project: { id: 1, name: 'Source project' },
+      source_script: null,
+      source_vars: '---\n',
+      update_cache_timeout: 0,
+      update_on_launch: true,
+      update_on_project_update: false,
+      verbosity: 1,
+    };
+    let customWrapper;
+    await act(async () => {
+      customWrapper = mountWithContexts(
+        <Formik initialValues={customInitialValues}>
+          <SCMSubForm />
+        </Formik>
+      );
+    });
+    expect(
+      customWrapper
+        .find('Checkbox[aria-label="Update on project update"]')
+        .prop('isDisabled')
+    ).toBe(true);
+  });
+
+  test('Update on launch should be disabled', async () => {
+    const customInitialValues = {
+      credential: { id: 1, name: 'Credential' },
+      custom_virtualenv: '',
+      overwrite: false,
+      overwrite_vars: false,
+      source_path: '/path',
+      source_project: { id: 1, name: 'Source project' },
+      source_script: null,
+      source_vars: '---\n',
+      update_cache_timeout: 0,
+      update_on_launch: false,
+      update_on_project_update: true,
+      verbosity: 1,
+    };
+    let customWrapper;
+    await act(async () => {
+      customWrapper = mountWithContexts(
+        <Formik initialValues={customInitialValues}>
+          <SCMSubForm />
+        </Formik>
+      );
+    });
+    expect(
+      customWrapper
+        .find('Checkbox[aria-label="Update on launch"]')
+        .prop('isDisabled')
+    ).toBe(true);
+  });
 });

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { withI18n } from '@lingui/react';
 import { t, Trans } from '@lingui/macro';
 import { useField } from 'formik';
+import { Link } from 'react-router-dom';
 import { FormGroup } from '@patternfly/react-core';
 import { minMaxValue, regExp } from '../../../../util/validators';
 import AnsibleSelect from '../../../../components/AnsibleSelect';
@@ -108,6 +109,8 @@ export const OptionsField = withI18n()(
   ({ i18n, showProjectUpdate = false }) => {
     const [updateOnLaunchField] = useField('update_on_launch');
     const [, , updateCacheTimeoutHelper] = useField('update_cache_timeout');
+    const [updatedOnProjectUpdateField] = useField('update_on_project_update');
+    const [projectField] = useField('source_project');
 
     useEffect(() => {
       if (!updateOnLaunchField.value) {
@@ -162,22 +165,62 @@ export const OptionsField = withI18n()(
                 }
               />
               <CheckboxField
+                isDisabled={updatedOnProjectUpdateField.value}
                 id="update_on_launch"
                 name="update_on_launch"
                 label={i18n._(t`Update on launch`)}
-                tooltip={i18n._(t`Each time a job runs using this inventory,
+                tooltip={
+                  <>
+                    <div>
+                      {i18n._(t`Each time a job runs using this inventory,
             refresh the inventory from the selected source before
             executing job tasks.`)}
+                    </div>
+                    <br />
+                    {projectField?.value && (
+                      <div>
+                        {i18n._(t`If you want the Inventory Source to update on
+                      launch and on project update, click on Update on launch, and also go to`)}
+                        <Link to={`/projects/${projectField.value.id}/details`}>
+                          {' '}
+                          {projectField.value.name}{' '}
+                        </Link>
+                        {i18n._(t`and click on Update Revision on Launch`)}
+                      </div>
+                    )}
+                  </>
+                }
               />
               {showProjectUpdate && (
                 <CheckboxField
+                  isDisabled={updateOnLaunchField.value}
                   id="update_on_project_update"
                   name="update_on_project_update"
                   label={i18n._(t`Update on project update`)}
-                  tooltip={i18n._(t`After every project update where the SCM revision
+                  tooltip={
+                    <>
+                      <div>
+                        {i18n._(t`After every project update where the SCM revision
               changes, refresh the inventory from the selected source
               before executing job tasks. This is intended for static content,
               like the Ansible inventory .ini file format.`)}
+                      </div>
+                      <br />
+                      {projectField?.value && (
+                        <div>
+                          {i18n._(t`If you want the Inventory Source to update on
+                      launch and on project update, click on Update on launch, and also go to`)}
+                          <Link
+                            to={`/projects/${projectField.value.id}/details`}
+                          >
+                            {' '}
+                            {projectField.value.name}{' '}
+                          </Link>
+                          {i18n._(t`and click on Update Revision on Launch`)}
+                        </div>
+                      )}
+                    </>
+                  }
                 />
               )}
             </FormCheckboxLayout>


### PR DESCRIPTION
##### SUMMARY
This addresses #9373.  It disallows the user to select both Update on launch and update on project update. It also adds a bit of info to the tool tip including a link to the project in question so the user can edit the project to allow them to update on launch and on project update

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

##### ADDITIONAL INFORMATION
![Screen Shot 2021-03-12 at 3 06 04 PM](https://user-images.githubusercontent.com/39280967/110993000-be616200-8344-11eb-8d6f-81e75146f0fe.png)

