### PR TITLE
Always overwrite the contents of .git/hooks/pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ I18N_FLAG_FILE = .i18n_built
 	receiver test test_unit test_coverage coverage_html \
 	dev_build release_build sdist \
 	ui-release ui-devel \
-	VERSION docker-compose-sources
+	VERSION docker-compose-sources \
+	.git/hooks/pre-commit
 
 clean-tmp:
 	rm -rf tmp/


### PR DESCRIPTION
##### SUMMARY
Set the `make` command to always write into the pre-commit hook file, even if it already exists.  This will allow this file to be updated when changes are made without the developer having to jump through hoops or remember that it is a thing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```