### PR TITLE
Set a custom name for Docker volumes

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -87,8 +87,11 @@ services:
       - "awx_db:/var/lib/postgresql/data"
 volumes:
   awx_db:
+    name: tools_awx_db
 {% for i in range(cluster_node_count|int) -%}
   {% set container_postfix = loop.index %}
   receptor_{{ container_postfix }}:
+    name: tools_receptor_{{ container_postfix }}
   redis_socket_{{ container_postfix }}:
+    name: tools_redis_socket_{{ container_postfix }}
 {% endfor -%}


### PR DESCRIPTION
##### SUMMARY

This pull request is related to #9695 and will make sure that the command ```make docker-compose``` does not create additional Docker volumes with the wrong prefix. 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Installer

##### AWX VERSION

```
awx: 18.0.0
```

##### ADDITIONAL INFORMATION

The current version of ```docker-compose.yml.j2``` does not care about the Docker volumes created during the execution of ```migrate.yml```. This means new Docker volumes will be created with the wrong prefix, which only contain the preloaded data. 

This does not make sense, because I want to keep my data and according to the docs, the following command is necessary to load the demo data.  

```
$ docker exec tools_awx_1 awx-manage create_preload_data
```
