### PR TITLE
Add uwsgi stats to metrics endpoint

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -152,6 +152,7 @@ class Metrics:
         self.auto_pipe_execute = auto_pipe_execute
         Instance = apps.get_model('main', 'Instance')
         self.instance_name = Instance.objects.me().hostname
+        self.wsgi_stats_socket = settings.WSGI_STATS_SOCKET
 
         # metric name, help_text
         METRICSLIST = [
@@ -231,10 +232,9 @@ class Metrics:
 
     def get_uwsgi_stats(self):
         json_str = ''
-        addr = "/tmp/stats.socket"
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.connect(addr)
+            sock.connect(self.wsgi_stats_socket)
             while True:
                 data = sock.recv(4096)
                 if len(data) < 1:

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -2,6 +2,7 @@ import redis
 import json
 import time
 import logging
+import socket
 
 from django.conf import settings
 from django.apps import apps
@@ -166,6 +167,10 @@ class Metrics:
             FloatM('subsystem_metrics_pipe_execute_seconds', 'Time spent saving metrics to redis'),
             IntM('subsystem_metrics_pipe_execute_calls', 'Number of calls to pipe_execute'),
             FloatM('subsystem_metrics_send_metrics_seconds', 'Time spent sending metrics to other nodes'),
+            SetIntM('uwsgi_workers', 'Number of workers'),
+            SetIntM('uwsgi_worker_busy', 'Number of workers with busy status'),
+            SetIntM('uwsgi_requests', 'Number of requests across workers'),
+            SetFloatM('uwsgi_average_response_time', 'Average of average response times (ms) across workers'),
         ]
         # turn metric list into dictionary with the metric name as a key
         self.METRICS = {}
@@ -219,12 +224,44 @@ class Metrics:
         self.conn.set(root_key + "_instance_" + data['instance'], data['metrics'])
 
     def should_pipe_execute(self):
-        if self.metrics_have_changed is False:
-            return False
         if time.time() - self.last_pipe_execute > self.pipe_execute_interval:
             return True
         else:
             return False
+
+    def get_uwsgi_stats(self):
+        json_str = ''
+        addr = "/tmp/stats.socket"
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.connect(addr)
+            while True:
+                data = sock.recv(4096)
+                if len(data) < 1:
+                    break
+                json_str += data.decode('utf8', 'ignore')
+            sock.close()
+            return json.loads(json_str)
+        except:
+            raise Exception("unable to get uWSGI statistics")
+
+    def update_uwsgi_stats(self):
+        data = self.get_uwsgi_stats()
+        num_workers = len(data['workers'])
+        self.set('uwsgi_workers', len(data['workers']))
+        num_busy = 0
+        requests = 0
+        avg_rt = 0
+        for worker in data['workers']:
+            if worker['status'] == 'busy':
+                num_busy += 1
+            requests += worker['requests']
+            avg_rt += worker['avg_rt']
+        avg_rt = avg_rt / num_workers / 1000
+        self.set('uwsgi_workers', num_workers)
+        self.set('uwsgi_worker_busy', num_busy)
+        self.set('uwsgi_requests', requests)
+        self.set('uwsgi_average_response_time', avg_rt)
 
     def pipe_execute(self):
         if self.metrics_have_changed is True:

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -168,7 +168,7 @@ class Metrics:
             IntM('subsystem_metrics_pipe_execute_calls', 'Number of calls to pipe_execute'),
             FloatM('subsystem_metrics_send_metrics_seconds', 'Time spent sending metrics to other nodes'),
             SetIntM('uwsgi_workers', 'Number of workers'),
-            SetIntM('uwsgi_worker_busy', 'Number of workers with busy status'),
+            SetIntM('uwsgi_workers_busy', 'Number of workers with busy status'),
             SetIntM('uwsgi_requests', 'Number of requests across workers'),
             SetFloatM('uwsgi_average_response_time', 'Average of average response times (ms) across workers'),
         ]
@@ -259,7 +259,7 @@ class Metrics:
             avg_rt += worker['avg_rt']
         avg_rt = avg_rt / num_workers / 1000
         self.set('uwsgi_workers', num_workers)
