### PR TITLE
Prevent execution environment from being assigned to a new organization

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1412,6 +1412,14 @@ class ExecutionEnvironmentSerializer(BaseSerializer):
             res['credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.credential.pk})
         return res
 
+    def validate(self, attrs):
+        # prevent changing organization of ee. Unsetting (change to null) is allowed
+        if self.instance:
+            org = attrs.get('organization', None)
+            if org and org.pk != self.instance.organization_id:
+                raise serializers.ValidationError({"organization": _("Cannot change the organization of an execution environment")})
+        return super(ExecutionEnvironmentSerializer, self).validate(attrs)
+
 
 class ProjectSerializer(UnifiedJobTemplateSerializer, ProjectOptionsSerializer):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related https://github.com/ansible/awx/issues/9769
- ee organization can be changed to null (less restrictive)
- if organization is null, cannot be assigned to org (more restrictive)
- if org is assigned, it cannot be set to a different org

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.0.0
```
