### PR TITLE
add the fallback satellite_instance_var_id

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -706,10 +706,10 @@ TOWER_INSTANCE_ID_VAR = 'remote_tower_id'
 # ---------------------
 # ----- Foreman -----
 # ---------------------
-SATELLITE6_ENABLED_VAR = 'foreman_enabled'
+SATELLITE6_ENABLED_VAR = 'foreman_enabled, foreman.enabled'
 SATELLITE6_ENABLED_VALUE = 'True'
 SATELLITE6_EXCLUDE_EMPTY_GROUPS = True
-SATELLITE6_INSTANCE_ID_VAR = 'foreman_id'
+SATELLITE6_INSTANCE_ID_VAR = 'foreman_id, foreman.id'
 # SATELLITE6_GROUP_PREFIX and SATELLITE6_GROUP_PATTERNS defined in source vars
 
 # ---------------------


### PR DESCRIPTION
##### SUMMARY
With https://github.com/ansible/awx/pull/9037, we fixed the issue to use the foreman_* because we had an migration which was converting the vars as foreman_*. Here:

https://github.com/ansible/tower/blob/devel/awx/main/migrations/_inventory_source_vars.py#L663

But this migration only happens on upgrade. But for new users this migration wont run and hence the variable would not be in foreman_* format. This produces a warning like following:

```
6.240 WARNING  Host "example.com" has no "foreman_id" variable(s)
```
We should have a fallback on the new var of foreman.id with foreman_id in there too. This PR adds that.
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION

Thanks @gamuniz for finding the bug and pointing the migration.
 