### PR TITLE
Remove/Modify Usage of tower-cli (Deprecated) in Collections Test

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2106,7 +2106,7 @@ class RunProjectUpdate(BaseTask):
         d = super(RunProjectUpdate, self).get_password_prompts(passwords)
         d[r'Username for.*:\s*?$'] = 'scm_username'
         d[r'Password for.*:\s*?$'] = 'scm_password'
-        d['Password:\s*?$'] = 'scm_password'  # noqa
+        d[r'Password:\s*?$'] = 'scm_password'
         d[r'\S+?@\S+?\'s\s+?password:\s*?$'] = 'scm_password'
         d[r'Enter passphrase for .*:\s*?$'] = 'scm_key_unlock'
         d[r'Bad passphrase, try again for .*:\s*?$'] = ''

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -272,7 +272,9 @@ class TowerAPIModule(TowerModule):
             if self._COLLECTION_TYPE not in self.collection_to_version or self.collection_to_version[self._COLLECTION_TYPE] != tower_type:
                 self.warn("You are using the {0} version of this collection but connecting to {1}".format(self._COLLECTION_TYPE, tower_type))
             elif collection_compare_ver != tower_compare_ver:
-                self.warn("You are running collection version {0} but connecting to {2} version {1}".format(self._COLLECTION_VERSION, tower_version, tower_type))
+                self.warn(
+                    "You are running collection version {0} but connecting to {2} version {1}".format(self._COLLECTION_VERSION, tower_version, tower_type)
+                )
 
             self.version_checked = True
 

--- a/awx_collection/plugins/module_utils/tower_api.py
+++ b/awx_collection/plugins/module_utils/tower_api.py
@@ -272,7 +272,7 @@ class TowerAPIModule(TowerModule):
             if self._COLLECTION_TYPE not in self.collection_to_version or self.collection_to_version[self._COLLECTION_TYPE] != tower_type:
                 self.warn("You are using the {0} version of this collection but connecting to {1}".format(self._COLLECTION_TYPE, tower_type))
             elif collection_compare_ver != tower_compare_ver:
-                self.warn("You are running collection version {0} but connecting to tower version {1}".format(self._COLLECTION_VERSION, tower_version))
+                self.warn("You are running collection version {0} but connecting to {2} version {1}".format(self._COLLECTION_VERSION, tower_version, tower_type))
 
             self.version_checked = True
 

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -59,7 +59,7 @@ def test_version_warning(collection_import, silence_warning):
             my_module._COLLECTION_TYPE = "awx"
             my_module.get_endpoint('ping')
     silence_warning.assert_called_once_with(
-        'You are running collection version {} but connecting to tower version {}'.format(my_module._COLLECTION_VERSION, ping_version)
+        'You are running collection version {} but connecting to {} version {}'.format(my_module._COLLECTION_VERSION, awx_name, ping_version)
     )
 
 
@@ -107,7 +107,7 @@ def test_version_warning_strictness_tower(collection_import, silence_warning):
             my_module._COLLECTION_TYPE = "tower"
             my_module.get_endpoint('ping')
     silence_warning.assert_called_once_with(
-        'You are running collection version {} but connecting to tower version {}'.format(my_module._COLLECTION_VERSION, ping_version)
+        'You are running collection version {} but connecting to {} version {}'.format(my_module._COLLECTION_VERSION, tower_name, ping_version)
     )
 
 

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
@@ -40,7 +40,7 @@
         job_type: run
         module_args: "mkdir -p {{ project_base_dir }}/{{ project_dir_name }}"
         module_name: command
-        wait: True
+        wait: true
 
   always:
     - name: Delete path from setting

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
@@ -1,16 +1,4 @@
 ---
-- name: get tower host variable
-  shell: tower-cli config host | cut -d ' ' -f2
-  register: host
-
-- name: get tower username variable
-  shell: tower-cli config username | cut -d ' ' -f2
-  register: username
-
-- name: get tower password variable
-  shell: tower-cli config password | cut -d ' ' -f2
-  register: password
-
 - name: Fetch project_base_dir
   uri:
     url: "{{ host.stdout }}/api/v2/config/"
@@ -44,15 +32,15 @@
     organization: Default
 
 - name: Disable process isolation
-  command: tower-cli setting modify AWX_PROOT_ENABLED false
+  command: awx-cli setting modify AWX_PROOT_ENABLED false
 
 - block:
     - name: Create a directory for manual project
       vars:
         project_base_dir: "{{ awx_config.json.project_base_dir }}"
