### PR TITLE
CredentialPluginField: Fixes bug to display invalid helper text for empty required field.

### DIFF
--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
@@ -11,6 +11,8 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { KeyIcon } from '@patternfly/react-icons';
+import styles from '@patternfly/react-styles/css/components/Form/form';
+import { css } from '@patternfly/react-styles';
 import FieldWithPrompt from '../../../../components/FieldWithPrompt';
 import Popover from '../../../../components/Popover';
 import { CredentialPluginPrompt } from './CredentialPluginPrompt';
@@ -101,6 +103,16 @@ function CredentialPluginField(props) {
   const [, meta, helpers] = useField(`inputs.${fieldOptions.id}`);
   const [passwordPromptField] = useField(`passwordPrompts.${fieldOptions.id}`);
 
+  const invalidHelperTextToDisplay = meta.error && meta.touched && (
+    <div
+      className={css(styles.formHelperText, styles.modifiers.error)}
+      id={`${fieldOptions.id}-helper`}
+      aria-live="polite"
+    >
+      {meta.error}
+    </div>
+  );
+
   useEffect(() => {
     if (passwordPromptField.value) {
       helpers.setValue('');
@@ -121,15 +133,7 @@ function CredentialPluginField(props) {
           tooltip={fieldOptions.help_text}
         >
           <CredentialPluginInput {...props} />
-          {meta.error && meta.touched && (
-            <div
-              className="pf-c-form__helper-text pf-m-error"
-              id={`${fieldOptions.id}-helper`}
-              aria-live="polite"
-            >
-              {meta.error}
-            </div>
-          )}
+          {invalidHelperTextToDisplay}
         </FieldWithPrompt>
       ) : (
         <FormGroup
@@ -145,6 +149,7 @@ function CredentialPluginField(props) {
           }
         >
           <CredentialPluginInput {...props} />
+          {invalidHelperTextToDisplay}
         </FormGroup>
       )}
     </>


### PR DESCRIPTION
Fixes #9911. Include the HTML element of displaying helper text which is similar to FormGroup.tsx's inValidHelperText implementation

Signed-off-by: seiwailai <laiseiwai@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Under normal circumstances, we initiate `input` fields using `FormGroup` element. However, for credentials purpose, we customized the `FormGroup` by adding another children element called `CredentialPluginInput` which comprised of `Input Group`. Thus, events related to the input fields will happen within the `InputGroup` logic. However, the `Input Group` doesn't have the functionality of rendering error at the moment.

Thus, we should explicitly render the error under `FormGroup` element if there is an error and needed to be displayed.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI: `CredentialPluginField.jsx`

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx=19.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste screenshot below, e.g. before and after your change -->
**After**
![show_empty_required_field_error_helper_text](https://user-images.githubusercontent.com/67208821/115196522-970b6b00-a122-11eb-8c52-f68e26ce8cfd.gif)

