### PR TITLE
Use validated prop in cred plugin field

### DIFF
--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
@@ -22,7 +22,7 @@ function CredentialPluginInput(props) {
     i18n,
     isDisabled,
     isRequired,
-    isValid,
+    validated,
     fieldOptions,
   } = props;
 
@@ -52,7 +52,7 @@ function CredentialPluginInput(props) {
           {React.cloneElement(children, {
             ...inputField,
             isRequired,
-            validated: isValid ? 'default' : 'error',
+            validated: validated ? 'default' : 'error',
             isDisabled: disableFieldAndButtons,
             onChange: (_, event) => {
               inputField.onChange(event);
@@ -96,7 +96,7 @@ function CredentialPluginInput(props) {
 }
 
 function CredentialPluginField(props) {
-  const { fieldOptions, isRequired, isValid } = props;
+  const { fieldOptions, isRequired, validated } = props;
 
   const [, meta, helpers] = useField(`inputs.${fieldOptions.id}`);
   const [passwordPromptField] = useField(`passwordPrompts.${fieldOptions.id}`);
@@ -136,7 +136,7 @@ function CredentialPluginField(props) {
           fieldId={`credential-${fieldOptions.id}`}
           helperTextInvalid={meta.error}
           isRequired={isRequired}
-          validated={isValid ? 'default' : 'error'}
+          validated={validated ? 'default' : 'error'}
           label={fieldOptions.label}
           labelIcon={
             fieldOptions.help_text && (


### PR DESCRIPTION
##### SUMMARY
Fxes an initialization bug for cred plugin fields, introduced by [this commit](https://github.com/ansible/awx/pull/9662/commits/f444870c0cfe3cd8f922fd34d3e439ed8af75969)

This pr applies the patch described below:

cc @marshmalien @unlikelyzero 

![Screenshot from 2021-04-09 10-54-12](https://user-images.githubusercontent.com/9753817/114199095-ff3b9f00-9921-11eb-80c8-e9d41db9202f.png)



**before**
![cred_validation_before](https://user-images.githubusercontent.com/9753817/114199479-56417400-9922-11eb-9a9d-2a1d600a2d6e.gif)

---

**after**
![cred_validation_after](https://user-images.githubusercontent.com/9753817/114199508-5ccfeb80-9922-11eb-95c3-bb598db54124.gif)





