### PR TITLE
Document usage of workflow job template nodes with approvals

### DIFF
--- a/awx_collection/plugins/modules/tower_workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template_node.py
@@ -174,6 +174,54 @@ EXAMPLES = '''
     organization: Default
     success_nodes:
       - my-first-node
+
+- name: Create workflow with 2 Job Templates and an approval node in between
+  block:
+  - name: Create a workflow job template
+    tower_workflow_job_template:
+      name: my-workflow-job-template
+      ask_scm_branch_on_launch: true
+      organization: Default
+
+  - name: Create 1st node
+    tower_workflow_job_template_node:
+      identifier: my-first-node
+      workflow_job_template: my-workflow-job-template
+      unified_job_template: some_job_template
+      organization: Default
+
+  - name: Create 2nd approval node
+    tower_workflow_job_template_node:
+      identifier: my-second-approval-node
+      workflow_job_template: my-workflow-job-template
+      organization: Default
+      approval_node:
+        description: "Do this?"
+        name: my-second-approval-node
+        timeout: 3600
+
+  - name: Create 3rd node
+    tower_workflow_job_template_node:
+      identifier: my-third-node
+      workflow_job_template: my-workflow-job-template
+      unified_job_template: some_other_job_template
+      organization: Default
+
+  - name: Link 1st node to 2nd Approval node
+    tower_workflow_job_template_node:
+      identifier: my-first-node
+      workflow_job_template: my-workflow-job-template
+      organization: Default
+      success_nodes:
+        - my-second-approval-node
+
+  - name: Link 2nd Approval Node 3rd node
+    tower_workflow_job_template_node:
+      identifier: my-second-approval-node
+      workflow_job_template: my-workflow-job-template
+      organization: Default
+      success_nodes:
+        - my-third-node
 '''
 
 from ..module_utils.tower_api import TowerAPIModule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I'm not sure if this procedure is mandatory, but it was the only way it worked for me.

It's already documented in [one sentence](https://github.com/ansible/awx/blob/devel/awx_collection/plugins/modules/tower_workflow_job_template_node.py#L24-L26) that you can create all workflow template nodes first and then link them later. However in the Examples it has been missing to make it explicit, as it's not really intuitive when you create the nodes and link them at the same time, it won't work and you run into https://github.com/ansible/awx/issues/8777

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.0.0
```