### PR TITLE
let jupyter install ipython

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,7 +1,6 @@
 django-debug-toolbar==1.11
 django-rest-swagger
 pprofile
-ipython==5.2.1
 unittest2
 black
 pytest


### PR DESCRIPTION
running akit with ipython on py38:

```
In [1]: jt = v2.job_templates.create()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/usr/lib64/python3.8/codeop.py in __call__(self, source, filename, symbol)
    141
    142     def __call__(self, source, filename, symbol):
--> 143         codeob = compile(source, filename, symbol, self.flags, 1)
    144         for feature in _features:
    145             if codeob.co_flags & feature.compiler_flag:

TypeError: required field "type_ignores" missing from Module
```

Looks like we need a newer version of ipython:
https://github.com/ipython/ipython/issues/12558#issuecomment-701074964

.. because we pinned ipython in 2017
https://github.com/ansible/awx/commit/a39b1e84367bd5ed084a30c674377ffb3dbcb992

If I try to install the newer ipython alongside jupyter, pip's dep resolver [mentions a conflict](https://gist.github.com/jladdjr/1b7634f03db6a939d3872c45680a2442#file-pip_conflict-L19-L20)

.. but if we just install jupyter there are no conflicts and a newer ipython (that avoids the original issue) gets installed.

```
pip freeze | grep "ipython\|jupyter"
ipython==7.21.0
ipython-genutils==0.2.0
jupyter==1.0.0
jupyter-client==6.1.12
jupyter-console==6.4.0
jupyter-core==4.7.1
jupyterlab-pygments==0.1.2
jupyterlab-widgets==1.0.0
```

```
In [1]: jt = v2.job_templates.create()

In [2]: jt
Out[2]:
{
    "id": 12,
    "type": "job_template",
    "url": "/api/v2/job_templates/12/",
```