### PR TITLE
Removed trailing whitespace to pass awx-api-lint check

### DIFF
--- a/awx/conf/migrations/0005_v330_rename_two_session_settings.py
+++ b/awx/conf/migrations/0005_v330_rename_two_session_settings.py
@@ -23,4 +23,4 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(copy_session_settings, reverse_copy_session_settings),
     ]
-    
+


### PR DESCRIPTION
##### SUMMARY
From flake8 v3.9, the check of W292 has been enhanced. I think this is the reason why `awx-api-lint` fails in the CI process like https://github.com/ansible/awx/pull/9580#issuecomment-799126807

```
2021-03-15 04:58:49.331349 | TASK [run_awx_tests : Run /var/lib/awx/venv/awx/bin/tox -e linters]
2021-03-15 04:58:50.348565 | static | cannot clone: Operation not permitted
2021-03-15 04:58:50.348947 | static | user namespaces are not enabled in /proc/sys/user/max_user_namespaces
2021-03-15 04:58:50.349036 | static | Error: cannot re-exec process
2021-03-15 04:58:50.644619 | static | GLOB sdist-make: /awx_devel/setup.py
2021-03-15 04:58:52.164211 | static | linters create: /awx_devel/.tox/linters
2021-03-15 04:58:52.952025 | static | linters installdeps: make, flake8, yamllint
2021-03-15 04:58:57.406322 | static | linters inst: /awx_devel/.tox/.tmp/package/1/awx-17.0.1.zip
2021-03-15 04:59:01.711980 | static | linters installed: arrow==1.0.3,awx @ file:///awx_devel/.tox/.tmp/package/1/awx-17.0.1.zip,flake8==3.9.0,importlib-metadata==3.7.3,Jinja2==2.11.3,jinja2-time==0.2.0,make==0.1.6.post2,MarkupSafe==1.1.1,mccabe==0.6.1,pathspec==0.8.1,pycodestyle==2.7.0,pyflakes==2.3.0,python-dateutil==2.8.1,PyYAML==5.4.1,six==1.15.0,typing-extensions==3.7.4.3,yamllint==1.26.0,zipp==3.4.1
2021-03-15 04:59:01.712409 | static | linters run-test-pre: PYTHONHASHSEED='853659925'
2021-03-15 04:59:01.712605 | static | linters run-test: commands[0] | make flake8
2021-03-15 04:59:01.741806 | static | mkdir -p reports
2021-03-15 04:59:19.556658 | static | ./awx/conf/migrations/0005_v330_rename_two_session_settings.py:26:5: W292 no newline at end of file
2021-03-15 04:59:19.585876 | static | make: *** [Makefile:278: flake8] Error 1
2021-03-15 04:59:19.586363 | static | ERROR: InvocationError for command /usr/bin/make flake8 (exited with code 2)
2021-03-15 04:59:19.587210 | static | ___________________________________ summary ____________________________________
2021-03-15 04:59:19.587336 | static | ERROR:   linters: commands failed
2021-03-15 04:59:20.493218 | static | ERROR
2021-03-15 04:59:20.493607 | static | {
2021-03-15 04:59:20.493680 | static |   "delta": "0:00:30.329930",
2021-03-15 04:59:20.493735 | static |   "end": "2021-03-15 04:59:20.013197",
2021-03-15 04:59:20.493778 | static |   "msg": "non-zero return code",
2021-03-15 04:59:20.493819 | static |   "rc": 1,
2021-03-15 04:59:20.493859 | static |   "start": "2021-03-15 04:58:49.683267"
2021-03-15 04:59:20.493899 | static | }
2021-03-15 04:59:20.515115 | 
2021-03-15 04:59:20.515243 | PLAY RECAP
2021-03-15 04:59:20.515348 | static | ok: 12 changed: 5 unreachable: 0 failed: 1 skipped: 1 rescued: 0 ignored: 0
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Installer

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
flake8 check passed if we use flake8 v3.8.x like below:

```
$ flake8 --version
3.8.4 (mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0) CPython 3.6.8 on
Linux
$ flake8 awx/conf/migrations/0005_v330_rename_two_session_settings.py
$
```
But it did not pass with v3.9:

```
$ flake8 --version
3.9.0 (mccabe: 0.6.1, pycodestyle: 2.7.0, pyflakes: 2.3.0) CPython 3.6.8 on
Linux
$ flake8 awx/conf/migrations/0005_v330_rename_two_session_settings.py
awx/conf/migrations/0005_v330_rename_two_session_settings.py:26:5: W292 no newline at end of file
$
```