-      command: tower-cli ad_hoc launch --wait --inventory localhost
+      command: awx-cli ad_hoc launch --wait --inventory localhost
         --credential dummy --module-name command
         --module-args "mkdir -p {{ project_base_dir }}/{{ project_dir_name }}"
   always:
     - name: enable process isolation
-      command: tower-cli setting modify AWX_PROOT_ENABLED true
+      command: awx-cli setting modify AWX_PROOT_ENABLED true

--- a/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
+++ b/awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml
@@ -1,13 +1,9 @@
 ---
-- name: Fetch project_base_dir
-  uri:
-    url: "{{ host.stdout }}/api/v2/config/"
-    user: "{{ username.stdout }}"
-    password: "{{ password.stdout }}"
-    validate_certs: false
-    return_content: true
-    force_basic_auth: true
-  register: awx_config
+- name: Load the UI settings
+  set_fact:
+    project_base_dir: "{{ tower_settings.project_base_dir }}"
+  vars:
+    tower_settings: "{{ lookup('awx.awx.tower_api', 'config/') }}"
 
 - tower_inventory:
     name: localhost
@@ -31,16 +27,29 @@
       -----END EC PRIVATE KEY-----
     organization: Default
 
-- name: Disable process isolation
-  command: awx-cli setting modify AWX_PROOT_ENABLED false
-
 - block:
+    - name: Add a path to a setting
+      tower_settings:
+        name: AWX_ISOLATION_SHOW_PATHS
+        value: "[{{ project_base_dir }}]"
+
     - name: Create a directory for manual project
-      vars:
-        project_base_dir: "{{ awx_config.json.project_base_dir }}"
-      command: awx-cli ad_hoc launch --wait --inventory localhost
-        --credential dummy --module-name command
-        --module-args "mkdir -p {{ project_base_dir }}/{{ project_dir_name }}"
+      tower_ad_hoc_command:
+        credential: dummy
+        inventory: localhost
+        job_type: run
+        module_args: "mkdir -p {{ project_base_dir }}/{{ project_dir_name }}"
+        module_name: command
+        wait: True
+
   always:
-    - name: enable process isolation
-      command: awx-cli setting modify AWX_PROOT_ENABLED true
+    - name: Delete path from setting
+      tower_settings:
+        name: AWX_ISOLATION_SHOW_PATHS
+        value: []
+
+    - name: Delete dummy credential
+      tower_credential:
+        name: dummy
+        kind: ssh
+        state: absent

--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -127,7 +127,7 @@ py.test awx_collection/test/awx/
 
 ## Running Integration Tests
 
-The integration tests require a virtualenv with `ansible` >= 2.9 and `tower_cli`.
+The integration tests require a virtualenv with `ansible` >= 2.9 and `awxkit`.
 The collection must first be installed, which can be done using `make install_collection`.
 You also need a configuration file, as described in the running section.
 


### PR DESCRIPTION
`tower-cli` is no longer being maintained; this PR removes three test tasks that are no longer necessary from `awx_collection/tests/integration/targets/tower_project_manual/tasks/create_project_dir.yml`, and it modifies the last task in that test file to use `awx-cli` instead.

* * *

I also noticed this warning while running Collections tests:
```
awx/main/tasks.py:2109
  /awx_devel/awx/main/tasks.py:2109: DeprecationWarning: invalid escape sequence \s
    d['Password:\s*?$'] = 'scm_password'  # noqa
```
This PR modifies that part of `/awx_devel/awx/main/tasks.py` into a raw string to fix this issue.

* * *

FYI, some deprecated Collections modules depend on the usage of `tower-cli`, but those tests are currently getting skipped:

```
awx_collection/test/awx/test_send_receive.py::test_receive_send_jt SKIPPED (The tower-cli library is needed to run th...) [ 56%]
awx_collection/test/awx/test_workflow_template.py::test_create_workflow_job_template SKIPPED (The tower-cli library i...) [ 73%]
awx_collection/test/awx/test_workflow_template.py::test_with_nested_workflow SKIPPED (The tower-cli library is needed...) [ 74%]
awx_collection/test/awx/test_workflow_template.py::test_schema_with_branches SKIPPED (The tower-cli library is needed...) [ 74%]
awx_collection/test/awx/test_workflow_template.py::test_with_missing_ujt SKIPPED (The tower-cli library is needed to ...) [ 75%]
``` 