### PR TITLE
Return distinct labels for normal Users

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2627,7 +2627,7 @@ class LabelAccess(BaseAccess):
         return self.model.objects.filter(
             Q(organization__in=Organization.accessible_pk_qs(self.user, 'read_role'))
             | Q(unifiedjobtemplate_labels__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-        )
+        ).distinct()
 
     @check_superuser
     def can_add(self, data):


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

1. Create a single label and add it to 2 or more JTs
2. Visit `/api/v2/labels` as superuser and you'll see a single label
3. Create a normal user and give admin role to each JT in step 1
4. Visit `/api/v2/labels` as this normal user and you will see duplicate entries for the label. Number of entries will be equal to the number of JTs in step 1

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.0.0
```
