### PR TITLE
only run black on files added or modified in the commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ black: reports
 	(set -o pipefail && $@ $(BLACK_ARGS) awx awxkit awx_collection | tee reports/$@.report)
 
 .git/hooks/pre-commit:
-	echo "[ -z \$$AWX_IGNORE_BLACK ] && (black --check \`git diff --cached --name-only | grep -E '\.py$\'\` || (echo 'To fix this, run \`make black\` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && exit 1))" > .git/hooks/pre-commit
+	echo "[ -z \$$AWX_IGNORE_BLACK ] && (black --check \`git diff --cached --name-only --diff-filter=AM | grep -E '\.py$\'\` || (echo 'To fix this, run \`make black\` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && exit 1))" > .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 
 genschema: reports


### PR DESCRIPTION
1.  `git rm <somefile>`
2. `git commit`

`black` will attempt to lint the file path to the deleted file (and will fail, because the file is gone)

`--diff-filter` will limit what we run listing against to files in the changes that are *added* or *modified*

https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203