### PR TITLE
Add in the missing dry-run check for csv analytics collectors

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -259,9 +259,10 @@ def gather(dest=None, module=None, subset=None, since=None, until=None, collecti
                         tgzfile = package(dest.parent, payload, until)
                         if tgzfile is not None:
                             tarfiles.append(tgzfile)
-                            if not ship(tgzfile):
-                                slice_succeeded, succeeded = False, False
-                                break
+                            if collection_type != 'dry-run':
+                                if not ship(tgzfile):
+                                    slice_succeeded, succeeded = False, False
+                                    break
 
                     if slice_succeeded and collection_type != 'dry-run':
                         with disable_activity_stream():


### PR DESCRIPTION
##### SUMMARY
Follow on bug fix for the analytics gathering feature.  @chrismeyersfsu noticed that dry-run gathers of sufficiently large data was breaking out of the loop after the first csv chunk was packaged.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 19.0.0
```