### PR TITLE
Don't unnecessarily expand YAML expressions

### DIFF
--- a/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
+++ b/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
@@ -11,7 +11,6 @@ import 'ace-builds/src-noconflict/theme-github';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import styled from 'styled-components';
-import debounce from '../../util/debounce';
 
 config.set('loadWorkerFromBlob', false);
 
@@ -140,7 +139,8 @@ function CodeEditor({
           mode={aceModes[mode] || 'text'}
           className={`pf-c-form-control ${className}`}
           theme="github"
-          onChange={debounce(onChange, 250)}
+          onChange={onChange}
+          debounceChangePeriod={250}
           value={value}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
+++ b/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
@@ -11,6 +11,7 @@ import 'ace-builds/src-noconflict/theme-github';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import styled from 'styled-components';
+import debounce from '../../util/debounce';
 
 config.set('loadWorkerFromBlob', false);
 
@@ -139,8 +140,7 @@ function CodeEditor({
           mode={aceModes[mode] || 'text'}
           className={`pf-c-form-control ${className}`}
           theme="github"
-          onChange={onChange}
-          debounceChangePeriod={250}
+          onChange={debounce(onChange, 250)}
           value={value}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/awx/ui_next/src/components/CodeEditor/VariablesDetail.test.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesDetail.test.jsx
@@ -39,7 +39,7 @@ describe('<VariablesDetail>', () => {
     wrapper.find('MultiButtonToggle').invoke('onChange')('yaml');
     const input2 = wrapper.find('VariablesDetail___StyledCodeEditor');
     expect(input2.prop('mode')).toEqual('yaml');
-    expect(input2.prop('value')).toEqual('foo: bar\n');
+    expect(input2.prop('value')).toEqual('---foo: bar');
   });
 
   test('should render label and value= --- when there are no values', () => {

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
@@ -73,7 +73,28 @@ function VariablesField({
     },
     [shouldValidate, validate] // eslint-disable-line react-hooks/exhaustive-deps
   );
+  const [initialYamlValue] = useState(mode === YAML_MODE ? field.value : null);
+  const [isEdited, setIsEdited] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleModeChange = newMode => {
+    if (newMode === YAML_MODE && !isEdited && initialYamlValue) {
+      helpers.setValue(initialYamlValue);
+      setMode(newMode);
+      return;
+    }
+
+    try {
+      const newVal =
+        newMode === YAML_MODE
+          ? jsonToYaml(field.value)
+          : yamlToJson(field.value);
+      helpers.setValue(newVal);
+      setMode(newMode);
+    } catch (err) {
+      helpers.setError(err.message);
+    }
+  };
 
   return (
     <>
@@ -87,7 +108,8 @@ function VariablesField({
         tooltip={tooltip}
         onExpand={() => setIsExpanded(true)}
         mode={mode}
-        setMode={setMode}
+        setMode={handleModeChange}
+        setIsEdited={setIsEdited}
         setShouldValidate={setShouldValidate}
       />
       <Modal
@@ -118,7 +140,8 @@ function VariablesField({
             tooltip={tooltip}
             fullHeight
             mode={mode}
-            setMode={setMode}
+            setMode={handleModeChange}
+            setIsEdited={setIsEdited}
             setShouldValidate={setShouldValidate}
           />
         </div>
@@ -155,6 +178,7 @@ function VariablesFieldInternals({
   mode,
   setMode,
   onExpand,
+  setIsEdited,
   setShouldValidate,
 }) {
   const [field, meta, helpers] = useField(name);
@@ -176,18 +200,7 @@ function VariablesFieldInternals({
                 [JSON_MODE, 'JSON'],
               ]}
               value={mode}
-              onChange={newMode => {
-                try {
-                  const newVal =
-                    newMode === YAML_MODE
-                      ? jsonToYaml(field.value)
-                      : yamlToJson(field.value);
-                  helpers.setValue(newVal);
-                  setMode(newMode);
-                } catch (err) {
-                  helpers.setError(err.message);
-                }
-              }}
+              onChange={setMode}
             />
           </SplitItem>
         </Split>
@@ -214,6 +227,7 @@ function VariablesFieldInternals({
         readOnly={readOnly}
         {...field}
         onChange={newVal => {
+          setIsEdited(true);
           helpers.setValue(newVal);
         }}
         fullHeight={fullHeight}

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
@@ -81,7 +81,7 @@ function VariablesField({
 
   const handleModeChange = newMode => {
     if (newMode === YAML_MODE && !isJsonEdited && lastYamlValue !== null) {
-      helpers.setValue(lastYamlValue);
+      helpers.setValue(lastYamlValue, false);
       setMode(newMode);
       return;
     }
@@ -91,7 +91,7 @@ function VariablesField({
         newMode === YAML_MODE
           ? jsonToYaml(field.value)
           : yamlToJson(field.value);
-      helpers.setValue(newVal);
+      helpers.setValue(newVal, false);
       setMode(newMode);
     } catch (err) {
       helpers.setError(err.message);
@@ -109,7 +109,7 @@ function VariablesField({
   };
 
   return (
-    <>
+    <div>
       <VariablesFieldInternals
         i18n={i18n}
         id={id}
@@ -163,7 +163,7 @@ function VariablesField({
           {meta.error}
         </div>
       ) : null}
-    </>
+    </div>
   );
 }
 VariablesField.propTypes = {

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.jsx
@@ -73,13 +73,15 @@ function VariablesField({
     },
     [shouldValidate, validate] // eslint-disable-line react-hooks/exhaustive-deps
   );
-  const [initialYamlValue] = useState(mode === YAML_MODE ? field.value : null);
-  const [isEdited, setIsEdited] = useState(false);
+  const [lastYamlValue, setLastYamlValue] = useState(
+    mode === YAML_MODE ? field.value : null
+  );
+  const [isJsonEdited, setIsJsonEdited] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
   const handleModeChange = newMode => {
-    if (newMode === YAML_MODE && !isEdited && initialYamlValue) {
-      helpers.setValue(initialYamlValue);
+    if (newMode === YAML_MODE && !isJsonEdited && lastYamlValue !== null) {
+      helpers.setValue(lastYamlValue);
       setMode(newMode);
       return;
     }
@@ -96,6 +98,16 @@ function VariablesField({
     }
   };
 
+  const handleChange = newVal => {
+    helpers.setValue(newVal);
+    if (mode === JSON_MODE) {
+      setIsJsonEdited(true);
+    } else {
+      setLastYamlValue(newVal);
+      setIsJsonEdited(false);
+    }
+  };
+
   return (
     <>
       <VariablesFieldInternals
@@ -109,8 +121,8 @@ function VariablesField({
         onExpand={() => setIsExpanded(true)}
         mode={mode}
         setMode={handleModeChange}
-        setIsEdited={setIsEdited}
         setShouldValidate={setShouldValidate}
+        handleChange={handleChange}
       />
       <Modal
         variant="xlarge"
@@ -141,8 +153,8 @@ function VariablesField({
             fullHeight
             mode={mode}
             setMode={handleModeChange}
-            setIsEdited={setIsEdited}
             setShouldValidate={setShouldValidate}
+            handleChange={handleChange}
           />
         </div>
       </Modal>
@@ -178,10 +190,10 @@ function VariablesFieldInternals({
   mode,
   setMode,
   onExpand,
-  setIsEdited,
   setShouldValidate,
+  handleChange,
 }) {
-  const [field, meta, helpers] = useField(name);
+  const [field, meta] = useField(name);
 
   return (
     <div className="pf-c-form__group">
@@ -226,10 +238,7 @@ function VariablesFieldInternals({
         mode={mode}
         readOnly={readOnly}
         {...field}
-        onChange={newVal => {
-          setIsEdited(true);
-          helpers.setValue(newVal);
-        }}
+        onChange={handleChange}
         fullHeight={fullHeight}
         onFocus={() => setShouldValidate(false)}
         onBlur={() => setShouldValidate(true)}

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
@@ -56,7 +56,7 @@ describe('VariablesField', () => {
     );
   });
 
-  it('should retain non-expanded yaml if value not edited', async () => {
+  it('should retain non-expanded yaml if JSON value not edited', async () => {
     const value = '---\na: &aa [a,b,c]\nb: *aa';
     const wrapper = mountWithContexts(
       <Formik initialValues={{ variables: value }}>
@@ -80,7 +80,7 @@ describe('VariablesField', () => {
     expect(wrapper.find('CodeEditor').prop('value')).toEqual(value);
   });
 
-  it('should retain expanded yaml if value is edited', async () => {
+  it('should retain expanded yaml if JSON value is edited', async () => {
     const value = '---\na: &aa [a,b,c]\nb: *aa';
     const wrapper = mountWithContexts(
       <Formik initialValues={{ variables: value }}>
@@ -106,6 +106,34 @@ describe('VariablesField', () => {
     expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
     expect(wrapper.find('CodeEditor').prop('value')).toEqual(
       'foo: bar\nbaz: 3\n'
+    );
+  });
+
+  it('should retain non-expanded yaml if YAML value is edited', async () => {
+    const value = '---\na: &aa [a,b,c]\nb: *aa';
+    const wrapper = mountWithContexts(
+      <Formik initialValues={{ variables: value }}>
+        {() => (
+          <VariablesField id="the-field" name="variables" label="Variables" />
+        )}
+      </Formik>
+    );
+    wrapper.find('CodeEditor').invoke('onChange')(
+      '---\na: &aa [a,b,c]\nb: *aa\n'
+    );
+    const buttons = wrapper.find('Button');
+    await act(async () => {
+      buttons.at(1).simulate('click');
+    });
+    wrapper.update();
+    const buttons2 = wrapper.find('Button');
+    await act(async () => {
+      buttons2.at(0).simulate('click');
+    });
+    wrapper.update();
+    expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
+    expect(wrapper.find('CodeEditor').prop('value')).toEqual(
+      '---\na: &aa [a,b,c]\nb: *aa\n'
     );
   });
 

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
@@ -65,15 +65,14 @@ describe('VariablesField', () => {
         )}
       </Formik>
     );
-    const buttons = wrapper.find('Button');
-    expect(buttons).toHaveLength(2);
+    const jsButton = wrapper.find('Button.toggle-button-javascript');
     await act(async () => {
-      buttons.at(1).simulate('click');
+      jsButton.simulate('click');
     });
     wrapper.update();
-    const buttons2 = wrapper.find('Button');
+    const yamlButton = wrapper.find('Button.toggle-button-yaml');
     await act(async () => {
-      buttons2.at(0).simulate('click');
+      yamlButton.simulate('click');
     });
     wrapper.update();
     expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
@@ -89,18 +88,17 @@ describe('VariablesField', () => {
         )}
       </Formik>
     );
-    const buttons = wrapper.find('Button');
-    expect(buttons).toHaveLength(2);
+    const jsButton = wrapper.find('Button.toggle-button-javascript');
     await act(async () => {
-      buttons.at(1).simulate('click');
+      jsButton.simulate('click');
     });
     wrapper.update();
     wrapper.find('CodeEditor').invoke('onChange')(
       '{\n  "foo": "bar",\n  "baz": 3\n}'
     );
-    const buttons2 = wrapper.find('Button');
+    const yamlButton = wrapper.find('Button.toggle-button-yaml');
     await act(async () => {
-      buttons2.at(0).simulate('click');
+      yamlButton.simulate('click');
     });
     wrapper.update();
     expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');

--- a/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesField.test.jsx
@@ -52,6 +52,59 @@ describe('VariablesField', () => {
     wrapper.update();
     expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
     expect(wrapper.find('CodeEditor').prop('value')).toEqual(
+      '---\nfoo: bar\nbaz: 3'
+    );
+  });
+
+  it('should retain non-expanded yaml if value not edited', async () => {
+    const value = '---\na: &aa [a,b,c]\nb: *aa';
+    const wrapper = mountWithContexts(
+      <Formik initialValues={{ variables: value }}>
+        {() => (
+          <VariablesField id="the-field" name="variables" label="Variables" />
+        )}
+      </Formik>
+    );
+    const buttons = wrapper.find('Button');
+    expect(buttons).toHaveLength(2);
+    await act(async () => {
+      buttons.at(1).simulate('click');
+    });
+    wrapper.update();
+    const buttons2 = wrapper.find('Button');
+    await act(async () => {
+      buttons2.at(0).simulate('click');
+    });
+    wrapper.update();
+    expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
+    expect(wrapper.find('CodeEditor').prop('value')).toEqual(value);
+  });
+
+  it('should retain expanded yaml if value is edited', async () => {
+    const value = '---\na: &aa [a,b,c]\nb: *aa';
+    const wrapper = mountWithContexts(
+      <Formik initialValues={{ variables: value }}>
+        {() => (
+          <VariablesField id="the-field" name="variables" label="Variables" />
+        )}
+      </Formik>
+    );
+    const buttons = wrapper.find('Button');
+    expect(buttons).toHaveLength(2);
+    await act(async () => {
+      buttons.at(1).simulate('click');
+    });
+    wrapper.update();
+    wrapper.find('CodeEditor').invoke('onChange')(
+      '{\n  "foo": "bar",\n  "baz": 3\n}'
+    );
+    const buttons2 = wrapper.find('Button');
+    await act(async () => {
+      buttons2.at(0).simulate('click');
+    });
+    wrapper.update();
+    expect(wrapper.find('CodeEditor').prop('mode')).toEqual('yaml');
+    expect(wrapper.find('CodeEditor').prop('value')).toEqual(
       'foo: bar\nbaz: 3\n'
     );
   });

--- a/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.jsx
+++ b/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.jsx
@@ -25,6 +25,7 @@ function MultiButtonToggle({ buttons, value, onChange }) {
           <SmallButton
             aria-label={buttonLabel}
             key={buttonLabel}
+            className={`toggle-button-${buttonValue}`}
             onClick={() => setValue(buttonValue)}
             variant={buttonValue === value ? 'primary' : 'secondary'}
           >


### PR DESCRIPTION
##### SUMMARY
Prevents variables fields from expanding YAML expressions when possible:
* In the detail view, the user may toggle to JSON (seeing the data structure fully expanded), but toggling back to YAML will continue to display the original un-expanded value with expressions intact
* In edit mode, this works the same way, UNLESS the user edits the value while in JSON mode.

Addresses #7506

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
![yaml-expand](https://user-images.githubusercontent.com/410794/111365690-0982ba00-8650-11eb-8b64-b69253c2b22f.gif)

