### PR TITLE
Prevent users from selecting credentials that prompt for passwords on workflow nodes and schedules

### DIFF
--- a/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
+++ b/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
@@ -36,6 +36,7 @@ function LaunchButton({ resource, i18n, children, history }) {
   const [showLaunchPrompt, setShowLaunchPrompt] = useState(false);
   const [launchConfig, setLaunchConfig] = useState(null);
   const [surveyConfig, setSurveyConfig] = useState(null);
+  const [resourceCredentials, setResourceCredentials] = useState([]);
   const [error, setError] = useState(null);
   const handleLaunch = async () => {
     const readLaunch =
@@ -54,6 +55,17 @@ function LaunchButton({ resource, i18n, children, history }) {
         const { data } = await readSurvey;
 
         setSurveyConfig(data);
+      }
+
+      if (
+        launch.ask_credential_on_launch &&
+        resource.type === 'workflow_job_template'
+      ) {
+        const {
+          data: { results: jobTemplateCredentials },
+        } = await JobTemplatesAPI.readCredentials(resource.id);
+
+        setResourceCredentials(jobTemplateCredentials);
       }
 
       if (canLaunchWithoutPrompt(launch)) {
@@ -161,6 +173,7 @@ function LaunchButton({ resource, i18n, children, history }) {
           resource={resource}
           onLaunch={launchWithParams}
           onCancel={() => setShowLaunchPrompt(false)}
+          resourceDefaultCredentials={resourceCredentials}
         />
       )}
     </Fragment>

--- a/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.jsx
@@ -18,6 +18,7 @@ function PromptModalForm({
   onSubmit,
   resource,
   surveyConfig,
+  resourceDefaultCredentials,
 }) {
   const { setFieldTouched, values } = useFormikContext();
 
@@ -28,7 +29,13 @@ function PromptModalForm({
     visitStep,
     visitAllSteps,
     contentError,
-  } = useLaunchSteps(launchConfig, surveyConfig, resource, i18n);
+  } = useLaunchSteps(
+    launchConfig,
+    surveyConfig,
+    resource,
+    i18n,
+    resourceDefaultCredentials
+  );
 
   const handleSubmit = () => {
     const postValues = {};
@@ -122,6 +129,7 @@ function LaunchPrompt({
   onLaunch,
   resource = {},
   surveyConfig,
+  resourceDefaultCredentials = [],
 }) {
   return (
     <Formik initialValues={{}} onSubmit={values => onLaunch(values)}>
@@ -132,6 +140,7 @@ function LaunchPrompt({
         launchConfig={launchConfig}
         surveyConfig={surveyConfig}
         resource={resource}
+        resourceDefaultCredentials={resourceDefaultCredentials}
       />
     </Formik>
   );

--- a/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/LaunchPrompt.test.jsx
@@ -87,7 +87,9 @@ describe('LaunchPrompt', () => {
               credentials: [
                 {
                   id: 1,
+                  name: 'cred that prompts',
                   passwords_needed: ['ssh_password'],
+                  credential_type: 1,
                 },
               ],
             },
@@ -122,6 +124,16 @@ describe('LaunchPrompt', () => {
               },
             ],
           }}
+          resourceDefaultCredentials={[
+            {
+              id: 5,
+              name: 'cred that prompts',
+              credential_type: 1,
+              inputs: {
+                password: 'ASK',
+              },
+            },
+          ]}
         />
       );
     });

--- a/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.jsx
@@ -4,7 +4,8 @@ import { useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { useField } from 'formik';
-import { ToolbarItem } from '@patternfly/react-core';
+import styled from 'styled-components';
+import { Alert, ToolbarItem } from '@patternfly/react-core';
 import { CredentialsAPI, CredentialTypesAPI } from '../../../api';
 import AnsibleSelect from '../../AnsibleSelect';
 import OptionsList from '../../OptionsList';
@@ -13,7 +14,11 @@ import CredentialChip from '../../CredentialChip';
 import ContentError from '../../ContentError';
 import { getQSConfig, parseQueryString } from '../../../util/qs';
 import useRequest from '../../../util/useRequest';
-import { required } from '../../../util/validators';
+import credentialsValidator from './credentialsValidator';
+
+const CredentialErrorAlert = styled(Alert)`
+  margin-bottom: 20px;
+`;
 
 const QS_CONFIG = getQSConfig('credential', {
   page: 1,
@@ -21,10 +26,21 @@ const QS_CONFIG = getQSConfig('credential', {
   order_by: 'name',
 });
 
-function CredentialsStep({ i18n }) {
-  const [field, , helpers] = useField({
+function CredentialsStep({
+  i18n,
+  allowCredentialsWithPasswords,
+  defaultCredentials = [],
+}) {
+  const [field, meta, helpers] = useField({
     name: 'credentials',
-    validate: required(null, i18n),
+    validate: val => {
+      return credentialsValidator(
+        i18n,
+        defaultCredentials,
+        allowCredentialsWithPasswords,
+        val
+      );
+    },
   });
   const [selectedType, setSelectedType] = useState(null);
   const history = useHistory();
@@ -87,6 +103,18 @@ function CredentialsStep({ i18n }) {
     fetchCredentials();
   }, [fetchCredentials]);
 
+  useEffect(() => {
+    helpers.setError(
+      credentialsValidator(
+        i18n,
+        defaultCredentials,
+        allowCredentialsWithPasswords,
+        field.value
+      )
+    );
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, []);
+
   if (isTypesLoading) {
     return <ContentLoading />;
   }
@@ -97,17 +125,23 @@ function CredentialsStep({ i18n }) {
 
   const isVault = selectedType?.kind === 'vault';
 
-  const renderChip = ({ item, removeItem, canDelete }) => (
-    <CredentialChip
-      key={item.id}
-      onClick={() => removeItem(item)}
-      isReadOnly={!canDelete}
-      credential={item}
-    />
-  );
+  const renderChip = ({ item, removeItem, canDelete }) => {
+    return (
+      <CredentialChip
+        id={`credential-chip-${item.id}`}
+        key={item.id}
+        onClick={() => removeItem(item)}
+        isReadOnly={!canDelete}
+        credential={item}
+      />
+    );
+  };
 
   return (
     <>
+      {meta.error && (
+        <CredentialErrorAlert variant="danger" isInline title={meta.error} />
+      )}
       {types && types.length > 0 && (
         <ToolbarItem css=" display: flex; align-items: center;">
           <div css="flex: 0 0 25%; margin-right: 32px">
@@ -130,57 +164,56 @@ function CredentialsStep({ i18n }) {
           />
         </ToolbarItem>
       )}
-      {!isCredentialsLoading && (
-        <OptionsList
-          value={field.value || []}
-          options={credentials}
-          optionCount={count}
-          searchColumns={[
-            {
-              name: i18n._(t`Name`),
-              key: 'name__icontains',
-              isDefault: true,
-            },
-            {
-              name: i18n._(t`Created By (Username)`),
-              key: 'created_by__username__icontains',
-            },
-            {
-              name: i18n._(t`Modified By (Username)`),
-              key: 'modified_by__username__icontains',
-            },
-          ]}
-          sortColumns={[
-            {
-              name: i18n._(t`Name`),
-              key: 'name',
-            },
-          ]}
-          searchableKeys={searchableKeys}
-          relatedSearchableKeys={relatedSearchableKeys}
-          multiple={isVault}
-          header={i18n._(t`Credentials`)}
-          name="credentials"
-          qsConfig={QS_CONFIG}
-          readOnly={false}
-          selectItem={item => {
-            const hasSameVaultID = val =>
-              val?.inputs?.vault_id !== undefined &&
-              val?.inputs?.vault_id === item?.inputs?.vault_id;
-            const hasSameCredentialType = val =>
-              val.credential_type === item.credential_type;
-            const newItems = field.value.filter(i =>
-              isVault ? !hasSameVaultID(i) : !hasSameCredentialType(i)
-            );
-            newItems.push(item);
-            helpers.setValue(newItems);
-          }}
-          deselectItem={item => {
-            helpers.setValue(field.value.filter(i => i.id !== item.id));
-          }}
-          renderItemChip={renderChip}
-        />
-      )}
+      <OptionsList
+        isLoading={isCredentialsLoading}
+        value={field.value || []}
+        options={credentials}
+        optionCount={count}
+        searchColumns={[
+          {
+            name: i18n._(t`Name`),
+            key: 'name__icontains',
+            isDefault: true,
+          },
+          {
+            name: i18n._(t`Created By (Username)`),
+            key: 'created_by__username__icontains',
+          },
+          {
+            name: i18n._(t`Modified By (Username)`),
+            key: 'modified_by__username__icontains',
+          },
+        ]}
+        sortColumns={[
+          {
+            name: i18n._(t`Name`),
+            key: 'name',
+          },
+        ]}
+        searchableKeys={searchableKeys}
+        relatedSearchableKeys={relatedSearchableKeys}
+        multiple={isVault}
+        header={i18n._(t`Credentials`)}
+        name="credentials"
+        qsConfig={QS_CONFIG}
+        readOnly={false}
+        selectItem={item => {
+          const hasSameVaultID = val =>
+            val?.inputs?.vault_id !== undefined &&
+            val?.inputs?.vault_id === item?.inputs?.vault_id;
+          const hasSameCredentialType = val =>
+            val.credential_type === item.credential_type;
+          const newItems = field.value.filter(i =>
+            isVault ? !hasSameVaultID(i) : !hasSameCredentialType(i)
+          );
+          newItems.push(item);
+          helpers.setValue(newItems);
+        }}
+        deselectItem={item => {
+          helpers.setValue(field.value.filter(i => i.id !== item.id));
+        }}
+        renderItemChip={renderChip}
+      />
     </>
   );
 }

--- a/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/InventoryStep.jsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { useField } from 'formik';
+import styled from 'styled-components';
 import { Alert } from '@patternfly/react-core';
 import { InventoriesAPI } from '../../../api';
 import { getQSConfig, parseQueryString } from '../../../util/qs';
@@ -10,6 +11,10 @@ import useRequest from '../../../util/useRequest';
 import OptionsList from '../../OptionsList';
 import ContentLoading from '../../ContentLoading';
 import ContentError from '../../ContentError';
+
+const InventoryErrorAlert = styled(Alert)`
+  margin-bottom: 20px;
+`;
 
 const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
@@ -68,6 +73,9 @@ function InventoryStep({ i18n, warningMessage = null }) {
 
   return (
     <>
+      {meta.touched && meta.error && (
+        <InventoryErrorAlert variant="danger" isInline title={meta.error} />
+      )}
       {warningMessage}
       <OptionsList
         value={field.value ? [field.value] : []}
@@ -103,9 +111,6 @@ function InventoryStep({ i18n, warningMessage = null }) {
         selectItem={helpers.setValue}
         deselectItem={() => field.onChange(null)}
       />
-      {meta.touched && meta.error && (
-        <Alert variant="danger" isInline title={meta.error} />
-      )}
     </>
   );
 }

--- a/awx/ui_next/src/components/LaunchPrompt/steps/credentialsValidator.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/credentialsValidator.jsx
@@ -1,0 +1,66 @@
+import { t } from '@lingui/macro';
+
+const credentialPromptsForPassword = credential =>
+  credential?.inputs?.password === 'ASK' ||
+  credential?.inputs?.ssh_key_unlock === 'ASK' ||
+  credential?.inputs?.become_password === 'ASK' ||
+  credential?.inputs?.vault_password === 'ASK';
+
+export default function credentialsValidator(
+  i18n,
+  defaultCredentials = [],
+  allowCredentialsWithPasswords,
+  selectedCredentials
+) {
+  if (defaultCredentials.length > 0 && selectedCredentials) {
+    const missingCredentialTypes = [];
+    defaultCredentials.forEach(defaultCredential => {
+      if (
+        !selectedCredentials.find(selectedCredential => {
+          return (
+            (selectedCredential.credential_type ===
+              defaultCredential.credential_type &&
+              !selectedCredential.inputs.vault_id &&
+              !defaultCredential.inputs.vault_id) ||
+            (selectedCredential.inputs.vault_id &&
+              defaultCredential.inputs.vault_id &&
+              selectedCredential.inputs.vault_id ===
+                defaultCredential.inputs.vault_id)
+          );
+        })
+      ) {
+        missingCredentialTypes.push(
+          defaultCredential.inputs.vault_id
+            ? `${defaultCredential.summary_fields.credential_type.name} | ${defaultCredential.inputs.vault_id}`
+            : defaultCredential.summary_fields.credential_type.name
+        );
+      }
+    });
+
+    if (missingCredentialTypes.length > 0) {
+      return i18n._(
+        t`Job Template default credentials must be replaced with one of the same type.  Please select a credential for the following types in order to proceed: ${missingCredentialTypes.join(
+          ', '
+        )}`
+      );
+    }
+  }
+
+  if (!allowCredentialsWithPasswords && selectedCredentials) {
+    const credentialsThatPrompt = [];
+    selectedCredentials.forEach(selectedCredential => {
+      if (credentialPromptsForPassword(selectedCredential)) {
+        credentialsThatPrompt.push(selectedCredential.name);
+      }
+    });
+    if (credentialsThatPrompt.length > 0) {
+      return i18n._(
+        t`Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: ${credentialsThatPrompt.join(
+          ', '
+        )}`
+      );
+    }
+  }
+
+  return undefined;
+}

--- a/awx/ui_next/src/components/LaunchPrompt/useLaunchSteps.js
+++ b/awx/ui_next/src/components/LaunchPrompt/useLaunchSteps.js
@@ -43,14 +43,21 @@ export default function useLaunchSteps(
   launchConfig,
   surveyConfig,
   resource,
-  i18n
+  i18n,
+  resourceDefaultCredentials
 ) {
   const [visited, setVisited] = useState({});
   const [isReady, setIsReady] = useState(false);
   const { touched, values: formikValues } = useFormikContext();
   const steps = [
     useInventoryStep(launchConfig, resource, i18n, visited),
-    useCredentialsStep(launchConfig, resource, i18n),
+    useCredentialsStep(
+      launchConfig,
+      resource,
+      resourceDefaultCredentials,
+      i18n,
+      true
+    ),
     useCredentialPasswordsStep(
       launchConfig,
       i18n,

--- a/awx/ui_next/src/components/Schedule/Schedule.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.jsx
@@ -26,6 +26,7 @@ function Schedule({
   launchConfig,
   surveyConfig,
   hasDaysToKeepField,
+  resourceDefaultCredentials,
 }) {
   const { scheduleId } = useParams();
 
@@ -114,6 +115,7 @@ function Schedule({
               resource={resource}
               launchConfig={launchConfig}
               surveyConfig={surveyConfig}
+              resourceDefaultCredentials={resourceDefaultCredentials}
             />
           </Route>,
           <Route

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.jsx
@@ -22,6 +22,7 @@ function ScheduleAdd({
   launchConfig,
   surveyConfig,
   hasDaysToKeepField,
+  resourceDefaultCredentials,
 }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const history = useHistory();
@@ -117,6 +118,7 @@ function ScheduleAdd({
           launchConfig={launchConfig}
           surveyConfig={surveyConfig}
           resource={resource}
+          resourceDefaultCredentials={resourceDefaultCredentials}
         />
       </CardBody>
     </Card>

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.jsx
@@ -22,6 +22,7 @@ function ScheduleEdit({
   resource,
   launchConfig,
   surveyConfig,
+  resourceDefaultCredentials,
 }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const history = useHistory();
@@ -131,6 +132,7 @@ function ScheduleEdit({
           resource={resource}
           launchConfig={launchConfig}
           surveyConfig={surveyConfig}
+          resourceDefaultCredentials={resourceDefaultCredentials}
         />
       </CardBody>
     </Card>

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
@@ -30,8 +30,20 @@ SchedulesAPI.readZoneInfo.mockResolvedValue({
 SchedulesAPI.readCredentials.mockResolvedValue({
   data: {
     results: [
-      { name: 'schedule credential 1', id: 1, kind: 'vault' },
-      { name: 'schedule credential 2', id: 2, kind: 'aws' },
+      {
+        name: 'schedule credential 1',
+        id: 1,
+        kind: 'vault',
+        credential_type: 3,
+        inputs: {},
+      },
+      {
+        name: 'schedule credential 2',
+        id: 2,
+        kind: 'aws',
+        credential_type: 4,
+        inputs: {},
+      },
     ],
     count: 2,
   },
@@ -45,9 +57,9 @@ CredentialsAPI.read.mockResolvedValue({
   data: {
     count: 3,
     results: [
-      { id: 1, name: 'Credential 1', kind: 'ssh', url: '' },
-      { id: 2, name: 'Credential 2', kind: 'ssh', url: '' },
-      { id: 3, name: 'Credential 3', kind: 'ssh', url: '' },
+      { id: 1, name: 'Credential 1', kind: 'ssh', url: '', credential_type: 1 },
+      { id: 2, name: 'Credential 2', kind: 'ssh', url: '', credential_type: 1 },
+      { id: 3, name: 'Credential 3', kind: 'ssh', url: '', credential_type: 1 },
     ],
   },
 });
@@ -115,6 +127,7 @@ describe('<ScheduleEdit />', () => {
               ],
             },
           }}
+          resourceDefaultCredentials={[]}
           launchConfig={{
             can_start_without_user_input: false,
             passwords_needed_to_start: [],
@@ -150,6 +163,7 @@ describe('<ScheduleEdit />', () => {
                 id: null,
               },
               scm_branch: '',
+              credentials: [],
             },
           }}
           surveyConfig={{}}
@@ -466,7 +480,7 @@ describe('<ScheduleEdit />', () => {
         .prop('isCurrent')
     ).toBe(true);
 
-    expect(wrapper.find('CredentialChip').length).toBe(3);
+    expect(wrapper.find('CredentialChip').length).toBe(2);
 
     wrapper.update();
 

--- a/awx/ui_next/src/components/Schedule/Schedules.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedules.jsx
@@ -13,6 +13,7 @@ function Schedules({
   launchConfig,
   surveyConfig,
   resource,
+  resourceDefaultCredentials,
 }) {
   const match = useRouteMatch();
 
@@ -32,6 +33,7 @@ function Schedules({
           resource={resource}
           launchConfig={launchConfig}
           surveyConfig={surveyConfig}
+          resourceDefaultCredentials={resourceDefaultCredentials}
         />
       </Route>
       <Route key="details" path={`${match.path}/:scheduleId`}>
@@ -41,6 +43,7 @@ function Schedules({
           resource={resource}
           launchConfig={launchConfig}
           surveyConfig={surveyConfig}
+          resourceDefaultCredentials={resourceDefaultCredentials}
         />
       </Route>
       <Route key="list" path={`${match.path}`}>

--- a/awx/ui_next/src/components/Schedule/shared/SchedulePromptableFields.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/SchedulePromptableFields.jsx
@@ -17,10 +17,10 @@ function SchedulePromptableFields({
   onSave,
   credentials,
   resource,
+  resourceDefaultCredentials,
   i18n,
 }) {
   const {
-    validateForm,
     setFieldTouched,
     values,
     initialValues,
@@ -39,12 +39,12 @@ function SchedulePromptableFields({
     schedule,
     resource,
     i18n,
-    credentials
+    credentials,
+    resourceDefaultCredentials
   );
 
   const { error, dismissError } = useDismissableError(contentError);
   const cancelPromptableValues = async () => {
-    const hasErrors = await validateForm();
     resetForm({
       values: {
         ...initialValues,
@@ -66,7 +66,7 @@ function SchedulePromptableFields({
         timezone: values.timezone,
       },
     });
-    onCloseWizard(Object.keys(hasErrors).length > 0);
+    onCloseWizard();
   };
 
   if (error) {
@@ -89,13 +89,16 @@ function SchedulePromptableFields({
       isOpen
       onClose={cancelPromptableValues}
       onSave={onSave}
+      onBack={async nextStep => {
+        validateStep(nextStep.id);
+      }}
       onNext={async (nextStep, prevStep) => {
         if (nextStep.id === 'preview') {
           visitAllSteps(setFieldTouched);
         } else {
           visitStep(prevStep.prevId, setFieldTouched);
+          validateStep(nextStep.id);
         }
-        await validateForm();
       }}
       onGoToStep={async (nextStep, prevStep) => {
         if (nextStep.id === 'preview') {
@@ -104,7 +107,6 @@ function SchedulePromptableFields({
           visitStep(prevStep.prevId, setFieldTouched);
           validateStep(nextStep.id);
         }
-        await validateForm();
       }}
       title={i18n._(t`Prompts`)}
       steps={

--- a/awx/ui_next/src/components/SelectedList/SelectedList.jsx
+++ b/awx/ui_next/src/components/SelectedList/SelectedList.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import ChipGroup from '../ChipGroup';
 
 const Split = styled(PFSplit)`
-  margin: 20px 0 5px 0;
+  margin: 20px 0 5px 0 !important;
   align-items: baseline;
 `;
 

--- a/awx/ui_next/src/screens/Template/Template.jsx
+++ b/awx/ui_next/src/screens/Template/Template.jsx
@@ -32,7 +32,13 @@ function Template({ i18n, setBreadcrumb }) {
   const { me = {} } = useConfig();
 
   const {
-    result: { isNotifAdmin, template, surveyConfig, launchConfig },
+    result: {
+      isNotifAdmin,
+      template,
+      surveyConfig,
+      launchConfig,
+      resourceDefaultCredentials,
+    },
     isLoading,
     error: contentError,
     request: loadTemplateAndRoles,
@@ -40,11 +46,17 @@ function Template({ i18n, setBreadcrumb }) {
     useCallback(async () => {
       const [
         { data },
+        {
+          data: { results: defaultCredentials },
+        },
         actions,
         notifAdminRes,
         { data: launchConfiguration },
       ] = await Promise.all([
         JobTemplatesAPI.readDetail(templateId),
+        JobTemplatesAPI.readCredentials(templateId, {
+          page_size: 200,
+        }),
         JobTemplatesAPI.readTemplateOptions(templateId),
         OrganizationsAPI.read({
           page_size: 1,
@@ -52,7 +64,7 @@ function Template({ i18n, setBreadcrumb }) {
         }),
         JobTemplatesAPI.readLaunch(templateId),
       ]);
-      let surveyConfiguration = null;
+      let surveyConfiguration = {};
 
       if (data.survey_enabled) {
         const { data: survey } = await JobTemplatesAPI.readSurvey(templateId);
@@ -86,9 +98,10 @@ function Template({ i18n, setBreadcrumb }) {
         isNotifAdmin: notifAdminRes.data.results.length > 0,
         surveyConfig: surveyConfiguration,
         launchConfig: launchConfiguration,
+        resourceDefaultCredentials: defaultCredentials,
       };
     }, [templateId]),
-    { isNotifAdmin: false, template: null }
+    { isNotifAdmin: false, template: null, resourceDefaultCredentials: [] }
   );
 
   useEffect(() => {
@@ -221,6 +234,7 @@ function Template({ i18n, setBreadcrumb }) {
                 loadScheduleOptions={loadScheduleOptions}
                 surveyConfig={surveyConfig}
                 launchConfig={launchConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
               />
             </Route>
             {canSeeNotificationsTab && (

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx
@@ -41,6 +41,7 @@ function NodeModalForm({
   launchConfig,
   surveyConfig,
   isLaunchLoading,
+  resourceDefaultCredentials,
 }) {
   const history = useHistory();
   const dispatch = useContext(WorkflowDispatchContext);
@@ -69,7 +70,8 @@ function NodeModalForm({
     surveyConfig,
     i18n,
     values.nodeResource,
-    askLinkType
+    askLinkType,
+    resourceDefaultCredentials
   );
 
   const handleSaveNode = () => {
@@ -229,7 +231,7 @@ const NodeModalInner = ({ i18n, title, ...rest }) => {
   const {
     request: readLaunchConfigs,
     error: launchConfigError,
-    result: { launchConfig, surveyConfig },
+    result: { launchConfig, surveyConfig, resourceDefaultCredentials },
     isLoading,
   } = useRequest(
     useCallback(async () => {
@@ -247,6 +249,7 @@ const NodeModalInner = ({ i18n, title, ...rest }) => {
         return {
           launchConfig: {},
           surveyConfig: {},
+          resourceDefaultCredentials: [],
         };
       }
 
@@ -267,9 +270,21 @@ const NodeModalInner = ({ i18n, title, ...rest }) => {
         survey = data;
       }
 
+      let defaultCredentials = [];
+
+      if (launch.ask_credential_on_launch) {
+        const {
+          data: { results },
+        } = await JobTemplatesAPI.readCredentials(values?.nodeResource?.id, {
+          page_size: 200,
+        });
+        defaultCredentials = results;
+      }
+
       return {
         launchConfig: launch,
         surveyConfig: survey,
+        resourceDefaultCredentials: defaultCredentials,
       };
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -319,6 +334,7 @@ const NodeModalInner = ({ i18n, title, ...rest }) => {
       {...rest}
       launchConfig={launchConfig}
       surveyConfig={surveyConfig}
+      resourceDefaultCredentials={resourceDefaultCredentials}
       isLaunchLoading={isLoading}
       title={wizardTitle}
       i18n={i18n}

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
@@ -115,6 +115,11 @@ describe('NodeModal', () => {
       },
     });
     JobTemplatesAPI.readLaunch.mockResolvedValue({ data: jtLaunchConfig });
+    JobTemplatesAPI.readCredentials.mockResolvedValue({
+      data: {
+        results: [],
+      },
+    });
     JobTemplatesAPI.readSurvey.mockResolvedValue({
       data: {
         name: '',
@@ -239,7 +244,12 @@ describe('NodeModal', () => {
                 nodeToEdit: null,
               }}
             >
-              <NodeModal askLinkType onSave={onSave} title="Add Node" />
+              <NodeModal
+                askLinkType
+                onSave={onSave}
+                title="Add Node"
+                resourceDefaultCredentials={[]}
+              />
             </WorkflowStateContext.Provider>
           </WorkflowDispatchContext.Provider>
         );
@@ -254,8 +264,9 @@ describe('NodeModal', () => {
 
     test('Can successfully create a new job template node', async () => {
       act(() => {
-        wrapper.find('#link-type-always').simulate('click');
+        wrapper.find('SelectableCard#link-type-always').simulate('click');
       });
+      wrapper.update();
       await act(async () => {
         wrapper.find('button#next-node-modal').simulate('click');
       });
@@ -271,6 +282,9 @@ describe('NodeModal', () => {
       wrapper.update();
 
       expect(JobTemplatesAPI.readLaunch).toBeCalledWith(1);
+      expect(JobTemplatesAPI.readCredentials).toBeCalledWith(1, {
+        page_size: 200,
+      });
       expect(JobTemplatesAPI.readSurvey).toBeCalledWith(25);
       wrapper.update();
       expect(wrapper.find('NodeNextButton').prop('buttonText')).toBe('Next');
@@ -281,11 +295,6 @@ describe('NodeModal', () => {
       await act(async () => {
         wrapper.find('button#next-node-modal').simulate('click');
       });
-
-      wrapper.update();
-
-      expect(JobTemplatesAPI.readLaunch).toBeCalledWith(1);
-      expect(JobTemplatesAPI.readSurvey).toBeCalledWith(25);
       wrapper.update();
       expect(wrapper.find('NodeNextButton').prop('buttonText')).toBe('Save');
       act(() => {
@@ -317,7 +326,7 @@ describe('NodeModal', () => {
 
     test('Can successfully create a new project sync node', async () => {
       act(() => {
-        wrapper.find('#link-type-failure').simulate('click');
+        wrapper.find('SelectableCard#link-type-failure').simulate('click');
       });
       await act(async () => {
         wrapper.find('button#next-node-modal').simulate('click');
@@ -352,7 +361,7 @@ describe('NodeModal', () => {
 
     test('Can successfully create a new inventory source sync node', async () => {
       act(() => {
-        wrapper.find('#link-type-failure').simulate('click');
+        wrapper.find('SelectableCard#link-type-failure').simulate('click');
       });
       await act(async () => {
         wrapper.find('button#next-node-modal').simulate('click');
@@ -446,7 +455,7 @@ describe('NodeModal', () => {
 
     test('Can successfully create a new approval template node', async () => {
       act(() => {
-        wrapper.find('#link-type-always').simulate('click');
+        wrapper.find('SelectableCard#link-type-always').simulate('click');
       });
       await act(async () => {
         wrapper.find('button#next-node-modal').simulate('click');
@@ -543,6 +552,7 @@ describe('NodeModal', () => {
                 askLinkType={false}
                 onSave={onSave}
                 title="Edit Node"
+                resourceDefaultCredentials={[]}
               />
             </WorkflowStateContext.Provider>
           </WorkflowDispatchContext.Provider>
@@ -629,6 +639,7 @@ describe('NodeModal', () => {
                 askLinkType={false}
                 onSave={onSave}
                 title="Edit Node"
+                resourceDefaultCredentials={[]}
               />
             </WorkflowStateContext.Provider>
           </WorkflowDispatchContext.Provider>

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router-dom';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
 import { func, shape } from 'prop-types';
-import { Tooltip } from '@patternfly/react-core';
 import { JobTemplatesAPI } from '../../../../../../api';
 import { getQSConfig, parseQueryString } from '../../../../../../util/qs';
 import useRequest from '../../../../../../util/useRequest';
@@ -57,56 +56,26 @@ function JobTemplatesList({ i18n, nodeResource, onUpdateNodeResource }) {
     fetchJobTemplates();
   }, [fetchJobTemplates]);
 
-  const onSelectRow = row => {
-    if (
-      row.project &&
-      row.project !== null &&
-      ((row.inventory && row.inventory !== null) || row.ask_inventory_on_launch)
-    ) {
-      onUpdateNodeResource(row);
-    }
-  };
-
   return (
     <PaginatedDataList
       contentError={error}
       hasContentLoading={isLoading}
       itemCount={count}
       items={jobTemplates}
-      onRowClick={row => onSelectRow(row)}
+      onRowClick={row => onUpdateNodeResource(row)}
       qsConfig={QS_CONFIG}
-      renderItem={item => {
-        const isDisabled =
-          !item.project ||
-          item.project === null ||
-          ((!item.inventory || item.inventory === null) &&
-            !item.ask_inventory_on_launch);
-        const listItem = (
-          <CheckboxListItem
-            isDisabled={isDisabled}
-            isSelected={!!(nodeResource && nodeResource.id === item.id)}
-            itemId={item.id}
-            key={`${item.id}-listItem`}
-            name={item.name}
-            label={item.name}
-            onSelect={() => onSelectRow(item)}
-            onDeselect={() => onUpdateNodeResource(null)}
-            isRadio
-          />
-        );
-        return isDisabled ? (
-          <Tooltip
-            key={`${item.id}-tooltip`}
-            content={i18n._(
-              t`Job Templates with a missing inventory or project cannot be selected when creating or editing nodes`
-            )}
-          >
-            {listItem}
-          </Tooltip>
-        ) : (
-          listItem
-        );
-      }}
+      renderItem={item => (
+        <CheckboxListItem
+          isSelected={!!(nodeResource && nodeResource.id === item.id)}
+          itemId={item.id}
+          key={`${item.id}-listItem`}
+          name={item.name}
+          label={item.name}
+          onSelect={() => onUpdateNodeResource(item)}
+          onDeselect={() => onUpdateNodeResource(null)}
+          isRadio
+        />
+      )}
       renderToolbar={props => <DataListToolbar {...props} fillWidth />}
       showPageSizeOptions={false}
       toolbarSearchColumns={[

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
@@ -61,21 +61,14 @@ describe('JobTemplatesList', () => {
       );
     });
     wrapper.update();
+    // expect(wrapper.debug()).toBe(false);
     expect(
       wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
         .isSelected
     ).toBe(true);
     expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
-        .isDisabled
-    ).toBe(false);
-    expect(
       wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
         .isSelected
-    ).toBe(false);
-    expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
-        .isDisabled
     ).toBe(false);
     wrapper
       .find('CheckboxListItem[name="Test Job Template 2"]')
@@ -88,71 +81,6 @@ describe('JobTemplatesList', () => {
       inventory: 1,
       project: 2,
     });
-  });
-  test('Row disabled when job template missing inventory or project', async () => {
-    JobTemplatesAPI.read.mockResolvedValueOnce({
-      data: {
-        count: 2,
-        results: [
-          {
-            id: 1,
-            name: 'Test Job Template',
-            type: 'job_template',
-            url: '/api/v2/job_templates/1',
-            inventory: 1,
-            project: null,
-            ask_inventory_on_launch: false,
-          },
-          {
-            id: 2,
-            name: 'Test Job Template 2',
-            type: 'job_template',
-            url: '/api/v2/job_templates/2',
-            inventory: null,
-            project: 2,
-            ask_inventory_on_launch: false,
-          },
-        ],
-      },
-    });
-    JobTemplatesAPI.readOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <JobTemplatesList
-          nodeResource={nodeResource}
-          onUpdateNodeResource={onUpdateNodeResource}
-        />
-      );
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
-        .isSelected
-    ).toBe(true);
-    expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template"]').props()
-        .isDisabled
-    ).toBe(true);
-    expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
-        .isSelected
-    ).toBe(false);
-    expect(
-      wrapper.find('CheckboxListItem[name="Test Job Template 2"]').props()
-        .isDisabled
-    ).toBe(true);
-    wrapper
-      .find('CheckboxListItem[name="Test Job Template 2"]')
-      .simulate('click');
-    expect(onUpdateNodeResource).not.toHaveBeenCalled();
   });
   test('Error shown when read() request errors', async () => {
     JobTemplatesAPI.read.mockRejectedValue(new Error());

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx
@@ -4,7 +4,7 @@ import { withI18n } from '@lingui/react';
 import { t, Trans } from '@lingui/macro';
 import styled from 'styled-components';
 import { useField } from 'formik';
-import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+import { Alert, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { required } from '../../../../../../util/validators';
 
 import { FormFullWidthLayout } from '../../../../../../components/FormLayout';
@@ -14,6 +14,10 @@ import JobTemplatesList from './JobTemplatesList';
 import ProjectsList from './ProjectsList';
 import WorkflowJobTemplatesList from './WorkflowJobTemplatesList';
 import FormField from '../../../../../../components/FormField';
+
+const NodeTypeErrorAlert = styled(Alert)`
+  margin-bottom: 20px;
+`;
 
 const TimeoutInput = styled(TextInput)`
   width: 200px;
@@ -29,7 +33,9 @@ const TimeoutLabel = styled.p`
 
 function NodeTypeStep({ i18n }) {
   const [nodeTypeField, , nodeTypeHelpers] = useField('nodeType');
-  const [nodeResourceField, , nodeResourceHelpers] = useField('nodeResource');
+  const [nodeResourceField, nodeResourceMeta, nodeResourceHelpers] = useField(
+    'nodeResource'
+  );
   const [, approvalNameMeta, approvalNameHelpers] = useField('approvalName');
   const [, , approvalDescriptionHelpers] = useField('approvalDescription');
   const [timeoutMinutesField, , timeoutMinutesHelpers] = useField(
@@ -42,6 +48,13 @@ function NodeTypeStep({ i18n }) {
   const isValid = !approvalNameMeta.touched || !approvalNameMeta.error;
   return (
     <>
+      {nodeResourceMeta.error && (
+        <NodeTypeErrorAlert
+          variant="danger"
+          isInline
+          title={nodeResourceMeta.error}
+        />
+      )}
       <div css="display: flex; align-items: center; margin-bottom: 20px;">
         <b css="margin-right: 24px">{i18n._(t`Node Type`)}</b>
         <div>


### PR DESCRIPTION
##### SUMMARY
link #8921 

If a user selects a job template with default credentials that prompt for passwords (but does not prompt for credentials) then the user should not be allowed to create the node and a different JT must be selected:

<img width="1317" alt="Screen Shot 2021-03-18 at 9 33 14 AM" src="https://user-images.githubusercontent.com/9889020/111634699-22fd4080-87cd-11eb-856a-e26dd2633d47.png">

If a user selects a credential that prompts for passwords when creating/editing a workflow node or schedule then we show this error:

<img width="1268" alt="Screen Shot 2021-03-18 at 9 48 43 AM" src="https://user-images.githubusercontent.com/9889020/111636747-25f93080-87cf-11eb-88e7-16017cf65d4f.png">

If a user removes a credential that exists in the default collection of credentials on the JT then it must be replaced.  This is the error we show:

<img width="1294" alt="Screen Shot 2021-03-18 at 9 49 49 AM" src="https://user-images.githubusercontent.com/9889020/111636904-4cb76700-87cf-11eb-999e-188fc2eb61ff.png">

If a user attempts to create a schedule for a job template with default credentials that prompt (but does not prompt for credentials) then the API responds with this error:

<img width="1501" alt="Screen Shot 2021-03-18 at 9 45 06 AM" src="https://user-images.githubusercontent.com/9889020/111636342-c3079980-87ce-11eb-973c-f0b325e67c22.png">

I believe this UX is consistent with the old UI but I am double checking that now.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
