### PR TITLE
Allow one to select non-global execution environments for organizations

### DIFF
--- a/awx/ui_next/src/screens/Organization/shared/OrganizationForm.jsx
+++ b/awx/ui_next/src/screens/Organization/shared/OrganizationForm.jsx
@@ -21,7 +21,12 @@ import { required, minMaxValue } from '../../../util/validators';
 import { FormColumnLayout } from '../../../components/FormLayout';
 import CredentialLookup from '../../../components/Lookup/CredentialLookup';
 
-function OrganizationFormFields({ i18n, instanceGroups, setInstanceGroups }) {
+function OrganizationFormFields({
+  i18n,
+  instanceGroups,
+  setInstanceGroups,
+  organizationId,
+}) {
   const { license_info = {}, me = {} } = useConfig();
   const { custom_virtualenvs } = useContext(ConfigContext);
 
@@ -124,6 +129,7 @@ function OrganizationFormFields({ i18n, instanceGroups, setInstanceGroups }) {
           t`Select the default execution environment for this organization.`
         )}
         globallyAvailable
+        organizationId={organizationId}
         isDefaultEnvironment
       />
       <CredentialLookup
@@ -222,6 +228,7 @@ function OrganizationForm({
             <OrganizationFormFields
               instanceGroups={instanceGroups}
               setInstanceGroups={setInstanceGroups}
+              organizationId={organization?.id || null}
               {...rest}
             />
             <FormSubmitError error={submitError} />
@@ -245,6 +252,7 @@ OrganizationForm.propTypes = {
 
 OrganizationForm.defaultProps = {
   organization: {
+    id: '',
     name: '',
     description: '',
     max_hosts: '0',


### PR DESCRIPTION
Allow one to select non-global EE when editing an Organization.

See: https://github.com/ansible/awx/issues/9592

All those EE should be present as a choice when editing the `Default` organization.

![image](https://user-images.githubusercontent.com/9053044/111376560-fbe02b00-8675-11eb-8087-ba3e1435f417.png)

Editing `Default` organization.

![image](https://user-images.githubusercontent.com/9053044/111376706-3053e700-8676-11eb-9427-47d1c458c205.png)
