### PR TITLE
surface jobs.extra_vars in custom notification templates

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -345,6 +345,7 @@ class JobNotificationMixin(object):
                 'launch_type': 'workflow',
                 'limit': 'bar_limit',
                 'modified': datetime.datetime(2018, 12, 13, 6, 4, 0, 0, tzinfo=datetime.timezone.utc),
+                'extra_vars': {'foo': 'bar'},
                 'name': 'Stub JobTemplate',
                 'playbook': 'ping.yml',
                 'scm_branch': '',
@@ -434,12 +435,18 @@ class JobNotificationMixin(object):
                 if event:
                     summary = event.get_host_status_counts()
         job_context['host_status_counts'] = summary
+        notification_data = self.notification_data()
         context = {
             'job': job_context,
             'job_friendly_name': self.get_notification_friendly_name(),
             'url': self.get_ui_url(),
-            'job_metadata': json.dumps(self.notification_data(), ensure_ascii=False, indent=4),
+            'job_metadata': json.dumps(notification_data, ensure_ascii=False, indent=4),
         }
+        # if notification_data includes extra_vars, associate that with the job field as well
+        # Note: self.notification_data() uses LaunchTimeConfig.display_extra_vars to filter
+        # out fields marked as passwords in a survery.
+        if 'extra_vars' in notification_data:
+            context['job']['extra_vars'] = notification_data['extra_vars']
 
         def build_context(node, fields, allowed_fields):
             for safe_field in allowed_fields:

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -120,7 +120,6 @@ class TestJobNotificationMixin(object):
     @pytest.mark.django_db
     def test_schedule_context(self, job_template, admin_user):
         schedule = Schedule.objects.create(name='job-schedule', rrule='DTSTART:20171129T155939z\nFREQ=MONTHLY', unified_job_template=job_template)
-        kwargs = {}
         job = Job.objects.create(name='fake-job', launch_type='workflow', schedule=schedule, job_template=job_template, extra_vars={'foo': 'bar'})
 
         job_serialization = UnifiedJobSerializer(job).to_representation(job)

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -35,6 +35,7 @@ class TestJobNotificationMixin(object):
             'launch_type': str,
             'limit': str,
             'modified': datetime.datetime,
+            'extra_vars': dict,
             'name': str,
             'playbook': str,
             'scm_branch': str,
@@ -102,6 +103,8 @@ class TestJobNotificationMixin(object):
         """The Jinja context defines all of the fields that can be used by a template. Ensure that the context generated
         for each job type has the expected structure."""
         kwargs = {}
+        if JobClass in (AdHocCommand, Job, SystemJob, WorkflowJob):
+            kwargs['extra_vars'] = {'foo': 'bar'}
         if JobClass is InventoryUpdate:
             kwargs['inventory_source'] = inventory_source
             kwargs['source'] = inventory_source.source
@@ -117,7 +120,8 @@ class TestJobNotificationMixin(object):
     @pytest.mark.django_db
     def test_schedule_context(self, job_template, admin_user):
         schedule = Schedule.objects.create(name='job-schedule', rrule='DTSTART:20171129T155939z\nFREQ=MONTHLY', unified_job_template=job_template)
-        job = Job.objects.create(name='fake-job', launch_type='workflow', schedule=schedule, job_template=job_template)
+        kwargs = {}
+        job = Job.objects.create(name='fake-job', launch_type='workflow', schedule=schedule, job_template=job_template, extra_vars={'foo': 'bar'})
 
         job_serialization = UnifiedJobSerializer(job).to_representation(job)
 


### PR DESCRIPTION
We're already surfacing (a filtered version of) extra_vars in `{{ job_metadata }}` for webhooks. This surfaces the same information in `job.extra_vars`.

Related:
https://github.com/ansible/awx/issues/4539

---

Given job with extra vars set to:
```
---
key_for_value: simple_value
key_for_list:
- list_item1
- list_item2
- list_item3
key_for_dict:
  subkey1: subvalue1
  subkey2: subvalue2
  subkey3: subvalue3
```

And custom NT with message set to:
`Job #{{ job.id }} extra vars: {{ job.extra_vars }}`

Delivers notification:
`Job #15 extra vars: {"key_for_value": "simple_value", "key_for_list": ["list_item1", "list_item2", "list_item3"], "key_for_dict": {"subkey1": "subvalue1", "subkey2": "subvalue2", "subkey3": "subvalue3"}}`