### PR TITLE
remove ansible_version from the API config and metrics endpoints

### DIFF
--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -24,7 +24,7 @@ from awx.api.generics import APIView
 from awx.conf.registry import settings_registry
 from awx.main.analytics import all_collectors
 from awx.main.ha import is_ha_environment
-from awx.main.utils import get_awx_version, get_ansible_version, get_custom_venv_choices, to_python_boolean
+from awx.main.utils import get_awx_version, get_custom_venv_choices, to_python_boolean
 from awx.main.utils.licensing import validate_entitlement_manifest
 from awx.api.versioning import reverse, drf_reverse
 from awx.main.constants import PRIVILEGE_ESCALATION_METHODS
@@ -279,7 +279,6 @@ class ApiV2ConfigView(APIView):
             time_zone=settings.TIME_ZONE,
             license_info=license_data,
             version=get_awx_version(),
-            ansible_version=get_ansible_version(),
             eula=render_to_string("eula.md") if license_data.get('license_type', 'UNLICENSED') != 'open' else '',
             analytics_status=pendo_state,
             analytics_collectors=all_collectors(),

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -11,7 +11,7 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
 from awx.conf.license import get_license
-from awx.main.utils import get_awx_version, get_ansible_version, get_custom_venv_choices, camelcase_to_underscore
+from awx.main.utils import get_awx_version, get_custom_venv_choices, camelcase_to_underscore
 from awx.main import models
 from django.contrib.sessions.models import Session
 from awx.main.analytics import register
@@ -33,7 +33,7 @@ data _since_ the last report date - i.e., new data in the last 24 hours)
 '''
 
 
-@register('config', '1.2', description=_('General platform configuration.'))
+@register('config', '1.3', description=_('General platform configuration.'))
 def config(since, **kwargs):
     license_info = get_license()
     install_type = 'traditional'
@@ -52,7 +52,6 @@ def config(since, **kwargs):
         'instance_uuid': settings.SYSTEM_UUID,
         'tower_url_base': settings.TOWER_URL_BASE,
         'tower_version': get_awx_version(),
-        'ansible_version': get_ansible_version(),
         'license_type': license_info.get('license_type', 'UNLICENSED'),
         'free_instances': license_info.get('free_instances', 0),
         'total_licensed_instances': license_info.get('instance_count', 0),

--- a/awx/main/analytics/metrics.py
+++ b/awx/main/analytics/metrics.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from prometheus_client import REGISTRY, PROCESS_COLLECTOR, PLATFORM_COLLECTOR, GC_COLLECTOR, Gauge, Info, generate_latest
 
 from awx.conf.license import get_license
-from awx.main.utils import get_awx_version, get_ansible_version
+from awx.main.utils import get_awx_version
 from awx.main.analytics.collectors import (
     counts,
     instance_info,
@@ -127,7 +127,6 @@ def metrics():
             'insights_analytics': str(settings.INSIGHTS_TRACKING_STATE),
             'tower_url_base': settings.TOWER_URL_BASE,
             'tower_version': get_awx_version(),
-            'ansible_version': get_ansible_version(),
             'license_type': license_info.get('license_type', 'UNLICENSED'),
             'license_expiry': str(license_info.get('time_remaining', 0)),
             'pendo_tracking': settings.PENDO_TRACKING_STATE,

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -44,7 +44,6 @@ __all__ = [
     'underscore_to_camelcase',
     'memoize',
     'memoize_delete',
-    'get_ansible_version',
     'get_licenser',
     'get_awx_http_client_headers',
     'get_awx_version',
@@ -190,20 +189,6 @@ def memoize(ttl=60, cache_key=None, track_function=False, cache=None):
 def memoize_delete(function_name):
     cache = get_memoize_cache()
     return cache.delete(function_name)
-
-
-@memoize()
-def get_ansible_version():
-    """
-    Return Ansible version installed.
-    Ansible path needs to be provided to account for custom virtual environments
-    """
-    try:
-        proc = subprocess.Popen(['ansible', '--version'], stdout=subprocess.PIPE)
-        result = smart_str(proc.communicate()[0])
-        return result.split('\n')[0].replace('ansible', '').strip()
-    except Exception:
-        return 'unknown'
 
 
 def get_awx_version():

--- a/awx/ui_next/src/components/About/About.jsx
+++ b/awx/ui_next/src/components/About/About.jsx
@@ -2,17 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withI18n } from '@lingui/react';
 import { t } from '@lingui/macro';
-import {
-  AboutModal,
-  TextContent,
-  TextList,
-  TextListItem,
-} from '@patternfly/react-core';
+import { AboutModal } from '@patternfly/react-core';
 
 import { BrandName } from '../../variables';
 import brandLogoImg from './brand-logo.svg';
 
-function About({ ansible_version, version, isOpen, onClose, i18n }) {
+function About({ version, isOpen, onClose, i18n }) {
   const createSpeechBubble = () => {
     let text = `${BrandName} ${version}`;
     let top = '';
@@ -52,27 +47,17 @@ function About({ ansible_version, version, isOpen, onClose, i18n }) {
                   ||     ||
                     `}
       </pre>
-      <TextContent>
-        <TextList component="dl">
-          <TextListItem component="dt">
-            {i18n._(t`Ansible Version`)}
-          </TextListItem>
-          <TextListItem component="dd">{ansible_version}</TextListItem>
-        </TextList>
-      </TextContent>
     </AboutModal>
   );
 }
 
 About.propTypes = {
-  ansible_version: PropTypes.string,
   isOpen: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   version: PropTypes.string,
 };
 
 About.defaultProps = {
-  ansible_version: null,
   isOpen: false,
   version: null,
 };

--- a/awx/ui_next/src/components/AppContainer/AppContainer.jsx
+++ b/awx/ui_next/src/components/AppContainer/AppContainer.jsx
@@ -204,7 +204,6 @@ function AppContainer({ i18n, navRouteConfig = [], children }) {
         {isReady && <ConfigProvider value={config}>{children}</ConfigProvider>}
       </Page>
       <About
-        ansible_version={config?.ansible_version}
         version={config?.version}
         isOpen={isAboutModalOpen}
         onClose={handleAboutModalClose}

--- a/awx/ui_next/src/components/AppContainer/AppContainer.test.jsx
+++ b/awx/ui_next/src/components/AppContainer/AppContainer.test.jsx
@@ -10,13 +10,11 @@ import AppContainer from './AppContainer';
 jest.mock('../../api');
 
 describe('<AppContainer />', () => {
-  const ansible_version = '111';
   const version = '222';
 
   beforeEach(() => {
     ConfigAPI.read.mockResolvedValue({
       data: {
-        ansible_version,
         version,
       },
     });
@@ -93,7 +91,6 @@ describe('<AppContainer />', () => {
 
     // check about modal content
     const content = await waitForElement(wrapper, aboutModalContent);
-    expect(content.find('dd').text()).toContain(ansible_version);
     expect(content.find('pre').text()).toContain(`<  AWX ${version}  >`);
 
     // close about modal


### PR DESCRIPTION
AWX no longer includes Ansible on the control plane and there is no
"global" version of Ansible aside from what's configured at the
Execution Environment level

see: https://github.com/ansible/awx/issues/9472