### PR TITLE
Add instance_groups option to tower_organization

### DIFF
--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -71,6 +71,11 @@ options:
         - list of Ansible Galaxy credentials to associate to the organization
       type: list
       elements: str
+    instance_groups:
+      description:
+        - list of Ansible Tower instance groups to associate to the organization
+      type: list
+      elements: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -97,6 +102,15 @@ EXAMPLES = '''
     galaxy_credentials:
       - Ansible Galaxy
     tower_config_file: "~/tower_cli.cfg"
+
+- name: Create tower organization and assign instance groups
+  tower_organization:
+    name: "Foo"
+    state: present
+    instance_groups:
+      - tokyo
+      - osaka
+    tower_config_file: "~/tower_cli.cfg"
 '''
 
 from ..module_utils.tower_api import TowerAPIModule
@@ -114,6 +128,7 @@ def main():
         notification_templates_error=dict(type="list", elements='str'),
         notification_templates_approvals=dict(type="list", elements='str'),
         galaxy_credentials=dict(type="list", elements='str'),
+        instance_groups=dict(type="list", elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -125,7 +140,6 @@ def main():
     description = module.params.get('description')
     default_ee = module.params.get('default_environment')
     max_hosts = module.params.get('max_hosts')
-    # instance_group_names = module.params.get('instance_groups')
     state = module.params.get('state')
 
     # Attempt to look up organization based on the provided name
@@ -166,6 +180,12 @@ def main():
         association_fields['galaxy_credentials'] = []
         for item in galaxy_credentials:
             association_fields['galaxy_credentials'].append(module.resolve_name_to_id('credentials', item))
+
+    instance_groups = module.params.get('instance_groups')
+    if instance_groups is not None:
+        association_fields['instance_groups']  = []
+        for item in instance_groups:
+            association_fields['instance_groups'].append(module.resolve_name_to_id('instance_groups', item))
 
     # Create the data that gets sent for create and update
     org_fields = {'name': module.get_item_name(organization) if organization else name}

--- a/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_organization/tasks/main.yml
@@ -3,6 +3,19 @@
   set_fact:
     org_name: "AWX-Collection-tests-tower_organization-org-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
 
+- name: Generate an instance group test_id
+  set_fact:
+    test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: Generate an instance group name
+  set_fact:
+    group_name: "{{ org_name }}-instance_group-group-{{ test_id }}"
+
+- name: Create an instance group
+  tower_instance_group:
+    name: "{{ group_name }}"
+    state: present
+
 - name: Make sure {{ org_name }} is not there
   tower_organization:
     name: "{{ org_name }}"
@@ -14,6 +27,8 @@
     name: "{{ org_name }}"
     galaxy_credentials:
       - Ansible Galaxy
+    instance_groups:
+      - "{{ group_name }}"
   register: result
 
 - assert:
@@ -67,6 +82,11 @@
 - assert:
     that:
       - "result is not changed"
+
+- name: Remove the instance group
+  tower_instance_group:
+    name: "{{ group_name }}"
+    state: absent
 
 # Test behaviour common to all tower modules
 - name: Check that SSL is available and verify_ssl is enabled (task must fail)


### PR DESCRIPTION
##### SUMMARY

Add instance_groups option to tower_organization module.
This PR addresses part of issue #8604. After applying this, the `tower_organization` module can associate instance groups with the specified organization.

* Fixes #8604

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - awx_collection

##### AWX VERSION
```
devel
```


##### ADDITIONAL INFORMATION
```
None
```
