### PR TITLE
refactor payload construction for awxkit

### DIFF
--- a/awxkit/awxkit/api/pages/instance_groups.py
+++ b/awxkit/awxkit/api/pages/instance_groups.py
@@ -1,4 +1,4 @@
-from awxkit.utils import PseudoNamespace, random_title, suppress, update_payload
+from awxkit.utils import PseudoNamespace, random_title, suppress, update_payload, set_payload_foreign_key_args
 from awxkit.api.resources import resources
 from awxkit.api.mixins import HasCreate
 import awxkit.exceptions as exc
@@ -19,8 +19,11 @@ class InstanceGroup(HasCreate, base.Base):
     def payload(self, **kwargs):
         payload = PseudoNamespace(name=kwargs.get('name') or
                                   'Instance Group - {}'.format(random_title()))
-        fields = ('policy_instance_percentage', 'policy_instance_minimum', 'policy_instance_list')
+        fields = ('policy_instance_percentage', 'policy_instance_minimum', 'policy_instance_list', 'is_container_group')
         update_payload(payload, fields, kwargs)
+
+        set_payload_foreign_key_args(payload, ('credential',), kwargs)
+
         return payload
 
     def create_payload(self, name='', **kwargs):

--- a/awxkit/awxkit/api/pages/job_templates.py
+++ b/awxkit/awxkit/api/pages/job_templates.py
@@ -6,6 +6,7 @@ from awxkit.utils import (
     random_title,
     suppress,
     update_payload,
+    set_payload_foreign_key_args,
     PseudoNamespace)
 from awxkit.api.pages import Credential, Inventory, Project, UnifiedJobTemplate
 from awxkit.api.mixins import HasCreate, HasInstanceGroups, HasNotifications, HasSurvey, HasCopy, DSAdapter
@@ -102,16 +103,7 @@ class JobTemplate(
         if kwargs.get('project'):
             payload.update(project=kwargs.get('project').id, playbook=playbook)
 
-        for fk_field in ('inventory', 'credential', 'webhook_credential', 'execution_environment'):
-            rel_obj = kwargs.get(fk_field)
-            if rel_obj is None:
-                continue
-            elif isinstance(rel_obj, int):
-                payload.update(**{fk_field: int(rel_obj)})
-            elif hasattr(rel_obj, 'id'):
-                payload.update(**{fk_field: rel_obj.id})
-            else:
-                raise AttributeError(f'Related field {fk_field} must be either integer of pkid or object')
+        payload = set_payload_foreign_key_args(payload, ('inventory', 'credential', 'webhook_credential', 'execution_environment'), kwargs)
 
         return payload
 

--- a/awxkit/awxkit/api/pages/organizations.py
+++ b/awxkit/awxkit/api/pages/organizations.py
@@ -1,5 +1,5 @@
 from awxkit.api.mixins import HasCreate, HasInstanceGroups, HasNotifications, DSAdapter
-from awxkit.utils import random_title, suppress, PseudoNamespace
+from awxkit.utils import random_title, suppress, set_payload_foreign_key_args, PseudoNamespace
 from awxkit.api.resources import resources
 import awxkit.exceptions as exc
 from . import base
@@ -43,16 +43,8 @@ class Organization(HasCreate, HasInstanceGroups, HasNotifications, base.Base):
         payload = PseudoNamespace(name=kwargs.get('name') or 'Organization - {}'.format(random_title()),
                                   description=kwargs.get('description') or random_title(10))
 
-        for fk_field in ('default_environment',):
-            rel_obj = kwargs.get(fk_field)
-            if rel_obj is None:
-                continue
-            elif isinstance(rel_obj, int):
-                payload.update(**{fk_field: int(rel_obj)})
-            elif hasattr(rel_obj, 'id'):
-                payload.update(**{fk_field: rel_obj.id})
-            else:
-                raise AttributeError(f'Related field {fk_field} must be either integer of pkid or object')
+        payload = set_payload_foreign_key_args(payload, ('default_environment',), kwargs)
+
         return payload
 
     def create_payload(self, name='', description='', **kwargs):

--- a/awxkit/awxkit/api/pages/projects.py
+++ b/awxkit/awxkit/api/pages/projects.py
@@ -1,7 +1,7 @@
 import json
 
 from awxkit.api.pages import Credential, Organization, UnifiedJob, UnifiedJobTemplate
-from awxkit.utils import filter_by_class, random_title, update_payload, PseudoNamespace
+from awxkit.utils import filter_by_class, random_title, update_payload, set_payload_foreign_key_args, PseudoNamespace
 from awxkit.api.mixins import HasCreate, HasNotifications, HasCopy, DSAdapter
 from awxkit.api.resources import resources
 from awxkit.config import config
@@ -43,16 +43,8 @@ class Project(HasCopy, HasCreate, HasNotifications, UnifiedJobTemplate):
             'allow_override')
         update_payload(payload, fields, kwargs)
 
-        for fk_field in ('execution_environment', 'default_environment'):
-            rel_obj = kwargs.get(fk_field)
-            if rel_obj is None:
-                continue
-            elif isinstance(rel_obj, int):
-                payload.update(**{fk_field: int(rel_obj)})
-            elif hasattr(rel_obj, 'id'):
-                payload.update(**{fk_field: rel_obj.id})
-            else:
-                raise AttributeError(f'Related field {fk_field} must be either integer of pkid or object')
+        payload = set_payload_foreign_key_args(payload, ('execution_environment', 'default_environment'), kwargs)
+
         return payload
 
     def create_payload(

--- a/awxkit/awxkit/utils/__init__.py
+++ b/awxkit/awxkit/utils/__init__.py
@@ -319,6 +319,23 @@ def update_payload(payload, fields, kwargs):
     return payload
 
 
+def set_payload_foreign_key_args(payload, fk_fields, kwargs):
+    if isinstance(fk_fields, str):
+        fk_fields = (fk_fields,)
+
+    for fk_field in fk_fields:
+        rel_obj = kwargs.get(fk_field)
+        if rel_obj is None:
+            continue
+        elif isinstance(rel_obj, int):
+            payload.update(**{fk_field: int(rel_obj)})
+        elif hasattr(rel_obj, 'id'):
+            payload.update(**{fk_field: rel_obj.id})
+        else:
+            raise AttributeError(f'Related field {fk_field} must be either integer of pkid or object')
+    return payload
+
+
 def to_str(obj):
     if isinstance(obj, bytes):
         return obj.decode('utf-8')


### PR DESCRIPTION
This fixes container_group creation to allow passing
"is_container_group" and "credential" to the "create" method
on instance groups, and refactors other page objects
to use a common utility function to eliminate copy-pasted code

This will help us update to set `is_container_group` correctly as is now needed since https://github.com/ansible/awx/commit/de52adedef525b3c67a42f218f2a736aa1e8c7db