### PR TITLE
Fix non-translatable template string

### DIFF
--- a/awx/ui_next/src/components/About/About.jsx
+++ b/awx/ui_next/src/components/About/About.jsx
@@ -25,13 +25,15 @@ function About({ version, isOpen, onClose, i18n }) {
   };
 
   const speechBubble = createSpeechBubble();
+  const copyright = i18n._(t`Copyright`);
+  const redHatInc = i18n._(t`Red Hat, Inc.`);
 
   return (
     <AboutModal
       isOpen={isOpen}
       onClose={onClose}
       productName={`Ansible ${BrandName}`}
-      trademark={i18n._(t`Copyright ${new Date().getFullYear()} Red Hat, Inc.`)}
+      trademark={`${copyright} ${new Date().getFullYear()} ${redHatInc}`}
       brandImageSrc="/static/media/logo-header.svg"
       brandImageAlt={i18n._(t`Brand Image`)}
     >


### PR DESCRIPTION
##### SUMMARY
The template string for the trademark doesn't seem like it can be used for a valid translation key. This caused the raw variable to be displayed for production builds instead of a readable string.  see: https://github.com/ansible/awx/issues/9296#issuecomment-816282325


##### ADDITIONAL INFORMATION
Screenshots, after applying this patch:

**development environment**
![about_dev](https://user-images.githubusercontent.com/9753817/114107842-bd6a1480-989f-11eb-8fec-b6ebc5a118cc.png)

---
**production build**
![about_prod](https://user-images.githubusercontent.com/9753817/114107796-a1667300-989f-11eb-9a28-99ad24b53a6d.png)

```
