### PR TITLE
Adjust datetimes to be aware when using awx-manage gather_analytics

### DIFF
--- a/awx/main/management/commands/gather_analytics.py
+++ b/awx/main/management/commands/gather_analytics.py
@@ -3,7 +3,7 @@ import logging
 from awx.main import analytics
 from dateutil import parser
 from django.core.management.base import BaseCommand
-from django.utils.timezone import now
+from django.utils import timezone
 
 
 class Command(BaseCommand):
@@ -36,14 +36,12 @@ class Command(BaseCommand):
         opt_since = options.get('since') or None
         opt_until = options.get('until') or None
 
-        if opt_since:
-            since = parser.parse(opt_since)
-        else:
-            since = None
-        if opt_until:
-            until = parser.parse(opt_until)
-        else:
-            until = now()
+        since = parser.parse(opt_since) if opt_since else None
+        if since and since.tzinfo is None:
+            since = since.replace(tzinfo=timezone.utc)
+        until = parser.parse(opt_until) if opt_until else None
+        if until and until.tzinfo is None:
+            until = until.replace(tzinfo=timezone.utc)
 
         if opt_ship and opt_dry_run:
             self.logger.error('Both --ship and --dry-run cannot be processed at the same time.')


### PR DESCRIPTION
##### SUMMARY
Adjust datetimes to be aware when using awx-manage gather_analytics

Also, make sure that an explicit `since` parameter will win over
default `until=now()` when calculating the 4-week data limit.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```

```