### PR TITLE
Add managed by tower as part of the EE details page

### DIFF
--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx
@@ -65,6 +65,11 @@ function ExecutionEnvironmentDetails({ executionEnvironment, i18n }) {
           dataCy="execution-environment-detail-description"
         />
         <Detail
+          label={i18n._(t`Managed by Tower`)}
+          value={managedByTower ? i18n._(t`True`) : i18n._(t`False`)}
+          dataCy="execution-environment-managed-by-tower"
+        />
+        <Detail
           label={i18n._(t`Organization`)}
           value={
             organization ? (
@@ -79,6 +84,7 @@ function ExecutionEnvironmentDetails({ executionEnvironment, i18n }) {
           }
           dataCy="execution-environment-detail-organization"
         />
+
         <Detail
           label={i18n._(t`Pull`)}
           value={pull === '' ? i18n._(t`Missing`) : toTitleCase(pull)}

--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.jsx
@@ -73,6 +73,9 @@ describe('<ExecutionEnvironmentDetails/>', () => {
     expect(
       wrapper.find('Detail[label="Credential"]').prop('value').props.children
     ).toEqual(executionEnvironment.summary_fields.credential.name);
+    expect(
+      wrapper.find('Detail[label="Managed by Tower"]').prop('value')
+    ).toEqual('False');
     const dates = wrapper.find('UserDateDetail');
     expect(dates).toHaveLength(2);
     expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);
@@ -167,6 +170,9 @@ describe('<ExecutionEnvironmentDetails/>', () => {
     expect(
       wrapper.find('Detail[label="Credential"]').prop('value').props.children
     ).toEqual(executionEnvironment.summary_fields.credential.name);
+    expect(
+      wrapper.find('Detail[label="Managed by Tower"]').prop('value')
+    ).toEqual('True');
     const dates = wrapper.find('UserDateDetail');
     expect(dates).toHaveLength(2);
     expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);


### PR DESCRIPTION
Add managed by tower as part of the EE details page.

See: https://github.com/ansible/awx/issues/8171

<img width="1462" alt="image" src="https://user-images.githubusercontent.com/9053044/112887177-d6551780-90a0-11eb-9a3f-42b916e1b842.png">

