### PR TITLE
Define variables in the correct Ansible role

### DIFF
--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -4,3 +4,7 @@ kube_dev: false
 dockerfile_dest: '../..'
 dockerfile_name: 'Dockerfile'
 template_dest: '_build'
+
+# Helper vars to construct the proper download URL for the current architecture
+tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
+kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'

--- a/tools/ansible/roles/image_build/defaults/main.yml
+++ b/tools/ansible/roles/image_build/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 awx_image: quay.io/ansible/awx
-
-# Helper vars to construct the proper download URL for the current architecture
-tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
-kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'


### PR DESCRIPTION
##### SUMMARY

This pull request is related to #9913.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - Docker

##### AWX VERSION

```
awx: 19.0.0
```

##### ADDITIONAL INFORMATION

This pull request ensures that ```tini``` is downloaded for the correct architecture. 

```
$ grep tini Dockerfil
# Install tini
RUN curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-arm64 && \
    chmod +x /usr/bin/tini
```
