### PR TITLE
Fixes bug where users could not delete a single inventory source

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx
@@ -98,8 +98,7 @@ function InventorySourceDetail({ inventorySource, i18n }) {
   };
 
   const deleteDetailsRequests = relatedResourceDeleteRequests.inventorySource(
-    inventorySource.inventory,
-    inventorySource
+    inventorySource.id
   );
 
   const VERBOSITY = {

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
@@ -145,8 +145,7 @@ function InventorySourceList({ i18n }) {
   const listUrl = `/inventories/${inventoryType}/${id}/sources/`;
 
   const deleteDetailsRequests = relatedResourceDeleteRequests.inventorySource(
-    id,
-    selected[0]
+    selected[0]?.id
   );
   return (
     <>

--- a/awx/ui_next/src/util/getRelatedResouceDeleteDetails.test.js
+++ b/awx/ui_next/src/util/getRelatedResouceDeleteDetails.test.js
@@ -91,9 +91,8 @@ describe('delete details', () => {
     await getRelatedResourceDeleteCounts(
       relatedResourceDeleteRequests.inventorySource(1)
     );
-    expect(InventoriesAPI.updateSources).toBeCalledWith(1);
     expect(WorkflowJobTemplateNodesAPI.read).toBeCalledWith({
-      unified_job_template: 2,
+      unified_job_template: 1,
     });
   });
 
@@ -105,11 +104,11 @@ describe('delete details', () => {
   });
 
   test('should call return error for inventory source list', async () => {
-    InventoriesAPI.updateSources.mockRejectedValue({
+    WorkflowJobTemplateNodesAPI.read.mockRejectedValue({
       response: {
         config: {
-          method: 'post',
-          url: '/api/v2/inventories/1/ad_hoc_commands',
+          method: 'get',
+          url: '/api/v2/workflow_job_template_nodesP',
         },
         data: 'An error occurred',
         status: 403,
@@ -119,7 +118,6 @@ describe('delete details', () => {
       relatedResourceDeleteRequests.inventorySource(1)
     );
 
-    expect(InventoriesAPI.updateSources).toBeCalledWith(1);
     expect(error).toBeDefined();
   });
 

--- a/awx/ui_next/src/util/getRelatedResouceDeleteDetails.test.js
+++ b/awx/ui_next/src/util/getRelatedResouceDeleteDetails.test.js
@@ -108,7 +108,7 @@ describe('delete details', () => {
       response: {
         config: {
           method: 'get',
-          url: '/api/v2/workflow_job_template_nodesP',
+          url: '/api/v2/workflow_job_template_nodes',
         },
         data: 'An error occurred',
         status: 403,

--- a/awx/ui_next/src/util/getRelatedResourceDeleteDetails.js
+++ b/awx/ui_next/src/util/getRelatedResourceDeleteDetails.js
@@ -113,37 +113,20 @@ export const relatedResourceDeleteRequests = {
     },
   ],
 
-  inventorySource: (inventoryId, inventorySource) => [
+  inventorySource: inventorySourceId => [
     {
-      request: async () => {
-        try {
-          const { data } = await InventoriesAPI.updateSources(inventoryId);
-
-          const results = await Promise.all(
-            data.map(async datum =>
-              WorkflowJobTemplateNodesAPI.read({
-                unified_job_template: datum.inventory_source,
-              })
-            )
-          );
-          const total = results.reduce(
-            ({ data: { count: acc } }, { data: { count: cur } }) => acc + cur,
-            { data: { count: 0 } }
-          );
-
-          return { data: { count: total } };
-        } catch (err) {
-          throw new Error(err);
-        }
-      },
+      request: async () =>
+        WorkflowJobTemplateNodesAPI.read({
+          unified_job_template: inventorySourceId,
+        }),
       label: i18n._(t`Workflow Job Template Nodes`),
     },
     {
-      request: async () => InventorySourcesAPI.readGroups(inventorySource.id),
+      request: async () => InventorySourcesAPI.readGroups(inventorySourceId),
       label: i18n._(t`Groups`),
     },
     {
-      request: async () => InventorySourcesAPI.readHosts(inventorySource.id),
+      request: async () => InventorySourcesAPI.readHosts(inventorySourceId),
       label: i18n._(t`Hosts`),
     },
   ],


### PR DESCRIPTION
##### SUMMARY
link #9852 

Also fixes a bug that I came across with deletion warnings.  The deletion warning was showing a count for workflow nodes that referenced any inventory source with the same parent inventory.  For example:

Create an inventory
Create two inventory sources invsrc1 and invsrc2
Create a workflow with a node that syncs invsrc1
Attempt to delete invsrc2

The warning will indicate that there's 1 workflow node that uses the inventory source but that's actually not true.  There should be no deletion warning in this case.

This PR addresses ^^

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
