### PR TITLE
[devel] calculate 4 week limit based on since, when since is provided

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -154,9 +154,9 @@ def gather(dest=None, module=None, subset=None, since=None, until=None, collecti
         until = None if until is None else min(until, _now)
         since = None if since is None else min(since, _now)
 
-        if since and not until:
-            # If `since` is explicit but not `until`, `since` should be used to calculate the 4-week limit
-            until = min(since + timedelta(weeks=4), _now)
+        if since:
+            # If `since` is explicit, the four-week limit should be calculated from `since`
+            until = min(since + timedelta(weeks=4), _now if until is None else until)
         else:
             until = _now if until is None else until
 

--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -156,6 +156,8 @@ def gather(dest=None, module=None, subset=None, since=None, until=None, collecti
 
         if since:
             # If `since` is explicit, the four-week limit should be calculated from `since`
+            if until and until > since + timedelta(weeks=4):
+                logger.warning(f'collection interval exceeds four weeks, reducing interval to {since} - {since + timedelta(weeks=4)}')
             until = min(since + timedelta(weeks=4), _now if until is None else until)
         else:
             until = _now if until is None else until


### PR DESCRIPTION
If `since` is provided, we should be calculating the horizon starting from that point and moving forward
.. instead of starting from the end and working backwards.