### PR TITLE
Pull with credentials from protected registries

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1412,6 +1412,11 @@ class ExecutionEnvironmentSerializer(BaseSerializer):
             res['credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.credential.pk})
         return res
 
+    def validate_credential(self, value):
+        if value and value.kind != 'registry':
+            raise serializers.ValidationError(_('Only Container Registry credentials can be associated with an Execution Environment'))
+        return value
+
     def validate(self, attrs):
         # prevent changing organization of ee. Unsetting (change to null) is allowed
         if self.instance:

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1106,7 +1106,7 @@ ManagedCredentialType(
             },
             {
                 'id': 'password',
-                'label': ugettext_noop('Password'),
+                'label': ugettext_noop('Password or Token'),
                 'type': 'string',
                 'secret': True,
                 'help_text': ugettext_noop('A password or token used to authenticate with'),

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -297,8 +297,11 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
 
     def has_inputs(self, field_names=()):
         for name in field_names:
-            if name not in self.inputs:
-                return False
+            if name in self.inputs:
+                if self.inputs[name] in ('', None):
+                    return False
+            else:
+                raise ValueError('{} is not an input field'.format(name))
         return True
 
     def _get_dynamic_input(self, field_name):

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -295,6 +295,12 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
             return True
         return field_name in self.inputs and self.inputs[field_name] not in ('', None)
 
+    def has_inputs(self, field_names=()):
+        for name in field_names:
+            if name not in self.inputs:
+                return False
+        return True
+
     def _get_dynamic_input(self, field_name):
         for input_source in self.input_sources.all():
             if input_source.input_field_name == field_name:
@@ -1096,11 +1102,11 @@ ManagedCredentialType(
                 'type': 'string',
             },
             {
-                'id': 'password/token',
-                'label': ugettext_noop('Password/Token'),
+                'id': 'password',
+                'label': ugettext_noop('Password'),
                 'type': 'string',
                 'secret': True,
-                'help_text': ugettext_noop('A token to use to authenticate with. ' 'This should not be set if username/password are being used.'),
+                'help_text': ugettext_noop('A password or token used to authenticate with'),
             },
         ],
         'required': ['host'],

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1096,14 +1096,8 @@ ManagedCredentialType(
                 'type': 'string',
             },
             {
-                'id': 'password',
-                'label': ugettext_noop('Password'),
-                'type': 'string',
-                'secret': True,
-            },
-            {
-                'id': 'token',
-                'label': ugettext_noop('Access Token'),
+                'id': 'password/token',
+                'label': ugettext_noop('Password/Token'),
                 'type': 'string',
                 'secret': True,
                 'help_text': ugettext_noop('A token to use to authenticate with. ' 'This should not be set if username/password are being used.'),

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -834,7 +834,7 @@ class BaseTask(object):
         """
         return os.path.abspath(os.path.join(os.path.dirname(__file__), *args))
 
-    def build_execution_environment_params(self, instance):
+    def build_execution_environment_params(self, instance, private_data_dir):
         if settings.IS_K8S:
             return {}
 
@@ -854,7 +854,7 @@ class BaseTask(object):
         if instance.execution_environment.credential:
             cred = instance.execution_environment.credential
             if cred.has_inputs(field_names=('host', 'username', 'password')):
-                path = self.build_private_data_dir(instance)
+                path = os.path.split(private_data_dir)[0]
                 with open(path + '/auth.json', 'w') as authfile:
                     host = cred.get_input('host')
                     username = cred.get_input('username')
@@ -866,7 +866,7 @@ class BaseTask(object):
                 os.chmod(authfile.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
                 params["container_options"].append(f'--authfile={authfile.name}')
             else:
-                logger.exception('Please recheck that your host, username, and password fields are all filled.')
+                raise RuntimeError('Please recheck that your host, username, and password fields are all filled.')
 
         pull = instance.execution_environment.pull
         if pull:
@@ -1726,11 +1726,11 @@ class RunJob(BaseTask):
         """
         return settings.AWX_RESOURCE_PROFILING_ENABLED
 
-    def build_execution_environment_params(self, instance):
+    def build_execution_environment_params(self, instance, private_data_dir):
         if settings.IS_K8S:
             return {}
 
-        params = super(RunJob, self).build_execution_environment_params(instance)
+        params = super(RunJob, self).build_execution_environment_params(instance, private_data_dir)
         # If this has an insights agent and it is not already mounted then show it
         insights_dir = os.path.dirname(settings.INSIGHTS_SYSTEM_ID_FILE)
         if instance.use_fact_cache and os.path.exists(insights_dir):
@@ -2341,11 +2341,11 @@ class RunProjectUpdate(BaseTask):
             if status == 'successful' and instance.launch_type != 'sync':
                 self._update_dependent_inventories(instance, dependent_inventory_sources)
 
-    def build_execution_environment_params(self, instance):
+    def build_execution_environment_params(self, instance, private_data_dir):
         if settings.IS_K8S:
             return {}
 
-        params = super(RunProjectUpdate, self).build_execution_environment_params(instance)
+        params = super(RunProjectUpdate, self).build_execution_environment_params(instance, private_data_dir)
         project_path = instance.get_project_path(check_if_exists=False)
         cache_path = instance.get_cache_path()
         params.setdefault('container_volume_mounts', [])
@@ -2848,7 +2848,7 @@ class RunSystemJob(BaseTask):
     event_model = SystemJobEvent
     event_data_key = 'system_job_id'
 
-    def build_execution_environment_params(self, system_job):
+    def build_execution_environment_params(self, system_job, private_data_dir):
         return {}
 
     def build_args(self, system_job, private_data_dir, passwords):
@@ -2964,7 +2964,7 @@ class AWXReceptorJob:
         self.unit_id = None
 
         if self.task and not self.task.instance.is_container_group_task:
-            execution_environment_params = self.task.build_execution_environment_params(self.task.instance)
+            execution_environment_params = self.task.build_execution_environment_params(self.task.instance, runner_params['private_data_dir'])
             self.runner_params['settings'].update(execution_environment_params)
 
     def run(self):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -852,15 +852,21 @@ class BaseTask(object):
         }
 
         if instance.execution_environment.credential:
-            with open('/tmp/auth.json', 'w') as authfile:
-                host = instance.execution_environment.credential.get_input('host')
-                username = instance.execution_environment.credential.get_input('username')
-                password = instance.execution_environment.credential.get_input('password')
-                token = "{}:{}".format(username, password)
-                auth_data = {'auths': {host: {'auth': b64encode(token.encode('ascii')).decode()}}}
-                authfile.write(json.dumps(auth_data, indent=4))
-            authfile.close()
-            params["container_options"].append(f'--authfile={authfile.name}')
+            cred = instance.execution_environment.credential
+            if cred.has_inputs(field_names=('host', 'username', 'password')):
+                path = self.build_private_data_dir(instance)
+                with open(path + '/auth.json', 'w') as authfile:
+                    host = cred.get_input('host')
+                    username = cred.get_input('username')
+                    password = cred.get_input('password')
+                    token = "{}:{}".format(username, password)
+                    auth_data = {'auths': {host: {'auth': b64encode(token.encode('ascii')).decode()}}}
+                    authfile.write(json.dumps(auth_data, indent=4))
+                authfile.close()
+                os.chmod(authfile.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+                params["container_options"].append(f'--authfile={authfile.name}')
+            else:
+                logger.exception('Please recheck that your host, username, and password fields are all filled.')
 
         pull = instance.execution_environment.pull
         if pull:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -851,6 +851,17 @@ class BaseTask(object):
             "container_options": ['--user=root'],
         }
 
+        if instance.execution_environment.credential:
+            with open('/tmp/auth.json', 'w') as authfile:
+                host = instance.execution_environment.credential.get_input('host')
+                username = instance.execution_environment.credential.get_input('username')
+                password = instance.execution_environment.credential.get_input('password')
+                token = "{}:{}".format(username, password)
+                auth_data = {'auths': {host: {'auth': b64encode(token.encode('ascii')).decode()}}}
+                authfile.write(json.dumps(auth_data, indent=4))
+            authfile.close()
+            params["container_options"].append(f'--authfile={authfile.name}')
+
         pull = instance.execution_environment.pull
         if pull:
             params['container_options'].append(f'--pull={pull}')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
relates to #7066
if a credential is associated with an EE this will create a JSON authfile that is then passed with the pull request to the host of the registry
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 18.0.0
```


----
#### TODOs
- [x] Remove separate `token` field from the registry credential. 
- [x] Rename the existing password field to say "password/token"
- [x] Ensure only registry credentials can be associated with an EE https://github.com/ansible/awx/issues/9628
- [x] Write out the `auth.json` file to the `pdd_wrapper_` directory. https://github.com/ansible/awx/pull/9683#issuecomment-808254962
- [x] Use secure permissions for `auth.json` https://github.com/ansible/awx/pull/9683#discussion_r600645653