### PR TITLE
metadata: Fixes invalid model classes field.

### DIFF
--- a/awx/api/metadata.py
+++ b/awx/api/metadata.py
@@ -26,6 +26,9 @@ from awx.main.fields import JSONField, ImplicitRoleField
 from awx.main.models import NotificationTemplate
 from awx.main.tasks import AWXReceptorJob
 
+# Polymorphic
+from polymorphic.models import PolymorphicModel
+
 
 class Metadata(metadata.SimpleMetadata):
     def get_field_info(self, field):
@@ -78,7 +81,9 @@ class Metadata(metadata.SimpleMetadata):
                 field_info['help_text'] = field_help_text[field.field_name].format(verbose_name)
 
             if field.field_name == 'type':
-                field_info['filterable'] = True
+                # Only include model classes with `type` field.
+                if issubclass(serializer.Meta.model, PolymorphicModel):
+                    field_info['filterable'] = True
             else:
                 for model_field in serializer.Meta.model._meta.fields:
                     if field.field_name == model_field.name:


### PR DESCRIPTION
Fixes #9441.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Set `type`' field's filterable as `True` only if the model classes contain `type` field such as `UnifiedJob`, `WorkflowApproval`, `UnifiedJobTemplate`, `Project` and `SystemJobTemplate`

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API - metadata.py

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
