### PR TITLE
Fix docker-compose up options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e cluster_node_count=$(CLUSTER_NODE_COUNT)
 
 docker-compose: docker-auth awx/projects docker-compose-sources
-	docker-compose -f tools/docker-compose/_sources/docker-compose.yml $(COMPOSE_UP_OPTS) up
+	docker-compose -f tools/docker-compose/_sources/docker-compose.yml up $(COMPOSE_UP_OPTS)
 
 docker-compose-credential-plugins: docker-auth awx/projects docker-compose-sources
 	echo -e "\033[0;31mTo generate a CyberArk Conjur API key: docker exec -it tools_conjur_1 conjurctl account create quick-start\033[0m"


### PR DESCRIPTION


##### SUMMARY
Should the `up` options be after the `up` command? I'm assuming `COMPOSE_UP_OPTS` exists so we can run detached like so:

`COMPOSE_UP_OPTS=-d make docker-compose`

If I am misunderstanding the purpose of `COMPOSE_UP_OPTS`, is there other guidance on how to autostart AWX detached?

##### ISSUE TYPE
 - Bugfix Pull Request
 

##### COMPONENT NAME
 - Installer


##### AWX VERSION
```
awx: 18.0.0
```


