### PR TITLE
Allow stable use of AWXKIT_PREVENT_TEARDOWN by disabling schedules at the end

### DIFF
--- a/awxkit/awxkit/api/pages/schedules.py
+++ b/awxkit/awxkit/api/pages/schedules.py
@@ -2,7 +2,9 @@ from contextlib import suppress
 
 from awxkit.api.pages import UnifiedJob
 from awxkit.api.resources import resources
+from awxkit.config import config
 import awxkit.exceptions as exc
+
 from . import page
 from . import base
 
@@ -10,6 +12,17 @@ from . import base
 class Schedule(UnifiedJob):
 
     NATURAL_KEY = ('unified_job_template', 'name')
+
+    def silent_delete(self):
+        """If we are told to prevent_teardown of schedules, then keep them
+        but do not leave them activated, or system will be swamped quickly"""
+        try:
+            if not config.prevent_teardown:
+                return self.delete()
+            else:
+                self.patch(enabled=False)
+        except (exc.NoContent, exc.NotFound, exc.Forbidden):
+            pass
 
 
 page.register_page([resources.schedule, resources.related_schedule], Schedule)

--- a/awxkit/awxkit/api/pages/unified_job_templates.py
+++ b/awxkit/awxkit/api/pages/unified_job_templates.py
@@ -1,6 +1,7 @@
 from awxkit.api.resources import resources
 from awxkit.utils import random_title, update_payload
 from awxkit.api.mixins import HasStatus
+from awxkit.config import config
 from . import base
 from . import page
 
@@ -42,7 +43,22 @@ class UnifiedJobTemplate(HasStatus, base.Base):
 
         update_payload(payload, self.optional_schedule_fields, kwargs)
 
-        return self.related.schedules.post(payload)
+        schedule = self.related.schedules.post(payload)
+        # register schedule in temporary dependency store as means of
+        # getting its teardown method to run on cleanup
+        if not hasattr(self, '_schedules_store'):
+            self._schedules_store = set()
+        if schedule not in self._schedules_store:
+            self._schedules_store.add(schedule)
+        return schedule
+
+    def silent_delete(self):
+        if hasattr(self, '_schedules_store') and config.prevent_teardown:
+            # when prevent_teardown is off, we rely on cascade deletes
+            # in this case, looping is needed to turn them off
+            for schedule in self._schedules_store:
+                schedule.silent_delete()
+        return super(UnifiedJobTemplate, self).silent_delete()
 
     @property
     def is_successful(self):


### PR DESCRIPTION
##### SUMMARY
Reviving https://github.com/ansible/awx/pull/5861

I actually really want this. The prevent_teardown setting is a minefield without it, because minutely schedules will kill your server. Here is a schedule list after running a lot of tests with this patch & teardown prevented:

![Screenshot from 2021-04-19 12-04-35](https://user-images.githubusercontent.com/1385596/115271994-e8f4c680-a10b-11eb-9c7f-076701cb08a5.png)

This is perfect. If you run a test, you want to be able to view the schedules produced by it, but you don't want the server to become overwhelmed and inoperable.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

