### PR TITLE
Fix service reference error for cred plugin dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,7 @@ docker-compose: docker-auth awx/projects docker-compose-sources
 
 docker-compose-credential-plugins: docker-auth awx/projects docker-compose-sources
 	echo -e "\033[0;31mTo generate a CyberArk Conjur API key: docker exec -it tools_conjur_1 conjurctl account create quick-start\033[0m"
-	docker-compose -f tools/docker-compose/_sources/docker-compose.yml -f tools/docker-credential-plugins-override.yml up --no-recreate awx
+	docker-compose -f tools/docker-compose/_sources/docker-compose.yml -f tools/docker-credential-plugins-override.yml up --no-recreate awx_1
 
 docker-compose-test: docker-auth awx/projects docker-compose-sources
 	docker-compose -f tools/docker-compose/_sources/docker-compose.yml run --rm --service-ports awx_1 /bin/bash

--- a/tools/docker-credential-plugins-override.yml
+++ b/tools/docker-credential-plugins-override.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   # Primary Tower Development Container link
-  awx:
+  awx_1:
     links:
       - hashivault
       - conjur


### PR DESCRIPTION
##### SUMMARY
Intended to fix the error I see when running `COMPOSE_TAG=devel make docker-compose-credential-plugins`:

![Screenshot from 2021-03-23 08-30-24](https://user-images.githubusercontent.com/9753817/112152920-2c195380-8bb9-11eb-8430-4e4f2b62b30f.png)
