### PR TITLE
Hide commands that are being run for `make black`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,12 +272,12 @@ reports:
 	mkdir -p $@
 
 black: reports
-	command -v black >/dev/null 2>&1 || { echo "could not find black on your PATH, you may need to \`pip install black\`, or set AWX_IGNORE_BLACK=1" && exit 1; }
-	(set -o pipefail && $@ $(BLACK_ARGS) awx awxkit awx_collection | tee reports/$@.report)
+	@command -v black >/dev/null 2>&1 || { echo "could not find black on your PATH, you may need to \`pip install black\`, or set AWX_IGNORE_BLACK=1" && exit 1; }
+	@(set -o pipefail && $@ $(BLACK_ARGS) awx awxkit awx_collection | tee reports/$@.report)
 
 .git/hooks/pre-commit:
-	echo "[ -z \$$AWX_IGNORE_BLACK ] && (black --check \`git diff --cached --name-only --diff-filter=AM | grep -E '\.py$\'\` || (echo 'To fix this, run \`make black\` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && exit 1))" > .git/hooks/pre-commit
-	chmod +x .git/hooks/pre-commit
+	@echo "[ -z \$$AWX_IGNORE_BLACK ] && (black --check \`git diff --cached --name-only --diff-filter=AM | grep -E '\.py$\'\` || (echo 'To fix this, run \`make black\` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && exit 1))" > .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-commit
 
 genschema: reports
 	$(MAKE) swagger PYTEST_ARGS="--genschema --create-db "


### PR DESCRIPTION
Before:

```
$ make black
command -v black >/dev/null 2>&1 || { echo "could not find black on your PATH, you may need to \`pip install black\`, or set AWX_IGNORE_BLACK=1" && exit 1; }
could not find black on your PATH, you may need to `pip install black`, or set AWX_IGNORE_BLACK=1
make: *** [Makefile:275: black] Error 1
```

After:
```
$ make black
could not find black on your PATH, you may need to `pip install black`, or set AWX_IGNORE_BLACK=1
make: *** [Makefile:275: black] Error 1
```