### PR TITLE
fix port conflict in dev cluster

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -3,8 +3,8 @@ version: '2'
 services:
 {% for i in range(cluster_node_count|int) %}
   {% set container_postfix = loop.index %}
-  {% set awx_sdb_port_start = 7899 + (loop.index0*100) | int %}
-  {% set awx_sdb_port_end = 7999 + (loop.index0*100) | int %}
+  {% set awx_sdb_port_start = 7899 + (loop.index0*1000) | int %}
+  {% set awx_sdb_port_end = 7999 + (loop.index0*1000) | int %}
   # Primary AWX Development Container
   awx_{{ container_postfix }}:
     user: "{{ ansible_user_uid }}"
@@ -37,27 +37,13 @@ services:
     privileged: true
     tty: true
     ports:
-      - "6899:6899"
       - "{{ awx_sdb_port_start }}-{{ awx_sdb_port_end }}:{{ awx_sdb_port_start }}-{{ awx_sdb_port_end }}"  # sdb-listen
 {% if cluster_node_count|int == 1 %}
+      - "6899:6899"
       - "8080:8080"  # unused but mapped for debugging
       - "8888:8888"  # jupyter notebook
       - "8013:8013"  # http
       - "8043:8043"  # https
-{% else %}
-  haproxy:
-    image: haproxy
-    volumes:
-      - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
-    depends_on:
-{% for i in range(cluster_node_count|int) -%}
-  {% set container_postfix = loop.index %}
-      - "awx_{{ container_postfix }}"
-{% endfor %}
-    ports:
-      - "8013:8013"
-      - "8043:8043"
-      - "1936:1936"
 {% endif %}
   redis_{{ container_postfix }}:
     image: redis:latest
@@ -68,6 +54,21 @@ services:
     entrypoint: ["redis-server"]
     command: ["/usr/local/etc/redis/redis.conf"]
 {% endfor %}
+{% if cluster_node_count|int > 1 %}
+  haproxy:
+    image: haproxy
+    volumes:
+      - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
+    ports:
+      - "8013:8013"
+      - "8043:8043"
+      - "1936:1936"
+    depends_on:
+  {% for i in range(cluster_node_count|int) -%}
+  {% set container_postfix = loop.index %}
+    - "awx_{{ container_postfix }}"
+  {% endfor %}
+{% endif %}
   # A useful container that simply passes through log messages to the console
   # helpful for testing awx/tower logging
   # logstash:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
problem: loop adds 100 to ports 7899 and 7999, which would yield 7999 to 8099 on the next iteration, so the 7999 is conflicting
fix: add 1000 instead
Also, haproxy was being defined twice, now it renders once.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 17.0.1
```
