### PR TITLE
Make tower_license module idempotent

### DIFF
--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -59,6 +59,7 @@ def main():
         argument_spec=dict(
             manifest=dict(type='str', required=True),
             eula_accepted=dict(type='bool', required=True),
+            force=dict(type='bool', required=False),
         ),
     )
 

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -33,7 +33,7 @@ options:
     force:
       description:
         - By default, the license manifest will only be applied if Tower is currently
-          unlicensed or trial licensed.  When force=true, the license is always applied. 
+          unlicensed or trial licensed.  When force=true, the license is always applied.
       required: True
       type: bool
       default: 'False'
@@ -62,7 +62,7 @@ def main():
         ),
     )
 
-    json_output = {}
+    json_output = {'changed': False}
 
     if not module.params.get('eula_accepted'):
         module.fail_json(msg='You must accept the EULA by passing in the param eula_accepted as True')
@@ -83,7 +83,7 @@ def main():
     )
 
     # Determine if we will install the license
-    perform_install = (not already_licensed) or module.params.get('force')
+    perform_install = bool((not already_licensed) or module.params.get('force'))
 
     # Handle check mode
     if module.check_mode:


### PR DESCRIPTION
##### SUMMARY

Currently, the tower_license module always installs a license, without checking if Tower is already licensed.  In general, Ansible modules are supposed to be idempotent.  This PR updates the module to check whether Tower is already licensed, and do nothing in that case.  A new parameter `force` is provided so the user can always install the license, or override an existing license with a new one.

##### ISSUE TYPE

Bughancement

##### COMPONENT NAME

awx_collection

##### AWX VERSION

awx: 18.0.0
(but really Tower 3.8.2)