### PR TITLE
Remove invocation of Ansible from launch script

### DIFF
--- a/tools/ansible/roles/dockerfile/files/launch_awx.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx.sh
@@ -13,13 +13,6 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
-source /etc/tower/conf.d/environment.sh
-
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m wait_for -a "host=$DATABASE_HOST port=$DATABASE_PORT" all
-ANSIBLE_REMOTE_TEMP=/tmp ANSIBLE_LOCAL_TEMP=/tmp ansible -i "127.0.0.1," -c local -v -m postgresql_db --become-user $DATABASE_USER -a "name=$DATABASE_NAME owner=$DATABASE_USER login_user=$DATABASE_USER login_host=$DATABASE_HOST login_password=$DATABASE_PASSWORD port=$DATABASE_PORT" all
-
 awx-manage collectstatic --noinput --clear
-
-unset $(cut -d = -f -1 /etc/tower/conf.d/environment.sh)
 
 supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
This was missed in the initial EE PR. Ansible is no longer installed inside of the web & task containers, causing this to show up in the container logs:

```
/usr/bin/launch_awx.sh: line 18: ansible: command not found
/usr/bin/launch_awx.sh: line 19: ansible: command not found
```
