### PR TITLE
Make logs more readable in development environment

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -119,7 +119,7 @@ RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master
 RUN curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-{{ tini_architecture | default('amd64') }} && \
     chmod +x /usr/bin/tini
 
-RUN python3.8 -m ensurepip && pip3 install "virtualenv < 20" supervisor {% if build_dev|bool %}black{% endif %}
+RUN python3.8 -m ensurepip && pip3 install "virtualenv < 20" supervisor
 
 RUN rm -rf /root/.cache && rm -rf /tmp/*
 
@@ -152,6 +152,8 @@ RUN dnf -y install \
     diffutils \
     unzip && \
     npm install -g n && n 14.15.1 && dnf remove -y nodejs
+
+RUN pip3 install black git+https://github.com/coderanger/supervisor-stdout
 
 # This package randomly fails to download.
 # It is nice to have in the dev env, but not necessary.

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -12,8 +12,9 @@ stopsignal=KILL
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
+
 
 [program:awx-receiver]
 command = make receiver
@@ -24,8 +25,8 @@ stopsignal=KILL
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-wsbroadcast]
 command = make wsbroadcast
@@ -36,8 +37,8 @@ stopsignal=KILL
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-uwsgi]
 command = make uwsgi
@@ -48,8 +49,8 @@ stopwaitsecs = 1
 stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-daphne]
 command = make daphne
@@ -60,16 +61,16 @@ stopwaitsecs = 1
 stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-nginx]
 command = make nginx
 autostart = true
 autorestart = true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-rsyslogd]
 command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
@@ -80,8 +81,8 @@ stopsignal=TERM
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-receptor]
 command = receptor --config /etc/receptor/receptor.conf
@@ -91,8 +92,8 @@ stopsignal = KILL
 stopasgroup = true
 killasgroup = true
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [group:tower-processes]
 programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsbroadcast,awx-rsyslogd
@@ -106,3 +107,9 @@ serverurl=unix:///var/run/supervisor/supervisor.sock ; use a unix:// URL  for a 
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
This uses https://github.com/coderanger/supervisor-stdout to prefix process
names before log messages in the dev env

Before:

<img width="991" alt="Screen Shot 2021-04-02 at 2 13 57 PM" src="https://user-images.githubusercontent.com/773186/113442523-30661d80-93be-11eb-9ee1-21b3236923e0.png">

After:

<img width="991" alt="Screen Shot 2021-04-02 at 2 15 20 PM" src="https://user-images.githubusercontent.com/773186/113442533-33f9a480-93be-11eb-9762-a63ace23f287.png">