-        self.set('uwsgi_worker_busy', num_busy)
+        self.set('uwsgi_workers_busy', num_busy)
         self.set('uwsgi_requests', requests)
         self.set('uwsgi_average_response_time', avg_rt)
 

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -285,7 +285,6 @@ class Metrics:
             begin_time = time.perf_counter()
             for m in self.METRICS:
                 self.METRICS[m].store_value(self.pipe)
-            logger.debug(f"======{len(self.pipe.command_stack)}======")
             self.pipe.execute()
             self.last_pipe_execute = time.time()
             self.metrics_have_changed = False

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -136,7 +136,6 @@ class AWXConsumerRedis(AWXConsumerBase):
             # if no requests were made since last time, skip the redis save
             if requests != previous_requests:
                 subsystem_metrics.pipe_execute()
-                logger.info("==== uwsgi stats update =====")
                 previous_requests = requests
             time.sleep(subsystem_metrics.pipe_execute_interval)
             now = time.time()

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -75,9 +75,8 @@ class CallbackBrokerWorker(BaseWorker):
         return {'event': 'FLUSH'}
 
     def record_read_metrics(self):
-        if self.queue_pop == 0:
-            return
         if self.subsystem_metrics.should_pipe_execute() is True:
+            self.subsystem_metrics.update_uwsgi_stats()
             queue_size = self.redis.llen(self.queue_name)
             self.subsystem_metrics.set('callback_receiver_events_queue_size_redis', queue_size)
             self.subsystem_metrics.pipe_execute()

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -75,8 +75,9 @@ class CallbackBrokerWorker(BaseWorker):
         return {'event': 'FLUSH'}
 
     def record_read_metrics(self):
+        if self.queue_pop == 0:
+            return
         if self.subsystem_metrics.should_pipe_execute() is True:
-            self.subsystem_metrics.update_uwsgi_stats()
             queue_size = self.redis.llen(self.queue_name)
             self.subsystem_metrics.set('callback_receiver_events_queue_size_redis', queue_size)
             self.subsystem_metrics.pipe_execute()

--- a/awx/main/management/commands/deprovision_instance.py
+++ b/awx/main/management/commands/deprovision_instance.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved
-
+import redis
 from django.db import transaction
 from django.core.management.base import BaseCommand, CommandError
-
+from django.conf import settings
 from awx.main.models import Instance
 from awx.main.utils.pglock import advisory_lock
+from awx.main.analytics.subsystem_metrics import root_key
 
 
 class Command(BaseCommand):
@@ -24,6 +25,13 @@ class Command(BaseCommand):
         hostname = options.get('hostname')
         if not hostname:
             raise CommandError("--hostname is a required argument")
+        # remove redis metrics keys
+        conn = redis.Redis.from_url(settings.BROKER_URL)
+        metrics_key = root_key + '_instance_' + hostname
+        if conn.exists(metrics_key):
+            conn.delete(metrics_key)
+            print(f"Removed {hostname} metric data from redis")
+
         with advisory_lock('instance_registration_%s' % hostname):
             instance = Instance.objects.filter(hostname=hostname)
             if instance.exists():

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -290,6 +290,8 @@ ROOT_URLCONF = 'awx.urls'
 
 WSGI_APPLICATION = 'awx.wsgi.application'
 
+WSGI_STATS_SOCKET = '/var/lib/awx/uwsgi.stats'
+
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -73,6 +73,8 @@ INSIGHTS_TRACKING_STATE = False
 
 INSTALLED_APPS += ['rest_framework_swagger', 'debug_toolbar']  # NOQA
 
+WSGI_STATS_SOCKET = '/tmp/stats.socket'
+
 MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE  # NOQA
 
 DEBUG_TOOLBAR_CONFIG = {'ENABLE_STACKTRACES': True}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
![image](https://user-images.githubusercontent.com/8745776/112906563-5cca2300-90ba-11eb-8e40-6a0d2fdf47a6.png)
Adds new stats to the api/metrics endpoint such as number of workers busy, number of requests, and request response times
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 18.0.0
```
