### PR TITLE
Adding back in missing functionality of Custom Docker Image Builds

### DIFF
--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -4,3 +4,8 @@ kube_dev: false
 dockerfile_dest: '../..'
 dockerfile_name: 'Dockerfile'
 template_dest: '_build'
+
+# Helper vars to construct the proper multi-arch configuration
+tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'
+kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'
+base_container: '{{ { "x86_64": "centos:8", "aarch64": "centos:8", "armv7": "centos:8", "ppc64le": "centos:8" }[ansible_facts.architecture] }}'

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -5,7 +5,7 @@
 ###
 
 # Build container
-FROM centos:8 as builder
+FROM {{ base_container | default('centos:8') }}
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -70,7 +70,7 @@ RUN make sdist && \
 {% endif %}
 
 # Final container(s)
-FROM centos:8
+FROM {{ base_container | default('centos:8') }}
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -5,7 +5,7 @@
 ###
 
 # Build container
-FROM {{ base_container | default('centos:8') }}
+FROM {{ base_container | default('centos:8') }} as builder
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/tools/ansible/roles/image_build/defaults/main.yml
+++ b/tools/ansible/roles/image_build/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 awx_image: quay.io/ansible/awx
-
-# Helper vars to construct the proper download URL for the current architecture
-tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
-kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'

--- a/tools/docker-compose/inventory
+++ b/tools/docker-compose/inventory
@@ -17,3 +17,9 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 
 # awx_image="ansible/awx"
 # migrate_local_docker=false
+
+# Define if you want the image pushed to a registry. The container definition will also use these images
+# docker_registry=172.30.1.1:5000
+# docker_registry_repository=awx
+# docker_registry_username=developer
+# docker_registry_password=""


### PR DESCRIPTION
##### SUMMARY
With the switch to 18.0, the removal of local docker install was removed. During this shuffle of code, it looks like some functionality was dropped. This PR aims to add back in that functionality. Plus add unofficial support for ppc64le like there is for arm64.  

##### ISSUE TYPE
 - Feature/Bug Pull Request

##### COMPONENT NAME
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 18.0.0
```


##### ADDITIONAL INFORMATION
The functionality that was delete/shifted was:

- Allowing for custom build images to be pushed to remote registry
- Allowing for multi-arch builds via rendering the right download paths

New Stuff Added:

- Unofficial support for build ppc64le
- Support for custom base images(aka if a certain arch does not support `centos:8`, you could swap it for `fedora` or something similar)
