### PR TITLE
Fixes bug where workflow approvals page would crash if deleted username was referenced

### DIFF
--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -13,13 +13,17 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/contexts/Network.jsx:52
+#~ msgid "404"
+#~ msgstr ""
+
 #: components/Schedule/ScheduleOccurrences/ScheduleOccurrences.jsx:43
 msgid "(Limited to first 10)"
 msgstr "(Limited to first 10)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr "(Prompt on launch)"
 
@@ -27,11 +31,11 @@ msgstr "(Prompt on launch)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* This field will be retrieved from an external secret management system using the specified credential."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr "- Enable Concurrent Jobs"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr "- Enable Webhooks"
 
@@ -205,8 +209,8 @@ msgstr "Account token"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -234,7 +238,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -242,7 +246,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -257,7 +261,7 @@ msgstr "Actions"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr "Activity"
 
@@ -382,6 +386,10 @@ msgstr "Add workflow template"
 msgid "Administration"
 msgstr ""
 
+#: src/pages/Organizations/components/OrganizationListItem.jsx:66
+#~ msgid "Admins"
+#~ msgstr ""
+
 #: components/DataListToolbar/DataListToolbar.jsx:86
 #: screens/Job/JobOutput/JobOutput.jsx:669
 msgid "Advanced"
@@ -407,6 +415,11 @@ msgstr ""
 "changes, refresh the inventory from the selected source\n"
 "before executing job tasks. This is intended for static content,\n"
 "like the Ansible inventory .ini file format."
+
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:168
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:177
+#~ msgid "After every project update where the SCM revision changes, refresh the inventory from the selected source before executing job tasks. This is intended for static content, like the Ansible inventory .ini file format."
+#~ msgstr "After every project update where the SCM revision changes, refresh the inventory from the selected source before executing job tasks. This is intended for static content, like the Ansible inventory .ini file format."
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:508
 msgid "After number of occurrences"
@@ -434,7 +447,7 @@ msgid "All job types"
 msgstr "All job types"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Allow Branch Override"
@@ -479,6 +492,16 @@ msgstr "An error occurred"
 msgid "An inventory must be selected"
 msgstr "An inventory must be selected"
 
+#: src/components/PromptDetail/PromptInventorySourceDetail.jsx:87
+#: src/components/PromptDetail/PromptProjectDetail.jsx:92
+#: src/screens/Inventory/shared/InventorySourceForm.jsx:143
+#: src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx:94
+#: src/screens/Organization/shared/OrganizationForm.jsx:82
+#: src/screens/Project/ProjectDetail/ProjectDetail.jsx:128
+#: src/screens/Project/shared/ProjectForm.jsx:274
+#~ msgid "Ansible Environment"
+#~ msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:98
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
@@ -486,6 +509,14 @@ msgstr "Ansible Tower"
 #: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:99
 msgid "Ansible Tower Documentation."
 msgstr "Ansible Tower Documentation."
+
+#: src/components/About/About.jsx:58
+#~ msgid "Ansible Version"
+#~ msgstr ""
+
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:204
+#~ msgid "Ansible environment"
+#~ msgstr "Ansible environment"
 
 #: screens/Template/Survey/SurveyQuestionForm.jsx:44
 msgid "Answer type"
@@ -563,21 +594,21 @@ msgstr "Approval"
 msgid "Approve"
 msgstr "Approve"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr "Approved"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr "Approved - {0}.  See the Activity Stream for more information."
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr "Approved by {0} - {1}"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "April"
-
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr "Are you sure you want to cancel this job?"
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -615,6 +646,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Are you sure you want to submit the request to cancel this job?"
@@ -624,7 +656,7 @@ msgstr "Are you sure you want to submit the request to cancel this job?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr "Artifacts"
 
@@ -653,6 +685,10 @@ msgstr "August"
 msgid "Authentication"
 msgstr ""
 
+#: src/pages/AuthSettings.jsx:19
+#~ msgid "Authentication Settings"
+#~ msgstr ""
+
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:88
 #: screens/Setting/MiscSystem/MiscSystemEdit/MiscSystemEdit.jsx:93
 msgid "Authorization Code Expiration"
@@ -663,7 +699,7 @@ msgstr "Authorization Code Expiration"
 msgid "Authorization grant type"
 msgstr "Authorization grant type"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr "Auto"
 
@@ -804,6 +840,10 @@ msgstr ""
 "Together the base path and selected playbook directory provide the full\n"
 "path used to locate playbooks."
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:70
+#~ msgid "Base path used for locating playbooks. Directories found inside this path will be listed in the playbook directory drop-down. Together the base path and selected playbook directory provide the full path used to locate playbooks."
+#~ msgstr "Base path used for locating playbooks. Directories found inside this path will be listed in the playbook directory drop-down. Together the base path and selected playbook directory provide the full path used to locate playbooks."
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:456
 msgid "Basic auth password"
 msgstr "Basic auth password"
@@ -840,13 +880,9 @@ msgstr "Browse"
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr "CPU {0}"
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Cache Timeout"
@@ -882,6 +918,8 @@ msgstr "Cache timeout (seconds)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -904,25 +942,17 @@ msgstr "Cache timeout (seconds)"
 msgid "Cancel"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr "Cancel Inventory Source Sync"
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Cancel Job"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr "Cancel Project Sync"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr "Cancel Sync"
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -962,27 +992,21 @@ msgid "Cancel subscription edit"
 msgstr "Cancel subscription edit"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr "Cancel sync"
+msgid "Cancel sync"
+msgstr "Cancel sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr "Cancel sync process"
+msgid "Cancel sync process"
+msgstr "Cancel sync process"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr "Cancel sync source"
+msgid "Cancel sync source"
+msgstr "Cancel sync source"
 
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
-msgstr "Cancel {0}"
-
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr "Canceled"
 
@@ -1043,6 +1067,10 @@ msgstr ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:76
+#~ msgid "Change PROJECTS_ROOT when deploying {brandName} to change this location."
+#~ msgstr "Change PROJECTS_ROOT when deploying {brandName} to change this location."
+
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:43
 msgid "Changed"
 msgstr "Changed"
@@ -1081,7 +1109,7 @@ msgstr "Choose a Notification Type"
 msgid "Choose a Playbook Directory"
 msgstr "Choose a Playbook Directory"
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr "Choose a Source Control Type"
 
@@ -1116,6 +1144,20 @@ msgstr ""
 "Refer to the Ansible Tower Documentation for more additional\n"
 "information about each option."
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+
+#: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
+#~ msgstr "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:142
 msgid "Choose an email option"
 msgstr "Choose an email option"
@@ -1133,7 +1175,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choose the type of resource that will be receiving new roles.  For example, if you'd like to add new roles to a set of users please choose Users and click Next.  You'll be able to select the specific resources in the next step."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Clean"
@@ -1166,10 +1208,6 @@ msgstr "Click this button to verify connection to the secret management system u
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr "Click to create a new link to this node."
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr "Click to select this answer as a default answer."
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1218,18 +1256,34 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Command"
+
+#: src/screens/Host/Host.jsx:67
+#: src/screens/Host/Hosts.jsx:32
+#: src/screens/Inventory/Inventory.jsx:68
+#: src/screens/Inventory/InventoryHost/InventoryHost.jsx:88
+#: src/screens/Template/Template.jsx:151
+#: src/screens/Template/Templates.jsx:48
+#: src/screens/Template/WorkflowJobTemplate.jsx:145
+#~ msgid "Completed Jobs"
+#~ msgstr "Completed Jobs"
+
+#: src/screens/Inventory/Inventories.jsx:59
+#: src/screens/Inventory/Inventories.jsx:73
+#: src/screens/Inventory/SmartInventory.jsx:73
+#~ msgid "Completed jobs"
+#~ msgstr "Completed jobs"
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:53
 msgid "Compliant"
 msgstr "Compliant"
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr "Concurrent Jobs"
 
@@ -1241,14 +1295,6 @@ msgstr "Confirm Delete"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "Confirm Password"
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr "Confirm cancel job"
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
-msgstr "Confirm cancellation"
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1278,7 +1324,7 @@ msgstr "Confirm revert all"
 msgid "Confirm selection"
 msgstr "Confirm selection"
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr "Container Group"
 
@@ -1321,13 +1367,23 @@ msgstr ""
 "Control the level of output ansible\n"
 "will produce as the playbook executes."
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
 msgstr ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:152
+#: src/screens/Template/shared/JobTemplateForm.jsx:414
+#~ msgid "Control the level of output ansible will produce as the playbook executes."
+#~ msgstr "Control the level of output ansible will produce as the playbook executes."
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:69
+#~ msgid "Controller"
+#~ msgstr "Controller"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:208
 msgid "Convergence"
@@ -1362,7 +1418,7 @@ msgstr "Copy Inventory"
 msgid "Copy Notification Template"
 msgstr "Copy Notification Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr "Copy Project"
 
@@ -1370,7 +1426,7 @@ msgstr "Copy Project"
 msgid "Copy Template"
 msgstr "Copy Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr "Copy full revision to clipboard."
 
@@ -1386,10 +1442,15 @@ msgstr "Copyright"
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr "Create"
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr "Create Execution environments"
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1529,14 +1590,14 @@ msgstr "Create user token"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1555,7 +1616,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1659,7 +1720,7 @@ msgstr "Credential to authenticate with a protected container registry."
 msgid "Credential type not found."
 msgstr "Credential type not found."
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1674,9 +1735,9 @@ msgstr "Credential type not found."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1694,10 +1755,10 @@ msgid "Custom pod spec"
 msgstr "Custom pod spec"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr "Custom virtual environment {0} must be replaced by an execution environment."
 
@@ -1771,7 +1832,7 @@ msgstr "Default Execution Environment"
 msgid "Default answer"
 msgstr "Default answer"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr "Default choice must be answered from the choices listed."
 
@@ -1794,7 +1855,7 @@ msgstr "Define system-level features and functions"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1806,16 +1867,16 @@ msgstr "Define system-level features and functions"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1830,7 +1891,7 @@ msgstr "Delete All Groups and Hosts"
 msgid "Delete Credential"
 msgstr "Delete Credential"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr "Delete Execution Environment"
 
@@ -1851,9 +1912,9 @@ msgstr "Delete Host"
 msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr "Delete Job"
 
@@ -1869,7 +1930,7 @@ msgstr "Delete Notification"
 msgid "Delete Organization"
 msgstr "Delete Organization"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr "Delete Project"
 
@@ -1901,7 +1962,7 @@ msgstr "Delete User Token"
 msgid "Delete Workflow Approval"
 msgstr "Delete Workflow Approval"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr "Delete Workflow Job Template"
 
@@ -1932,7 +1993,7 @@ msgid "Delete inventory source"
 msgstr "Delete inventory source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr "Delete on Update"
 
@@ -1995,11 +2056,15 @@ msgstr "Deletion Error"
 msgid "Deletion error"
 msgstr "Deletion error"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr "Denied"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr "Denied - {0}.  See the Activity Stream for more information."
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr "Denied by {0} - {1}"
 
@@ -2059,16 +2124,16 @@ msgstr "Deprecated"
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2259,7 +2324,7 @@ msgstr "Disassociate role!"
 msgid "Disassociate?"
 msgstr "Disassociate?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2284,8 +2349,8 @@ msgstr "Documentation."
 msgid "Done"
 msgstr "Done"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr "Download Output"
 
@@ -2297,7 +2362,7 @@ msgstr "E-mail"
 msgid "E-mail options"
 msgstr "E-mail options"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr "Each answer choice must be on a separate line."
 
@@ -2335,7 +2400,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2344,14 +2409,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2381,8 +2446,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2477,8 +2542,8 @@ msgstr "Edit Notification Template"
 msgid "Edit Organization"
 msgstr "Edit Organization"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr "Edit Project"
 
@@ -2492,7 +2557,7 @@ msgstr "Edit Question"
 msgid "Edit Schedule"
 msgstr "Edit Schedule"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr "Edit Source"
 
@@ -2562,16 +2627,16 @@ msgid "Edit this node"
 msgstr "Edit this node"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Elapsed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr "Elapsed Time"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr "Elapsed time that the job ran"
 
@@ -2589,11 +2654,11 @@ msgstr "Email Options"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr "Enable Concurrent Jobs"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr "Enable Fact Storage"
 
@@ -2606,14 +2671,14 @@ msgstr "Enable HTTPS certificate verification"
 msgid "Enable Privilege Escalation"
 msgstr "Enable Privilege Escalation"
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr "Enable Webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr "Enable Webhook for this workflow job template."
 
@@ -2638,7 +2703,7 @@ msgstr "Enable privilege escalation"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "Enable simplified login for your {brandName} applications"
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr "Enable webhook for this template."
 
@@ -2669,7 +2734,7 @@ msgstr "Enabled Variable"
 #~ "and request a configuration update using this job\n"
 #~ "template."
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2734,9 +2799,17 @@ msgstr "Enter at least one search filter to create a new Smart Inventory"
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2748,9 +2821,27 @@ msgstr ""
 "Use the radio button to toggle between the two. Refer to the\n"
 "Ansible Tower documentation for example syntax."
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
+
+#: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2766,6 +2857,10 @@ msgstr ""
 "symbol (#) for channels, and the at (@) symbol for users, are not\n"
 "required."
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:244
+#~ msgid "Enter one IRC channel or username per line. The pound symbol (#) for channels, and the at (@) symbol for users, are not required."
+#~ msgstr "Enter one IRC channel or username per line. The pound symbol (#) for channels, and the at (@) symbol for users, are not required."
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
 msgid ""
 "Enter one Slack channel per line. The pound symbol (#)\n"
@@ -2773,6 +2868,10 @@ msgid ""
 msgstr ""
 "Enter one Slack channel per line. The pound symbol (#)\n"
 "is required for channels."
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
+#~ msgid "Enter one Slack channel per line. The pound symbol (#) is required for channels."
+#~ msgstr "Enter one Slack channel per line. The pound symbol (#) is required for channels."
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
 msgid ""
@@ -2782,6 +2881,10 @@ msgstr ""
 "Enter one email address per line to create a recipient\n"
 "list for this type of notification."
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
+#~ msgid "Enter one email address per line to create a recipient list for this type of notification."
+#~ msgstr "Enter one email address per line to create a recipient list for this type of notification."
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
 msgid ""
 "Enter one phone number per line to specify where to\n"
@@ -2790,6 +2893,10 @@ msgstr ""
 "Enter one phone number per line to specify where to\n"
 "route SMS messages."
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
+#~ msgid "Enter one phone number per line to specify where to route SMS messages."
+#~ msgstr "Enter one phone number per line to specify where to route SMS messages."
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
 msgid ""
 "Enter the number associated with the \"Messaging\n"
@@ -2797,6 +2904,10 @@ msgid ""
 msgstr ""
 "Enter the number associated with the \"Messaging\n"
 "Service\" in Twilio in the format +18005550199."
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
+#~ msgid "Enter the number associated with the \"Messaging Service\" in Twilio in the format +18005550199."
+#~ msgstr "Enter the number associated with the \"Messaging Service\" in Twilio in the format +18005550199."
 
 #: screens/Inventory/shared/InventorySourceSubForms/TowerSubForm.jsx:60
 msgid "Enter variables to configure the inventory source. For a detailed description of how to configure this plugin, see <0>Inventory Plugins</0> in the documentation and the <1>Tower</1> plugin configuration guide."
@@ -2838,11 +2949,11 @@ msgstr "Enter variables using either JSON or YAML syntax. Use the radio button t
 #~ msgid "Environment"
 #~ msgstr "Environment"
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2872,8 +2983,8 @@ msgstr "Error saving the workflow!"
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2897,7 +3008,6 @@ msgstr "Error saving the workflow!"
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2913,7 +3023,8 @@ msgstr "Error saving the workflow!"
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2921,7 +3032,7 @@ msgstr "Error saving the workflow!"
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2930,7 +3041,7 @@ msgstr "Error saving the workflow!"
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -3012,7 +3123,7 @@ msgstr "Execute when the parent node results in a successful state."
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr "Execution Environment"
 
@@ -3034,7 +3145,7 @@ msgstr "Execution Environment"
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr "Execution Node"
 
@@ -3049,6 +3160,11 @@ msgstr "Execution environment name"
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr "Execution environment not found."
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr "Execution environments"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -3093,11 +3209,11 @@ msgid "Expires on UTC"
 msgstr "Expires on UTC"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr "Expires on {0}"
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explanation"
@@ -3112,9 +3228,9 @@ msgid "Extra variables"
 msgstr "Extra variables"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr "FINISHED:"
 
@@ -3127,19 +3243,19 @@ msgstr "FINISHED:"
 msgid "Facts"
 msgstr "Facts"
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr "Failed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr "Failed Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr "Failed Hosts"
 
@@ -3173,33 +3289,13 @@ msgstr "Failed to associate role"
 msgid "Failed to associate."
 msgstr "Failed to associate."
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr "Failed to cancel Inventory Source Sync"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr "Failed to cancel Project Sync"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr "Failed to cancel Project Update"
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr "Failed to cancel inventory source sync."
+msgid "Failed to cancel inventory source sync."
+msgstr "Failed to cancel inventory source sync."
 
-#: components/JobList/JobList.jsx:295
+#: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
-
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
-msgstr "Failed to cancel {0}"
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3213,7 +3309,7 @@ msgstr "Failed to copy execution environment"
 msgid "Failed to copy inventory."
 msgstr "Failed to copy inventory."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr "Failed to copy project."
 
@@ -3296,7 +3392,7 @@ msgstr "Failed to delete one or more inventory sources."
 msgid "Failed to delete one or more job templates."
 msgstr "Failed to delete one or more job templates."
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr "Failed to delete one or more jobs."
 
@@ -3344,7 +3440,7 @@ msgstr "Failed to delete one or more workflow approval."
 msgid "Failed to delete organization."
 msgstr "Failed to delete organization."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr "Failed to delete project."
 
@@ -3377,7 +3473,7 @@ msgstr "Failed to delete user."
 msgid "Failed to delete workflow approval."
 msgstr "Failed to delete workflow approval."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr "Failed to delete workflow job template."
 
@@ -3438,7 +3534,7 @@ msgstr "Failed to retrieve node credentials."
 msgid "Failed to send test notification."
 msgstr "Failed to send test notification."
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr "Failed to sync inventory source."
 
@@ -3465,10 +3561,6 @@ msgstr "Failed to toggle notification."
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "Failed to toggle schedule."
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
-msgstr "Failed to update capacity adjustment."
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3533,12 +3625,12 @@ msgstr "File upload rejected. Please select a single .json file."
 msgid "File, directory or script"
 msgstr "File, directory or script"
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr "Finish Time"
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Finished"
@@ -3615,7 +3707,7 @@ msgstr "For more information, refer to the"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr "Forks"
 
@@ -3662,7 +3754,7 @@ msgstr "Get subscription"
 msgid "Get subscriptions"
 msgstr "Get subscriptions"
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3841,11 +3933,11 @@ msgstr "Host Async OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr "Host Config Key"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr "Host Count"
 
@@ -3928,7 +4020,7 @@ msgstr "Host status information for this job is unavailable."
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hosts"
@@ -3954,7 +4046,7 @@ msgstr "Hour"
 msgid "I agree to the End User License Agreement"
 msgstr "I agree to the End User License Agreement"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4032,7 +4124,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -4075,7 +4167,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4097,7 +4189,7 @@ msgstr ""
 "by Ansible tasks, where supported. This is equivalent to Ansible’s\n"
 "--diff mode."
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4115,7 +4207,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4127,11 +4219,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr "If enabled, simultaneous runs of this job template will be allowed."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "If enabled, simultaneous runs of this workflow job template will be allowed."
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4140,6 +4232,10 @@ msgstr ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
 "injected into the fact cache at runtime."
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:559
+#~ msgid "If enabled, this will store gathered facts so they can be viewed at the host level. Facts are persisted and injected into the fact cache at runtime."
+#~ msgstr "If enabled, this will store gathered facts so they can be viewed at the host level. Facts are persisted and injected into the fact cache at runtime."
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:140
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
@@ -4165,6 +4261,10 @@ msgid ""
 msgstr ""
 "If you want the Inventory Source to update on\n"
 "launch and on project update, click on Update on launch, and also go to"
+
+#: src/pages/Organizations/components/DeleteRoleConfirmationModal.jsx:54
+#~ msgid "If you {0} want to remove access for this particular user, please remove them from the team."
+#~ msgstr ""
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:57
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:132
@@ -4227,12 +4327,12 @@ msgid "Input configuration"
 msgstr "Input configuration"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr "Insights Analytics"
+msgid "Insights Analytics"
+msgstr "Insights Analytics"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr "Insights Analytics dashboard"
+msgid "Insights Analytics dashboard"
+msgstr "Insights Analytics dashboard"
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4240,17 +4340,8 @@ msgid "Insights Credential"
 msgstr "Insights Credential"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr "Insights analytics"
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr "Insights for Ansible"
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
-msgstr "Insights for Ansible dashboard"
+msgid "Insights analytics"
+msgstr "Insights analytics"
 
 #: components/Lookup/HostFilterLookup.jsx:107
 msgid "Insights system ID"
@@ -4264,7 +4355,7 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Instance Filters"
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr "Instance Group"
 
@@ -4314,6 +4405,10 @@ msgstr "Instances"
 msgid "Integer"
 msgstr "Integer"
 
+#: src/index.jsx:193
+#~ msgid "Integrations"
+#~ msgstr ""
+
 #: util/validators.jsx:67
 msgid "Invalid email address"
 msgstr "Invalid email address"
@@ -4348,7 +4443,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Inventories with sources cannot be copied"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4371,11 +4466,11 @@ msgstr "Inventories with sources cannot be copied"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr "Inventory"
 
@@ -4396,21 +4491,13 @@ msgstr "Inventory ID"
 #~ msgid "Inventory Scripts"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr "Inventory Source"
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr "Inventory Source Error"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Inventory Source Sync"
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
-msgstr "Inventory Source Sync Error"
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4419,11 +4506,11 @@ msgstr "Inventory Source Sync Error"
 msgid "Inventory Sources"
 msgstr "Inventory Sources"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr "Inventory Sync"
 
@@ -4470,14 +4557,22 @@ msgstr "Item Skipped"
 msgid "Items"
 msgstr "Items"
 
+#: src/components/Pagination/Pagination.jsx:142
+#~ msgid "Items Per Page"
+#~ msgstr ""
+
 #: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr ""
 
+#: src/components/Pagination/Pagination.jsx:162
+#~ msgid "Items {itemMin} – {itemMax} of {count}"
+#~ msgstr ""
+
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr "JOB ID:"
 
@@ -4502,27 +4597,26 @@ msgstr "January"
 msgid "Job"
 msgstr "Job"
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Job Delete Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr "Job Slice"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr "Job Slicing"
 
@@ -4535,19 +4629,19 @@ msgstr "Job Status"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "Job Tags"
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Job Template"
@@ -4572,14 +4666,14 @@ msgstr "Job Templates with a missing inventory or project cannot be selected whe
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "Job Type"
@@ -4598,8 +4692,8 @@ msgstr "Job status graph tab"
 msgid "Job templates"
 msgstr "Job templates"
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4709,19 +4803,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr "Label Name"
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr "Labels"
 
@@ -4729,7 +4823,7 @@ msgstr "Labels"
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr "Last Job Status"
 
@@ -4752,10 +4846,10 @@ msgstr "Last Login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4795,7 +4889,7 @@ msgstr "Last job run"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr "Last modified"
 
@@ -4804,7 +4898,7 @@ msgstr "Last modified"
 msgid "Last name"
 msgstr "Last name"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr "Last used"
 
@@ -4814,8 +4908,8 @@ msgstr "Last used"
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr "Launch"
 
@@ -4850,17 +4944,13 @@ msgstr "Launch workflow"
 msgid "Launched By"
 msgstr "Launched By"
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr "Launched By (Username)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr "Learn more about Insights Analytics"
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
-msgstr "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
+msgstr "Learn more about Insights Analytics"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
 msgid "Leave this field blank to make the execution environment globally available."
@@ -4890,15 +4980,15 @@ msgstr "Less than or equal to comparison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "Limit"
@@ -4962,16 +5052,16 @@ msgstr "Lookup type"
 msgid "Lookup typeahead"
 msgstr "Lookup typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr "MOST RECENT SYNC"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr "Machine Credential"
 
@@ -4988,10 +5078,10 @@ msgstr "Managed by Tower"
 msgid "Managed nodes"
 msgstr "Managed nodes"
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr "Management Job"
 
@@ -5017,14 +5107,14 @@ msgstr "Management job not found."
 msgid "Management jobs"
 msgstr "Management jobs"
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manual"
@@ -5134,7 +5224,7 @@ msgstr "Missing resource"
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -5150,7 +5240,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5236,10 +5326,6 @@ msgstr "Multiple Choice (single select)"
 msgid "Multiple Choice Options"
 msgstr "Multiple Choice Options"
 
-#: components/FormField/TextAndCheckboxField.jsx:87
-#~ msgid "Must type an answer choice before a default value can be selected"
-#~ msgstr "Must type an answer choice before a default value can be selected"
-
 #: src/index.jsx:110
 #: src/pages/Portal.jsx:19
 #~ msgid "My View"
@@ -5254,9 +5340,9 @@ msgstr "Multiple Choice Options"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5279,8 +5365,8 @@ msgstr "Multiple Choice Options"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5374,7 +5460,7 @@ msgstr "Multiple Choice Options"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5400,13 +5486,13 @@ msgstr "Multiple Choice Options"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5414,7 +5500,7 @@ msgstr "Multiple Choice Options"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5456,11 +5542,11 @@ msgid "Never Updated"
 msgstr "Never Updated"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr "Never expires"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "New"
@@ -5749,7 +5835,7 @@ msgstr "October"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr "Off"
 
@@ -5767,7 +5853,7 @@ msgstr "Off"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr "On"
 
@@ -5805,8 +5891,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Option Details"
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5835,12 +5921,12 @@ msgstr "Optionally select the credential to use to send status updates back to t
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr "Options"
 
@@ -5871,15 +5957,15 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5890,9 +5976,17 @@ msgstr "Organization"
 msgid "Organization (Name)"
 msgstr "Organization (Name)"
 
+#: src/pages/Organizations/views/Organization.add.jsx:79
+#~ msgid "Organization Add"
+#~ msgstr ""
+
 #: screens/Team/TeamList/TeamList.jsx:138
 msgid "Organization Name"
 msgstr "Organization Name"
+
+#: src/pages/Organizations/screens/Organization/Organization.jsx:144
+#~ msgid "Organization detail tabs"
+#~ msgstr ""
 
 #: screens/Organization/Organization.jsx:154
 msgid "Organization not found."
@@ -5912,6 +6006,10 @@ msgstr "Organization not found."
 #: util/getRelatedResourceDeleteDetails.js:272
 msgid "Organizations"
 msgstr ""
+
+#: src/pages/Organizations/views/Organizations.list.jsx:218
+#~ msgid "Organizations List"
+#~ msgstr ""
 
 #: components/LaunchPrompt/steps/useOtherPromptsStep.jsx:50
 msgid "Other prompts"
@@ -5948,6 +6046,18 @@ msgstr "POST"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:503
 msgid "PUT"
 msgstr "PUT"
+
+#: src/components/Pagination/Pagination.jsx:190
+#~ msgid "Page"
+#~ msgstr ""
+
+#: src/components/Pagination/Pagination.jsx:189
+#~ msgid "Page <0/> of {pageCount}"
+#~ msgstr ""
+
+#: src/components/Pagination/Pagination.jsx:193
+#~ msgid "Page Number"
+#~ msgstr ""
 
 #: components/NotificationList/NotificationList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:156
@@ -5998,7 +6108,7 @@ msgstr "Pass extra command line changes. There are two ansible command line para
 #~ "Provide key/value pairs using either YAML or JSON. Refer to the\n"
 #~ "Ansible Tower documentation for example syntax."
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -6010,9 +6120,13 @@ msgstr ""
 "Provide key/value pairs using either YAML or JSON. Refer to the\n"
 "documentation for example syntax."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -6035,7 +6149,7 @@ msgstr "Past two weeks"
 msgid "Past week"
 msgstr "Past week"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "Pending"
@@ -6064,7 +6178,7 @@ msgstr "Personal access token"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr "Play Count"
 
@@ -6073,13 +6187,13 @@ msgid "Play Started"
 msgstr "Play Started"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr "Playbook Check"
 
@@ -6088,15 +6202,15 @@ msgid "Playbook Complete"
 msgstr "Playbook Complete"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook Directory"
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr "Playbook Run"
 
@@ -6115,7 +6229,7 @@ msgstr "Playbook name"
 msgid "Playbook run"
 msgstr "Playbook run"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr "Plays"
 
@@ -6161,7 +6275,7 @@ msgstr "Please log in"
 msgid "Please select a day number between 1 and 31."
 msgstr "Please select a day number between 1 and 31."
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "Please select an Inventory or check the Prompt on Launch option."
 
@@ -6204,6 +6318,18 @@ msgstr "Populate field from an external secret management system"
 #~ "Refer to the Ansible Tower documentation for further syntax and\n"
 #~ "examples."
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -6243,29 +6369,25 @@ msgstr "Press 'Enter' to add more answer choices. One answer choice per line."
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr "Press Enter to edit. Press ESC to stop editing."
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr "Press Enter to get additional inputs."
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr "Press Enter to get additional inputs. Refer to the"
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr "Press Enter to get additional {num} inputs. Refer to the"
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
 msgid "Preview"
 msgstr "Preview"
 
+#: src/components/Pagination/Pagination.jsx:179
+#~ msgid "Previous"
+#~ msgstr ""
+
+#: src/index.jsx:88
+#~ msgid "Primary Navigation"
+#~ msgstr ""
+
 #: components/LaunchPrompt/steps/CredentialPasswordsStep.jsx:103
 msgid "Private key passphrase"
 msgstr "Private key passphrase"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr "Privilege Escalation"
 
@@ -6273,17 +6395,17 @@ msgstr "Privilege Escalation"
 msgid "Privilege escalation password"
 msgstr "Privilege escalation password"
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6291,7 +6413,7 @@ msgid "Project"
 msgstr "Project"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Project Base Path"
@@ -6301,19 +6423,9 @@ msgstr "Project Base Path"
 msgid "Project Sync"
 msgstr "Project Sync"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr "Project Sync Error"
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "Project Update"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr "Project Update Error"
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6366,7 +6478,7 @@ msgstr "Prompted Values"
 msgid "Prompts"
 msgstr "Prompts"
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6426,25 +6538,21 @@ msgstr ""
 "retrieving renewal or expanded subscriptions."
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
-msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr "Provisioning Callback URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr "Provisioning Callback details"
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr "Provisioning Callbacks"
 
@@ -6464,10 +6572,6 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS settings"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
-msgstr "RAM {0}"
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6497,7 +6601,7 @@ msgstr "Recipient List"
 msgid "Recipient list"
 msgstr "Recipient list"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6541,7 +6645,7 @@ msgstr "Redirecting to subscription detail"
 msgid "Refer to the"
 msgstr "Refer to the"
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6580,16 +6684,16 @@ msgstr "Regular expression where only matching host names will be imported. The 
 msgid "Related Groups"
 msgstr "Related Groups"
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr "Relaunch Job"
 
@@ -6606,12 +6710,12 @@ msgstr "Relaunch failed hosts"
 msgid "Relaunch on"
 msgstr "Relaunch on"
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr "Relaunch using host parameters"
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6722,10 +6826,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6774,9 +6878,9 @@ msgstr "Revert settings"
 msgid "Revert to factory default."
 msgstr "Revert to factory default."
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr "Revision"
 
@@ -6847,7 +6951,7 @@ msgstr "Run on"
 msgid "Run type"
 msgstr "Run type"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6862,7 +6966,7 @@ msgid "Running Jobs"
 msgstr "Running Jobs"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr "Running jobs"
 
@@ -6897,9 +7001,9 @@ msgid "START"
 msgstr "START"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr "STATUS:"
 
@@ -7036,7 +7140,7 @@ msgstr "Second"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr "Seconds"
 
@@ -7044,7 +7148,7 @@ msgstr "Seconds"
 msgid "See errors on the left"
 msgstr "See errors on the left"
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7208,7 +7312,7 @@ msgstr "Select a valid date and time for this field"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7240,11 +7344,11 @@ msgstr "Select an instance and a metric to show chart"
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr "Select an organization before editing the default execution environment."
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7286,6 +7390,10 @@ msgstr ""
 "the Project Base Path. Together the base path and the playbook\n"
 "directory provide the full path used to locate playbooks."
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:89
+#~ msgid "Select from the list of directories found in the Project Base Path. Together the base path and the playbook directory provide the full path used to locate playbooks."
+#~ msgstr "Select from the list of directories found in the Project Base Path. Together the base path and the playbook directory provide the full path used to locate playbooks."
+
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.jsx:94
 msgid "Select items from list"
 msgstr ""
@@ -7323,7 +7431,7 @@ msgstr "Select the Execution Environment you want this command to run inside."
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Select the Instance Groups for this Inventory to run on."
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7347,7 +7455,7 @@ msgstr "Select the credential you want to use when accessing the remote hosts to
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "Select the custom Python virtual environment for this inventory source sync to run on."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr "Select the default execution environment for this organization to run on."
 
@@ -7355,7 +7463,7 @@ msgstr "Select the default execution environment for this organization to run on
 msgid "Select the default execution environment for this organization."
 msgstr "Select the default execution environment for this organization."
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr "Select the default execution environment for this project."
 
@@ -7371,6 +7479,11 @@ msgid ""
 msgstr ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
+
+#: src/components/Lookup/InventoryLookup.jsx:89
+#: src/screens/Template/shared/JobTemplateForm.jsx:248
+#~ msgid "Select the inventory containing the hosts you want this job to manage."
+#~ msgstr "Select the inventory containing the hosts you want this job to manage."
 
 #: screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx:105
 msgid ""
@@ -7391,7 +7504,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "Select the inventory that this host will belong to."
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr "Select the playbook to be executed by this job."
 
@@ -7437,7 +7550,7 @@ msgstr "Select {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7472,7 +7585,7 @@ msgid "Service account JSON file"
 msgstr "Service account JSON file"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr "Set a value for this field"
 
@@ -7541,7 +7654,7 @@ msgstr "Show"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr "Show Changes"
 
@@ -7612,9 +7725,9 @@ msgstr "Simple key select"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr "Skip Tags"
 
@@ -7632,7 +7745,7 @@ msgstr "Skip Tags"
 #~ "to Ansible Tower documentation for details on the usage\n"
 #~ "of tags."
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7657,6 +7770,11 @@ msgstr ""
 "playbook, and you want to skip specific parts of a play or task.\n"
 "Use commas to separate multiple tags. Refer to Ansible Tower\n"
 "documentation for details on the usage of tags."
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:74
+#: src/screens/Template/shared/JobTemplateForm.jsx:487
+#~ msgid "Skip tags are useful when you have a large playbook, and you want to skip specific parts of a play or task. Use commas to separate multiple tags. Refer to Ansible Tower documentation for details on the usage of tags."
+#~ msgstr "Skip tags are useful when you have a large playbook, and you want to skip specific parts of a play or task. Use commas to separate multiple tags. Refer to Ansible Tower documentation for details on the usage of tags."
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:39
 msgid "Skipped"
@@ -7721,10 +7839,8 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "Source Control Branch"
@@ -7734,41 +7850,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Source Control Branch/Tag/Commit"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Source Control Credential"
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr "Source Control Credential Type"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Source Control Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr "Source Control Type"
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "Source Control URL"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr "Source Control Update"
 
@@ -7780,8 +7896,8 @@ msgstr "Source Phone Number"
 msgid "Source Variables"
 msgstr "Source Variables"
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr "Source Workflow Job"
 
@@ -7818,6 +7934,18 @@ msgid ""
 msgstr ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:392
 msgid ""
@@ -7862,8 +7990,8 @@ msgstr "Standard out tab"
 msgid "Start"
 msgstr "Start"
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr "Start Time"
 
@@ -7881,32 +8009,32 @@ msgstr "Start message"
 msgid "Start message body"
 msgstr "Start message body"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr "Start sync process"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr "Start sync source"
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Started"
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7975,7 +8103,7 @@ msgstr "Subscription type"
 msgid "Subscriptions table"
 msgstr "Subscriptions table"
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7999,13 +8127,13 @@ msgstr "Success message"
 msgid "Success message body"
 msgstr "Success message body"
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr "Successfully copied to clipboard!"
 
@@ -8045,14 +8173,14 @@ msgstr "Survey preview modal"
 msgid "Survey questions"
 msgstr "Survey questions"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -8071,7 +8199,7 @@ msgstr "Sync all sources"
 msgid "Sync error"
 msgstr "Sync error"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr "Sync for revision"
 
@@ -8134,7 +8262,7 @@ msgstr "Tabs"
 #~ "Refer to Ansible Tower documentation for details on\n"
 #~ "the usage of tags."
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -8186,7 +8314,7 @@ msgstr "Target URL"
 msgid "Task"
 msgstr "Task"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr "Task Count"
 
@@ -8194,7 +8322,7 @@ msgstr "Task Count"
 msgid "Task Started"
 msgstr "Task Started"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -8319,7 +8447,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8328,6 +8456,10 @@ msgstr ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
 "timeout."
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:439
+#~ msgid "The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout."
+#~ msgstr "The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout."
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:164
 msgid ""
@@ -8371,7 +8503,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8457,7 +8589,7 @@ msgstr "There must be a value in at least one input"
 msgid "There was a problem logging in. Please try again."
 msgstr "There was a problem logging in. Please try again."
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr "There was a problem signing in. Please try again."
 
@@ -8531,15 +8663,25 @@ msgstr "This credential is currently being used by other resources. Are you sure
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr "This credential type is currently being used by some credentials and cannot be deleted"
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8552,16 +8694,16 @@ msgstr ""
 "streamline customer experience and success."
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8662,7 +8804,7 @@ msgstr "This job template is currently being used by other resources. Are you su
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "This organization is currently being by other resources. Are you sure you want to delete it?"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This project is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8707,7 +8849,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "This workflow does not have any nodes configured."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8765,7 +8907,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr "Timed out"
 
@@ -8774,7 +8916,7 @@ msgstr "Timed out"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -8886,7 +9028,7 @@ msgid "Total Nodes"
 msgstr "Total Nodes"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr "Total jobs"
 
@@ -8895,7 +9037,7 @@ msgid "Track submodules"
 msgstr "Track submodules"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr "Track submodules latest commit on branch"
 
@@ -8928,9 +9070,9 @@ msgstr "Tuesday"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8950,12 +9092,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8963,7 +9105,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8976,7 +9118,7 @@ msgstr "Type"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr "Type Details"
 
@@ -8986,7 +9128,7 @@ msgstr "Type answer then click checkbox on right to select answer as default."
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr "Unavailable"
 
@@ -9000,15 +9142,15 @@ msgid "Unlimited"
 msgstr "Unlimited"
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr "Unreachable"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr "Unreachable Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr "Unreachable Hosts"
 
@@ -9021,7 +9163,7 @@ msgid "Unsaved changes modal"
 msgstr "Unsaved changes modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Update Revision on Launch"
@@ -9103,10 +9245,14 @@ msgstr ""
 "notifications sent when a job starts, succeeds, or fails. Use\n"
 "curly braces to access information about the job:"
 
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:72
+#~ msgid "Use custom messages to change the content of notifications sent when a job starts, succeeds, or fails. Use curly braces to access information about the job:"
+#~ msgstr "Use custom messages to change the content of notifications sent when a job starts, succeeds, or fails. Use curly braces to access information about the job:"
+
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr "Used capacity"
 
@@ -9222,11 +9368,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr "Variables"
 
@@ -9254,9 +9400,9 @@ msgstr "Verbose"
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr "Verbosity"
 
@@ -9526,7 +9672,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "WARNING:"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "Waiting"
@@ -9560,14 +9706,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook Credential"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr "Webhook Credentials"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook Key"
@@ -9575,7 +9721,7 @@ msgstr "Webhook Key"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook Service"
@@ -9583,14 +9729,14 @@ msgstr "Webhook Service"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr "Webhook details"
 
@@ -9627,7 +9773,7 @@ msgstr "Weekend day"
 msgid "Welcome to Ansible {brandName}!"
 msgstr "Welcome to Ansible {brandName}!"
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr ""
 
@@ -9666,6 +9812,11 @@ msgstr ""
 "hosts and groups not found on the external source will remain\n"
 "untouched by the inventory update process."
 
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:127
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:141
+#~ msgid "When not checked, local child hosts and groups not found on the external source will remain untouched by the inventory update process."
+#~ msgstr "When not checked, local child hosts and groups not found on the external source will remain untouched by the inventory update process."
+
 #: components/Workflow/WorkflowLegend.jsx:96
 msgid "Workflow"
 msgstr "Workflow"
@@ -9687,18 +9838,18 @@ msgstr "Workflow Approval not found."
 msgid "Workflow Approvals"
 msgstr "Workflow Approvals"
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Workflow Job"
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9829,6 +9980,10 @@ msgstr "You do not have permission to delete {pluralizedItemName}: {itemsUnableT
 msgid "You do not have permission to disassociate the following: {itemsUnableToDisassociate}"
 msgstr "You do not have permission to disassociate the following: {itemsUnableToDisassociate}"
 
+#: src/contexts/Network.jsx:40
+#~ msgid "You have been logged out."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:90
 msgid ""
 "You may apply a number of possible variables in the\n"
@@ -9837,7 +9992,7 @@ msgstr ""
 "You may apply a number of possible variables in the\n"
 "message. For more information, refer to the"
 
-#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:90
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:89
 #~ msgid "You may apply a number of possible variables in the message. Refer to the"
 #~ msgstr "You may apply a number of possible variables in the message. Refer to the"
 
@@ -9857,18 +10012,18 @@ msgstr "Zoom In"
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "a new webhook key will be generated on save."
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "a new webhook url will be generated on save."
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9902,10 +10057,6 @@ msgstr "brand logo"
 msgid "cancel delete"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr "capacity adjustment"
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "command"
@@ -9929,7 +10080,7 @@ msgstr "confirm disassociate"
 #~ msgid "controller instance"
 #~ msgstr "controller instance"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr "copy to clipboard disabled"
 
@@ -9959,18 +10110,22 @@ msgid "documentation"
 msgstr "documentation"
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
 msgstr "edit"
+
+#: src/pages/Organizations/components/OrganizationEdit.jsx:20
+#~ msgid "edit view"
+#~ msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.jsx:123
 msgid "encrypted"
@@ -10013,25 +10168,31 @@ msgstr "here."
 msgid "hosts"
 msgstr "hosts"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr "instance counts"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr "instance group used capacity"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr "instance host name"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr "instance type"
 
 #: components/Lookup/HostListItem.jsx:30
 msgid "inventory"
 msgstr "inventory"
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:51
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:59
+#: screens/Job/JobDetail/JobDetail.jsx:119
+#~ msgid "isolated instance"
+#~ msgstr "isolated instance"
 
 #: components/Pagination/Pagination.jsx:23
 msgid "items"
@@ -10076,6 +10237,10 @@ msgstr "of"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:238
 msgid "option to the"
 msgstr "option to the"
+
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:84
+#~ msgid "or attributes of the job such as"
+#~ msgstr "or attributes of the job such as"
 
 #: components/Pagination/Pagination.jsx:24
 msgid "page"
@@ -10142,11 +10307,6 @@ msgstr "select verbosity"
 msgid "social login"
 msgstr "social login"
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr "source control branch"
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "system"
@@ -10191,7 +10351,7 @@ msgstr "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 
@@ -10219,17 +10379,13 @@ msgstr "{0, plural, one {This execution environment is currently being used by o
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -10263,6 +10419,10 @@ msgstr ""
 msgid "{0} (deleted)"
 msgstr "{0} (deleted)"
 
+#: src/components/PaginatedDataList/PaginatedDataList.jsx:135
+#~ msgid "{0} List"
+#~ msgstr ""
+
 #: components/ChipGroup/ChipGroup.jsx:13
 msgid "{0} more"
 msgstr "{0} more"
@@ -10279,13 +10439,13 @@ msgstr "{0}: {1}"
 msgid "{brandName} logo"
 msgstr "{brandName} logo"
 
+#: src/pages/Organizations/components/OrganizationDetail.jsx:54
+#~ msgid "{currentTab} detail view"
+#~ msgstr ""
+
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} by <0>{username}</0>"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr "{forks, plural, one {# fork} other {# forks}}"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"
@@ -10311,13 +10471,25 @@ msgstr "{intervalValue, plural, one {week} other {weeks}}"
 msgid "{intervalValue, plural, one {year} other {years}}"
 msgstr "{intervalValue, plural, one {year} other {years}}"
 
+#: src/components/Pagination/Pagination.jsx:163
+#~ msgid "{itemMin} - {itemMax} of {count}"
+#~ msgstr ""
+
 #: components/PromptDetail/PromptDetail.jsx:43
 msgid "{minutes} min {seconds} sec"
 msgstr "{minutes} min {seconds} sec"
 
+#: src/screens/Inventory/InventoryList/InventoryList.jsx:215
+#~ msgid "{numItemsToDelete, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
+#~ msgstr "{numItemsToDelete, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
+
 #: components/JobList/JobListCancelButton.jsx:106
 msgid "{numJobsToCancel, plural, one {Cancel job} other {Cancel jobs}}"
 msgstr "{numJobsToCancel, plural, one {Cancel job} other {Cancel jobs}}"
+
+#: src/components/JobList/JobListCancelButton.jsx:81
+#~ msgid "{numJobsToCancel, plural, one {Cancel selected job} other {Cancel selected jobs}}"
+#~ msgstr "{numJobsToCancel, plural, one {Cancel selected job} other {Cancel selected jobs}}"
 
 #: components/JobList/JobListCancelButton.jsx:167
 msgid "{numJobsToCancel, plural, one {This action will cancel the following job:} other {This action will cancel the following jobs:}}"
@@ -10327,7 +10499,19 @@ msgstr "{numJobsToCancel, plural, one {This action will cancel the following job
 msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
+#: src/components/JobList/JobListCancelButton.jsx:68
+#~ msgid "{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}"
+#~ msgstr "{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}"
+
+#: src/components/JobList/JobListCancelButton.jsx:57
+#~ msgid "{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}"
+#~ msgstr "{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}"
+
 #: components/PaginatedDataList/PaginatedDataList.jsx:92
 #: components/PaginatedTable/PaginatedTable.jsx:77
 msgid "{pluralizedItemName} List"
 msgstr "{pluralizedItemName} List"
+
+#: src/components/JobList/JobListCancelButton.jsx:96
+#~ msgid "{zeroOrOneJobSelected, plural, one {Cancel job} other {Cancel jobs}}"
+#~ msgstr "{zeroOrOneJobSelected, plural, one {Cancel job} other {Cancel jobs}}"

--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -23,7 +23,7 @@ msgstr "(Limited to first 10)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr "(Prompt on launch)"
 
@@ -31,11 +31,11 @@ msgstr "(Prompt on launch)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* This field will be retrieved from an external secret management system using the specified credential."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr "- Enable Concurrent Jobs"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr "- Enable Webhooks"
 
@@ -209,8 +209,8 @@ msgstr "Account token"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -238,7 +238,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -246,7 +246,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -261,7 +261,7 @@ msgstr "Actions"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr "Activity"
 
@@ -447,7 +447,7 @@ msgid "All job types"
 msgstr "All job types"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Allow Branch Override"
@@ -610,6 +610,10 @@ msgstr "Approved by {0} - {1}"
 msgid "April"
 msgstr "April"
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr "Are you sure you want to cancel this job?"
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr "Are you sure you want to delete the {0} below?"
@@ -646,7 +650,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Are you sure you want to submit the request to cancel this job?"
@@ -656,7 +659,7 @@ msgstr "Are you sure you want to submit the request to cancel this job?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr "Artifacts"
 
@@ -699,7 +702,7 @@ msgstr "Authorization Code Expiration"
 msgid "Authorization grant type"
 msgstr "Authorization grant type"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr "Auto"
 
@@ -770,7 +773,7 @@ msgstr "Back to Schedules"
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -880,9 +883,13 @@ msgstr "Browse"
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr "CPU {0}"
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Cache Timeout"
@@ -918,8 +925,6 @@ msgstr "Cache timeout (seconds)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -942,17 +947,25 @@ msgstr "Cache timeout (seconds)"
 msgid "Cancel"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr "Cancel Inventory Source Sync"
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Cancel Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr "Cancel Project Sync"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr "Cancel Sync"
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -992,18 +1005,24 @@ msgid "Cancel subscription edit"
 msgstr "Cancel subscription edit"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "Cancel sync"
+#~ msgid "Cancel sync"
+#~ msgstr "Cancel sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "Cancel sync process"
+#~ msgid "Cancel sync process"
+#~ msgstr "Cancel sync process"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "Cancel sync source"
+#~ msgid "Cancel sync source"
+#~ msgstr "Cancel sync source"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
+msgstr "Cancel {0}"
+
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1109,7 +1128,7 @@ msgstr "Choose a Notification Type"
 msgid "Choose a Playbook Directory"
 msgstr "Choose a Playbook Directory"
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr "Choose a Source Control Type"
 
@@ -1175,7 +1194,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choose the type of resource that will be receiving new roles.  For example, if you'd like to add new roles to a set of users please choose Users and click Next.  You'll be able to select the specific resources in the next step."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Clean"
@@ -1256,9 +1275,9 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Command"
@@ -1283,7 +1302,7 @@ msgstr "Command"
 msgid "Compliant"
 msgstr "Compliant"
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr "Concurrent Jobs"
 
@@ -1295,6 +1314,14 @@ msgstr "Confirm Delete"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "Confirm Password"
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr "Confirm cancel job"
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
+msgstr "Confirm cancellation"
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1324,7 +1351,7 @@ msgstr "Confirm revert all"
 msgid "Confirm selection"
 msgstr "Confirm selection"
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr "Container Group"
 
@@ -1367,7 +1394,7 @@ msgstr ""
 "Control the level of output ansible\n"
 "will produce as the playbook executes."
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1418,7 +1445,7 @@ msgstr "Copy Inventory"
 msgid "Copy Notification Template"
 msgstr "Copy Notification Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "Copy Project"
 
@@ -1426,7 +1453,7 @@ msgstr "Copy Project"
 msgid "Copy Template"
 msgstr "Copy Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "Copy full revision to clipboard."
 
@@ -1442,8 +1469,8 @@ msgstr "Copyright"
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr "Create"
 
@@ -1590,14 +1617,14 @@ msgstr "Create user token"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1616,7 +1643,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1712,7 +1739,7 @@ msgstr "Credential passwords"
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr "Credential to authenticate with a protected container registry."
 
@@ -1720,7 +1747,7 @@ msgstr "Credential to authenticate with a protected container registry."
 msgid "Credential type not found."
 msgstr "Credential type not found."
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1735,9 +1762,9 @@ msgstr "Credential type not found."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1755,10 +1782,10 @@ msgid "Custom pod spec"
 msgstr "Custom pod spec"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr "Custom virtual environment {0} must be replaced by an execution environment."
 
@@ -1855,7 +1882,7 @@ msgstr "Define system-level features and functions"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1867,16 +1894,16 @@ msgstr "Define system-level features and functions"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1891,7 +1918,7 @@ msgstr "Delete All Groups and Hosts"
 msgid "Delete Credential"
 msgstr "Delete Credential"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr "Delete Execution Environment"
 
@@ -1912,9 +1939,9 @@ msgstr "Delete Host"
 msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "Delete Job"
 
@@ -1930,7 +1957,7 @@ msgstr "Delete Notification"
 msgid "Delete Organization"
 msgstr "Delete Organization"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "Delete Project"
 
@@ -1962,7 +1989,7 @@ msgstr "Delete User Token"
 msgid "Delete Workflow Approval"
 msgstr "Delete Workflow Approval"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr "Delete Workflow Job Template"
 
@@ -1993,7 +2020,7 @@ msgid "Delete inventory source"
 msgstr "Delete inventory source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "Delete on Update"
 
@@ -2102,7 +2129,7 @@ msgstr "Deprecated"
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2124,16 +2151,16 @@ msgstr "Deprecated"
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2216,7 +2243,7 @@ msgstr "Destination channels or users"
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2324,7 +2351,7 @@ msgstr "Disassociate role!"
 msgid "Disassociate?"
 msgstr "Disassociate?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2349,8 +2376,8 @@ msgstr "Documentation."
 msgid "Done"
 msgstr "Done"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "Download Output"
 
@@ -2400,7 +2427,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2409,14 +2436,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2425,8 +2452,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2446,8 +2473,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2542,8 +2569,8 @@ msgstr "Edit Notification Template"
 msgid "Edit Organization"
 msgstr "Edit Organization"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "Edit Project"
 
@@ -2557,7 +2584,7 @@ msgstr "Edit Question"
 msgid "Edit Schedule"
 msgstr "Edit Schedule"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "Edit Source"
 
@@ -2627,16 +2654,16 @@ msgid "Edit this node"
 msgstr "Edit this node"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Elapsed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "Elapsed Time"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "Elapsed time that the job ran"
 
@@ -2654,11 +2681,11 @@ msgstr "Email Options"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr "Enable Concurrent Jobs"
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr "Enable Fact Storage"
 
@@ -2671,14 +2698,14 @@ msgstr "Enable HTTPS certificate verification"
 msgid "Enable Privilege Escalation"
 msgstr "Enable Privilege Escalation"
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr "Enable Webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr "Enable Webhook for this workflow job template."
 
@@ -2703,7 +2730,7 @@ msgstr "Enable privilege escalation"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "Enable simplified login for your {brandName} applications"
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr "Enable webhook for this template."
 
@@ -2734,7 +2761,7 @@ msgstr "Enabled Variable"
 #~ "and request a configuration update using this job\n"
 #~ "template."
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2949,11 +2976,11 @@ msgstr "Enter variables using either JSON or YAML syntax. Use the radio button t
 #~ msgid "Environment"
 #~ msgstr "Environment"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2983,9 +3010,9 @@ msgstr "Error saving the workflow!"
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -3008,6 +3035,7 @@ msgstr "Error saving the workflow!"
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -3023,8 +3051,7 @@ msgstr "Error saving the workflow!"
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -3032,7 +3059,7 @@ msgstr "Error saving the workflow!"
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3041,7 +3068,7 @@ msgstr "Error saving the workflow!"
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -3107,6 +3134,10 @@ msgstr "Example URLs for Subversion Source Control include:"
 msgid "Examples include:"
 msgstr "Examples include:"
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr "Examples:"
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr "Execute regardless of the parent node's final state."
@@ -3123,7 +3154,7 @@ msgstr "Execute when the parent node results in a successful state."
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr "Execution Environment"
 
@@ -3145,7 +3176,7 @@ msgstr "Execution Environment"
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr "Execution Node"
 
@@ -3213,7 +3244,7 @@ msgstr "Expires on UTC"
 msgid "Expires on {0}"
 msgstr "Expires on {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explanation"
@@ -3228,9 +3259,9 @@ msgid "Extra variables"
 msgstr "Extra variables"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "FINISHED:"
 
@@ -3243,19 +3274,19 @@ msgstr "FINISHED:"
 msgid "Facts"
 msgstr "Facts"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "Failed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "Failed Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "Failed Hosts"
 
@@ -3289,13 +3320,28 @@ msgstr "Failed to associate role"
 msgid "Failed to associate."
 msgstr "Failed to associate."
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
+msgstr "Failed to cancel Inventory Source Sync"
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr "Failed to cancel Project Sync"
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "Failed to cancel inventory source sync."
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
+msgstr "Failed to cancel {0}"
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3309,7 +3355,7 @@ msgstr "Failed to copy execution environment"
 msgid "Failed to copy inventory."
 msgstr "Failed to copy inventory."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "Failed to copy project."
 
@@ -3392,7 +3438,7 @@ msgstr "Failed to delete one or more inventory sources."
 msgid "Failed to delete one or more job templates."
 msgstr "Failed to delete one or more job templates."
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "Failed to delete one or more jobs."
 
@@ -3440,7 +3486,7 @@ msgstr "Failed to delete one or more workflow approval."
 msgid "Failed to delete organization."
 msgstr "Failed to delete organization."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "Failed to delete project."
 
@@ -3473,7 +3519,7 @@ msgstr "Failed to delete user."
 msgid "Failed to delete workflow approval."
 msgstr "Failed to delete workflow approval."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr "Failed to delete workflow job template."
 
@@ -3513,7 +3559,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr "Failed to launch job."
@@ -3534,7 +3580,7 @@ msgstr "Failed to retrieve node credentials."
 msgid "Failed to send test notification."
 msgstr "Failed to send test notification."
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "Failed to sync inventory source."
 
@@ -3561,6 +3607,10 @@ msgstr "Failed to toggle notification."
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "Failed to toggle schedule."
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
+msgstr "Failed to update capacity adjustment."
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3625,12 +3675,12 @@ msgstr "File upload rejected. Please select a single .json file."
 msgid "File, directory or script"
 msgstr "File, directory or script"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "Finish Time"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Finished"
@@ -3707,7 +3757,7 @@ msgstr "For more information, refer to the"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr "Forks"
 
@@ -3754,7 +3804,7 @@ msgstr "Get subscription"
 msgid "Get subscriptions"
 msgstr "Get subscriptions"
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3815,7 +3865,7 @@ msgstr "Global Default Execution Environment"
 msgid "Globally Available"
 msgstr "Globally Available"
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr "Globally available execution environment can not be reassigned to a specific Organization"
 
@@ -3933,11 +3983,11 @@ msgstr "Host Async OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr "Host Config Key"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "Host Count"
 
@@ -4020,7 +4070,7 @@ msgstr "Host status information for this job is unavailable."
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hosts"
@@ -4046,7 +4096,7 @@ msgstr "Hour"
 msgid "I agree to the End User License Agreement"
 msgstr "I agree to the End User License Agreement"
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4167,7 +4217,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4189,7 +4239,7 @@ msgstr ""
 "by Ansible tasks, where supported. This is equivalent to Ansible’s\n"
 "--diff mode."
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4207,7 +4257,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4219,11 +4269,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr "If enabled, simultaneous runs of this job template will be allowed."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "If enabled, simultaneous runs of this workflow job template will be allowed."
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4271,14 +4321,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr "Image"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr "Image name"
+#~ msgid "Image name"
+#~ msgstr "Image name"
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4327,12 +4378,12 @@ msgid "Input configuration"
 msgstr "Input configuration"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr "Insights Analytics"
+#~ msgid "Insights Analytics"
+#~ msgstr "Insights Analytics"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr "Insights Analytics dashboard"
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr "Insights Analytics dashboard"
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4340,8 +4391,17 @@ msgid "Insights Credential"
 msgstr "Insights Credential"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
-msgstr "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr "Insights analytics"
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr "Insights for Ansible"
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
+msgstr "Insights for Ansible dashboard"
 
 #: components/Lookup/HostFilterLookup.jsx:107
 msgid "Insights system ID"
@@ -4355,7 +4415,7 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Instance Filters"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr "Instance Group"
 
@@ -4443,7 +4503,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Inventories with sources cannot be copied"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4466,11 +4526,11 @@ msgstr "Inventories with sources cannot be copied"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr "Inventory"
 
@@ -4491,13 +4551,17 @@ msgstr "Inventory ID"
 #~ msgid "Inventory Scripts"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr "Inventory Source"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Inventory Source Sync"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr "Inventory Source Sync Error"
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4506,11 +4570,11 @@ msgstr "Inventory Source Sync"
 msgid "Inventory Sources"
 msgstr "Inventory Sources"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr "Inventory Sync"
 
@@ -4570,9 +4634,9 @@ msgstr ""
 #~ msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "JOB ID:"
 
@@ -4597,26 +4661,27 @@ msgstr "January"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Job Delete Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr "Job Slice"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr "Job Slicing"
 
@@ -4629,19 +4694,19 @@ msgstr "Job Status"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr "Job Tags"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Job Template"
@@ -4666,14 +4731,14 @@ msgstr "Job Templates with a missing inventory or project cannot be selected whe
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "Job Type"
@@ -4692,8 +4757,8 @@ msgstr "Job status graph tab"
 msgid "Job templates"
 msgstr "Job templates"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4803,19 +4868,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "Label Name"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr "Labels"
 
@@ -4823,7 +4888,7 @@ msgstr "Labels"
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr "Last Job Status"
 
@@ -4846,10 +4911,10 @@ msgstr "Last Login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4889,7 +4954,7 @@ msgstr "Last job run"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "Last modified"
 
@@ -4898,7 +4963,7 @@ msgstr "Last modified"
 msgid "Last name"
 msgstr "Last name"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr "Last used"
 
@@ -4908,8 +4973,8 @@ msgstr "Last used"
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr "Launch"
 
@@ -4944,13 +5009,17 @@ msgstr "Launch workflow"
 msgid "Launched By"
 msgstr "Launched By"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "Launched By (Username)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
-msgstr "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr "Learn more about Insights Analytics"
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
+msgstr "Learn more about Insights for Ansible"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
 msgid "Leave this field blank to make the execution environment globally available."
@@ -4980,15 +5049,15 @@ msgstr "Less than or equal to comparison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "Limit"
@@ -5052,16 +5121,16 @@ msgstr "Lookup type"
 msgid "Lookup typeahead"
 msgstr "Lookup typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "MOST RECENT SYNC"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr "Machine Credential"
 
@@ -5078,10 +5147,10 @@ msgstr "Managed by Tower"
 msgid "Managed nodes"
 msgstr "Managed nodes"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr "Management Job"
 
@@ -5107,14 +5176,14 @@ msgstr "Management job not found."
 msgid "Management jobs"
 msgstr "Management jobs"
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manual"
@@ -5224,7 +5293,7 @@ msgstr "Missing resource"
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -5240,7 +5309,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5340,9 +5409,9 @@ msgstr "Multiple Choice Options"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5365,8 +5434,8 @@ msgstr "Multiple Choice Options"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5460,7 +5529,7 @@ msgstr "Multiple Choice Options"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5486,13 +5555,13 @@ msgstr "Multiple Choice Options"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5500,7 +5569,7 @@ msgstr "Multiple Choice Options"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5546,7 +5615,7 @@ msgstr "Never Updated"
 msgid "Never expires"
 msgstr "Never expires"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "New"
@@ -5835,7 +5904,7 @@ msgstr "October"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr "Off"
 
@@ -5853,7 +5922,7 @@ msgstr "Off"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr "On"
 
@@ -5891,8 +5960,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Option Details"
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5921,12 +5990,12 @@ msgstr "Optionally select the credential to use to send status updates back to t
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr "Options"
 
@@ -5957,15 +6026,15 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -6108,7 +6177,7 @@ msgstr "Pass extra command line changes. There are two ansible command line para
 #~ "Provide key/value pairs using either YAML or JSON. Refer to the\n"
 #~ "Ansible Tower documentation for example syntax."
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -6120,7 +6189,7 @@ msgstr ""
 "Provide key/value pairs using either YAML or JSON. Refer to the\n"
 "documentation for example syntax."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 
@@ -6149,7 +6218,7 @@ msgstr "Past two weeks"
 msgid "Past week"
 msgstr "Past week"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "Pending"
@@ -6178,7 +6247,7 @@ msgstr "Personal access token"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "Play Count"
 
@@ -6187,13 +6256,13 @@ msgid "Play Started"
 msgstr "Play Started"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr "Playbook Check"
 
@@ -6202,15 +6271,15 @@ msgid "Playbook Complete"
 msgstr "Playbook Complete"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook Directory"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr "Playbook Run"
 
@@ -6229,7 +6298,7 @@ msgstr "Playbook name"
 msgid "Playbook run"
 msgstr "Playbook run"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Plays"
 
@@ -6275,7 +6344,7 @@ msgstr "Please log in"
 msgid "Please select a day number between 1 and 31."
 msgstr "Please select a day number between 1 and 31."
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "Please select an Inventory or check the Prompt on Launch option."
 
@@ -6387,7 +6456,7 @@ msgstr "Preview"
 msgid "Private key passphrase"
 msgstr "Private key passphrase"
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr "Privilege Escalation"
 
@@ -6395,17 +6464,17 @@ msgstr "Privilege Escalation"
 msgid "Privilege escalation password"
 msgstr "Privilege escalation password"
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6413,7 +6482,7 @@ msgid "Project"
 msgstr "Project"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Project Base Path"
@@ -6422,6 +6491,11 @@ msgstr "Project Base Path"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
 msgstr "Project Sync"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr "Project Sync Error"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
@@ -6478,7 +6552,7 @@ msgstr "Prompted Values"
 msgid "Prompts"
 msgstr "Prompts"
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6538,26 +6612,30 @@ msgstr ""
 "retrieving renewal or expanded subscriptions."
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr "Provisioning Callback URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr "Provisioning Callback details"
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr "Provisioning Callbacks"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr "Pull"
 
@@ -6572,6 +6650,10 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS settings"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
+msgstr "RAM {0}"
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6601,7 +6683,7 @@ msgstr "Recipient List"
 msgid "Recipient list"
 msgstr "Recipient list"
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6645,7 +6727,7 @@ msgstr "Redirecting to subscription detail"
 msgid "Refer to the"
 msgstr "Refer to the"
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6670,7 +6752,7 @@ msgstr "Refresh Token Expiration"
 msgid "Regions"
 msgstr "Regions"
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr "Registry credential"
 
@@ -6684,16 +6766,16 @@ msgstr "Regular expression where only matching host names will be imported. The 
 msgid "Related Groups"
 msgstr "Related Groups"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "Relaunch Job"
 
@@ -6710,12 +6792,12 @@ msgstr "Relaunch failed hosts"
 msgid "Relaunch on"
 msgstr "Relaunch on"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "Relaunch using host parameters"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6826,10 +6908,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6878,9 +6960,9 @@ msgstr "Revert settings"
 msgid "Revert to factory default."
 msgstr "Revert to factory default."
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "Revision"
 
@@ -6951,7 +7033,7 @@ msgstr "Run on"
 msgid "Run type"
 msgstr "Run type"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6966,7 +7048,7 @@ msgid "Running Jobs"
 msgstr "Running Jobs"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr "Running jobs"
 
@@ -7001,9 +7083,9 @@ msgid "START"
 msgstr "START"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "STATUS:"
 
@@ -7140,7 +7222,7 @@ msgstr "Second"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "Seconds"
 
@@ -7148,7 +7230,7 @@ msgstr "Seconds"
 msgid "See errors on the left"
 msgstr "See errors on the left"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7312,7 +7394,7 @@ msgstr "Select a valid date and time for this field"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7344,11 +7426,11 @@ msgstr "Select an instance and a metric to show chart"
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr "Select an organization before editing the default execution environment."
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7431,7 +7513,7 @@ msgstr "Select the Execution Environment you want this command to run inside."
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Select the Instance Groups for this Inventory to run on."
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7455,7 +7537,7 @@ msgstr "Select the credential you want to use when accessing the remote hosts to
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "Select the custom Python virtual environment for this inventory source sync to run on."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr "Select the default execution environment for this organization to run on."
 
@@ -7463,7 +7545,7 @@ msgstr "Select the default execution environment for this organization to run on
 msgid "Select the default execution environment for this organization."
 msgstr "Select the default execution environment for this organization."
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr "Select the default execution environment for this project."
 
@@ -7504,7 +7586,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "Select the inventory that this host will belong to."
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr "Select the playbook to be executed by this job."
 
@@ -7550,7 +7632,7 @@ msgstr "Select {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7585,7 +7667,7 @@ msgid "Service account JSON file"
 msgstr "Service account JSON file"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr "Set a value for this field"
 
@@ -7654,7 +7736,7 @@ msgstr "Show"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr "Show Changes"
 
@@ -7725,9 +7807,9 @@ msgstr "Simple key select"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr "Skip Tags"
 
@@ -7745,7 +7827,7 @@ msgstr "Skip Tags"
 #~ "to Ansible Tower documentation for details on the usage\n"
 #~ "of tags."
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7839,8 +7921,10 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "Source Control Branch"
@@ -7850,41 +7934,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Source Control Branch/Tag/Commit"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Source Control Credential"
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr "Source Control Credential Type"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Source Control Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "Source Control Type"
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "Source Control URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr "Source Control Update"
 
@@ -7896,8 +7980,8 @@ msgstr "Source Phone Number"
 msgid "Source Variables"
 msgstr "Source Variables"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr "Source Workflow Job"
 
@@ -7990,8 +8074,8 @@ msgstr "Standard out tab"
 msgid "Start"
 msgstr "Start"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "Start Time"
 
@@ -8009,32 +8093,32 @@ msgstr "Start message"
 msgid "Start message body"
 msgstr "Start message body"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "Start sync process"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "Start sync source"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Started"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -8103,7 +8187,7 @@ msgstr "Subscription type"
 msgid "Subscriptions table"
 msgstr "Subscriptions table"
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -8127,13 +8211,13 @@ msgstr "Success message"
 msgid "Success message body"
 msgstr "Success message body"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "Successfully copied to clipboard!"
 
@@ -8173,14 +8257,14 @@ msgstr "Survey preview modal"
 msgid "Survey questions"
 msgstr "Survey questions"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -8199,7 +8283,7 @@ msgstr "Sync all sources"
 msgid "Sync error"
 msgstr "Sync error"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "Sync for revision"
 
@@ -8262,7 +8346,7 @@ msgstr "Tabs"
 #~ "Refer to Ansible Tower documentation for details on\n"
 #~ "the usage of tags."
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -8314,7 +8398,7 @@ msgstr "Target URL"
 msgid "Task"
 msgstr "Task"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "Task Count"
 
@@ -8322,7 +8406,7 @@ msgstr "Task Count"
 msgid "Task Started"
 msgstr "Task Started"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -8447,7 +8531,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8489,6 +8573,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr "The full image location, including the container registry, image name, and version tag."
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8503,7 +8591,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8535,8 +8623,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr "The registry location where the container is stored."
+#~ msgid "The registry location where the container is stored."
+#~ msgstr "The registry location where the container is stored."
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8683,6 +8771,16 @@ msgstr "This credential type is currently being used by some credentials and can
 #~ "future releases of the Software and to provide\n"
 #~ "Insights Analytics to subscribers."
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8694,16 +8792,16 @@ msgstr ""
 "streamline customer experience and success."
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8804,7 +8902,7 @@ msgstr "This job template is currently being used by other resources. Are you su
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "This organization is currently being by other resources. Are you sure you want to delete it?"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This project is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8849,7 +8947,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "This workflow does not have any nodes configured."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8916,7 +9014,7 @@ msgstr "Timed out"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -9028,7 +9126,7 @@ msgid "Total Nodes"
 msgstr "Total Nodes"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr "Total jobs"
 
@@ -9037,7 +9135,7 @@ msgid "Track submodules"
 msgstr "Track submodules"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr "Track submodules latest commit on branch"
 
@@ -9070,9 +9168,9 @@ msgstr "Tuesday"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -9092,12 +9190,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -9105,7 +9203,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -9118,7 +9216,7 @@ msgstr "Type"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr "Type Details"
 
@@ -9128,7 +9226,7 @@ msgstr "Type answer then click checkbox on right to select answer as default."
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr "Unavailable"
 
@@ -9142,15 +9240,15 @@ msgid "Unlimited"
 msgstr "Unlimited"
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "Unreachable"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "Unreachable Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "Unreachable Hosts"
 
@@ -9163,7 +9261,7 @@ msgid "Unsaved changes modal"
 msgstr "Unsaved changes modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Update Revision on Launch"
@@ -9252,7 +9350,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr "Used capacity"
 
@@ -9368,11 +9466,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr "Variables"
 
@@ -9400,9 +9498,9 @@ msgstr "Verbose"
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr "Verbosity"
 
@@ -9672,7 +9770,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "WARNING:"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "Waiting"
@@ -9706,14 +9804,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook Credential"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr "Webhook Credentials"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook Key"
@@ -9721,7 +9819,7 @@ msgstr "Webhook Key"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook Service"
@@ -9729,14 +9827,14 @@ msgstr "Webhook Service"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr "Webhook details"
 
@@ -9838,18 +9936,18 @@ msgstr "Workflow Approval not found."
 msgid "Workflow Approvals"
 msgstr "Workflow Approvals"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Workflow Job"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -10012,18 +10110,18 @@ msgstr "Zoom In"
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "a new webhook key will be generated on save."
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "a new webhook url will be generated on save."
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -10057,6 +10155,10 @@ msgstr "brand logo"
 msgid "cancel delete"
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr "capacity adjustment"
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "command"
@@ -10080,7 +10182,7 @@ msgstr "confirm disassociate"
 #~ msgid "controller instance"
 #~ msgstr "controller instance"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "copy to clipboard disabled"
 
@@ -10110,14 +10212,14 @@ msgid "documentation"
 msgstr "documentation"
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -10168,19 +10270,19 @@ msgstr "here."
 msgid "hosts"
 msgstr "hosts"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr "instance counts"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr "instance group used capacity"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr "instance host name"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr "instance type"
 
@@ -10307,6 +10409,11 @@ msgstr "select verbosity"
 msgid "social login"
 msgstr "social login"
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr "source control branch"
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "system"
@@ -10351,7 +10458,7 @@ msgstr "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 
@@ -10379,13 +10486,17 @@ msgstr "{0, plural, one {This execution environment is currently being used by o
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -10446,6 +10557,10 @@ msgstr "{brandName} logo"
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} by <0>{username}</0>"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
+msgstr "{forks, plural, one {# fork} other {# forks}}"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -238,7 +238,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr ""
 
@@ -416,7 +416,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -573,6 +573,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr ""
@@ -609,7 +613,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -619,7 +622,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr ""
 
@@ -658,7 +661,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr ""
 
@@ -729,7 +732,7 @@ msgstr ""
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -831,9 +834,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -869,8 +876,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -893,17 +898,25 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -943,18 +956,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
+#~ msgid "Cancel sync source"
+#~ msgstr ""
+
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1044,7 +1063,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1104,7 +1123,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1185,9 +1204,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1212,7 +1231,7 @@ msgstr ""
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1223,6 +1242,14 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1253,7 +1280,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr ""
 
@@ -1292,7 +1319,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1341,7 +1368,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1349,7 +1376,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1361,8 +1388,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr ""
 
@@ -1509,14 +1536,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1535,7 +1562,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1631,7 +1658,7 @@ msgstr ""
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1639,7 +1666,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1654,9 +1681,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1674,10 +1701,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1774,7 +1801,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1786,16 +1813,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1810,7 +1837,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1831,9 +1858,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1849,7 +1876,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -1881,7 +1908,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1912,7 +1939,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -2009,7 +2036,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2031,16 +2058,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2123,7 +2150,7 @@ msgstr ""
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2231,7 +2258,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2253,8 +2280,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2299,7 +2326,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2308,14 +2335,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2324,8 +2351,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2345,8 +2372,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2441,8 +2468,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2456,7 +2483,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2526,16 +2553,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2553,11 +2580,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2570,14 +2597,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2602,7 +2629,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2629,7 +2656,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2819,11 +2846,11 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2853,9 +2880,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2878,6 +2905,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2893,8 +2921,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2902,7 +2929,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2911,7 +2938,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2977,6 +3004,10 @@ msgstr ""
 msgid "Examples include:"
 msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr ""
@@ -2993,7 +3024,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -3015,7 +3046,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr ""
 
@@ -3083,7 +3114,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -3098,9 +3129,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -3113,19 +3144,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3159,12 +3190,27 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3179,7 +3225,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3262,7 +3308,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3310,7 +3356,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3343,7 +3389,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3383,7 +3429,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr ""
@@ -3404,7 +3450,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3430,6 +3476,10 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3495,12 +3545,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3570,7 +3620,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr ""
 
@@ -3617,7 +3667,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3678,7 +3728,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3796,11 +3846,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3883,7 +3933,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3909,7 +3959,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4013,7 +4063,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4030,7 +4080,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4045,7 +4095,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4055,11 +4105,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4096,14 +4146,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4149,12 +4200,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4162,7 +4213,16 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4177,7 +4237,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr ""
 
@@ -4261,7 +4321,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4284,11 +4344,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr ""
 
@@ -4304,12 +4364,16 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4319,11 +4383,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4375,9 +4439,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4402,26 +4466,27 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr ""
 
@@ -4434,19 +4499,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4471,14 +4536,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4497,8 +4562,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4604,19 +4669,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr ""
 
@@ -4624,7 +4689,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4647,10 +4712,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4690,7 +4755,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4699,7 +4764,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4709,8 +4774,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr ""
 
@@ -4745,12 +4810,16 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4781,15 +4850,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4849,16 +4918,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr ""
 
@@ -4875,10 +4944,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr ""
 
@@ -4904,14 +4973,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -5017,7 +5086,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -5033,7 +5102,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5128,9 +5197,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5153,8 +5222,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5248,7 +5317,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5274,13 +5343,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5288,7 +5357,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5334,7 +5403,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5602,7 +5671,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr ""
 
@@ -5620,7 +5689,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr ""
 
@@ -5658,8 +5727,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5685,12 +5754,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr ""
 
@@ -5721,15 +5790,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5844,7 +5913,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5852,7 +5921,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
@@ -5881,7 +5950,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5906,7 +5975,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5915,13 +5984,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5930,15 +5999,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr ""
 
@@ -5957,7 +6026,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -5994,7 +6063,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -6081,7 +6150,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -6089,17 +6158,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6107,7 +6176,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6115,6 +6184,11 @@ msgstr ""
 #: components/Workflow/WorkflowLegend.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
@@ -6172,7 +6246,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6218,26 +6292,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr ""
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6251,6 +6329,10 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6281,7 +6363,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6325,7 +6407,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6348,7 +6430,7 @@ msgstr ""
 msgid "Regions"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6362,16 +6444,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6388,12 +6470,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6502,10 +6584,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6554,9 +6636,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6627,7 +6709,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6642,7 +6724,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr ""
 
@@ -6677,9 +6759,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6816,7 +6898,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6824,7 +6906,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6982,7 +7064,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7014,11 +7096,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7088,7 +7170,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7110,7 +7192,7 @@ msgstr ""
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7118,7 +7200,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7154,7 +7236,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -7194,7 +7276,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7229,7 +7311,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7298,7 +7380,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr ""
 
@@ -7369,9 +7451,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr ""
 
@@ -7384,7 +7466,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7469,8 +7551,10 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7480,41 +7564,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr ""
 
@@ -7526,8 +7610,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7614,8 +7698,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7633,32 +7717,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7721,7 +7805,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7745,13 +7829,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7791,14 +7875,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7817,7 +7901,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7871,7 +7955,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7914,7 +7998,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7922,7 +8006,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -8044,7 +8128,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8077,6 +8161,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8088,7 +8176,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8115,8 +8203,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8248,6 +8336,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8256,13 +8351,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8363,7 +8458,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8406,7 +8501,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8462,7 +8557,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr ""
 
@@ -8574,7 +8669,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr ""
 
@@ -8583,7 +8678,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8616,9 +8711,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8638,12 +8733,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8651,7 +8746,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8664,7 +8759,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr ""
 
@@ -8674,7 +8769,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr ""
 
@@ -8688,15 +8783,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8709,7 +8804,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8791,7 +8886,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr ""
 
@@ -8903,11 +8998,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr ""
 
@@ -8935,9 +9030,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr ""
 
@@ -9207,7 +9302,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9241,14 +9336,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -9256,7 +9351,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -9264,14 +9359,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr ""
 
@@ -9365,18 +9460,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9529,18 +9624,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9566,6 +9661,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9585,7 +9684,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9607,14 +9706,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9661,19 +9760,19 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr ""
 
@@ -9784,6 +9883,11 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9828,7 +9932,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9856,13 +9960,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9914,6 +10022,10 @@ msgstr ""
 
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -238,7 +238,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr ""
 
@@ -385,6 +385,11 @@ msgid ""
 "like the Ansible inventory .ini file format."
 msgstr ""
 
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:168
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:177
+#~ msgid "After every project update where the SCM revision changes, refresh the inventory from the selected source before executing job tasks. This is intended for static content, like the Ansible inventory .ini file format."
+#~ msgstr ""
+
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:508
 msgid "After number of occurrences"
 msgstr ""
@@ -411,7 +416,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -454,6 +459,16 @@ msgstr ""
 msgid "An inventory must be selected"
 msgstr ""
 
+#: src/components/PromptDetail/PromptInventorySourceDetail.jsx:87
+#: src/components/PromptDetail/PromptProjectDetail.jsx:92
+#: src/screens/Inventory/shared/InventorySourceForm.jsx:143
+#: src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx:94
+#: src/screens/Organization/shared/OrganizationForm.jsx:82
+#: src/screens/Project/ProjectDetail/ProjectDetail.jsx:128
+#: src/screens/Project/shared/ProjectForm.jsx:274
+#~ msgid "Ansible Environment"
+#~ msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:98
 msgid "Ansible Tower"
 msgstr ""
@@ -461,6 +476,14 @@ msgstr ""
 #: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:99
 msgid "Ansible Tower Documentation."
 msgstr ""
+
+#: src/components/About/About.jsx:58
+#~ msgid "Ansible Version"
+#~ msgstr ""
+
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:204
+#~ msgid "Ansible environment"
+#~ msgstr ""
 
 #: screens/Template/Survey/SurveyQuestionForm.jsx:44
 msgid "Answer type"
@@ -534,11 +557,15 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr ""
 
@@ -546,9 +573,9 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr ""
+#: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
+#~ msgid "Are you sure you want to delete the {0} below?"
+#~ msgstr ""
 
 #: components/DeleteButton/DeleteButton.jsx:128
 msgid "Are you sure you want to delete:"
@@ -582,6 +609,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -591,7 +619,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr ""
 
@@ -630,7 +658,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr ""
 
@@ -767,6 +795,10 @@ msgid ""
 "path used to locate playbooks."
 msgstr ""
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:70
+#~ msgid "Base path used for locating playbooks. Directories found inside this path will be listed in the playbook directory drop-down. Together the base path and selected playbook directory provide the full path used to locate playbooks."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:456
 msgid "Basic auth password"
 msgstr ""
@@ -799,13 +831,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -841,6 +869,8 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -863,25 +893,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -921,27 +943,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr ""
-
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
+msgid "Cancel sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:211
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
+msgid "Cancel sync process"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
+msgid "Cancel sync source"
+msgstr ""
+
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr ""
 
@@ -986,6 +1002,10 @@ msgid ""
 "{brandName} to change this location."
 msgstr ""
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:76
+#~ msgid "Change PROJECTS_ROOT when deploying {brandName} to change this location."
+#~ msgstr ""
+
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:43
 msgid "Changed"
 msgstr ""
@@ -1024,7 +1044,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1056,6 +1076,17 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
+#: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:142
 msgid "Choose an email option"
 msgstr ""
@@ -1073,7 +1104,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1106,10 +1137,6 @@ msgstr ""
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr ""
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1158,18 +1185,34 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
+
+#: src/screens/Host/Host.jsx:67
+#: src/screens/Host/Hosts.jsx:32
+#: src/screens/Inventory/Inventory.jsx:68
+#: src/screens/Inventory/InventoryHost/InventoryHost.jsx:88
+#: src/screens/Template/Template.jsx:151
+#: src/screens/Template/Templates.jsx:48
+#: src/screens/Template/WorkflowJobTemplate.jsx:145
+#~ msgid "Completed Jobs"
+#~ msgstr ""
+
+#: src/screens/Inventory/Inventories.jsx:59
+#: src/screens/Inventory/Inventories.jsx:73
+#: src/screens/Inventory/SmartInventory.jsx:73
+#~ msgid "Completed jobs"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:53
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1180,14 +1223,6 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1218,7 +1253,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr ""
 
@@ -1257,11 +1292,21 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
 msgstr ""
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:152
+#: src/screens/Template/shared/JobTemplateForm.jsx:414
+#~ msgid "Control the level of output ansible will produce as the playbook executes."
+#~ msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:69
+#~ msgid "Controller"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:208
 msgid "Convergence"
@@ -1296,7 +1341,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr ""
 
@@ -1304,7 +1349,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1316,10 +1361,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1459,14 +1509,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1485,7 +1535,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1589,7 +1639,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1604,9 +1654,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1624,10 +1674,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1701,7 +1751,7 @@ msgstr ""
 msgid "Default answer"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr ""
 
@@ -1724,7 +1774,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1736,16 +1786,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1760,7 +1810,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1781,9 +1831,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr ""
 
@@ -1799,7 +1849,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr ""
 
@@ -1831,7 +1881,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1862,7 +1912,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr ""
 
@@ -1913,11 +1963,15 @@ msgstr ""
 msgid "Deletion error"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr ""
 
@@ -1977,16 +2031,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2177,7 +2231,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2199,8 +2253,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr ""
 
@@ -2212,7 +2266,7 @@ msgstr ""
 msgid "E-mail options"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr ""
 
@@ -2245,7 +2299,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2254,14 +2308,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2291,8 +2345,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2387,8 +2441,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr ""
 
@@ -2402,7 +2456,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr ""
 
@@ -2472,16 +2526,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2499,11 +2553,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2516,14 +2570,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2548,7 +2602,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2575,7 +2629,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2632,9 +2686,17 @@ msgstr ""
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2643,9 +2705,24 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr ""
+
+#: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr ""
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2658,11 +2735,19 @@ msgid ""
 "required."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:244
+#~ msgid "Enter one IRC channel or username per line. The pound symbol (#) for channels, and the at (@) symbol for users, are not required."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
 msgid ""
 "Enter one Slack channel per line. The pound symbol (#)\n"
 "is required for channels."
 msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
+#~ msgid "Enter one Slack channel per line. The pound symbol (#) is required for channels."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
 msgid ""
@@ -2670,17 +2755,29 @@ msgid ""
 "list for this type of notification."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
+#~ msgid "Enter one email address per line to create a recipient list for this type of notification."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
 msgid ""
 "Enter one phone number per line to specify where to\n"
 "route SMS messages."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
+#~ msgid "Enter one phone number per line to specify where to route SMS messages."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
 msgid ""
 "Enter the number associated with the \"Messaging\n"
 "Service\" in Twilio in the format +18005550199."
 msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
+#~ msgid "Enter the number associated with the \"Messaging Service\" in Twilio in the format +18005550199."
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSubForms/TowerSubForm.jsx:60
 msgid "Enter variables to configure the inventory source. For a detailed description of how to configure this plugin, see <0>Inventory Plugins</0> in the documentation and the <1>Tower</1> plugin configuration guide."
@@ -2722,11 +2819,11 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2756,8 +2853,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2781,7 +2878,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2797,7 +2893,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2805,7 +2902,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2814,7 +2911,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2896,7 +2993,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2918,7 +3015,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr ""
 
@@ -2933,6 +3030,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -2977,11 +3079,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -2996,9 +3098,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr ""
 
@@ -3011,19 +3113,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3057,32 +3159,12 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr ""
-
-#: components/JobList/JobList.jsx:295
-msgid "Failed to cancel one or more jobs."
+msgid "Failed to cancel inventory source sync."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
+#: components/JobList/JobList.jsx:290
+msgid "Failed to cancel one or more jobs."
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3097,7 +3179,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3180,7 +3262,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3228,7 +3310,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3261,7 +3343,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3322,7 +3404,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3348,10 +3430,6 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3417,12 +3495,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3492,7 +3570,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr ""
 
@@ -3539,7 +3617,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3718,11 +3796,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr ""
 
@@ -3805,7 +3883,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3831,7 +3909,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3906,7 +3984,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr ""
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -3935,7 +4013,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3952,7 +4030,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -3967,7 +4045,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3977,16 +4055,20 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
 "injected into the fact cache at runtime."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:559
+#~ msgid "If enabled, this will store gathered facts so they can be viewed at the host level. Facts are persisted and injected into the fact cache at runtime."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:140
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
@@ -4067,12 +4149,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4080,16 +4162,7 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4104,7 +4177,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr ""
 
@@ -4188,7 +4261,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4211,11 +4284,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr ""
 
@@ -4231,20 +4304,12 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
-
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
-msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4254,11 +4319,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4310,9 +4375,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr ""
 
@@ -4337,27 +4402,26 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr ""
 
@@ -4370,19 +4434,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4407,14 +4471,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4433,8 +4497,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4540,19 +4604,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr ""
 
@@ -4560,7 +4624,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4583,10 +4647,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4626,7 +4690,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr ""
 
@@ -4635,7 +4699,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4645,8 +4709,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr ""
 
@@ -4681,16 +4745,12 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4721,15 +4781,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4789,16 +4849,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr ""
 
@@ -4815,10 +4875,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr ""
 
@@ -4844,14 +4904,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -4957,7 +5017,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -4973,7 +5033,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5068,9 +5128,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5093,8 +5153,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5188,7 +5248,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5214,13 +5274,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5228,7 +5288,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5270,11 +5330,11 @@ msgid "Never Updated"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5542,7 +5602,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr ""
 
@@ -5560,7 +5620,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr ""
 
@@ -5598,8 +5658,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5625,12 +5685,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr ""
 
@@ -5661,15 +5721,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5784,7 +5844,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5792,9 +5852,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5817,7 +5881,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5842,7 +5906,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr ""
 
@@ -5851,13 +5915,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5866,15 +5930,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr ""
 
@@ -5893,7 +5957,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr ""
 
@@ -5930,7 +5994,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -5969,6 +6033,14 @@ msgstr ""
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -5999,18 +6071,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -6021,7 +6081,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -6029,17 +6089,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6047,7 +6107,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6057,19 +6117,9 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6122,7 +6172,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6168,25 +6218,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr ""
 
@@ -6205,10 +6251,6 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6239,7 +6281,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6283,7 +6325,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6320,16 +6362,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6346,12 +6388,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6460,10 +6502,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6512,9 +6554,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr ""
 
@@ -6585,7 +6627,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6600,7 +6642,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr ""
 
@@ -6635,9 +6677,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr ""
 
@@ -6774,7 +6816,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr ""
 
@@ -6782,7 +6824,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6940,7 +6982,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -6972,11 +7014,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7004,6 +7046,10 @@ msgid ""
 "the Project Base Path. Together the base path and the playbook\n"
 "directory provide the full path used to locate playbooks."
 msgstr ""
+
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:89
+#~ msgid "Select from the list of directories found in the Project Base Path. Together the base path and the playbook directory provide the full path used to locate playbooks."
+#~ msgstr ""
 
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.jsx:94
 msgid "Select items from list"
@@ -7042,7 +7088,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7064,7 +7110,7 @@ msgstr ""
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7072,7 +7118,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7086,6 +7132,11 @@ msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
 msgstr ""
+
+#: src/components/Lookup/InventoryLookup.jsx:89
+#: src/screens/Template/shared/JobTemplateForm.jsx:248
+#~ msgid "Select the inventory containing the hosts you want this job to manage."
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx:105
 msgid ""
@@ -7103,7 +7154,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -7143,7 +7194,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7178,7 +7229,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7247,7 +7298,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr ""
 
@@ -7318,9 +7369,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr ""
 
@@ -7333,7 +7384,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7349,6 +7400,11 @@ msgid ""
 "Use commas to separate multiple tags. Refer to Ansible Tower\n"
 "documentation for details on the usage of tags."
 msgstr ""
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:74
+#: src/screens/Template/shared/JobTemplateForm.jsx:487
+#~ msgid "Skip tags are useful when you have a large playbook, and you want to skip specific parts of a play or task. Use commas to separate multiple tags. Refer to Ansible Tower documentation for details on the usage of tags."
+#~ msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:39
 msgid "Skipped"
@@ -7413,10 +7469,8 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7426,41 +7480,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr ""
 
@@ -7472,8 +7526,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7508,6 +7562,16 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:392
 msgid ""
@@ -7550,8 +7614,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr ""
 
@@ -7569,32 +7633,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7657,7 +7721,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7681,13 +7745,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7727,14 +7791,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7753,7 +7817,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr ""
 
@@ -7807,7 +7871,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7850,7 +7914,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr ""
 
@@ -7858,7 +7922,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr ""
 
@@ -7980,12 +8044,16 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
 "timeout."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:439
+#~ msgid "The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:164
 msgid ""
@@ -8020,7 +8088,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8092,7 +8160,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr ""
 
@@ -8166,12 +8234,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8181,13 +8256,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8288,7 +8363,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8331,7 +8406,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8378,7 +8453,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr ""
 
@@ -8387,7 +8462,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr ""
 
@@ -8499,7 +8574,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr ""
 
@@ -8508,7 +8583,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8541,9 +8616,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8563,12 +8638,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8576,7 +8651,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8589,7 +8664,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr ""
 
@@ -8599,7 +8674,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr ""
 
@@ -8613,15 +8688,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8634,7 +8709,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8709,10 +8784,14 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr ""
 
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:72
+#~ msgid "Use custom messages to change the content of notifications sent when a job starts, succeeds, or fails. Use curly braces to access information about the job:"
+#~ msgstr ""
+
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr ""
 
@@ -8824,11 +8903,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr ""
 
@@ -8856,9 +8935,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr ""
 
@@ -9128,7 +9207,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9162,14 +9241,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -9177,7 +9256,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -9185,14 +9264,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr ""
 
@@ -9229,7 +9308,7 @@ msgstr ""
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr ""
 
@@ -9260,6 +9339,11 @@ msgid ""
 "untouched by the inventory update process."
 msgstr ""
 
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:127
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:141
+#~ msgid "When not checked, local child hosts and groups not found on the external source will remain untouched by the inventory update process."
+#~ msgstr ""
+
 #: components/Workflow/WorkflowLegend.jsx:96
 msgid "Workflow"
 msgstr ""
@@ -9281,18 +9365,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9445,18 +9529,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9482,10 +9566,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9505,7 +9585,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9527,14 +9607,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9581,25 +9661,31 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr ""
 
 #: components/Lookup/HostListItem.jsx:30
 msgid "inventory"
 msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:51
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:59
+#: screens/Job/JobDetail/JobDetail.jsx:119
+#~ msgid "isolated instance"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:23
 msgid "items"
@@ -9640,6 +9726,10 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:238
 msgid "option to the"
 msgstr ""
+
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:84
+#~ msgid "or attributes of the job such as"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:24
 msgid "page"
@@ -9694,11 +9784,6 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9743,7 +9828,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9771,17 +9856,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9835,10 +9916,6 @@ msgstr ""
 msgid "{dateStr} by <0>{username}</0>"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr ""
-
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"
 msgstr ""
@@ -9867,9 +9944,17 @@ msgstr ""
 msgid "{minutes} min {seconds} sec"
 msgstr ""
 
+#: src/screens/Inventory/InventoryList/InventoryList.jsx:215
+#~ msgid "{numItemsToDelete, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
+#~ msgstr ""
+
 #: components/JobList/JobListCancelButton.jsx:106
 msgid "{numJobsToCancel, plural, one {Cancel job} other {Cancel jobs}}"
 msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:81
+#~ msgid "{numJobsToCancel, plural, one {Cancel selected job} other {Cancel selected jobs}}"
+#~ msgstr ""
 
 #: components/JobList/JobListCancelButton.jsx:167
 msgid "{numJobsToCancel, plural, one {This action will cancel the following job:} other {This action will cancel the following jobs:}}"
@@ -9879,7 +9964,19 @@ msgstr ""
 msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr ""
 
+#: src/components/JobList/JobListCancelButton.jsx:68
+#~ msgid "{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}"
+#~ msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:57
+#~ msgid "{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}"
+#~ msgstr ""
+
 #: components/PaginatedDataList/PaginatedDataList.jsx:92
 #: components/PaginatedTable/PaginatedTable.jsx:77
 msgid "{pluralizedItemName} List"
 msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:96
+#~ msgid "{zeroOrOneJobSelected, plural, one {Cancel job} other {Cancel jobs}}"
+#~ msgstr ""

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -18,7 +18,7 @@ msgstr "(10 premiers seulement)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr "(Me le demander au lancement)"
 
@@ -26,11 +26,11 @@ msgstr "(Me le demander au lancement)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* Ce champ sera récupéré dans un système externe de gestion des secrets en utilisant le justificatif d'identité spécifié."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr "Activer les tâches parallèles"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr "Activer Webhooks"
 
@@ -185,8 +185,8 @@ msgstr "Token de compte"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "Actions"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr "Activité"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "Tous les types de tâche"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Autoriser le remplacement de la branche"
@@ -572,6 +572,10 @@ msgstr "Approuvé par {0} - {1}"
 msgid "April"
 msgstr "Avril"
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr "Voulez-vous vraiment supprimer la tâche {0} ci-dessous ?"
@@ -608,7 +612,6 @@ msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès à {1}?  Cela risque
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès de {1} ?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
@@ -618,7 +621,7 @@ msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr "Artefacts"
 
@@ -657,7 +660,7 @@ msgstr "Expiration du code d'autorisation"
 msgid "Authorization grant type"
 msgstr "Type d'autorisation"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr "Auto"
 
@@ -728,7 +731,7 @@ msgstr "Retour aux horaires"
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -830,9 +833,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Expiration Délai d’attente du cache"
@@ -868,8 +875,6 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -892,17 +897,25 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Annuler Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -942,18 +955,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "Annuler sync"
+#~ msgid "Cancel sync"
+#~ msgstr "Annuler sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "Annuler le processus de synchronisation"
+#~ msgid "Cancel sync process"
+#~ msgstr "Annuler le processus de synchronisation"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "Annuler la source de synchronisation"
+#~ msgid "Cancel sync source"
+#~ msgstr "Annuler la source de synchronisation"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
+msgstr ""
+
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1043,7 +1062,7 @@ msgstr "Choisissez un type de notification"
 msgid "Choose a Playbook Directory"
 msgstr "Choisissez un répertoire Playbook"
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr "Choisissez un type de contrôle à la source"
 
@@ -1103,7 +1122,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choisissez le type de ressource qui recevra de nouveaux rôles.  Par exemple, si vous souhaitez ajouter de nouveaux rôles à un ensemble d'utilisateurs, veuillez choisir Utilisateurs et cliquer sur Suivant.  Vous pourrez sélectionner les ressources spécifiques dans l'étape suivante."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Nettoyer"
@@ -1184,9 +1203,9 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr "Effondrement"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Commande"
@@ -1211,7 +1230,7 @@ msgstr "Commande"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr "Jobs parallèles"
 
@@ -1223,6 +1242,14 @@ msgstr "Confirmer Effacer"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
+msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1252,7 +1279,7 @@ msgstr "Confirmer annuler tout"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr "Groupe de conteneurs"
 
@@ -1291,7 +1318,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1340,7 +1367,7 @@ msgstr "Copier l'inventaire"
 msgid "Copy Notification Template"
 msgstr "Copie du modèle de notification"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "Copier le projet"
 
@@ -1348,7 +1375,7 @@ msgstr "Copier le projet"
 msgid "Copy Template"
 msgstr "Copier le modèle"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "Copier la révision complète dans le Presse-papiers."
 
@@ -1360,8 +1387,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr "Créer"
 
@@ -1508,14 +1535,14 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1534,7 +1561,7 @@ msgstr "Créé"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1630,7 +1657,7 @@ msgstr "Mots de passes d’identification"
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1638,7 +1665,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "Type d'informations d’identification non trouvé."
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1653,9 +1680,9 @@ msgstr "Type d'informations d’identification non trouvé."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "Informations d’identification"
@@ -1673,10 +1700,10 @@ msgid "Custom pod spec"
 msgstr "Spécifications des pods personnalisés"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1773,7 +1800,7 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1785,16 +1812,16 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1809,7 +1836,7 @@ msgstr "Supprimer les groupes et les hôtes"
 msgid "Delete Credential"
 msgstr "Supprimer les informations d’identification"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1830,9 +1857,9 @@ msgstr "Supprimer l'hôte"
 msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "Supprimer Job"
 
@@ -1848,7 +1875,7 @@ msgstr "Supprimer la notification"
 msgid "Delete Organization"
 msgstr "Supprimer l'organisation"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "Suppression du projet"
 
@@ -1880,7 +1907,7 @@ msgstr "Supprimer un jeton d'utilisateur"
 msgid "Delete Workflow Approval"
 msgstr "Supprimer l'approbation du flux de travail"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr "Supprimer le modèle de flux de travail "
 
@@ -1911,7 +1938,7 @@ msgid "Delete inventory source"
 msgstr "Supprimer la source de l'inventaire"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "Supprimer lors de la mise à jour"
 
@@ -2008,7 +2035,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2030,16 +2057,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2122,7 +2149,7 @@ msgstr "Canaux ou utilisateurs de destination"
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2230,7 +2257,7 @@ msgstr "Dissocier le rôle !"
 msgid "Disassociate?"
 msgstr "Dissocier ?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2252,8 +2279,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "Télécharger la sortie"
 
@@ -2298,7 +2325,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2307,14 +2334,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2323,8 +2350,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2344,8 +2371,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2440,8 +2467,8 @@ msgstr "Modèle de notification de modification"
 msgid "Edit Organization"
 msgstr "Modifier l'organisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "Modifier le projet"
 
@@ -2455,7 +2482,7 @@ msgstr "Modifier la question"
 msgid "Edit Schedule"
 msgstr "Modifier la programmation"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "Modifier la source"
 
@@ -2525,16 +2552,16 @@ msgid "Edit this node"
 msgstr "Modifier ce nœud"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "Temps écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "Temps écoulé (en secondes) pendant lequel la tâche s'est exécutée."
 
@@ -2552,11 +2579,11 @@ msgstr "Options d'email"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr "Activer les tâches parallèles"
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr "Utiliser le cache des faits"
 
@@ -2569,14 +2596,14 @@ msgstr "Activer/désactiver la vérification de certificat HTTPS"
 msgid "Enable Privilege Escalation"
 msgstr "Activer l’élévation des privilèges"
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr "Activer le webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr "Activez le webhook pour ce modèle de flux de travail."
 
@@ -2601,7 +2628,7 @@ msgstr "Activer l’élévation des privilèges"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "Activer la connexion simplifiée pour vos applications Tower"
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr "Activez le webhook pour ce modèle de tâche."
 
@@ -2620,7 +2647,7 @@ msgstr "Valeur activée"
 msgid "Enabled Variable"
 msgstr "Variable activée"
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2814,11 +2841,11 @@ msgstr "Entrez les variables avec la syntaxe JSON ou YAML. Utilisez le bouton ra
 #~ msgid "Environment"
 #~ msgstr "Environnement"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2848,9 +2875,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2873,6 +2900,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2888,8 +2916,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2897,7 +2924,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2906,7 +2933,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2972,6 +2999,10 @@ msgstr "Exemples d’URL pour le SCM Subversion :"
 msgid "Examples include:"
 msgstr "Voici quelques exemples :"
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr "Exécuter quel que soit l'état final du nœud parent."
@@ -2988,7 +3019,7 @@ msgstr "Exécuter lorsque le nœud parent se trouve dans un état de réussite."
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -3010,7 +3041,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr "Nœud d'exécution"
 
@@ -3078,7 +3109,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "Arrive à expiration le {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explication"
@@ -3093,9 +3124,9 @@ msgid "Extra variables"
 msgstr "Variables supplémentaires"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "TERMINÉ :"
 
@@ -3108,19 +3139,19 @@ msgstr "TERMINÉ :"
 msgid "Facts"
 msgstr "Faits"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "Échec"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "Échec du comptage des hôtes"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "Échec Hôtes"
 
@@ -3154,13 +3185,28 @@ msgstr "N'a pas réussi à associer le rôle"
 msgid "Failed to associate."
 msgstr "N'a pas réussi à associer."
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3174,7 +3220,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "N'a pas réussi à copier l'inventaire."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "Le projet n'a pas été copié."
 
@@ -3257,7 +3303,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs sources d'inventaire."
 msgid "Failed to delete one or more job templates."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles de Jobs."
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs."
 
@@ -3305,7 +3351,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs approbations de flux de tr
 msgid "Failed to delete organization."
 msgstr "N'a pas réussi à supprimer l'organisation."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "N'a pas réussi à supprimer le projet."
 
@@ -3338,7 +3384,7 @@ msgstr "Impossible de supprimer l'utilisateur."
 msgid "Failed to delete workflow approval."
 msgstr "N'a pas réussi à supprimer l'approbation du flux de travail."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr "N'a pas réussi à supprimer le modèle de flux de travail."
 
@@ -3378,7 +3424,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr "Impossible de récupérer les paramètres de configuration de connexion personnalisés.  Les paramètres par défaut du système seront affichés à la place."
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr "Echec du lancement du Job."
@@ -3399,7 +3445,7 @@ msgstr "Impossible de récupérer les informations d'identification des nœuds."
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "Impossible de synchroniser la source de l'inventaire."
 
@@ -3426,6 +3472,10 @@ msgstr "N'a pas réussi à basculer la notification."
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "Impossible de basculer le calendrier."
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
+msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3490,12 +3540,12 @@ msgstr "Téléchargement de fichier rejeté. Veuillez sélectionner un seul fich
 msgid "File, directory or script"
 msgstr "Fichier, répertoire ou script"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "Heure de Fin"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Terminé"
@@ -3565,7 +3615,7 @@ msgstr "Pour plus d'informations, reportez-vous à"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr "Forks"
 
@@ -3612,7 +3662,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3673,7 +3723,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3791,11 +3841,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr "Clé de configuration de l’hôte"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "Nombre d'hôtes"
 
@@ -3878,7 +3928,7 @@ msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas dis
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hôtes"
@@ -3904,7 +3954,7 @@ msgstr "Heure"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4008,7 +4058,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "Si cochés, tous les hôtes et groupes qui étaient présent auparavant sur la source externe, mais qui sont maintenant supprimés, seront supprimés de l'inventaire de Tower. Les hôtes et les groupes qui n'étaient pas gérés par la source de l'inventaire seront promus au prochain groupe créé manuellement ou s'il n'y a pas de groupe créé manuellement dans lequel les promouvoir, ils devront rester dans le groupe \"all\" par défaut de cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4025,7 +4075,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4040,7 +4090,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "Si activé, afficher les changements faits par les tâches Ansible, si supporté. C'est équivalent au mode --diff d’Ansible."
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4050,11 +4100,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "Si activé, il sera possible d’avoir des exécutions de ce modèle de job de flux de travail en simultané."
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4091,14 +4141,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4144,12 +4195,12 @@ msgid "Input configuration"
 msgstr "Configuration de l'entrée"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4157,7 +4208,16 @@ msgid "Insights Credential"
 msgstr "Information d’identification  d’Insights"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4172,7 +4232,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "Filtres de l'instance"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr "Groupe d'instance"
 
@@ -4256,7 +4316,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4279,11 +4339,11 @@ msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr "Inventaire"
 
@@ -4299,13 +4359,17 @@ msgstr "Fichier d'inventaire"
 msgid "Inventory ID"
 msgstr "ID Inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Sync Source d’inventaire"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4314,11 +4378,11 @@ msgstr "Sync Source d’inventaire"
 msgid "Inventory Sources"
 msgstr "Sources d'inventaire"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr "Sync Inventaires"
 
@@ -4370,9 +4434,9 @@ msgid "Items per page"
 msgstr "Éléments par page"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "ID JOB :"
 
@@ -4397,26 +4461,27 @@ msgstr "Janvier"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Erreur de suppression d’un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr "Découpage de job"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr "Découpage de job"
 
@@ -4429,19 +4494,19 @@ msgstr "Statut Job"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr "Balises Job"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Modèle de Job"
@@ -4466,14 +4531,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "Type de Job"
@@ -4492,8 +4557,8 @@ msgstr "Onglet Graphique de l'état des Jobs"
 msgid "Job templates"
 msgstr "Modèles de Jobs"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4599,19 +4664,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "Nom du label"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr "Libellés"
 
@@ -4619,7 +4684,7 @@ msgstr "Libellés"
 msgid "Last"
 msgstr "Dernier"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4642,10 +4707,10 @@ msgstr "Dernière connexion"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4685,7 +4750,7 @@ msgstr "Dernière exécution du Job"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "Dernière modification"
 
@@ -4694,7 +4759,7 @@ msgstr "Dernière modification"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4704,8 +4769,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr "Lancer"
 
@@ -4740,12 +4805,16 @@ msgstr "Lancer le flux de travail"
 msgid "Launched By"
 msgstr "Lancé par"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "Lancé par (Nom d'utilisateur)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4776,15 +4845,15 @@ msgstr "Moins ou égal à la comparaison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "Limite"
@@ -4844,16 +4913,16 @@ msgstr "Type de recherche"
 msgid "Lookup typeahead"
 msgstr "Recherche par type"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "DERNIÈRE SYNCHRONISATION"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr "Informations d’identification de la machine"
 
@@ -4870,10 +4939,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr "Job de gestion"
 
@@ -4899,14 +4968,14 @@ msgstr "Job de gestion non trouvé."
 msgid "Management jobs"
 msgstr "Jobs de gestion"
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manuel"
@@ -5012,7 +5081,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "Modifié"
@@ -5028,7 +5097,7 @@ msgstr "Modifié"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5123,9 +5192,9 @@ msgstr "Options à choix multiples."
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5148,8 +5217,8 @@ msgstr "Options à choix multiples."
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5243,7 +5312,7 @@ msgstr "Options à choix multiples."
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5269,13 +5338,13 @@ msgstr "Options à choix multiples."
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5283,7 +5352,7 @@ msgstr "Options à choix multiples."
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5329,7 +5398,7 @@ msgstr "Jamais mis à jour"
 msgid "Never expires"
 msgstr "N'expire jamais"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "Nouveau"
@@ -5597,7 +5666,7 @@ msgstr "Octobre"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr "Désactivé"
 
@@ -5615,7 +5684,7 @@ msgstr "Désactivé"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr "Le"
 
@@ -5653,8 +5722,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Détails de l'option"
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5680,12 +5749,12 @@ msgstr "En option, sélectionnez les informations d'identification à utiliser p
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr "Options"
 
@@ -5716,15 +5785,15 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5839,7 +5908,7 @@ msgstr "Passez des changements supplémentaires en ligne de commande. Il y a deu
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5847,7 +5916,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Transmettez des variables de ligne de commandes supplémentaires au playbook. Voici le paramètre de ligne de commande -e or --extra-vars pour ansible-playbook. Fournir la paire clé/valeur en utilisant YAML ou JSON. Consulter la documentation Ansible Tower pour obtenir des exemples de syntaxe."
 
@@ -5876,7 +5945,7 @@ msgstr "Les deux dernières semaines"
 msgid "Past week"
 msgstr "La semaine dernière"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "En attente"
@@ -5901,7 +5970,7 @@ msgstr "Jeton d'accès personnel"
 msgid "Play"
 msgstr "Lancer"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "Compte de jeux"
 
@@ -5910,13 +5979,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5925,15 +5994,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Répertoire de playbook"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr "Exécution du playbook"
 
@@ -5952,7 +6021,7 @@ msgstr "Nom du playbook"
 msgid "Playbook run"
 msgstr "Exécution du playbook"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Lancements"
 
@@ -5989,7 +6058,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "Veuillez choisir un numéro de jour entre 1 et 31."
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "Sélectionnez un inventaire ou cochez l’option Me le demander au lancement."
 
@@ -6076,7 +6145,7 @@ msgstr "Prévisualisation"
 msgid "Private key passphrase"
 msgstr "Phrase de passe pour la clé privée"
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr "Élévation des privilèges"
 
@@ -6084,17 +6153,17 @@ msgstr "Élévation des privilèges"
 msgid "Privilege escalation password"
 msgstr "Mot de passe pour l’élévation des privilèges"
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6102,7 +6171,7 @@ msgid "Project"
 msgstr "Projet"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Chemin de base du projet"
@@ -6111,6 +6180,11 @@ msgstr "Chemin de base du projet"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
 msgstr "Sync Projet"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
@@ -6167,7 +6241,7 @@ msgstr "Valeurs incitatrices"
 msgid "Prompts"
 msgstr "Invites"
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6213,26 +6287,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr "URL de rappel d’exécution "
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr "Détails de rappel d’exécution"
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr "Rappels d’exécution "
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6247,6 +6325,10 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "Paramètres RADIUS"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
+msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6276,7 +6358,7 @@ msgstr "Liste de destinataires"
 msgid "Recipient list"
 msgstr "Liste de destinataires"
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6320,7 +6402,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6343,7 +6425,7 @@ msgstr "Actualiser l’expiration du jeton"
 msgid "Regions"
 msgstr "Régions"
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6357,16 +6439,16 @@ msgstr "Expression régulière où seuls les noms d'hôtes correspondants seront
 msgid "Related Groups"
 msgstr "Groupes liés"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "Relancer le Job"
 
@@ -6383,12 +6465,12 @@ msgstr "Relancer les hôtes défaillants"
 msgid "Relaunch on"
 msgstr "Relancer sur"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "Relancer en utilisant les paramètres de l'hôte"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6497,10 +6579,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6549,9 +6631,9 @@ msgstr "Inverser les paramètres"
 msgid "Revert to factory default."
 msgstr "Revenir à la valeur usine par défaut."
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "Révision"
 
@@ -6622,7 +6704,7 @@ msgstr "Continuer"
 msgid "Run type"
 msgstr "Type d’exécution"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6637,7 +6719,7 @@ msgid "Running Jobs"
 msgstr "Jobs en cours d'exécution"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr "Jobs en cours d'exécution"
 
@@ -6672,9 +6754,9 @@ msgid "START"
 msgstr "DÉMARRER"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "ÉTAT :"
 
@@ -6811,7 +6893,7 @@ msgstr "Deuxième"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "Secondes"
 
@@ -6819,7 +6901,7 @@ msgstr "Secondes"
 msgid "See errors on the left"
 msgstr "Voir les erreurs sur la gauche"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6977,7 +7059,7 @@ msgstr "Sélectionnez une date et une heure valables pour ce champ"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7009,11 +7091,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "Sélectionnez un inventaire pour le flux de travail. Cet inventaire est appliqué à tous les nœuds de modèle de tâche qui demandent un inventaire."
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7083,7 +7165,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Sélectionnez les groupes d'instances sur lesquels exécuter cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7105,7 +7187,7 @@ msgstr "Sélectionnez les informations d’identification qu’il vous faut util
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "Sélectionnez l'environnement virtuel Python personnalisé sur lequel exécuter cette source d'inventaire."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7113,7 +7195,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7149,7 +7231,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "Sélectionnez l'inventaire auquel cet hôte appartiendra."
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr "Sélectionnez le playbook qui devra être exécuté par cette tâche."
 
@@ -7189,7 +7271,7 @@ msgstr "Sélectionnez {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7224,7 +7306,7 @@ msgid "Service account JSON file"
 msgstr "Fichier JSON Compte de service"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr "Définir une valeur pour ce champ"
 
@@ -7293,7 +7375,7 @@ msgstr "Afficher"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr "Afficher les modifications"
 
@@ -7364,9 +7446,9 @@ msgstr "Sélection par simple pression d'une touche"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr "Balises de saut"
 
@@ -7379,7 +7461,7 @@ msgstr "Balises de saut"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7464,8 +7546,10 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "Branche Contrôle de la source"
@@ -7475,41 +7559,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Branche/ Balise / Commit du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Identifiant Contrôle de la source"
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr "Type d’Identifiant du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Refspec Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "Type de Contrôle de la source"
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "URL Contrôle de la source"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr "Mise à jour du Contrôle de la source"
 
@@ -7521,8 +7605,8 @@ msgstr "Numéro de téléphone de la source"
 msgid "Source Variables"
 msgstr "Variables Source"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr "Flux de travail Source"
 
@@ -7609,8 +7693,8 @@ msgstr "Onglet Standard Out"
 msgid "Start"
 msgstr "Démarrer"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "Heure Début"
 
@@ -7628,32 +7712,32 @@ msgstr "Message de départ"
 msgid "Start message body"
 msgstr "Démarrer le corps du message"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "Démarrer le processus de synchronisation"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Démarré"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7716,7 +7800,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7740,13 +7824,13 @@ msgstr "Message de réussite"
 msgid "Success message body"
 msgstr "Corps du message de réussite"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "Réussi"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "Copie réussie dans le presse-papiers !"
 
@@ -7786,14 +7870,14 @@ msgstr "Aperçu de l'enquête modale"
 msgid "Survey questions"
 msgstr "Questions de l'enquête"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7812,7 +7896,7 @@ msgstr "Synchroniser toutes les sources"
 msgid "Sync error"
 msgstr "Erreur de synchronisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "Synchronisation pour la révision"
 
@@ -7866,7 +7950,7 @@ msgstr "Onglets"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7909,7 +7993,7 @@ msgstr "URL cible"
 msgid "Task"
 msgstr "Tâche"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "Nombre de tâches"
 
@@ -7917,7 +8001,7 @@ msgstr "Nombre de tâches"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "Tâches"
 
@@ -8039,7 +8123,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "Délai (en secondes) avant que la notification par e-mail cesse d'essayer de joindre l'hôte et expire. Compris entre 1 et 120 secondes."
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8072,6 +8156,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr "Le premier extrait toutes les références.  Le second extrait la requête Github pull numéro 62, dans cet exemple la branche doit être `pull/62/head`."
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8083,7 +8171,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "Nombre maximal d'hôtes pouvant être gérés par cette organisation. La valeur par défaut est 0, ce qui signifie aucune limite. Reportez-vous à la documentation Ansible pour plus de détails."
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8110,8 +8198,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr "Le modèle utilisé pour cibler les hôtes dans l'inventaire. En laissant le champ vide, tous et * cibleront tous les hôtes de l'inventaire. Vous pouvez trouver plus d'informations sur les modèles d'hôtes d'Ansible"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8243,6 +8331,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8251,13 +8346,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8358,7 +8453,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8401,7 +8496,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "Ce flux de travail ne comporte aucun nœud configuré."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8457,7 +8552,7 @@ msgstr "Expiré"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr "Délai d'attente"
 
@@ -8569,7 +8664,7 @@ msgid "Total Nodes"
 msgstr "Total Nœuds"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr "Total Jobs"
 
@@ -8578,7 +8673,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8611,9 +8706,9 @@ msgstr "Mardi"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8633,12 +8728,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8646,7 +8741,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8659,7 +8754,7 @@ msgstr "Type"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr "Détails sur le type"
 
@@ -8669,7 +8764,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr "Non disponible"
 
@@ -8683,15 +8778,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "Hôte inaccessible"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "Nombre d'hôtes inaccessibles"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "Hôtes inaccessibles"
 
@@ -8704,7 +8799,7 @@ msgid "Unsaved changes modal"
 msgstr "Annuler les modifications non enregistrées"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Mettre à jour Révision au lancement"
@@ -8786,7 +8881,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr "Capacité utilisée"
 
@@ -8898,11 +8993,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr "Variables"
 
@@ -8930,9 +9025,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr "Verbosité"
 
@@ -9202,7 +9297,7 @@ msgstr "Visualiseur"
 msgid "WARNING:"
 msgstr "AVERTISSEMENT :"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "En attente"
@@ -9236,14 +9331,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Informations d'identification du webhook"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr "Informations d'identification du webhook"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Clé du webhook"
@@ -9251,7 +9346,7 @@ msgstr "Clé du webhook"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Service webhook"
@@ -9259,14 +9354,14 @@ msgstr "Service webhook"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "URL du webhook"
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr "Détails de webhook"
 
@@ -9360,18 +9455,18 @@ msgstr "Approbation du flux de travail non trouvée."
 msgid "Workflow Approvals"
 msgstr "Approbations des flux de travail"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Job de flux de travail"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9524,18 +9619,18 @@ msgstr "Zoom avant"
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "une nouvelle clé webhook sera générée lors de la sauvegarde."
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "une nouvelle url de webhook sera générée lors de la sauvegarde."
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9561,6 +9656,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr "annuler supprimer"
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "commande"
@@ -9580,7 +9679,7 @@ msgstr "confirmer dissocier"
 #~ msgid "controller instance"
 #~ msgstr "instance de contrôleur"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "copie dans le presse-papiers désactivée"
 
@@ -9602,14 +9701,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9652,19 +9751,19 @@ msgstr "ici."
 msgid "hosts"
 msgstr "hôtes"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr "compte des instances"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr "la capacité utilisée par le groupe d'instances"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr "nom d'hôte de l'instance"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr "type d'instance"
 
@@ -9771,6 +9870,11 @@ msgstr "choisir la verbosité"
 msgid "social login"
 msgstr "social login"
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "système"
@@ -9815,7 +9919,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9843,13 +9947,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9902,6 +10010,10 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} par <0>{username}</0>"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
+msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -18,7 +18,7 @@ msgstr "(10 premiers seulement)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr "(Me le demander au lancement)"
 
@@ -26,11 +26,11 @@ msgstr "(Me le demander au lancement)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* Ce champ sera récupéré dans un système externe de gestion des secrets en utilisant le justificatif d'identité spécifié."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr "Activer les tâches parallèles"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr "Activer Webhooks"
 
@@ -185,8 +185,8 @@ msgstr "Token de compte"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "Actions"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr "Activité"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "Tous les types de tâche"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Autoriser le remplacement de la branche"
@@ -556,21 +556,21 @@ msgstr "Approbation"
 msgid "Approve"
 msgstr "Approuver"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr "Approuvé"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr "Approuvé par {0} - {1}"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "Avril"
-
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -608,6 +608,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès à {1}?  Cela risque
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès de {1} ?"
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
@@ -617,7 +618,7 @@ msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr "Artefacts"
 
@@ -656,7 +657,7 @@ msgstr "Expiration du code d'autorisation"
 msgid "Authorization grant type"
 msgstr "Type d'autorisation"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr "Auto"
 
@@ -829,13 +830,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Expiration Délai d’attente du cache"
@@ -871,6 +868,8 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -893,25 +892,17 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Annuler Job"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -951,27 +942,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr "Annuler sync"
+msgid "Cancel sync"
+msgstr "Annuler sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr "Annuler le processus de synchronisation"
+msgid "Cancel sync process"
+msgstr "Annuler le processus de synchronisation"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr "Annuler la source de synchronisation"
+msgid "Cancel sync source"
+msgstr "Annuler la source de synchronisation"
 
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
-msgstr ""
-
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr "Annulé"
 
@@ -1058,7 +1043,7 @@ msgstr "Choisissez un type de notification"
 msgid "Choose a Playbook Directory"
 msgstr "Choisissez un répertoire Playbook"
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr "Choisissez un type de contrôle à la source"
 
@@ -1090,6 +1075,13 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
 #: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
 #~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
 #~ msgstr ""
@@ -1111,7 +1103,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choisissez le type de ressource qui recevra de nouveaux rôles.  Par exemple, si vous souhaitez ajouter de nouveaux rôles à un ensemble d'utilisateurs, veuillez choisir Utilisateurs et cliquer sur Suivant.  Vous pourrez sélectionner les ressources spécifiques dans l'étape suivante."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Nettoyer"
@@ -1144,10 +1136,6 @@ msgstr "Cliquez sur ce bouton pour vérifier la connexion au système de gestion
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr "Cliquez pour créer un nouveau lien vers ce nœud."
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1196,9 +1184,9 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr "Effondrement"
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Commande"
@@ -1223,7 +1211,7 @@ msgstr "Commande"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr "Jobs parallèles"
 
@@ -1235,14 +1223,6 @@ msgstr "Confirmer Effacer"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
-msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1272,7 +1252,7 @@ msgstr "Confirmer annuler tout"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr "Groupe de conteneurs"
 
@@ -1311,7 +1291,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1360,7 +1340,7 @@ msgstr "Copier l'inventaire"
 msgid "Copy Notification Template"
 msgstr "Copie du modèle de notification"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr "Copier le projet"
 
@@ -1368,7 +1348,7 @@ msgstr "Copier le projet"
 msgid "Copy Template"
 msgstr "Copier le modèle"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr "Copier la révision complète dans le Presse-papiers."
 
@@ -1380,10 +1360,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr "Créer"
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1523,14 +1508,14 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1549,7 +1534,7 @@ msgstr "Créé"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1653,7 +1638,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "Type d'informations d’identification non trouvé."
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1668,9 +1653,9 @@ msgstr "Type d'informations d’identification non trouvé."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "Informations d’identification"
@@ -1688,10 +1673,10 @@ msgid "Custom pod spec"
 msgstr "Spécifications des pods personnalisés"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1765,7 +1750,7 @@ msgstr ""
 msgid "Default answer"
 msgstr "Réponse par défaut"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr "Une réponse doit être apportée au choix par défaut parmi les choix énumérés."
 
@@ -1788,7 +1773,7 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1800,16 +1785,16 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1824,7 +1809,7 @@ msgstr "Supprimer les groupes et les hôtes"
 msgid "Delete Credential"
 msgstr "Supprimer les informations d’identification"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1845,9 +1830,9 @@ msgstr "Supprimer l'hôte"
 msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr "Supprimer Job"
 
@@ -1863,7 +1848,7 @@ msgstr "Supprimer la notification"
 msgid "Delete Organization"
 msgstr "Supprimer l'organisation"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr "Suppression du projet"
 
@@ -1895,7 +1880,7 @@ msgstr "Supprimer un jeton d'utilisateur"
 msgid "Delete Workflow Approval"
 msgstr "Supprimer l'approbation du flux de travail"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr "Supprimer le modèle de flux de travail "
 
@@ -1926,7 +1911,7 @@ msgid "Delete inventory source"
 msgstr "Supprimer la source de l'inventaire"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr "Supprimer lors de la mise à jour"
 
@@ -1977,11 +1962,15 @@ msgstr "Erreur de suppression"
 msgid "Deletion error"
 msgstr "Erreur de suppression"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr "Refusé"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr "Refusé par {0} - {1}"
 
@@ -2041,16 +2030,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2241,7 +2230,7 @@ msgstr "Dissocier le rôle !"
 msgid "Disassociate?"
 msgstr "Dissocier ?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2263,8 +2252,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr "Télécharger la sortie"
 
@@ -2276,7 +2265,7 @@ msgstr "E-mail"
 msgid "E-mail options"
 msgstr "Options d'email"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr "Chaque choix de réponse doit figurer sur une ligne distincte."
 
@@ -2309,7 +2298,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2318,14 +2307,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2355,8 +2344,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2451,8 +2440,8 @@ msgstr "Modèle de notification de modification"
 msgid "Edit Organization"
 msgstr "Modifier l'organisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr "Modifier le projet"
 
@@ -2466,7 +2455,7 @@ msgstr "Modifier la question"
 msgid "Edit Schedule"
 msgstr "Modifier la programmation"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr "Modifier la source"
 
@@ -2536,16 +2525,16 @@ msgid "Edit this node"
 msgstr "Modifier ce nœud"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr "Temps écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr "Temps écoulé (en secondes) pendant lequel la tâche s'est exécutée."
 
@@ -2563,11 +2552,11 @@ msgstr "Options d'email"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr "Activer les tâches parallèles"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr "Utiliser le cache des faits"
 
@@ -2580,14 +2569,14 @@ msgstr "Activer/désactiver la vérification de certificat HTTPS"
 msgid "Enable Privilege Escalation"
 msgstr "Activer l’élévation des privilèges"
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr "Activer le webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr "Activez le webhook pour ce modèle de flux de travail."
 
@@ -2612,7 +2601,7 @@ msgstr "Activer l’élévation des privilèges"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "Activer la connexion simplifiée pour vos applications Tower"
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr "Activez le webhook pour ce modèle de tâche."
 
@@ -2631,7 +2620,7 @@ msgstr "Valeur activée"
 msgid "Enabled Variable"
 msgstr "Variable activée"
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2649,6 +2638,10 @@ msgstr ""
 
 #: src/screens/Template/shared/JobTemplateForm.jsx:517
 #~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact BRAND_NAME and request a configuration update using this job template."
+#~ msgstr ""
+
+#: src/components/AdHocCommands/AdHocDetailsStep.jsx:244
+#~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact {brandName} and request a configuration update using this job template"
 #~ msgstr ""
 
 #: src/screens/Template/shared/JobTemplateForm.jsx:517
@@ -2688,9 +2681,17 @@ msgstr "Veuillez saisir une expression de recherche au moins pour créer un nouv
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Entrez les injecteurs avec la syntaxe JSON ou YAML.  Consultez la documentation d’Ansible Tower pour avoir un exemple de syntaxe."
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Entrez les variables avec la syntaxe JSON ou YAML.  Consultez la documentation d’Ansible Tower pour avoir un exemple de syntaxe."
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2699,6 +2700,13 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr "Entrez les variables d’inventaire avec la syntaxe JSON ou YAML. Utilisez le bouton radio pour basculer entre les deux. Consultez la documentation d’Ansible Tower pour avoir un exemple de syntaxe."
@@ -2706,6 +2714,10 @@ msgstr "Entrez les variables d’inventaire avec la syntaxe JSON ou YAML. Utilis
 #: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
 #~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
 #~ msgstr "Entrez les variables d’inventaire avec la syntaxe JSON ou YAML. Utilisez le bouton radio pour basculer entre les deux. Consultez la documentation d’Ansible Tower pour avoir un exemple de syntaxe."
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2802,11 +2814,11 @@ msgstr "Entrez les variables avec la syntaxe JSON ou YAML. Utilisez le bouton ra
 #~ msgid "Environment"
 #~ msgstr "Environnement"
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2836,8 +2848,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2861,7 +2873,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2877,7 +2888,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2885,7 +2897,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2894,7 +2906,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2976,7 +2988,7 @@ msgstr "Exécuter lorsque le nœud parent se trouve dans un état de réussite."
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2998,7 +3010,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr "Nœud d'exécution"
 
@@ -3013,6 +3025,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -3057,11 +3074,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr "Arrive à expiration le {0}"
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explication"
@@ -3076,9 +3093,9 @@ msgid "Extra variables"
 msgstr "Variables supplémentaires"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr "TERMINÉ :"
 
@@ -3091,19 +3108,19 @@ msgstr "TERMINÉ :"
 msgid "Facts"
 msgstr "Faits"
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr "Échec"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr "Échec du comptage des hôtes"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr "Échec Hôtes"
 
@@ -3137,33 +3154,13 @@ msgstr "N'a pas réussi à associer le rôle"
 msgid "Failed to associate."
 msgstr "N'a pas réussi à associer."
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
+msgid "Failed to cancel inventory source sync."
+msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
 
-#: components/JobList/JobList.jsx:295
+#: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
-
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
-msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3177,7 +3174,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "N'a pas réussi à copier l'inventaire."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr "Le projet n'a pas été copié."
 
@@ -3260,7 +3257,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs sources d'inventaire."
 msgid "Failed to delete one or more job templates."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles de Jobs."
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs."
 
@@ -3308,7 +3305,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs approbations de flux de tr
 msgid "Failed to delete organization."
 msgstr "N'a pas réussi à supprimer l'organisation."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr "N'a pas réussi à supprimer le projet."
 
@@ -3341,7 +3338,7 @@ msgstr "Impossible de supprimer l'utilisateur."
 msgid "Failed to delete workflow approval."
 msgstr "N'a pas réussi à supprimer l'approbation du flux de travail."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr "N'a pas réussi à supprimer le modèle de flux de travail."
 
@@ -3402,7 +3399,7 @@ msgstr "Impossible de récupérer les informations d'identification des nœuds."
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr "Impossible de synchroniser la source de l'inventaire."
 
@@ -3429,10 +3426,6 @@ msgstr "N'a pas réussi à basculer la notification."
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "Impossible de basculer le calendrier."
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
-msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3497,12 +3490,12 @@ msgstr "Téléchargement de fichier rejeté. Veuillez sélectionner un seul fich
 msgid "File, directory or script"
 msgstr "Fichier, répertoire ou script"
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr "Heure de Fin"
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Terminé"
@@ -3572,7 +3565,7 @@ msgstr "Pour plus d'informations, reportez-vous à"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr "Forks"
 
@@ -3619,7 +3612,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3798,11 +3791,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr "Clé de configuration de l’hôte"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr "Nombre d'hôtes"
 
@@ -3885,7 +3878,7 @@ msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas dis
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hôtes"
@@ -3911,7 +3904,7 @@ msgstr "Heure"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3986,7 +3979,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr "Si cochées, toutes les variables des groupes et hôtes dépendants seront supprimées et remplacées par celles qui se trouvent dans la source externe."
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -4015,7 +4008,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "Si cochés, tous les hôtes et groupes qui étaient présent auparavant sur la source externe, mais qui sont maintenant supprimés, seront supprimés de l'inventaire de Tower. Les hôtes et les groupes qui n'étaient pas gérés par la source de l'inventaire seront promus au prochain groupe créé manuellement ou s'il n'y a pas de groupe créé manuellement dans lequel les promouvoir, ils devront rester dans le groupe \"all\" par défaut de cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4032,18 +4025,22 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr ""
 
+#: src/screens/Template/shared/JobTemplateForm.jsx:448
+#~ msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible's --diff mode."
+#~ msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:205
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "Si activé, afficher les changements faits par les tâches Ansible, si supporté. C'est équivalent au mode --diff d’Ansible."
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4053,11 +4050,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "Si activé, il sera possible d’avoir des exécutions de ce modèle de job de flux de travail en simultané."
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4147,12 +4144,12 @@ msgid "Input configuration"
 msgstr "Configuration de l'entrée"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4160,16 +4157,7 @@ msgid "Insights Credential"
 msgstr "Information d’identification  d’Insights"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4184,7 +4172,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "Filtres de l'instance"
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr "Groupe d'instance"
 
@@ -4268,7 +4256,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4291,11 +4279,11 @@ msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr "Inventaire"
 
@@ -4311,21 +4299,13 @@ msgstr "Fichier d'inventaire"
 msgid "Inventory ID"
 msgstr "ID Inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Sync Source d’inventaire"
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
-msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4334,11 +4314,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "Sources d'inventaire"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr "Sync Inventaires"
 
@@ -4390,9 +4370,9 @@ msgid "Items per page"
 msgstr "Éléments par page"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr "ID JOB :"
 
@@ -4417,27 +4397,26 @@ msgstr "Janvier"
 msgid "Job"
 msgstr "Job"
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Erreur de suppression d’un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr "Découpage de job"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr "Découpage de job"
 
@@ -4450,19 +4429,19 @@ msgstr "Statut Job"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "Balises Job"
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Modèle de Job"
@@ -4487,14 +4466,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "Type de Job"
@@ -4513,8 +4492,8 @@ msgstr "Onglet Graphique de l'état des Jobs"
 msgid "Job templates"
 msgstr "Modèles de Jobs"
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4620,19 +4599,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr "Nom du label"
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr "Libellés"
 
@@ -4640,7 +4619,7 @@ msgstr "Libellés"
 msgid "Last"
 msgstr "Dernier"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4663,10 +4642,10 @@ msgstr "Dernière connexion"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4706,7 +4685,7 @@ msgstr "Dernière exécution du Job"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr "Dernière modification"
 
@@ -4715,7 +4694,7 @@ msgstr "Dernière modification"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4725,8 +4704,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr "Lancer"
 
@@ -4761,16 +4740,12 @@ msgstr "Lancer le flux de travail"
 msgid "Launched By"
 msgstr "Lancé par"
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr "Lancé par (Nom d'utilisateur)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4801,15 +4776,15 @@ msgstr "Moins ou égal à la comparaison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "Limite"
@@ -4869,16 +4844,16 @@ msgstr "Type de recherche"
 msgid "Lookup typeahead"
 msgstr "Recherche par type"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr "DERNIÈRE SYNCHRONISATION"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr "Informations d’identification de la machine"
 
@@ -4895,10 +4870,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr "Job de gestion"
 
@@ -4924,14 +4899,14 @@ msgstr "Job de gestion non trouvé."
 msgid "Management jobs"
 msgstr "Jobs de gestion"
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manuel"
@@ -5037,7 +5012,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "Modifié"
@@ -5053,7 +5028,7 @@ msgstr "Modifié"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5148,9 +5123,9 @@ msgstr "Options à choix multiples."
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5173,8 +5148,8 @@ msgstr "Options à choix multiples."
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5268,7 +5243,7 @@ msgstr "Options à choix multiples."
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5294,13 +5269,13 @@ msgstr "Options à choix multiples."
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5308,7 +5283,7 @@ msgstr "Options à choix multiples."
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5350,11 +5325,11 @@ msgid "Never Updated"
 msgstr "Jamais mis à jour"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr "N'expire jamais"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "Nouveau"
@@ -5622,7 +5597,7 @@ msgstr "Octobre"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr "Désactivé"
 
@@ -5640,7 +5615,7 @@ msgstr "Désactivé"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr "Le"
 
@@ -5678,8 +5653,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Détails de l'option"
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5705,12 +5680,12 @@ msgstr "En option, sélectionnez les informations d'identification à utiliser p
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr "Options"
 
@@ -5741,15 +5716,15 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5864,7 +5839,7 @@ msgstr "Passez des changements supplémentaires en ligne de commande. Il y a deu
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5872,9 +5847,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "Transmettez des variables de ligne de commandes supplémentaires au playbook. Voici le paramètre de ligne de commande -e or --extra-vars pour ansible-playbook. Fournir la paire clé/valeur en utilisant YAML ou JSON. Consulter la documentation Ansible Tower pour obtenir des exemples de syntaxe."
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5897,7 +5876,7 @@ msgstr "Les deux dernières semaines"
 msgid "Past week"
 msgstr "La semaine dernière"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "En attente"
@@ -5922,7 +5901,7 @@ msgstr "Jeton d'accès personnel"
 msgid "Play"
 msgstr "Lancer"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr "Compte de jeux"
 
@@ -5931,13 +5910,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5946,15 +5925,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Répertoire de playbook"
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr "Exécution du playbook"
 
@@ -5973,7 +5952,7 @@ msgstr "Nom du playbook"
 msgid "Playbook run"
 msgstr "Exécution du playbook"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr "Lancements"
 
@@ -6010,7 +5989,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "Veuillez choisir un numéro de jour entre 1 et 31."
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "Sélectionnez un inventaire ou cochez l’option Me le demander au lancement."
 
@@ -6049,6 +6028,14 @@ msgstr "Remplir le champ à partir d'un système de gestion des secrets externes
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -6079,18 +6066,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -6101,7 +6076,7 @@ msgstr "Prévisualisation"
 msgid "Private key passphrase"
 msgstr "Phrase de passe pour la clé privée"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr "Élévation des privilèges"
 
@@ -6109,17 +6084,17 @@ msgstr "Élévation des privilèges"
 msgid "Privilege escalation password"
 msgstr "Mot de passe pour l’élévation des privilèges"
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6127,7 +6102,7 @@ msgid "Project"
 msgstr "Projet"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Chemin de base du projet"
@@ -6137,19 +6112,9 @@ msgstr "Chemin de base du projet"
 msgid "Project Sync"
 msgstr "Sync Projet"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "Mise à jour du projet"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6202,7 +6167,7 @@ msgstr "Valeurs incitatrices"
 msgid "Prompts"
 msgstr "Invites"
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6248,25 +6213,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr "URL de rappel d’exécution "
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr "Détails de rappel d’exécution"
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr "Rappels d’exécution "
 
@@ -6286,10 +6247,6 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "Paramètres RADIUS"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
-msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6319,7 +6276,7 @@ msgstr "Liste de destinataires"
 msgid "Recipient list"
 msgstr "Liste de destinataires"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6363,11 +6320,15 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:383
+#~ msgid "Refer to the Ansible documentation for details about the configuration file."
+#~ msgstr ""
 
 #: screens/User/UserTokens/UserTokens.jsx:76
 msgid "Refresh Token"
@@ -6396,16 +6357,16 @@ msgstr "Expression régulière où seuls les noms d'hôtes correspondants seront
 msgid "Related Groups"
 msgstr "Groupes liés"
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr "Relancer le Job"
 
@@ -6422,12 +6383,12 @@ msgstr "Relancer les hôtes défaillants"
 msgid "Relaunch on"
 msgstr "Relancer sur"
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr "Relancer en utilisant les paramètres de l'hôte"
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6536,10 +6497,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6588,9 +6549,9 @@ msgstr "Inverser les paramètres"
 msgid "Revert to factory default."
 msgstr "Revenir à la valeur usine par défaut."
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr "Révision"
 
@@ -6661,7 +6622,7 @@ msgstr "Continuer"
 msgid "Run type"
 msgstr "Type d’exécution"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6676,7 +6637,7 @@ msgid "Running Jobs"
 msgstr "Jobs en cours d'exécution"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr "Jobs en cours d'exécution"
 
@@ -6711,9 +6672,9 @@ msgid "START"
 msgstr "DÉMARRER"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr "ÉTAT :"
 
@@ -6850,7 +6811,7 @@ msgstr "Deuxième"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr "Secondes"
 
@@ -6858,7 +6819,7 @@ msgstr "Secondes"
 msgid "See errors on the left"
 msgstr "Voir les erreurs sur la gauche"
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7016,7 +6977,7 @@ msgstr "Sélectionnez une date et une heure valables pour ce champ"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7048,11 +7009,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "Sélectionnez un inventaire pour le flux de travail. Cet inventaire est appliqué à tous les nœuds de modèle de tâche qui demandent un inventaire."
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7122,7 +7083,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Sélectionnez les groupes d'instances sur lesquels exécuter cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7144,7 +7105,7 @@ msgstr "Sélectionnez les informations d’identification qu’il vous faut util
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "Sélectionnez l'environnement virtuel Python personnalisé sur lequel exécuter cette source d'inventaire."
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7152,7 +7113,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7188,7 +7149,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "Sélectionnez l'inventaire auquel cet hôte appartiendra."
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr "Sélectionnez le playbook qui devra être exécuté par cette tâche."
 
@@ -7228,7 +7189,7 @@ msgstr "Sélectionnez {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7263,7 +7224,7 @@ msgid "Service account JSON file"
 msgstr "Fichier JSON Compte de service"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr "Définir une valeur pour ce champ"
 
@@ -7332,7 +7293,7 @@ msgstr "Afficher"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr "Afficher les modifications"
 
@@ -7403,9 +7364,9 @@ msgstr "Sélection par simple pression d'une touche"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr "Balises de saut"
 
@@ -7418,7 +7379,7 @@ msgstr "Balises de saut"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7503,10 +7464,8 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "Branche Contrôle de la source"
@@ -7516,41 +7475,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Branche/ Balise / Commit du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Identifiant Contrôle de la source"
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr "Type d’Identifiant du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Refspec Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr "Type de Contrôle de la source"
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "URL Contrôle de la source"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr "Mise à jour du Contrôle de la source"
 
@@ -7562,8 +7521,8 @@ msgstr "Numéro de téléphone de la source"
 msgid "Source Variables"
 msgstr "Variables Source"
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr "Flux de travail Source"
 
@@ -7598,6 +7557,12 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
 
 #: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
 #~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
@@ -7644,8 +7609,8 @@ msgstr "Onglet Standard Out"
 msgid "Start"
 msgstr "Démarrer"
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr "Heure Début"
 
@@ -7663,32 +7628,32 @@ msgstr "Message de départ"
 msgid "Start message body"
 msgstr "Démarrer le corps du message"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr "Démarrer le processus de synchronisation"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Démarré"
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7751,7 +7716,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7775,13 +7740,13 @@ msgstr "Message de réussite"
 msgid "Success message body"
 msgstr "Corps du message de réussite"
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "Réussi"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr "Copie réussie dans le presse-papiers !"
 
@@ -7821,14 +7786,14 @@ msgstr "Aperçu de l'enquête modale"
 msgid "Survey questions"
 msgstr "Questions de l'enquête"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7847,7 +7812,7 @@ msgstr "Synchroniser toutes les sources"
 msgid "Sync error"
 msgstr "Erreur de synchronisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr "Synchronisation pour la révision"
 
@@ -7901,7 +7866,7 @@ msgstr "Onglets"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7944,7 +7909,7 @@ msgstr "URL cible"
 msgid "Task"
 msgstr "Tâche"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr "Nombre de tâches"
 
@@ -7952,7 +7917,7 @@ msgstr "Nombre de tâches"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr "Tâches"
 
@@ -8074,7 +8039,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "Délai (en secondes) avant que la notification par e-mail cesse d'essayer de joindre l'hôte et expire. Compris entre 1 et 120 secondes."
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8118,7 +8083,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "Nombre maximal d'hôtes pouvant être gérés par cette organisation. La valeur par défaut est 0, ce qui signifie aucune limite. Reportez-vous à la documentation Ansible pour plus de détails."
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8190,7 +8155,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr "Il y a eu un problème d'enregistrement. Veuillez réessayer."
 
@@ -8264,12 +8229,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8279,13 +8251,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8386,7 +8358,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8429,7 +8401,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "Ce flux de travail ne comporte aucun nœud configuré."
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8476,7 +8448,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr "Délai en secondes à prévoir pour qu'une synchronisation d'inventaire soit actualisée. Durant l’exécution du Job et les rappels, le système de tâches évalue l’horodatage de la dernière mise à jour du projet. Si elle est plus ancienne que le délai d’expiration du cache, elle n’est pas considérée comme actualisée, et une nouvelle synchronisation de l'inventaire sera effectuée."
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr "Expiré"
 
@@ -8485,7 +8457,7 @@ msgstr "Expiré"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr "Délai d'attente"
 
@@ -8597,7 +8569,7 @@ msgid "Total Nodes"
 msgstr "Total Nœuds"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr "Total Jobs"
 
@@ -8606,7 +8578,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8639,9 +8611,9 @@ msgstr "Mardi"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8661,12 +8633,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8674,7 +8646,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8687,7 +8659,7 @@ msgstr "Type"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr "Détails sur le type"
 
@@ -8697,7 +8669,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr "Non disponible"
 
@@ -8711,15 +8683,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr "Hôte inaccessible"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr "Nombre d'hôtes inaccessibles"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr "Hôtes inaccessibles"
 
@@ -8732,7 +8704,7 @@ msgid "Unsaved changes modal"
 msgstr "Annuler les modifications non enregistrées"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Mettre à jour Révision au lancement"
@@ -8814,7 +8786,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr "Capacité utilisée"
 
@@ -8926,11 +8898,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr "Variables"
 
@@ -8958,9 +8930,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr "Verbosité"
 
@@ -9230,7 +9202,7 @@ msgstr "Visualiseur"
 msgid "WARNING:"
 msgstr "AVERTISSEMENT :"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "En attente"
@@ -9264,14 +9236,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Informations d'identification du webhook"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr "Informations d'identification du webhook"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Clé du webhook"
@@ -9279,7 +9251,7 @@ msgstr "Clé du webhook"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Service webhook"
@@ -9287,14 +9259,14 @@ msgstr "Service webhook"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "URL du webhook"
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr "Détails de webhook"
 
@@ -9331,7 +9303,7 @@ msgstr "Jour du week-end"
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr "Bienvenue à Ansible Tower {brandName}! Veuillez vous connecter."
 
@@ -9388,18 +9360,18 @@ msgstr "Approbation du flux de travail non trouvée."
 msgid "Workflow Approvals"
 msgstr "Approbations des flux de travail"
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Job de flux de travail"
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9552,18 +9524,18 @@ msgstr "Zoom avant"
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "une nouvelle clé webhook sera générée lors de la sauvegarde."
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "une nouvelle url de webhook sera générée lors de la sauvegarde."
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9589,10 +9561,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr "annuler supprimer"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "commande"
@@ -9612,7 +9580,7 @@ msgstr "confirmer dissocier"
 #~ msgid "controller instance"
 #~ msgstr "instance de contrôleur"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr "copie dans le presse-papiers désactivée"
 
@@ -9634,14 +9602,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9684,19 +9652,19 @@ msgstr "ici."
 msgid "hosts"
 msgstr "hôtes"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr "compte des instances"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr "la capacité utilisée par le groupe d'instances"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr "nom d'hôte de l'instance"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr "type d'instance"
 
@@ -9803,11 +9771,6 @@ msgstr "choisir la verbosité"
 msgid "social login"
 msgstr "social login"
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "système"
@@ -9852,7 +9815,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9880,17 +9843,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9943,10 +9902,6 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} par <0>{username}</0>"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -18,7 +18,7 @@ msgstr "(最初の 10 件に制限)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr "(起動プロンプト)"
 
@@ -26,11 +26,11 @@ msgstr "(起動プロンプト)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "*このフィールドは、指定された認証情報を使用して外部のシークレット管理システムから取得されます。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr "- 同時実行ジョブの有効化"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr "- Webhook の有効化"
 
@@ -185,8 +185,8 @@ msgstr "アカウントトークン"
 msgid "Action"
 msgstr "アクション"
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "アクション"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "アクション"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "アクション"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr "アクティビティー"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "すべてのジョブタイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "ブランチの上書き許可"
@@ -556,21 +556,21 @@ msgstr "承認"
 msgid "Approve"
 msgstr "承認"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr "承認済"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr "{0} - {1} により承認済"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "4 月"
-
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -608,6 +608,7 @@ msgstr "{1} から {0} のアクセスを削除しますか? これを行うと�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "{username} からの {0} のアクセスを削除してもよろしいですか?"
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "このジョブをキャンセルする要求を送信してよろしいですか?"
@@ -617,7 +618,7 @@ msgstr "このジョブをキャンセルする要求を送信してよろしい
 msgid "Arguments"
 msgstr "引数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr "アーティファクト"
 
@@ -656,7 +657,7 @@ msgstr "認証コードの有効期限"
 msgid "Authorization grant type"
 msgstr "認証付与タイプ"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr "自動"
 
@@ -829,13 +830,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "キャッシュタイムアウト"
@@ -871,6 +868,8 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -893,25 +892,17 @@ msgstr "キャッシュのタイムアウト (秒)"
 msgid "Cancel"
 msgstr "取り消し"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "ジョブの取り消し"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -951,27 +942,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr "同期の取り消し"
+msgid "Cancel sync"
+msgstr "同期の取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr "同期プロセスの取り消し"
+msgid "Cancel sync process"
+msgstr "同期プロセスの取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr "同期プロセスの取り消し"
+msgid "Cancel sync source"
+msgstr "同期プロセスの取り消し"
 
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
-msgstr ""
-
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr "取り消されました"
 
@@ -1058,7 +1043,7 @@ msgstr "通知タイプの選択"
 msgid "Choose a Playbook Directory"
 msgstr "Playbook ディレクトリーの選択"
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr "ソースコントロールタイプの選択"
 
@@ -1090,6 +1075,13 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
 #: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
 #~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
 #~ msgstr ""
@@ -1111,7 +1103,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "新しいロールを受け取るリソースのタイプを選択します。たとえば、一連のユーザーに新しいロールを追加する場合は、ユーザーを選択して次へをクリックしてください。次のステップで特定のリソースを選択できるようになります。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "クリーニング"
@@ -1144,10 +1136,6 @@ msgstr "このボタンをクリックして、選択した認証情報と指定
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr "クリックして、このノードへの新しいリンクを作成します。"
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1196,9 +1184,9 @@ msgstr "クラウド"
 msgid "Collapse"
 msgstr "折りたたむ"
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "コマンド"
@@ -1223,7 +1211,7 @@ msgstr "コマンド"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr "同時実行ジョブ"
 
@@ -1235,14 +1223,6 @@ msgstr "削除の確認"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "パスワードの確認"
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
-msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1272,7 +1252,7 @@ msgstr "すべて元に戻すことを確認"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr "コンテナーグループ"
 
@@ -1311,7 +1291,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1360,7 +1340,7 @@ msgstr "インベントリーのコピー"
 msgid "Copy Notification Template"
 msgstr "通知テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr "プロジェクトのコピー"
 
@@ -1368,7 +1348,7 @@ msgstr "プロジェクトのコピー"
 msgid "Copy Template"
 msgstr "テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr "完全なリビジョンをクリップボードにコピーします。"
 
@@ -1380,10 +1360,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr "Copyright 2019 Red Hat, Inc."
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr "作成"
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1523,14 +1508,14 @@ msgstr "ユーザートークンの作成"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1549,7 +1534,7 @@ msgstr "作成済み"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1653,7 +1638,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "認証情報タイプが見つかりません。"
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1668,9 +1653,9 @@ msgstr "認証情報タイプが見つかりません。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "認証情報"
@@ -1688,10 +1673,10 @@ msgid "Custom pod spec"
 msgstr "カスタム Pod 仕様"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1765,7 +1750,7 @@ msgstr ""
 msgid "Default answer"
 msgstr "デフォルトの応答"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr "デフォルトで指定されている選択項目は、一覧から回答する必要があります。"
 
@@ -1788,7 +1773,7 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1800,16 +1785,16 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1824,7 +1809,7 @@ msgstr "すべてのグループおよびホストの削除"
 msgid "Delete Credential"
 msgstr "認証情報の削除"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1845,9 +1830,9 @@ msgstr "ホストの削除"
 msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr "ジョブの削除"
 
@@ -1863,7 +1848,7 @@ msgstr "通知の削除"
 msgid "Delete Organization"
 msgstr "組織の削除"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr "プロジェクトの削除"
 
@@ -1895,7 +1880,7 @@ msgstr "ユーザートークンの削除"
 msgid "Delete Workflow Approval"
 msgstr "ワークフロー承認の削除"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr "新規ワークフロージョブテンプレートの削除"
 
@@ -1926,7 +1911,7 @@ msgid "Delete inventory source"
 msgstr "インベントリーソースの削除"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr "更新時のデプロイ"
 
@@ -1977,11 +1962,15 @@ msgstr "削除エラー"
 msgid "Deletion error"
 msgstr "削除エラー"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr "拒否済み"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr "{0} - {1} により拒否済み"
 
@@ -2041,16 +2030,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2241,7 +2230,7 @@ msgstr "ロールの関連付けの解除!"
 msgid "Disassociate?"
 msgstr "関連付けを解除しますか?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2263,8 +2252,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr "出力のダウンロード"
 
@@ -2276,7 +2265,7 @@ msgstr "メール"
 msgid "E-mail options"
 msgstr "メールオプション"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr "各回答の選択肢は別々の行にある必要があります。"
 
@@ -2309,7 +2298,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2318,14 +2307,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2355,8 +2344,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2451,8 +2440,8 @@ msgstr "通知テンプレートの編集"
 msgid "Edit Organization"
 msgstr "組織の編集"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr "プロジェクトの編集"
 
@@ -2466,7 +2455,7 @@ msgstr "質問の編集"
 msgid "Edit Schedule"
 msgstr "スケジュールの編集"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr "ソースの編集"
 
@@ -2536,16 +2525,16 @@ msgid "Edit this node"
 msgstr "このノードの編集"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr "ジョブ実行の経過時間"
 
@@ -2563,11 +2552,11 @@ msgstr "メールオプション"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr "同時実行ジョブの有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr "ファクトストレージの有効化"
 
@@ -2580,14 +2569,14 @@ msgstr "HTTPS 証明書の検証を有効化"
 msgid "Enable Privilege Escalation"
 msgstr "権限昇格の有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr "Webhook の有効化"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr "このワークフローのジョブテンプレートの Webhook を有効にします。"
 
@@ -2612,7 +2601,7 @@ msgstr "権限昇格の有効化"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "{brandName} アプリケーションのログインの簡素化の有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr "このテンプレートの Webhook を有効にします。"
 
@@ -2631,7 +2620,7 @@ msgstr "有効な値"
 msgid "Enabled Variable"
 msgstr "有効な変数"
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2649,6 +2638,10 @@ msgstr ""
 
 #: src/screens/Template/shared/JobTemplateForm.jsx:517
 #~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact BRAND_NAME and request a configuration update using this job template."
+#~ msgstr ""
+
+#: src/components/AdHocCommands/AdHocDetailsStep.jsx:244
+#~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact {brandName} and request a configuration update using this job template"
 #~ msgstr ""
 
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:155
@@ -2684,9 +2677,17 @@ msgstr "新規スマートインベントリーを作成するために 1 つ以
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "JSON または YAML 構文のいずれかを使用してインジェクターを入力します。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "JSON または YAML 構文のいずれかを使用して入力を行います。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2695,6 +2696,13 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr "JSON または YAML 構文のいずれかを使用してインベントリー変数を入力します。ラジオボタンを使用して構文で切り替えを行います。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
@@ -2702,6 +2710,10 @@ msgstr "JSON または YAML 構文のいずれかを使用してインベント�
 #: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
 #~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
 #~ msgstr "JSON または YAML 構文のいずれかを使用してインベントリー変数を入力します。ラジオボタンを使用して構文間で切り替えを行います。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2798,11 +2810,11 @@ msgstr "JSON または YAML 構文のいずれかを使用して変数を入力�
 #~ msgid "Environment"
 #~ msgstr "環境"
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2832,8 +2844,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2857,7 +2869,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2873,7 +2884,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2881,7 +2893,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2890,7 +2902,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2972,7 +2984,7 @@ msgstr "親ノードが正常な状態になったときに実行します。"
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2994,7 +3006,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr "実行ノード"
 
@@ -3009,6 +3021,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -3053,11 +3070,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr "{0} の有効期限"
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "説明"
@@ -3072,9 +3089,9 @@ msgid "Extra variables"
 msgstr "追加変数"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr "終了日時:"
 
@@ -3087,19 +3104,19 @@ msgstr "終了日時:"
 msgid "Facts"
 msgstr "ファクト"
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr "失敗"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr "失敗したホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr "失敗したホスト"
 
@@ -3133,33 +3150,13 @@ msgstr "ロールの関連付けに失敗しました"
 msgid "Failed to associate."
 msgstr "関連付けに失敗しました。"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr "インベントリーソースの同期をキャンセルできませんでした。"
+msgid "Failed to cancel inventory source sync."
+msgstr "インベントリーソースの同期をキャンセルできませんでした。"
 
-#: components/JobList/JobList.jsx:295
+#: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
-
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
-msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3173,7 +3170,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "インベントリーをコピーできませんでした。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr "プロジェクトをコピーできませんでした。"
 
@@ -3256,7 +3253,7 @@ msgstr "1 つ以上のインベントリーリソースを削除できません�
 msgid "Failed to delete one or more job templates."
 msgstr "1 つ以上のジョブテンプレートを削除できませんでした"
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr "1 つ以上のジョブを削除できませんでした。"
 
@@ -3304,7 +3301,7 @@ msgstr "1 つ以上のワークフロー承認を削除できませんでした�
 msgid "Failed to delete organization."
 msgstr "組織を削除できませんでした。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr "プロジェクトを削除できませんでした。"
 
@@ -3337,7 +3334,7 @@ msgstr "ユーザーを削除できませんでした。"
 msgid "Failed to delete workflow approval."
 msgstr "ワークフロー承認を削除できませんでした。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr "ワークフロージョブテンプレートを削除できませんでした。"
 
@@ -3398,7 +3395,7 @@ msgstr "ノード認証情報を取得できませんでした。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr "インベントリーソースを同期できませんでした。"
 
@@ -3425,10 +3422,6 @@ msgstr "通知の切り替えに失敗しました。"
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "スケジュールの切り替えに失敗しました。"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
-msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3493,12 +3486,12 @@ msgstr "ファイルのアップロードが拒否されました。単一の .j
 msgid "File, directory or script"
 msgstr "ファイル、ディレクトリー、またはスクリプト"
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr "終了時間"
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "終了日時"
@@ -3568,7 +3561,7 @@ msgstr "詳しい情報は以下の情報を参照してください:"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr "フォーク"
 
@@ -3615,7 +3608,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3794,11 +3787,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr "ホスト設定キー"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr "ホスト数"
 
@@ -3881,7 +3874,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3907,7 +3900,7 @@ msgstr "時間"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3982,7 +3975,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr "チェックが付けられている場合、子グループおよびホストのすべての変数が削除され、外部ソースにあるものによって置き換えられます。"
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -4011,7 +4004,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "チェックを付けると、以前は外部ソースにあり、現在は削除されているホストおよびグループが Tower インベントリーから削除されます。インベントリーソースで管理されていなかったホストおよびグループは、次に手動で作成したグループにプロモートされます。プロモート先となる、手動で作成したグループがない場合、ホストおよびグループは、インベントリーの「すべて」のデフォルトグループに残ります。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4028,18 +4021,22 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr ""
 
+#: src/screens/Template/shared/JobTemplateForm.jsx:448
+#~ msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible's --diff mode."
+#~ msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:205
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "有効で、サポートされている場合は、Ansible タスクで加えられた変更を表示します。これは Ansible の --diff モードに相当します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4049,11 +4046,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "有効な場合は、このワークフロージョブテンプレートの同時実行が許可されます。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4143,12 +4140,12 @@ msgid "Input configuration"
 msgstr "入力の設定"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4156,16 +4153,7 @@ msgid "Insights Credential"
 msgstr "Insights 認証情報"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4180,7 +4168,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "インスタンスフィルター"
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr "インスタンスグループ"
 
@@ -4264,7 +4252,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "ソースを含むインベントリーはコピーできません。"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4287,11 +4275,11 @@ msgstr "ソースを含むインベントリーはコピーできません。"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr "インベントリー"
 
@@ -4307,21 +4295,13 @@ msgstr "インベントリーファイル"
 msgid "Inventory ID"
 msgstr "インベントリー ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "インベントリーソース同期"
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
-msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4330,11 +4310,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "インベントリーソース"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr "インベントリー同期"
 
@@ -4386,9 +4366,9 @@ msgid "Items per page"
 msgstr "ページ別の項目"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr "ジョブ ID:"
 
@@ -4413,27 +4393,26 @@ msgstr "1 月"
 msgid "Job"
 msgstr "ジョブ"
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "ジョブ削除エラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr "ジョブスライス"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr "ジョブスライス"
 
@@ -4446,19 +4425,19 @@ msgstr "ジョブステータス"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "ジョブタグ"
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "ジョブテンプレート"
@@ -4483,14 +4462,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "ジョブタイプ"
@@ -4509,8 +4488,8 @@ msgstr "ジョブステータスのグラフタブ"
 msgid "Job templates"
 msgstr "ジョブテンプレート"
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4616,19 +4595,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr "ラベル名"
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr "ラベル"
 
@@ -4636,7 +4615,7 @@ msgstr "ラベル"
 msgid "Last"
 msgstr "最終"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4659,10 +4638,10 @@ msgstr "前回のログイン"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4702,7 +4681,7 @@ msgstr "最後のジョブ実行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr "最終更新日"
 
@@ -4711,7 +4690,7 @@ msgstr "最終更新日"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4721,8 +4700,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr "起動"
 
@@ -4757,16 +4736,12 @@ msgstr "ワークフローの起動"
 msgid "Launched By"
 msgstr "起動者"
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr "起動者 (ユーザー名)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4797,15 +4772,15 @@ msgstr "Less than or equal to の比較条件"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "制限"
@@ -4865,16 +4840,16 @@ msgstr "ルックアップタイプ"
 msgid "Lookup typeahead"
 msgstr "ルックアップの先行入力"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr "直近の同期"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr "マシンの認証情報"
 
@@ -4891,10 +4866,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr "管理ジョブ"
 
@@ -4920,14 +4895,14 @@ msgstr "管理ジョブが見つかりません。"
 msgid "Management jobs"
 msgstr "管理ジョブ"
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手動"
@@ -5033,7 +5008,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "修正済み"
@@ -5049,7 +5024,7 @@ msgstr "修正済み"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5144,9 +5119,9 @@ msgstr "複数の選択オプション"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5169,8 +5144,8 @@ msgstr "複数の選択オプション"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5264,7 +5239,7 @@ msgstr "複数の選択オプション"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5290,13 +5265,13 @@ msgstr "複数の選択オプション"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5304,7 +5279,7 @@ msgstr "複数の選択オプション"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5346,11 +5321,11 @@ msgid "Never Updated"
 msgstr "未更新"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr "期限切れなし"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新規"
@@ -5618,7 +5593,7 @@ msgstr "10 月"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr "オフ"
 
@@ -5636,7 +5611,7 @@ msgstr "オフ"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr "オン"
 
@@ -5674,8 +5649,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "オプションの詳細"
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5701,12 +5676,12 @@ msgstr "必要に応じて、ステータスの更新を Webhook サービスに
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr "オプション"
 
@@ -5737,15 +5712,15 @@ msgstr "オプション"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5860,7 +5835,7 @@ msgstr "追加のコマンドライン変更を渡します。2 つの Ansible �
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5868,9 +5843,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "追加のコマンドライン変数を Playbook に渡します。これは、ansible-playbook の -e または --extra-vars コマンドラインパラメーターです。YAML または JSON のいずれかを使用してキーと値のペアを指定します。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5893,7 +5872,7 @@ msgstr "過去 2 週間"
 msgid "Past week"
 msgstr "過去 1 週間"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "保留中"
@@ -5918,7 +5897,7 @@ msgstr "パーソナルアクセストークン"
 msgid "Play"
 msgstr "プレイ"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr "再生回数"
 
@@ -5927,13 +5906,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5942,15 +5921,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook ディレクトリー"
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr "Playbook 実行"
 
@@ -5969,7 +5948,7 @@ msgstr "Playbook 名"
 msgid "Playbook run"
 msgstr "Playbook 実行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr "プレイ"
 
@@ -6006,7 +5985,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "1 から 31 までの日付を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "インベントリーを選択するか、または起動プロンプトオプションにチェックを付けてください。"
 
@@ -6045,6 +6024,14 @@ msgstr "外部のシークレット管理システムからフィールドにデ
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -6075,18 +6062,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -6097,7 +6072,7 @@ msgstr "プレビュー"
 msgid "Private key passphrase"
 msgstr "秘密鍵のパスフレーズ"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr "権限昇格"
 
@@ -6105,17 +6080,17 @@ msgstr "権限昇格"
 msgid "Privilege escalation password"
 msgstr "権限昇格のパスワード"
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6123,7 +6098,7 @@ msgid "Project"
 msgstr "プロジェクト"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "プロジェクトのベースパス"
@@ -6133,19 +6108,9 @@ msgstr "プロジェクトのベースパス"
 msgid "Project Sync"
 msgstr "プロジェクトの同期"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "プロジェクトの更新"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6198,7 +6163,7 @@ msgstr "プロンプト値"
 msgid "Prompts"
 msgstr "プロンプト"
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6244,25 +6209,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr "プロビジョニングコールバック URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr "プロビジョニングコールバックの詳細"
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr "プロビジョニングコールバック"
 
@@ -6282,10 +6243,6 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS 設定"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
-msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6315,7 +6272,7 @@ msgstr "受信者リスト"
 msgid "Recipient list"
 msgstr "受信者リスト"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6359,11 +6316,15 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:383
+#~ msgid "Refer to the Ansible documentation for details about the configuration file."
+#~ msgstr ""
 
 #: screens/User/UserTokens/UserTokens.jsx:76
 msgid "Refresh Token"
@@ -6392,16 +6353,16 @@ msgstr "一致するホスト名のみがインポートされる正規表現。
 msgid "Related Groups"
 msgstr "関連するグループ"
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr "再起動"
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr "ジョブの再起動"
 
@@ -6418,12 +6379,12 @@ msgstr "失敗したホストの再起動"
 msgid "Relaunch on"
 msgstr "再起動時"
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr "ホストパラメーターを使用した再起動"
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6532,10 +6493,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6584,9 +6545,9 @@ msgstr "設定を元に戻す"
 msgid "Revert to factory default."
 msgstr "工場出荷時のデフォルトに戻します。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr "リビジョン"
 
@@ -6657,7 +6618,7 @@ msgstr "実行:"
 msgid "Run type"
 msgstr "実行タイプ"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6672,7 +6633,7 @@ msgid "Running Jobs"
 msgstr "実行中のジョブ"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr "実行中のジョブ"
 
@@ -6707,9 +6668,9 @@ msgid "START"
 msgstr "開始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr "ステータス:"
 
@@ -6846,7 +6807,7 @@ msgstr "第 2"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr "秒"
 
@@ -6854,7 +6815,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "左側のエラーを参照してください"
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7012,7 +6973,7 @@ msgstr "このフィールドに有効な日時を選択"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7044,11 +7005,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "ワークフローのインベントリーを選択してください。このインベントリーが、インベントリーをプロンプトするすべてのジョブテンプレートノードに適用されます。"
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7118,7 +7079,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "このインベントリーが実行されるインスタンスグループを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7140,7 +7101,7 @@ msgstr "そのコマンドを実行するためにリモートホストへのア
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "このインベントリーソースの実行に使用するカスタム Python 仮想環境を選択します。"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7148,7 +7109,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7184,7 +7145,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "このホストが属するインベントリーを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr "このジョブで実行される Playbook を選択してください。"
 
@@ -7224,7 +7185,7 @@ msgstr "{0} の選択"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7259,7 +7220,7 @@ msgid "Service account JSON file"
 msgstr "サービスアカウント JSON ファイル"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr "このフィールドに値を設定します"
 
@@ -7328,7 +7289,7 @@ msgstr "表示"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr "変更の表示"
 
@@ -7399,9 +7360,9 @@ msgstr "簡易キー選択"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr "スキップタグ"
 
@@ -7414,7 +7375,7 @@ msgstr "スキップタグ"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7499,10 +7460,8 @@ msgstr "ソース"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "ソースコントロールブランチ"
@@ -7512,41 +7471,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "ソースコントロールブランチ/タグ/コミット"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "ソースコントロール認証情報"
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr "ソースコントロール認証情報タイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "ソースコントロールの Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr "ソースコントロールのタイプ"
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "ソースコントロールの URL"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr "ソースコントロールの更新"
 
@@ -7558,8 +7517,8 @@ msgstr "発信元の電話番号"
 msgid "Source Variables"
 msgstr "ソース変数"
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr "ソースワークフローのジョブ"
 
@@ -7594,6 +7553,12 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
 
 #: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
 #~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
@@ -7640,8 +7605,8 @@ msgstr "標準出力タブ"
 msgid "Start"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr "開始時間"
 
@@ -7659,32 +7624,32 @@ msgstr "開始メッセージ"
 msgid "Start message body"
 msgstr "開始メッセージのボディー"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr "同期プロセスの開始"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7747,7 +7712,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7771,13 +7736,13 @@ msgstr "成功メッセージ"
 msgid "Success message body"
 msgstr "成功メッセージボディー"
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr "クリップボードへのコピーに成功しました!"
 
@@ -7817,14 +7782,14 @@ msgstr "Survey プレビューモーダル"
 msgid "Survey questions"
 msgstr "Survey の質問"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同期"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7843,7 +7808,7 @@ msgstr "すべてのソースの同期"
 msgid "Sync error"
 msgstr "同期エラー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr "リビジョンの同期"
 
@@ -7897,7 +7862,7 @@ msgstr "タブ"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7940,7 +7905,7 @@ msgstr "ターゲット URL"
 msgid "Task"
 msgstr "タスク"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr "タスク数"
 
@@ -7948,7 +7913,7 @@ msgstr "タスク数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr "タスク"
 
@@ -8070,7 +8035,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "メール通知が、ホストへの到達を試行するのをやめてタイムアウトするまでの時間 (秒単位)。範囲は 1 から 120 秒です。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8114,7 +8079,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "この組織で管理可能な最大ホスト数。デフォルト値は 0 で、管理可能な数に制限がありません。詳細は、Ansible ドキュメントを参照してください。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8186,7 +8151,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr "サインインに問題がありました。もう一度やり直してください。"
 
@@ -8260,12 +8225,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8275,13 +8247,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8382,7 +8354,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8425,7 +8397,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "このワークフローには、ノードが構成されていません。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8472,7 +8444,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr "インベントリーの同期が最新の状態であることを判別するために使用される時間 (秒単位) です。ジョブの実行およびコールバック時に、タスクシステムは最新の同期のタイムスタンプを評価します。これがキャッシュタイムアウトよりも古い場合は最新とは見なされず、インベントリーの同期が新たに実行されます。"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr "タイムアウト"
 
@@ -8481,7 +8453,7 @@ msgstr "タイムアウト"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr "タイムアウト"
 
@@ -8593,7 +8565,7 @@ msgid "Total Nodes"
 msgstr "ノードの合計"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr "ジョブの合計"
 
@@ -8602,7 +8574,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8635,9 +8607,9 @@ msgstr "火曜"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8657,12 +8629,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8670,7 +8642,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8683,7 +8655,7 @@ msgstr "タイプ"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr "タイプの詳細"
 
@@ -8693,7 +8665,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr "利用不可"
 
@@ -8707,15 +8679,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr "到達不能"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr "到達不能なホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr "到達不能なホスト"
 
@@ -8728,7 +8700,7 @@ msgid "Unsaved changes modal"
 msgstr "保存されていない変更モーダル"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "起動時のリビジョン更新"
@@ -8810,7 +8782,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr "使用済み容量"
 
@@ -8922,11 +8894,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr "変数"
 
@@ -8954,9 +8926,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr "詳細"
 
@@ -9226,7 +9198,7 @@ msgstr "ビジュアライザー"
 msgid "WARNING:"
 msgstr "警告:"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "待機中"
@@ -9260,14 +9232,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook の認証情報"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr "Webhook の認証情報"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook キー"
@@ -9275,7 +9247,7 @@ msgstr "Webhook キー"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook サービス"
@@ -9283,14 +9255,14 @@ msgstr "Webhook サービス"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr "Webhook の詳細"
 
@@ -9327,7 +9299,7 @@ msgstr "週末"
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr "Ansible {brandName} へようこそ! サインインしてください。"
 
@@ -9384,18 +9356,18 @@ msgstr "ワークフローの承認が見つかりません。"
 msgid "Workflow Approvals"
 msgstr "ワークフローの承認"
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "ワークフロージョブ"
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9548,18 +9520,18 @@ msgstr "ズームイン"
 msgid "Zoom Out"
 msgstr "ズームアウト"
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "新規 Webhook キーは保存時に生成されます。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "新規 Webhook URL は保存時に生成されます。"
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9585,10 +9557,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr "削除のキャンセル"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "コマンド"
@@ -9608,7 +9576,7 @@ msgstr "関連付けの解除の確認"
 #~ msgid "controller instance"
 #~ msgstr "コントローラインスタンス"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr "クリップボードへのコピーが無効"
 
@@ -9630,14 +9598,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9680,19 +9648,19 @@ msgstr "ここ。"
 msgid "hosts"
 msgstr "ホスト"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr "インスタンス数"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr "インスタンスグループの使用容量"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr "インスタンスのホスト名"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr "インスタンスタイプ"
 
@@ -9799,11 +9767,6 @@ msgstr "冗長性の選択"
 msgid "social login"
 msgstr "ソーシャルログイン"
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "システム"
@@ -9848,7 +9811,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9876,17 +9839,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9939,10 +9898,6 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} (<0>{username}</0> による)"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -18,7 +18,7 @@ msgstr "(最初の 10 件に制限)"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr "(起動プロンプト)"
 
@@ -26,11 +26,11 @@ msgstr "(起動プロンプト)"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "*このフィールドは、指定された認証情報を使用して外部のシークレット管理システムから取得されます。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr "- 同時実行ジョブの有効化"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr "- Webhook の有効化"
 
@@ -185,8 +185,8 @@ msgstr "アカウントトークン"
 msgid "Action"
 msgstr "アクション"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "アクション"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "アクション"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "アクション"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr "アクティビティー"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "すべてのジョブタイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "ブランチの上書き許可"
@@ -572,6 +572,10 @@ msgstr "{0} - {1} により承認済"
 msgid "April"
 msgstr "4 月"
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr "以下の {0} を削除してもよろしいですか?"
@@ -608,7 +612,6 @@ msgstr "{1} から {0} のアクセスを削除しますか? これを行うと�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "{username} からの {0} のアクセスを削除してもよろしいですか?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "このジョブをキャンセルする要求を送信してよろしいですか?"
@@ -618,7 +621,7 @@ msgstr "このジョブをキャンセルする要求を送信してよろしい
 msgid "Arguments"
 msgstr "引数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr "アーティファクト"
 
@@ -657,7 +660,7 @@ msgstr "認証コードの有効期限"
 msgid "Authorization grant type"
 msgstr "認証付与タイプ"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr "自動"
 
@@ -728,7 +731,7 @@ msgstr "スケジュールに戻る"
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -830,9 +833,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "キャッシュタイムアウト"
@@ -868,8 +875,6 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -892,17 +897,25 @@ msgstr "キャッシュのタイムアウト (秒)"
 msgid "Cancel"
 msgstr "取り消し"
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "ジョブの取り消し"
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -942,18 +955,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "同期の取り消し"
+#~ msgid "Cancel sync"
+#~ msgstr "同期の取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "同期プロセスの取り消し"
+#~ msgid "Cancel sync process"
+#~ msgstr "同期プロセスの取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "同期プロセスの取り消し"
+#~ msgid "Cancel sync source"
+#~ msgstr "同期プロセスの取り消し"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
+msgstr ""
+
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1043,7 +1062,7 @@ msgstr "通知タイプの選択"
 msgid "Choose a Playbook Directory"
 msgstr "Playbook ディレクトリーの選択"
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr "ソースコントロールタイプの選択"
 
@@ -1103,7 +1122,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "新しいロールを受け取るリソースのタイプを選択します。たとえば、一連のユーザーに新しいロールを追加する場合は、ユーザーを選択して次へをクリックしてください。次のステップで特定のリソースを選択できるようになります。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "クリーニング"
@@ -1184,9 +1203,9 @@ msgstr "クラウド"
 msgid "Collapse"
 msgstr "折りたたむ"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "コマンド"
@@ -1211,7 +1230,7 @@ msgstr "コマンド"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr "同時実行ジョブ"
 
@@ -1223,6 +1242,14 @@ msgstr "削除の確認"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "パスワードの確認"
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
+msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1252,7 +1279,7 @@ msgstr "すべて元に戻すことを確認"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr "コンテナーグループ"
 
@@ -1291,7 +1318,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1340,7 +1367,7 @@ msgstr "インベントリーのコピー"
 msgid "Copy Notification Template"
 msgstr "通知テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "プロジェクトのコピー"
 
@@ -1348,7 +1375,7 @@ msgstr "プロジェクトのコピー"
 msgid "Copy Template"
 msgstr "テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "完全なリビジョンをクリップボードにコピーします。"
 
@@ -1360,8 +1387,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr "Copyright 2019 Red Hat, Inc."
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr "作成"
 
@@ -1508,14 +1535,14 @@ msgstr "ユーザートークンの作成"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1534,7 +1561,7 @@ msgstr "作成済み"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1630,7 +1657,7 @@ msgstr "認証情報のパスワード"
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1638,7 +1665,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "認証情報タイプが見つかりません。"
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1653,9 +1680,9 @@ msgstr "認証情報タイプが見つかりません。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "認証情報"
@@ -1673,10 +1700,10 @@ msgid "Custom pod spec"
 msgstr "カスタム Pod 仕様"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1773,7 +1800,7 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1785,16 +1812,16 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1809,7 +1836,7 @@ msgstr "すべてのグループおよびホストの削除"
 msgid "Delete Credential"
 msgstr "認証情報の削除"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1830,9 +1857,9 @@ msgstr "ホストの削除"
 msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "ジョブの削除"
 
@@ -1848,7 +1875,7 @@ msgstr "通知の削除"
 msgid "Delete Organization"
 msgstr "組織の削除"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "プロジェクトの削除"
 
@@ -1880,7 +1907,7 @@ msgstr "ユーザートークンの削除"
 msgid "Delete Workflow Approval"
 msgstr "ワークフロー承認の削除"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr "新規ワークフロージョブテンプレートの削除"
 
@@ -1911,7 +1938,7 @@ msgid "Delete inventory source"
 msgstr "インベントリーソースの削除"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "更新時のデプロイ"
 
@@ -2008,7 +2035,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2030,16 +2057,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2122,7 +2149,7 @@ msgstr "送信先チャネルまたはユーザー"
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2230,7 +2257,7 @@ msgstr "ロールの関連付けの解除!"
 msgid "Disassociate?"
 msgstr "関連付けを解除しますか?"
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2252,8 +2279,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "出力のダウンロード"
 
@@ -2298,7 +2325,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2307,14 +2334,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2323,8 +2350,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2344,8 +2371,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2440,8 +2467,8 @@ msgstr "通知テンプレートの編集"
 msgid "Edit Organization"
 msgstr "組織の編集"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "プロジェクトの編集"
 
@@ -2455,7 +2482,7 @@ msgstr "質問の編集"
 msgid "Edit Schedule"
 msgstr "スケジュールの編集"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "ソースの編集"
 
@@ -2525,16 +2552,16 @@ msgid "Edit this node"
 msgstr "このノードの編集"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "ジョブ実行の経過時間"
 
@@ -2552,11 +2579,11 @@ msgstr "メールオプション"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr "同時実行ジョブの有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr "ファクトストレージの有効化"
 
@@ -2569,14 +2596,14 @@ msgstr "HTTPS 証明書の検証を有効化"
 msgid "Enable Privilege Escalation"
 msgstr "権限昇格の有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr "Webhook の有効化"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr "このワークフローのジョブテンプレートの Webhook を有効にします。"
 
@@ -2601,7 +2628,7 @@ msgstr "権限昇格の有効化"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "{brandName} アプリケーションのログインの簡素化の有効化"
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr "このテンプレートの Webhook を有効にします。"
 
@@ -2620,7 +2647,7 @@ msgstr "有効な値"
 msgid "Enabled Variable"
 msgstr "有効な変数"
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2810,11 +2837,11 @@ msgstr "JSON または YAML 構文のいずれかを使用して変数を入力�
 #~ msgid "Environment"
 #~ msgstr "環境"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2844,9 +2871,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2869,6 +2896,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2884,8 +2912,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2893,7 +2920,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2902,7 +2929,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2968,6 +2995,10 @@ msgstr "Subversion Source Control のサンプル URL には以下が含まれ�
 msgid "Examples include:"
 msgstr "以下に例を示します。"
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr "親ノードの最終状態に関係なく実行します。"
@@ -2984,7 +3015,7 @@ msgstr "親ノードが正常な状態になったときに実行します。"
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -3006,7 +3037,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr "実行ノード"
 
@@ -3074,7 +3105,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "{0} の有効期限"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "説明"
@@ -3089,9 +3120,9 @@ msgid "Extra variables"
 msgstr "追加変数"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "終了日時:"
 
@@ -3104,19 +3135,19 @@ msgstr "終了日時:"
 msgid "Facts"
 msgstr "ファクト"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "失敗"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "失敗したホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "失敗したホスト"
 
@@ -3150,13 +3181,28 @@ msgstr "ロールの関連付けに失敗しました"
 msgid "Failed to associate."
 msgstr "関連付けに失敗しました。"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "インベントリーソースの同期をキャンセルできませんでした。"
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "インベントリーソースの同期をキャンセルできませんでした。"
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3170,7 +3216,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "インベントリーをコピーできませんでした。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "プロジェクトをコピーできませんでした。"
 
@@ -3253,7 +3299,7 @@ msgstr "1 つ以上のインベントリーリソースを削除できません�
 msgid "Failed to delete one or more job templates."
 msgstr "1 つ以上のジョブテンプレートを削除できませんでした"
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "1 つ以上のジョブを削除できませんでした。"
 
@@ -3301,7 +3347,7 @@ msgstr "1 つ以上のワークフロー承認を削除できませんでした�
 msgid "Failed to delete organization."
 msgstr "組織を削除できませんでした。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "プロジェクトを削除できませんでした。"
 
@@ -3334,7 +3380,7 @@ msgstr "ユーザーを削除できませんでした。"
 msgid "Failed to delete workflow approval."
 msgstr "ワークフロー承認を削除できませんでした。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr "ワークフロージョブテンプレートを削除できませんでした。"
 
@@ -3374,7 +3420,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr "カスタムログイン構成設定を取得できません。代わりに、システムのデフォルトが表示されます。"
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr "ジョブを起動できませんでした。"
@@ -3395,7 +3441,7 @@ msgstr "ノード認証情報を取得できませんでした。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "インベントリーソースを同期できませんでした。"
 
@@ -3422,6 +3468,10 @@ msgstr "通知の切り替えに失敗しました。"
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "スケジュールの切り替えに失敗しました。"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
+msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3486,12 +3536,12 @@ msgstr "ファイルのアップロードが拒否されました。単一の .j
 msgid "File, directory or script"
 msgstr "ファイル、ディレクトリー、またはスクリプト"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "終了時間"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "終了日時"
@@ -3561,7 +3611,7 @@ msgstr "詳しい情報は以下の情報を参照してください:"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr "フォーク"
 
@@ -3608,7 +3658,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3669,7 +3719,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3787,11 +3837,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr "ホスト設定キー"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "ホスト数"
 
@@ -3874,7 +3924,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3900,7 +3950,7 @@ msgstr "時間"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4004,7 +4054,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "チェックを付けると、以前は外部ソースにあり、現在は削除されているホストおよびグループが Tower インベントリーから削除されます。インベントリーソースで管理されていなかったホストおよびグループは、次に手動で作成したグループにプロモートされます。プロモート先となる、手動で作成したグループがない場合、ホストおよびグループは、インベントリーの「すべて」のデフォルトグループに残ります。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4021,7 +4071,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4036,7 +4086,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "有効で、サポートされている場合は、Ansible タスクで加えられた変更を表示します。これは Ansible の --diff モードに相当します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4046,11 +4096,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "有効な場合は、このワークフロージョブテンプレートの同時実行が許可されます。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4087,14 +4137,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4140,12 +4191,12 @@ msgid "Input configuration"
 msgstr "入力の設定"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4153,7 +4204,16 @@ msgid "Insights Credential"
 msgstr "Insights 認証情報"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4168,7 +4228,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "インスタンスフィルター"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr "インスタンスグループ"
 
@@ -4252,7 +4312,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "ソースを含むインベントリーはコピーできません。"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4275,11 +4335,11 @@ msgstr "ソースを含むインベントリーはコピーできません。"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr "インベントリー"
 
@@ -4295,13 +4355,17 @@ msgstr "インベントリーファイル"
 msgid "Inventory ID"
 msgstr "インベントリー ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "インベントリーソース同期"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4310,11 +4374,11 @@ msgstr "インベントリーソース同期"
 msgid "Inventory Sources"
 msgstr "インベントリーソース"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr "インベントリー同期"
 
@@ -4366,9 +4430,9 @@ msgid "Items per page"
 msgstr "ページ別の項目"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "ジョブ ID:"
 
@@ -4393,26 +4457,27 @@ msgstr "1 月"
 msgid "Job"
 msgstr "ジョブ"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "ジョブ削除エラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr "ジョブスライス"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr "ジョブスライス"
 
@@ -4425,19 +4490,19 @@ msgstr "ジョブステータス"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr "ジョブタグ"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "ジョブテンプレート"
@@ -4462,14 +4527,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "ジョブタイプ"
@@ -4488,8 +4553,8 @@ msgstr "ジョブステータスのグラフタブ"
 msgid "Job templates"
 msgstr "ジョブテンプレート"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4595,19 +4660,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "ラベル名"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr "ラベル"
 
@@ -4615,7 +4680,7 @@ msgstr "ラベル"
 msgid "Last"
 msgstr "最終"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4638,10 +4703,10 @@ msgstr "前回のログイン"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4681,7 +4746,7 @@ msgstr "最後のジョブ実行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "最終更新日"
 
@@ -4690,7 +4755,7 @@ msgstr "最終更新日"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4700,8 +4765,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr "起動"
 
@@ -4736,12 +4801,16 @@ msgstr "ワークフローの起動"
 msgid "Launched By"
 msgstr "起動者"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "起動者 (ユーザー名)"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4772,15 +4841,15 @@ msgstr "Less than or equal to の比較条件"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "制限"
@@ -4840,16 +4909,16 @@ msgstr "ルックアップタイプ"
 msgid "Lookup typeahead"
 msgstr "ルックアップの先行入力"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "直近の同期"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr "マシンの認証情報"
 
@@ -4866,10 +4935,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr "管理ジョブ"
 
@@ -4895,14 +4964,14 @@ msgstr "管理ジョブが見つかりません。"
 msgid "Management jobs"
 msgstr "管理ジョブ"
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手動"
@@ -5008,7 +5077,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "修正済み"
@@ -5024,7 +5093,7 @@ msgstr "修正済み"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5119,9 +5188,9 @@ msgstr "複数の選択オプション"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5144,8 +5213,8 @@ msgstr "複数の選択オプション"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5239,7 +5308,7 @@ msgstr "複数の選択オプション"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5265,13 +5334,13 @@ msgstr "複数の選択オプション"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5279,7 +5348,7 @@ msgstr "複数の選択オプション"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5325,7 +5394,7 @@ msgstr "未更新"
 msgid "Never expires"
 msgstr "期限切れなし"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新規"
@@ -5593,7 +5662,7 @@ msgstr "10 月"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr "オフ"
 
@@ -5611,7 +5680,7 @@ msgstr "オフ"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr "オン"
 
@@ -5649,8 +5718,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "オプションの詳細"
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5676,12 +5745,12 @@ msgstr "必要に応じて、ステータスの更新を Webhook サービスに
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr "オプション"
 
@@ -5712,15 +5781,15 @@ msgstr "オプション"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5835,7 +5904,7 @@ msgstr "追加のコマンドライン変更を渡します。2 つの Ansible �
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5843,7 +5912,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "追加のコマンドライン変数を Playbook に渡します。これは、ansible-playbook の -e または --extra-vars コマンドラインパラメーターです。YAML または JSON のいずれかを使用してキーと値のペアを指定します。構文のサンプルについては Ansible Tower ドキュメントを参照してください。"
 
@@ -5872,7 +5941,7 @@ msgstr "過去 2 週間"
 msgid "Past week"
 msgstr "過去 1 週間"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "保留中"
@@ -5897,7 +5966,7 @@ msgstr "パーソナルアクセストークン"
 msgid "Play"
 msgstr "プレイ"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "再生回数"
 
@@ -5906,13 +5975,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5921,15 +5990,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook ディレクトリー"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr "Playbook 実行"
 
@@ -5948,7 +6017,7 @@ msgstr "Playbook 名"
 msgid "Playbook run"
 msgstr "Playbook 実行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "プレイ"
 
@@ -5985,7 +6054,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "1 から 31 までの日付を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "インベントリーを選択するか、または起動プロンプトオプションにチェックを付けてください。"
 
@@ -6072,7 +6141,7 @@ msgstr "プレビュー"
 msgid "Private key passphrase"
 msgstr "秘密鍵のパスフレーズ"
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr "権限昇格"
 
@@ -6080,17 +6149,17 @@ msgstr "権限昇格"
 msgid "Privilege escalation password"
 msgstr "権限昇格のパスワード"
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6098,7 +6167,7 @@ msgid "Project"
 msgstr "プロジェクト"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "プロジェクトのベースパス"
@@ -6107,6 +6176,11 @@ msgstr "プロジェクトのベースパス"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
 msgstr "プロジェクトの同期"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
@@ -6163,7 +6237,7 @@ msgstr "プロンプト値"
 msgid "Prompts"
 msgstr "プロンプト"
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6209,26 +6283,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr "プロビジョニングコールバック URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr "プロビジョニングコールバックの詳細"
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr "プロビジョニングコールバック"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6243,6 +6321,10 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS 設定"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
+msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6272,7 +6354,7 @@ msgstr "受信者リスト"
 msgid "Recipient list"
 msgstr "受信者リスト"
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6316,7 +6398,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6339,7 +6421,7 @@ msgstr "トークンの有効期限の更新"
 msgid "Regions"
 msgstr "リージョン"
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6353,16 +6435,16 @@ msgstr "一致するホスト名のみがインポートされる正規表現。
 msgid "Related Groups"
 msgstr "関連するグループ"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "再起動"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "ジョブの再起動"
 
@@ -6379,12 +6461,12 @@ msgstr "失敗したホストの再起動"
 msgid "Relaunch on"
 msgstr "再起動時"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "ホストパラメーターを使用した再起動"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6493,10 +6575,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6545,9 +6627,9 @@ msgstr "設定を元に戻す"
 msgid "Revert to factory default."
 msgstr "工場出荷時のデフォルトに戻します。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "リビジョン"
 
@@ -6618,7 +6700,7 @@ msgstr "実行:"
 msgid "Run type"
 msgstr "実行タイプ"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6633,7 +6715,7 @@ msgid "Running Jobs"
 msgstr "実行中のジョブ"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr "実行中のジョブ"
 
@@ -6668,9 +6750,9 @@ msgid "START"
 msgstr "開始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "ステータス:"
 
@@ -6807,7 +6889,7 @@ msgstr "第 2"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "秒"
 
@@ -6815,7 +6897,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "左側のエラーを参照してください"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6973,7 +7055,7 @@ msgstr "このフィールドに有効な日時を選択"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7005,11 +7087,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "ワークフローのインベントリーを選択してください。このインベントリーが、インベントリーをプロンプトするすべてのジョブテンプレートノードに適用されます。"
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7079,7 +7161,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "このインベントリーが実行されるインスタンスグループを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7101,7 +7183,7 @@ msgstr "そのコマンドを実行するためにリモートホストへのア
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "このインベントリーソースの実行に使用するカスタム Python 仮想環境を選択します。"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7109,7 +7191,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7145,7 +7227,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "このホストが属するインベントリーを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr "このジョブで実行される Playbook を選択してください。"
 
@@ -7185,7 +7267,7 @@ msgstr "{0} の選択"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7220,7 +7302,7 @@ msgid "Service account JSON file"
 msgstr "サービスアカウント JSON ファイル"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr "このフィールドに値を設定します"
 
@@ -7289,7 +7371,7 @@ msgstr "表示"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr "変更の表示"
 
@@ -7360,9 +7442,9 @@ msgstr "簡易キー選択"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr "スキップタグ"
 
@@ -7375,7 +7457,7 @@ msgstr "スキップタグ"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7460,8 +7542,10 @@ msgstr "ソース"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "ソースコントロールブランチ"
@@ -7471,41 +7555,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "ソースコントロールブランチ/タグ/コミット"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "ソースコントロール認証情報"
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr "ソースコントロール認証情報タイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "ソースコントロールの Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "ソースコントロールのタイプ"
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "ソースコントロールの URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr "ソースコントロールの更新"
 
@@ -7517,8 +7601,8 @@ msgstr "発信元の電話番号"
 msgid "Source Variables"
 msgstr "ソース変数"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr "ソースワークフローのジョブ"
 
@@ -7605,8 +7689,8 @@ msgstr "標準出力タブ"
 msgid "Start"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "開始時間"
 
@@ -7624,32 +7708,32 @@ msgstr "開始メッセージ"
 msgid "Start message body"
 msgstr "開始メッセージのボディー"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "同期プロセスの開始"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7712,7 +7796,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7736,13 +7820,13 @@ msgstr "成功メッセージ"
 msgid "Success message body"
 msgstr "成功メッセージボディー"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "クリップボードへのコピーに成功しました!"
 
@@ -7782,14 +7866,14 @@ msgstr "Survey プレビューモーダル"
 msgid "Survey questions"
 msgstr "Survey の質問"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同期"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7808,7 +7892,7 @@ msgstr "すべてのソースの同期"
 msgid "Sync error"
 msgstr "同期エラー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "リビジョンの同期"
 
@@ -7862,7 +7946,7 @@ msgstr "タブ"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7905,7 +7989,7 @@ msgstr "ターゲット URL"
 msgid "Task"
 msgstr "タスク"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "タスク数"
 
@@ -7913,7 +7997,7 @@ msgstr "タスク数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "タスク"
 
@@ -8035,7 +8119,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "メール通知が、ホストへの到達を試行するのをやめてタイムアウトするまでの時間 (秒単位)。範囲は 1 から 120 秒です。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8068,6 +8152,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr "最初は全参照を取得します。2 番目は Github の Pull 要求の 62 番を取得します。この例では、ブランチは \"pull/62/head\" である必要があります。"
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8079,7 +8167,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "この組織で管理可能な最大ホスト数。デフォルト値は 0 で、管理可能な数に制限がありません。詳細は、Ansible ドキュメントを参照してください。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8106,8 +8194,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr "インベントリー内のホストをターゲットにするために使用されるパターン。フィールドを空白のままにすると、all、および * はすべて、インベントリー内のすべてのホストを対象とします。Ansible のホストパターンに関する詳細情報を確認できます。"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8239,6 +8327,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8247,13 +8342,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8354,7 +8449,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8397,7 +8492,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "このワークフローには、ノードが構成されていません。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8453,7 +8548,7 @@ msgstr "タイムアウト"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr "タイムアウト"
 
@@ -8565,7 +8660,7 @@ msgid "Total Nodes"
 msgstr "ノードの合計"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr "ジョブの合計"
 
@@ -8574,7 +8669,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8607,9 +8702,9 @@ msgstr "火曜"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8629,12 +8724,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8642,7 +8737,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8655,7 +8750,7 @@ msgstr "タイプ"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr "タイプの詳細"
 
@@ -8665,7 +8760,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr "利用不可"
 
@@ -8679,15 +8774,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "到達不能"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "到達不能なホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "到達不能なホスト"
 
@@ -8700,7 +8795,7 @@ msgid "Unsaved changes modal"
 msgstr "保存されていない変更モーダル"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "起動時のリビジョン更新"
@@ -8782,7 +8877,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr "使用済み容量"
 
@@ -8894,11 +8989,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr "変数"
 
@@ -8926,9 +9021,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr "詳細"
 
@@ -9198,7 +9293,7 @@ msgstr "ビジュアライザー"
 msgid "WARNING:"
 msgstr "警告:"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "待機中"
@@ -9232,14 +9327,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook の認証情報"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr "Webhook の認証情報"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook キー"
@@ -9247,7 +9342,7 @@ msgstr "Webhook キー"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook サービス"
@@ -9255,14 +9350,14 @@ msgstr "Webhook サービス"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr "Webhook の詳細"
 
@@ -9356,18 +9451,18 @@ msgstr "ワークフローの承認が見つかりません。"
 msgid "Workflow Approvals"
 msgstr "ワークフローの承認"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "ワークフロージョブ"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9520,18 +9615,18 @@ msgstr "ズームイン"
 msgid "Zoom Out"
 msgstr "ズームアウト"
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "新規 Webhook キーは保存時に生成されます。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "新規 Webhook URL は保存時に生成されます。"
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9557,6 +9652,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr "削除のキャンセル"
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "コマンド"
@@ -9576,7 +9675,7 @@ msgstr "関連付けの解除の確認"
 #~ msgid "controller instance"
 #~ msgstr "コントローラインスタンス"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "クリップボードへのコピーが無効"
 
@@ -9598,14 +9697,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9648,19 +9747,19 @@ msgstr "ここ。"
 msgid "hosts"
 msgstr "ホスト"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr "インスタンス数"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr "インスタンスグループの使用容量"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr "インスタンスのホスト名"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr "インスタンスタイプ"
 
@@ -9767,6 +9866,11 @@ msgstr "冗長性の選択"
 msgid "social login"
 msgstr "ソーシャルログイン"
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "システム"
@@ -9811,7 +9915,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9839,13 +9943,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9898,6 +10006,10 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr} (<0>{username}</0> による)"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
+msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -238,7 +238,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr ""
 
@@ -416,7 +416,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -573,6 +573,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr ""
@@ -609,7 +613,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -619,7 +622,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr ""
 
@@ -658,7 +661,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr ""
 
@@ -729,7 +732,7 @@ msgstr ""
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -831,9 +834,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -869,8 +876,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -893,17 +898,25 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -943,18 +956,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
+#~ msgid "Cancel sync source"
+#~ msgstr ""
+
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1044,7 +1063,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1104,7 +1123,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1185,9 +1204,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1212,7 +1231,7 @@ msgstr ""
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1223,6 +1242,14 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1253,7 +1280,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr ""
 
@@ -1292,7 +1319,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1341,7 +1368,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1349,7 +1376,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1361,8 +1388,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr ""
 
@@ -1509,14 +1536,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1535,7 +1562,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1631,7 +1658,7 @@ msgstr ""
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1639,7 +1666,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1654,9 +1681,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1674,10 +1701,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1774,7 +1801,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1786,16 +1813,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1810,7 +1837,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1831,9 +1858,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1849,7 +1876,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -1881,7 +1908,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1912,7 +1939,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -2009,7 +2036,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2031,16 +2058,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2123,7 +2150,7 @@ msgstr ""
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2231,7 +2258,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2253,8 +2280,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2299,7 +2326,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2308,14 +2335,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2324,8 +2351,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2345,8 +2372,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2441,8 +2468,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2456,7 +2483,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2526,16 +2553,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2553,11 +2580,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2570,14 +2597,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2602,7 +2629,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2629,7 +2656,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2819,11 +2846,11 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2853,9 +2880,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2878,6 +2905,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2893,8 +2921,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2902,7 +2929,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2911,7 +2938,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2977,6 +3004,10 @@ msgstr ""
 msgid "Examples include:"
 msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr ""
@@ -2993,7 +3024,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -3015,7 +3046,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr ""
 
@@ -3083,7 +3114,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -3098,9 +3129,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -3113,19 +3144,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3159,12 +3190,27 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3179,7 +3225,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3262,7 +3308,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3310,7 +3356,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3343,7 +3389,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3383,7 +3429,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr ""
@@ -3404,7 +3450,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3430,6 +3476,10 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3495,12 +3545,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3570,7 +3620,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr ""
 
@@ -3617,7 +3667,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3678,7 +3728,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3796,11 +3846,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3883,7 +3933,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3909,7 +3959,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4013,7 +4063,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4030,7 +4080,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4045,7 +4095,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4055,11 +4105,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4096,14 +4146,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4149,12 +4200,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4162,7 +4213,16 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4177,7 +4237,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr ""
 
@@ -4261,7 +4321,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4284,11 +4344,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr ""
 
@@ -4304,12 +4364,16 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4319,11 +4383,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4375,9 +4439,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4402,26 +4466,27 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr ""
 
@@ -4434,19 +4499,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4471,14 +4536,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4497,8 +4562,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4604,19 +4669,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr ""
 
@@ -4624,7 +4689,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4647,10 +4712,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4690,7 +4755,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4699,7 +4764,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4709,8 +4774,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr ""
 
@@ -4745,12 +4810,16 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4781,15 +4850,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4849,16 +4918,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr ""
 
@@ -4875,10 +4944,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr ""
 
@@ -4904,14 +4973,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -5017,7 +5086,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -5033,7 +5102,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5128,9 +5197,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5153,8 +5222,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5248,7 +5317,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5274,13 +5343,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5288,7 +5357,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5334,7 +5403,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5602,7 +5671,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr ""
 
@@ -5620,7 +5689,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr ""
 
@@ -5658,8 +5727,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5685,12 +5754,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr ""
 
@@ -5721,15 +5790,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5844,7 +5913,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5852,7 +5921,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
@@ -5881,7 +5950,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5906,7 +5975,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5915,13 +5984,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5930,15 +5999,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr ""
 
@@ -5957,7 +6026,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -5994,7 +6063,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -6081,7 +6150,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -6089,17 +6158,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6107,7 +6176,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6115,6 +6184,11 @@ msgstr ""
 #: components/Workflow/WorkflowLegend.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
@@ -6172,7 +6246,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6218,26 +6292,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr ""
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6251,6 +6329,10 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6281,7 +6363,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6325,7 +6407,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6348,7 +6430,7 @@ msgstr ""
 msgid "Regions"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6362,16 +6444,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6388,12 +6470,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6502,10 +6584,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6554,9 +6636,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6627,7 +6709,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6642,7 +6724,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr ""
 
@@ -6677,9 +6759,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6816,7 +6898,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6824,7 +6906,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6982,7 +7064,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7014,11 +7096,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7088,7 +7170,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7110,7 +7192,7 @@ msgstr ""
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7118,7 +7200,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7154,7 +7236,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -7194,7 +7276,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7229,7 +7311,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7298,7 +7380,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr ""
 
@@ -7369,9 +7451,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr ""
 
@@ -7384,7 +7466,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7469,8 +7551,10 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7480,41 +7564,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr ""
 
@@ -7526,8 +7610,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7614,8 +7698,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7633,32 +7717,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7721,7 +7805,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7745,13 +7829,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7791,14 +7875,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7817,7 +7901,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7871,7 +7955,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7914,7 +7998,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7922,7 +8006,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -8044,7 +8128,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8077,6 +8161,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8088,7 +8176,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8115,8 +8203,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8248,6 +8336,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8256,13 +8351,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8363,7 +8458,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8406,7 +8501,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8462,7 +8557,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr ""
 
@@ -8574,7 +8669,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr ""
 
@@ -8583,7 +8678,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8616,9 +8711,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8638,12 +8733,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8651,7 +8746,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8664,7 +8759,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr ""
 
@@ -8674,7 +8769,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr ""
 
@@ -8688,15 +8783,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8709,7 +8804,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8791,7 +8886,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr ""
 
@@ -8903,11 +8998,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr ""
 
@@ -8935,9 +9030,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr ""
 
@@ -9207,7 +9302,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9241,14 +9336,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -9256,7 +9351,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -9264,14 +9359,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr ""
 
@@ -9365,18 +9460,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9529,18 +9624,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9566,6 +9661,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9585,7 +9684,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9607,14 +9706,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9661,19 +9760,19 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr ""
 
@@ -9784,6 +9883,11 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9828,7 +9932,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9856,13 +9960,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9914,6 +10022,10 @@ msgstr ""
 
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -238,7 +238,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr ""
 
@@ -385,6 +385,11 @@ msgid ""
 "like the Ansible inventory .ini file format."
 msgstr ""
 
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:168
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:177
+#~ msgid "After every project update where the SCM revision changes, refresh the inventory from the selected source before executing job tasks. This is intended for static content, like the Ansible inventory .ini file format."
+#~ msgstr ""
+
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:508
 msgid "After number of occurrences"
 msgstr ""
@@ -411,7 +416,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -454,6 +459,16 @@ msgstr ""
 msgid "An inventory must be selected"
 msgstr ""
 
+#: src/components/PromptDetail/PromptInventorySourceDetail.jsx:87
+#: src/components/PromptDetail/PromptProjectDetail.jsx:92
+#: src/screens/Inventory/shared/InventorySourceForm.jsx:143
+#: src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx:94
+#: src/screens/Organization/shared/OrganizationForm.jsx:82
+#: src/screens/Project/ProjectDetail/ProjectDetail.jsx:128
+#: src/screens/Project/shared/ProjectForm.jsx:274
+#~ msgid "Ansible Environment"
+#~ msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:98
 msgid "Ansible Tower"
 msgstr ""
@@ -461,6 +476,14 @@ msgstr ""
 #: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:99
 msgid "Ansible Tower Documentation."
 msgstr ""
+
+#: src/components/About/About.jsx:58
+#~ msgid "Ansible Version"
+#~ msgstr ""
+
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:204
+#~ msgid "Ansible environment"
+#~ msgstr ""
 
 #: screens/Template/Survey/SurveyQuestionForm.jsx:44
 msgid "Answer type"
@@ -534,11 +557,15 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr ""
 
@@ -546,9 +573,9 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr ""
+#: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
+#~ msgid "Are you sure you want to delete the {0} below?"
+#~ msgstr ""
 
 #: components/DeleteButton/DeleteButton.jsx:128
 msgid "Are you sure you want to delete:"
@@ -582,6 +609,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -591,7 +619,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr ""
 
@@ -630,7 +658,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr ""
 
@@ -767,6 +795,10 @@ msgid ""
 "path used to locate playbooks."
 msgstr ""
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:70
+#~ msgid "Base path used for locating playbooks. Directories found inside this path will be listed in the playbook directory drop-down. Together the base path and selected playbook directory provide the full path used to locate playbooks."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:456
 msgid "Basic auth password"
 msgstr ""
@@ -799,13 +831,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -841,6 +869,8 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -863,25 +893,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -921,27 +943,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr ""
-
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
+msgid "Cancel sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:211
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
+msgid "Cancel sync process"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
+msgid "Cancel sync source"
+msgstr ""
+
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr ""
 
@@ -986,6 +1002,10 @@ msgid ""
 "{brandName} to change this location."
 msgstr ""
 
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:76
+#~ msgid "Change PROJECTS_ROOT when deploying {brandName} to change this location."
+#~ msgstr ""
+
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:43
 msgid "Changed"
 msgstr ""
@@ -1024,7 +1044,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1056,6 +1076,17 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
+#: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:142
 msgid "Choose an email option"
 msgstr ""
@@ -1073,7 +1104,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1106,10 +1137,6 @@ msgstr ""
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr ""
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1158,18 +1185,34 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
+
+#: src/screens/Host/Host.jsx:67
+#: src/screens/Host/Hosts.jsx:32
+#: src/screens/Inventory/Inventory.jsx:68
+#: src/screens/Inventory/InventoryHost/InventoryHost.jsx:88
+#: src/screens/Template/Template.jsx:151
+#: src/screens/Template/Templates.jsx:48
+#: src/screens/Template/WorkflowJobTemplate.jsx:145
+#~ msgid "Completed Jobs"
+#~ msgstr ""
+
+#: src/screens/Inventory/Inventories.jsx:59
+#: src/screens/Inventory/Inventories.jsx:73
+#: src/screens/Inventory/SmartInventory.jsx:73
+#~ msgid "Completed jobs"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:53
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1180,14 +1223,6 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1218,7 +1253,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr ""
 
@@ -1257,11 +1292,21 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
 msgstr ""
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:152
+#: src/screens/Template/shared/JobTemplateForm.jsx:414
+#~ msgid "Control the level of output ansible will produce as the playbook executes."
+#~ msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:69
+#~ msgid "Controller"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:208
 msgid "Convergence"
@@ -1296,7 +1341,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr ""
 
@@ -1304,7 +1349,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1316,10 +1361,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1459,14 +1509,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1485,7 +1535,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1589,7 +1639,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1604,9 +1654,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1624,10 +1674,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1701,7 +1751,7 @@ msgstr ""
 msgid "Default answer"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr ""
 
@@ -1724,7 +1774,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1736,16 +1786,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1760,7 +1810,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1781,9 +1831,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr ""
 
@@ -1799,7 +1849,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr ""
 
@@ -1831,7 +1881,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1862,7 +1912,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr ""
 
@@ -1913,11 +1963,15 @@ msgstr ""
 msgid "Deletion error"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr ""
 
@@ -1977,16 +2031,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2177,7 +2231,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2199,8 +2253,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr ""
 
@@ -2212,7 +2266,7 @@ msgstr ""
 msgid "E-mail options"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr ""
 
@@ -2245,7 +2299,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2254,14 +2308,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2291,8 +2345,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2387,8 +2441,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr ""
 
@@ -2402,7 +2456,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr ""
 
@@ -2472,16 +2526,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2499,11 +2553,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2516,14 +2570,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2548,7 +2602,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2575,7 +2629,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2632,9 +2686,17 @@ msgstr ""
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2643,9 +2705,24 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr ""
+
+#: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr ""
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2658,11 +2735,19 @@ msgid ""
 "required."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:244
+#~ msgid "Enter one IRC channel or username per line. The pound symbol (#) for channels, and the at (@) symbol for users, are not required."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
 msgid ""
 "Enter one Slack channel per line. The pound symbol (#)\n"
 "is required for channels."
 msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:377
+#~ msgid "Enter one Slack channel per line. The pound symbol (#) is required for channels."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
 msgid ""
@@ -2670,17 +2755,29 @@ msgid ""
 "list for this type of notification."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:92
+#~ msgid "Enter one email address per line to create a recipient list for this type of notification."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
 msgid ""
 "Enter one phone number per line to specify where to\n"
 "route SMS messages."
 msgstr ""
 
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:426
+#~ msgid "Enter one phone number per line to specify where to route SMS messages."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
 msgid ""
 "Enter the number associated with the \"Messaging\n"
 "Service\" in Twilio in the format +18005550199."
 msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:416
+#~ msgid "Enter the number associated with the \"Messaging Service\" in Twilio in the format +18005550199."
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSubForms/TowerSubForm.jsx:60
 msgid "Enter variables to configure the inventory source. For a detailed description of how to configure this plugin, see <0>Inventory Plugins</0> in the documentation and the <1>Tower</1> plugin configuration guide."
@@ -2722,11 +2819,11 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2756,8 +2853,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2781,7 +2878,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2797,7 +2893,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2805,7 +2902,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2814,7 +2911,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2896,7 +2993,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2918,7 +3015,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr ""
 
@@ -2933,6 +3030,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -2977,11 +3079,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -2996,9 +3098,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr ""
 
@@ -3011,19 +3113,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3057,32 +3159,12 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr ""
-
-#: components/JobList/JobList.jsx:295
-msgid "Failed to cancel one or more jobs."
+msgid "Failed to cancel inventory source sync."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
+#: components/JobList/JobList.jsx:290
+msgid "Failed to cancel one or more jobs."
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3097,7 +3179,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3180,7 +3262,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3228,7 +3310,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3261,7 +3343,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3322,7 +3404,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3348,10 +3430,6 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3417,12 +3495,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3492,7 +3570,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr ""
 
@@ -3539,7 +3617,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3718,11 +3796,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr ""
 
@@ -3805,7 +3883,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3831,7 +3909,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3906,7 +3984,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr ""
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -3935,7 +4013,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3952,7 +4030,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -3967,7 +4045,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3977,16 +4055,20 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
 "injected into the fact cache at runtime."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:559
+#~ msgid "If enabled, this will store gathered facts so they can be viewed at the host level. Facts are persisted and injected into the fact cache at runtime."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:140
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
@@ -4067,12 +4149,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4080,16 +4162,7 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4104,7 +4177,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr ""
 
@@ -4188,7 +4261,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4211,11 +4284,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr ""
 
@@ -4231,20 +4304,12 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
-
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
-msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4254,11 +4319,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4310,9 +4375,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr ""
 
@@ -4337,27 +4402,26 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr ""
 
@@ -4370,19 +4434,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4407,14 +4471,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4433,8 +4497,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4540,19 +4604,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr ""
 
@@ -4560,7 +4624,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4583,10 +4647,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4626,7 +4690,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr ""
 
@@ -4635,7 +4699,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4645,8 +4709,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr ""
 
@@ -4681,16 +4745,12 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4721,15 +4781,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4789,16 +4849,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr ""
 
@@ -4815,10 +4875,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr ""
 
@@ -4844,14 +4904,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -4957,7 +5017,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -4973,7 +5033,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5068,9 +5128,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5093,8 +5153,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5188,7 +5248,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5214,13 +5274,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5228,7 +5288,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5270,11 +5330,11 @@ msgid "Never Updated"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5542,7 +5602,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr ""
 
@@ -5560,7 +5620,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr ""
 
@@ -5598,8 +5658,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5625,12 +5685,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr ""
 
@@ -5661,15 +5721,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5784,7 +5844,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5792,9 +5852,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5817,7 +5881,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5842,7 +5906,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr ""
 
@@ -5851,13 +5915,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5866,15 +5930,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr ""
 
@@ -5893,7 +5957,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr ""
 
@@ -5930,7 +5994,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -5969,6 +6033,14 @@ msgstr ""
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -5999,18 +6071,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -6021,7 +6081,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -6029,17 +6089,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6047,7 +6107,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6057,19 +6117,9 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6122,7 +6172,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6168,25 +6218,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr ""
 
@@ -6205,10 +6251,6 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6239,7 +6281,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6283,7 +6325,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6320,16 +6362,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6346,12 +6388,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6460,10 +6502,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6512,9 +6554,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr ""
 
@@ -6585,7 +6627,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6600,7 +6642,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr ""
 
@@ -6635,9 +6677,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr ""
 
@@ -6774,7 +6816,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr ""
 
@@ -6782,7 +6824,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6940,7 +6982,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -6972,11 +7014,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7004,6 +7046,10 @@ msgid ""
 "the Project Base Path. Together the base path and the playbook\n"
 "directory provide the full path used to locate playbooks."
 msgstr ""
+
+#: src/screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:89
+#~ msgid "Select from the list of directories found in the Project Base Path. Together the base path and the playbook directory provide the full path used to locate playbooks."
+#~ msgstr ""
 
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.jsx:94
 msgid "Select items from list"
@@ -7042,7 +7088,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7064,7 +7110,7 @@ msgstr ""
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7072,7 +7118,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7086,6 +7132,11 @@ msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
 msgstr ""
+
+#: src/components/Lookup/InventoryLookup.jsx:89
+#: src/screens/Template/shared/JobTemplateForm.jsx:248
+#~ msgid "Select the inventory containing the hosts you want this job to manage."
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.jsx:105
 msgid ""
@@ -7103,7 +7154,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -7143,7 +7194,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7178,7 +7229,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7247,7 +7298,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr ""
 
@@ -7318,9 +7369,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr ""
 
@@ -7333,7 +7384,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7349,6 +7400,11 @@ msgid ""
 "Use commas to separate multiple tags. Refer to Ansible Tower\n"
 "documentation for details on the usage of tags."
 msgstr ""
+
+#: src/components/LaunchPrompt/steps/OtherPromptsStep.jsx:74
+#: src/screens/Template/shared/JobTemplateForm.jsx:487
+#~ msgid "Skip tags are useful when you have a large playbook, and you want to skip specific parts of a play or task. Use commas to separate multiple tags. Refer to Ansible Tower documentation for details on the usage of tags."
+#~ msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:39
 msgid "Skipped"
@@ -7413,10 +7469,8 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7426,41 +7480,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr ""
 
@@ -7472,8 +7526,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7508,6 +7562,16 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
+
+#: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:392
 msgid ""
@@ -7550,8 +7614,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr ""
 
@@ -7569,32 +7633,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7657,7 +7721,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7681,13 +7745,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7727,14 +7791,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7753,7 +7817,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr ""
 
@@ -7807,7 +7871,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7850,7 +7914,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr ""
 
@@ -7858,7 +7922,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr ""
 
@@ -7980,12 +8044,16 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
 "timeout."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:439
+#~ msgid "The amount of time (in seconds) to run before the job is canceled. Defaults to 0 for no job timeout."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:164
 msgid ""
@@ -8020,7 +8088,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8092,7 +8160,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr ""
 
@@ -8166,12 +8234,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8181,13 +8256,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8288,7 +8363,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8331,7 +8406,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8378,7 +8453,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr ""
 
@@ -8387,7 +8462,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr ""
 
@@ -8499,7 +8574,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr ""
 
@@ -8508,7 +8583,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8541,9 +8616,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8563,12 +8638,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8576,7 +8651,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8589,7 +8664,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr ""
 
@@ -8599,7 +8674,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr ""
 
@@ -8613,15 +8688,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8634,7 +8709,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8709,10 +8784,14 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr ""
 
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:72
+#~ msgid "Use custom messages to change the content of notifications sent when a job starts, succeeds, or fails. Use curly braces to access information about the job:"
+#~ msgstr ""
+
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr ""
 
@@ -8824,11 +8903,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr ""
 
@@ -8856,9 +8935,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr ""
 
@@ -9128,7 +9207,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9162,14 +9241,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -9177,7 +9256,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -9185,14 +9264,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr ""
 
@@ -9229,7 +9308,7 @@ msgstr ""
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr ""
 
@@ -9260,6 +9339,11 @@ msgid ""
 "untouched by the inventory update process."
 msgstr ""
 
+#: src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:127
+#: src/screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:141
+#~ msgid "When not checked, local child hosts and groups not found on the external source will remain untouched by the inventory update process."
+#~ msgstr ""
+
 #: components/Workflow/WorkflowLegend.jsx:96
 msgid "Workflow"
 msgstr ""
@@ -9281,18 +9365,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9445,18 +9529,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9482,10 +9566,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9505,7 +9585,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9527,14 +9607,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9581,25 +9661,31 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr ""
 
 #: components/Lookup/HostListItem.jsx:30
 msgid "inventory"
 msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:51
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:59
+#: screens/Job/JobDetail/JobDetail.jsx:119
+#~ msgid "isolated instance"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:23
 msgid "items"
@@ -9640,6 +9726,10 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:238
 msgid "option to the"
 msgstr ""
+
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:84
+#~ msgid "or attributes of the job such as"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:24
 msgid "page"
@@ -9694,11 +9784,6 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9743,7 +9828,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9771,17 +9856,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9835,10 +9916,6 @@ msgstr ""
 msgid "{dateStr} by <0>{username}</0>"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr ""
-
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"
 msgstr ""
@@ -9867,9 +9944,17 @@ msgstr ""
 msgid "{minutes} min {seconds} sec"
 msgstr ""
 
+#: src/screens/Inventory/InventoryList/InventoryList.jsx:215
+#~ msgid "{numItemsToDelete, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
+#~ msgstr ""
+
 #: components/JobList/JobListCancelButton.jsx:106
 msgid "{numJobsToCancel, plural, one {Cancel job} other {Cancel jobs}}"
 msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:81
+#~ msgid "{numJobsToCancel, plural, one {Cancel selected job} other {Cancel selected jobs}}"
+#~ msgstr ""
 
 #: components/JobList/JobListCancelButton.jsx:167
 msgid "{numJobsToCancel, plural, one {This action will cancel the following job:} other {This action will cancel the following jobs:}}"
@@ -9879,7 +9964,19 @@ msgstr ""
 msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr ""
 
+#: src/components/JobList/JobListCancelButton.jsx:68
+#~ msgid "{numJobsUnableToCancel, plural, one {You cannot cancel the following job because it is not running:} other {You cannot cancel the following jobs because they are not running:}}"
+#~ msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:57
+#~ msgid "{numJobsUnableToCancel, plural, one {You do not have permission to cancel the following job:} other {You do not have permission to cancel the following jobs:}}"
+#~ msgstr ""
+
 #: components/PaginatedDataList/PaginatedDataList.jsx:92
 #: components/PaginatedTable/PaginatedTable.jsx:77
 msgid "{pluralizedItemName} List"
 msgstr ""
+
+#: src/components/JobList/JobListCancelButton.jsx:96
+#~ msgid "{zeroOrOneJobSelected, plural, one {Cancel job} other {Cancel jobs}}"
+#~ msgstr ""

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -18,7 +18,7 @@ msgstr "（限制为前 10）"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr "（启动时提示）"
 
@@ -26,11 +26,11 @@ msgstr "（启动时提示）"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* 此字段将使用指定的凭证从外部 secret 管理系统检索。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr "- 启用并发作业"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr "- 启用 Webhook"
 
@@ -185,8 +185,8 @@ msgstr "帐户令牌"
 msgid "Action"
 msgstr "操作"
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "操作"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "操作"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "操作"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr "活动"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "作业作业类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "允许分支覆写"
@@ -556,21 +556,21 @@ msgstr "批准"
 msgid "Approve"
 msgstr "批准"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr "已批准"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr "于 {0} - {1} 批准"
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "4 月"
-
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
-msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -608,6 +608,7 @@ msgstr "您确定要从 {1} 中删除访问 {0} 吗？这样做会影响团队�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "您确定要从 {username} 中删除 {0} 吗？"
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "您确定要提交取消此作业的请求吗？"
@@ -617,7 +618,7 @@ msgstr "您确定要提交取消此作业的请求吗？"
 msgid "Arguments"
 msgstr "参数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr "工件"
 
@@ -656,7 +657,7 @@ msgstr "授权代码过期"
 msgid "Authorization grant type"
 msgstr "授权授予类型"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr "Auto"
 
@@ -829,13 +830,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "缓存超时"
@@ -871,6 +868,8 @@ msgstr "缓存超时（秒）"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -893,25 +892,17 @@ msgstr "缓存超时（秒）"
 msgid "Cancel"
 msgstr "取消"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "取消作业"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -951,27 +942,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr "取消同步"
+msgid "Cancel sync"
+msgstr "取消同步"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr "取消同步进程"
+msgid "Cancel sync process"
+msgstr "取消同步进程"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr "取消同步源"
+msgid "Cancel sync source"
+msgstr "取消同步源"
 
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
-msgstr ""
-
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr "已取消"
 
@@ -1058,7 +1043,7 @@ msgstr "选择通知类型"
 msgid "Choose a Playbook Directory"
 msgstr "选择 Playbook 目录"
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr "选择源控制类型"
 
@@ -1090,6 +1075,13 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
 #: src/screens/Template/Survey/SurveyQuestionForm.jsx:37
 #~ msgid "Choose an answer type or format you want as the prompt for the user. Refer to the Ansible Tower Documentation for more additional information about each option."
 #~ msgstr ""
@@ -1111,7 +1103,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "选择将获得新角色的资源类型。例如，如果您想为一组用户添加新角色，请选择用户并点击下一步。您可以选择下一步中的具体资源。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "清理"
@@ -1144,10 +1136,6 @@ msgstr "点击这个按钮使用所选凭证和指定的输入验证到 secret �
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr "点击以创建到此节点的新链接。"
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1196,9 +1184,9 @@ msgstr "云"
 msgid "Collapse"
 msgstr "折叠"
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "命令"
@@ -1223,7 +1211,7 @@ msgstr "命令"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr "并发作业"
 
@@ -1235,14 +1223,6 @@ msgstr "确认删除"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "确认密码"
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
-msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1272,7 +1252,7 @@ msgstr "确认全部恢复"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr "容器组"
 
@@ -1311,7 +1291,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1360,7 +1340,7 @@ msgstr "复制清单"
 msgid "Copy Notification Template"
 msgstr "复制通知模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr "复制项目"
 
@@ -1368,7 +1348,7 @@ msgstr "复制项目"
 msgid "Copy Template"
 msgstr "复制模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr "将完整修订复制到剪贴板。"
 
@@ -1380,10 +1360,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr "创建"
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1523,14 +1508,14 @@ msgstr "创建用户令牌"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1549,7 +1534,7 @@ msgstr "已创建"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1653,7 +1638,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "未找到凭证类型。"
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1668,9 +1653,9 @@ msgstr "未找到凭证类型。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "凭证"
@@ -1688,10 +1673,10 @@ msgid "Custom pod spec"
 msgstr "自定义 pod 规格"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1765,7 +1750,7 @@ msgstr ""
 msgid "Default answer"
 msgstr "默认回答"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr "默认的选择必须从列出的选择中回答。"
 
@@ -1788,7 +1773,7 @@ msgstr "定义系统级的特性和功能"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1800,16 +1785,16 @@ msgstr "定义系统级的特性和功能"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1824,7 +1809,7 @@ msgstr "删除所有组和主机"
 msgid "Delete Credential"
 msgstr "删除凭证"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1845,9 +1830,9 @@ msgstr "删除主机"
 msgid "Delete Inventory"
 msgstr "删除清单"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr "删除作业"
 
@@ -1863,7 +1848,7 @@ msgstr "删除通知"
 msgid "Delete Organization"
 msgstr "删除机构"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr "删除项目"
 
@@ -1895,7 +1880,7 @@ msgstr "删除用户令牌"
 msgid "Delete Workflow Approval"
 msgstr "删除工作流批准"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr "删除工作流作业模板"
 
@@ -1926,7 +1911,7 @@ msgid "Delete inventory source"
 msgstr "删除清单源"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr "更新时删除"
 
@@ -1977,11 +1962,15 @@ msgstr "删除错误"
 msgid "Deletion error"
 msgstr "删除错误"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr "已拒绝"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr "已拒绝 {0} - {1}"
 
@@ -2041,16 +2030,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2241,7 +2230,7 @@ msgstr "解除关联角色！"
 msgid "Disassociate?"
 msgstr "解除关联？"
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2263,8 +2252,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr "下载输出"
 
@@ -2276,7 +2265,7 @@ msgstr "电子邮件"
 msgid "E-mail options"
 msgstr "电子邮件选项"
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr "每个答案选择都必须在单独的行中。"
 
@@ -2309,7 +2298,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2318,14 +2307,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2355,8 +2344,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2451,8 +2440,8 @@ msgstr "编辑通知模板"
 msgid "Edit Organization"
 msgstr "编辑机构"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr "编辑项目"
 
@@ -2466,7 +2455,7 @@ msgstr "编辑问题"
 msgid "Edit Schedule"
 msgstr "编辑调度"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr "编辑源"
 
@@ -2536,16 +2525,16 @@ msgid "Edit this node"
 msgstr "编辑此节点"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "已经过"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr "过期的时间"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr "作业运行所经过的时间"
 
@@ -2563,11 +2552,11 @@ msgstr "电子邮件选项"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr "启用并发作业"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr "启用事实缓存"
 
@@ -2580,14 +2569,14 @@ msgstr "启用 HTTPS 证书验证"
 msgid "Enable Privilege Escalation"
 msgstr "启用权限升级"
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr "启用 Webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr "为此工作流作业模板启用 Webhook。"
 
@@ -2612,7 +2601,7 @@ msgstr "启用权限升级"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "为您的 {brandName} 应用启用简化的登录"
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr "为此模板启用 Webhook。"
 
@@ -2631,7 +2620,7 @@ msgstr "启用的值"
 msgid "Enabled Variable"
 msgstr "启用的变量"
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2649,6 +2638,10 @@ msgstr ""
 
 #: src/screens/Template/shared/JobTemplateForm.jsx:517
 #~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact BRAND_NAME and request a configuration update using this job template."
+#~ msgstr ""
+
+#: src/components/AdHocCommands/AdHocDetailsStep.jsx:244
+#~ msgid "Enables creation of a provisioning callback URL. Using the URL a host can contact {brandName} and request a configuration update using this job template"
 #~ msgstr ""
 
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:155
@@ -2684,9 +2677,17 @@ msgstr "请至少输入一个搜索过滤来创建一个新的智能清单。"
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "使用 JSON 或 YAML 语法输入注入程序。示例语法请参阅 Ansible Tower 文档。"
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr "使用 JSON 或 YAML 语法进行输入。示例语法请参阅 Ansible Tower 文档。"
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2695,6 +2696,13 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr "使用 JSON 或 YAML 语法输入清单变量。使用单选按钮在两者之间切换。示例语法请参阅 Ansible Tower 文档"
@@ -2702,6 +2710,10 @@ msgstr "使用 JSON 或 YAML 语法输入清单变量。使用单选按钮在两
 #: src/screens/Inventory/shared/SmartInventoryForm.jsx:100
 #~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax."
 #~ msgstr "使用 JSON 或 YAML 语法输入清单变量。使用单选按钮在两者之间切换。示例语法请参阅 Ansible Tower 文档。"
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2798,11 +2810,11 @@ msgstr "使用 JSON 或 YAML 语法输入变量。使用单选按钮在两者之
 #~ msgid "Environment"
 #~ msgstr "环境"
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2832,8 +2844,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2857,7 +2869,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2873,7 +2884,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2881,7 +2893,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2890,7 +2902,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2972,7 +2984,7 @@ msgstr "当父节点具有成功状态时执行。"
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2994,7 +3006,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr "执行节点"
 
@@ -3009,6 +3021,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -3053,11 +3070,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr "过期于 {0}"
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "解释"
@@ -3072,9 +3089,9 @@ msgid "Extra variables"
 msgstr "额外变量"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr "完成："
 
@@ -3087,19 +3104,19 @@ msgstr "完成："
 msgid "Facts"
 msgstr "事实"
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr "失败"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr "失败的主机计数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr "失败的主机"
 
@@ -3133,33 +3150,13 @@ msgstr "关联角色失败"
 msgid "Failed to associate."
 msgstr "关联失败。"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr "取消清单源同步失败。"
+msgid "Failed to cancel inventory source sync."
+msgstr "取消清单源同步失败。"
 
-#: components/JobList/JobList.jsx:295
+#: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
-
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
-msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3173,7 +3170,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "复制清单失败。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr "复制项目失败。"
 
@@ -3256,7 +3253,7 @@ msgstr "删除一个或多个清单源失败。"
 msgid "Failed to delete one or more job templates."
 msgstr "删除一个或多个作业模板失败。"
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr "删除一个或多个作业失败。"
 
@@ -3304,7 +3301,7 @@ msgstr "无法删除一个或多个工作流批准。"
 msgid "Failed to delete organization."
 msgstr "删除机构失败。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr "删除项目失败。"
 
@@ -3337,7 +3334,7 @@ msgstr "删除用户失败。"
 msgid "Failed to delete workflow approval."
 msgstr "删除工作流批准失败。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr "删除工作流任务模板失败。"
 
@@ -3398,7 +3395,7 @@ msgstr "获取节点凭证失败。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr "同步清单源失败。"
 
@@ -3425,10 +3422,6 @@ msgstr "切换通知失败。"
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "切换调度失败。"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
-msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3493,12 +3486,12 @@ msgstr "上传文件被拒绝。请选择单个 .json 文件。"
 msgid "File, directory or script"
 msgstr "文件、目录或脚本"
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr "完成时间"
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "完成"
@@ -3568,7 +3561,7 @@ msgstr "有关详情请参阅"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr "分叉"
 
@@ -3615,7 +3608,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3794,11 +3787,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr "主机配置键"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr "主机计数"
 
@@ -3881,7 +3874,7 @@ msgstr "此作业的主机状态信息不可用。"
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "主机"
@@ -3907,7 +3900,7 @@ msgstr "小时"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3982,7 +3975,7 @@ msgstr ""
 #~ msgid "If checked, all variables for child groups and hosts will be removed and replaced by those found on the external source."
 #~ msgstr "如果选中，子组和主机的所有变量都将被删除，并替换为外部源上的变量。"
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -4011,7 +4004,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "如果选中，以前存在于外部源上的但现已被删除的任何主机和组都将从 Tower 清单中删除。不由清单源管理的主机和组将提升到下一个手动创建的组，如果没有手动创建组来提升它们，则它们将保留在清单的“all”默认组中。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4028,18 +4021,22 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr ""
 
+#: src/screens/Template/shared/JobTemplateForm.jsx:448
+#~ msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible's --diff mode."
+#~ msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:205
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "如果启用，显示 Ansible 任务所做的更改（在支持的情况下）。这等同于 Ansible 的 --diff 模式。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4049,11 +4046,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "如果启用，将允许同时运行此工作流作业模板。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4143,12 +4140,12 @@ msgid "Input configuration"
 msgstr "输入配置"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4156,16 +4153,7 @@ msgid "Insights Credential"
 msgstr "Insights 凭证"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4180,7 +4168,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "实例过滤器"
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr "实例组"
 
@@ -4264,7 +4252,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "无法复制含有源的清单"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4287,11 +4275,11 @@ msgstr "无法复制含有源的清单"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr "清单"
 
@@ -4307,21 +4295,13 @@ msgstr "清单文件"
 msgid "Inventory ID"
 msgstr "清单 ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "清单源同步"
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
-msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4330,11 +4310,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "清单源"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr "清单同步"
 
@@ -4386,9 +4366,9 @@ msgid "Items per page"
 msgstr "每页的项"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr "作业 ID："
 
@@ -4413,27 +4393,26 @@ msgstr "1 月"
 msgid "Job"
 msgstr "作业"
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "作业删除错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr "作业分片"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr "作业分片"
 
@@ -4446,19 +4425,19 @@ msgstr "作业状态"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "作业标签"
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "作业模板"
@@ -4483,14 +4462,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "作业类型"
@@ -4509,8 +4488,8 @@ msgstr "作业状态图标签页"
 msgid "Job templates"
 msgstr "作业模板"
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4616,19 +4595,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr "标签名称"
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr "标签"
 
@@ -4636,7 +4615,7 @@ msgstr "标签"
 msgid "Last"
 msgstr "最后"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4659,10 +4638,10 @@ msgstr "最近登陆"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4702,7 +4681,7 @@ msgstr "最后作业运行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr "最后修改"
 
@@ -4711,7 +4690,7 @@ msgstr "最后修改"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4721,8 +4700,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr "启动"
 
@@ -4757,16 +4736,12 @@ msgstr "启动工作流"
 msgid "Launched By"
 msgstr "启动者"
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr "启动者（用户名）"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4797,15 +4772,15 @@ msgstr "小于或等于比较。"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "限制"
@@ -4865,16 +4840,16 @@ msgstr "查找类型"
 msgid "Lookup typeahead"
 msgstr "查找 typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr "最新同步"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr "机器凭证"
 
@@ -4891,10 +4866,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr "管理作业"
 
@@ -4920,14 +4895,14 @@ msgstr "未找到管理作业。"
 msgid "Management jobs"
 msgstr "管理作业"
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手动"
@@ -5033,7 +5008,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "修改"
@@ -5049,7 +5024,7 @@ msgstr "修改"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5144,9 +5119,9 @@ msgstr "多项选择选项"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5169,8 +5144,8 @@ msgstr "多项选择选项"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5264,7 +5239,7 @@ msgstr "多项选择选项"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5290,13 +5265,13 @@ msgstr "多项选择选项"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5304,7 +5279,7 @@ msgstr "多项选择选项"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5346,11 +5321,11 @@ msgid "Never Updated"
 msgstr "永不更新"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr "永不过期"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新"
@@ -5618,7 +5593,7 @@ msgstr "10 月"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr "关"
 
@@ -5636,7 +5611,7 @@ msgstr "关"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr "于"
 
@@ -5674,8 +5649,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "选项详情"
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5701,12 +5676,12 @@ msgstr "（可选）选择要用来向 Webhook 服务发回状态更新的凭证
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr "选项"
 
@@ -5737,15 +5712,15 @@ msgstr "选项"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5860,7 +5835,7 @@ msgstr "传递额外的命令行更改。有两个 ansible 命令行参数："
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5868,9 +5843,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "向 playbook 传递额外的命令行变量。这是 ansible-playbook 的 -e 或 --extra-vars 命令行参数。使用 YAML 或 JSON 提供键/值对。示例语法请参阅 Ansible Tower 文档。"
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5893,7 +5872,7 @@ msgstr "过去两周"
 msgid "Past week"
 msgstr "过去一周"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "待处理"
@@ -5918,7 +5897,7 @@ msgstr "个人访问令牌"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr "play 数量"
 
@@ -5927,13 +5906,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5942,15 +5921,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook 目录"
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr "Playbook 运行"
 
@@ -5969,7 +5948,7 @@ msgstr "Playbook 名称"
 msgid "Playbook run"
 msgstr "Playbook 运行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr "Play"
 
@@ -6006,7 +5985,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "选择的日数字应介于 1 到 31 之间。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "请选择一个清单或者选中“启动时提示”选项。"
 
@@ -6045,6 +6024,14 @@ msgstr "从外部 secret 管理系统填充字段"
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -6075,18 +6062,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -6097,7 +6072,7 @@ msgstr "预览"
 msgid "Private key passphrase"
 msgstr "私钥密码"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr "权限升级"
 
@@ -6105,17 +6080,17 @@ msgstr "权限升级"
 msgid "Privilege escalation password"
 msgstr "权限升级密码"
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6123,7 +6098,7 @@ msgid "Project"
 msgstr "项目"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "项目基本路径"
@@ -6133,19 +6108,9 @@ msgstr "项目基本路径"
 msgid "Project Sync"
 msgstr "项目同步"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "项目更新"
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6198,7 +6163,7 @@ msgstr "提示的值"
 msgid "Prompts"
 msgstr "提示"
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6244,25 +6209,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr "部署回调 URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr "置备回调详情"
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr "置备回调"
 
@@ -6282,10 +6243,6 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS 设置"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
-msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6315,7 +6272,7 @@ msgstr "接收者列表"
 msgid "Recipient list"
 msgstr "接收者列表"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6359,11 +6316,15 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
 msgstr ""
+
+#: src/screens/Template/shared/JobTemplateForm.jsx:383
+#~ msgid "Refer to the Ansible documentation for details about the configuration file."
+#~ msgstr ""
 
 #: screens/User/UserTokens/UserTokens.jsx:76
 msgid "Refresh Token"
@@ -6392,16 +6353,16 @@ msgstr "仅导入主机名与这个正则表达式匹配的主机。该过滤器
 msgid "Related Groups"
 msgstr "相关组"
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr "重新启动"
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr "重新启动作业"
 
@@ -6418,12 +6379,12 @@ msgstr "重新启动失败的主机"
 msgid "Relaunch on"
 msgstr "重新启动于"
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr "使用主机参数重新启动"
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6532,10 +6493,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6584,9 +6545,9 @@ msgstr "恢复设置"
 msgid "Revert to factory default."
 msgstr "恢复到工厂默认值。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr "修订"
 
@@ -6657,7 +6618,7 @@ msgstr "运行于"
 msgid "Run type"
 msgstr "运行类型"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6672,7 +6633,7 @@ msgid "Running Jobs"
 msgstr "运行作业"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr "运行作业"
 
@@ -6707,9 +6668,9 @@ msgid "START"
 msgstr "开始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr "状态："
 
@@ -6846,7 +6807,7 @@ msgstr "秒"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr "秒"
 
@@ -6854,7 +6815,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "在左侧查看错误"
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7012,7 +6973,7 @@ msgstr "为此字段选择有效日期和时间"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7044,11 +7005,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "为工作流选择清单。此清单应用于提示清单的所有作业模板节点。"
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7118,7 +7079,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "选择要运行此清单的实例组。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7140,7 +7101,7 @@ msgstr "选择要在访问远程主机时用来运行命令的凭证。选择包
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "选择要运行此清单源同步的自定义 Python 虚拟环境。"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7148,7 +7109,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7184,7 +7145,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "选择此主机要属于的清单。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr "选择要由此作业执行的 playbook。"
 
@@ -7224,7 +7185,7 @@ msgstr "选择 {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7259,7 +7220,7 @@ msgid "Service account JSON file"
 msgstr "服务账户 JSON 文件"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr "为这个字段设置值"
 
@@ -7328,7 +7289,7 @@ msgstr "显示"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr "显示更改"
 
@@ -7399,9 +7360,9 @@ msgstr "简单键选择"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr "跳过标签"
 
@@ -7414,7 +7375,7 @@ msgstr "跳过标签"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7499,10 +7460,8 @@ msgstr "源"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "源控制分支"
@@ -7512,41 +7471,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "源控制分支/标签/提交"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "源控制凭证"
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr "源控制凭证类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "源控制 Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr "源控制类型"
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "源控制 URL"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr "源控制更新"
 
@@ -7558,8 +7517,8 @@ msgstr "源电话号码"
 msgid "Source Variables"
 msgstr "源变量"
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr "源工作流作业"
 
@@ -7594,6 +7553,12 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
 
 #: src/screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
 #~ msgid "Specify HTTP Headers in JSON format. Refer to the Ansible Tower documentation for example syntax."
@@ -7640,8 +7605,8 @@ msgstr "标准输出标签页"
 msgid "Start"
 msgstr "开始"
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr "开始时间"
 
@@ -7659,32 +7624,32 @@ msgstr "开始消息"
 msgid "Start message body"
 msgstr "开始消息正文"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr "启动同步进程"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr "启动同步源"
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "已开始"
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7747,7 +7712,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7771,13 +7736,13 @@ msgstr "成功信息"
 msgid "Success message body"
 msgstr "成功消息正文"
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr "成功复制至剪贴板！"
 
@@ -7817,14 +7782,14 @@ msgstr "问卷调查预览 modal"
 msgid "Survey questions"
 msgstr "可选的问卷调查问题"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同步"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7843,7 +7808,7 @@ msgstr "同步所有源"
 msgid "Sync error"
 msgstr "同步错误"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr "修订版本同步"
 
@@ -7897,7 +7862,7 @@ msgstr "制表符"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7940,7 +7905,7 @@ msgstr "目标 URL"
 msgid "Task"
 msgstr "任务"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr "任务计数"
 
@@ -7948,7 +7913,7 @@ msgstr "任务计数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr "任务"
 
@@ -8070,7 +8035,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "电子邮件通知停止尝试到达主机并超时之前所经过的时间（以秒为单位）。范围为 1 秒到 120 秒。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8114,7 +8079,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "允许由此机构管理的最大主机数。默认值为 0，表示无限制。请参阅 Ansible 文档以了解更多详情。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8186,7 +8151,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr "登录时有问题。请重试。"
 
@@ -8260,12 +8225,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -8275,13 +8247,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8382,7 +8354,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8425,7 +8397,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "此工作流没有配置任何节点。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8472,7 +8444,7 @@ msgstr ""
 #~ msgid "Time in seconds to consider an inventory sync to be current. During job runs and callbacks the task system will evaluate the timestamp of the latest sync. If it is older than Cache Timeout, it is not considered current, and a new inventory sync will be performed."
 #~ msgstr "将清单同步视为最新的时间（以秒为单位）。在作业运行和回调期间，任务系统将评估最新同步的时间戳。如果它比缓存超时旧，则不被视为最新，并且会执行新的清单同步。"
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr "超时"
 
@@ -8481,7 +8453,7 @@ msgstr "超时"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr "超时"
 
@@ -8593,7 +8565,7 @@ msgid "Total Nodes"
 msgstr "节点总数"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr "作业总数"
 
@@ -8602,7 +8574,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8635,9 +8607,9 @@ msgstr "周二"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8657,12 +8629,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8670,7 +8642,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8683,7 +8655,7 @@ msgstr "类型"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr "类型详情"
 
@@ -8693,7 +8665,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr "不可用"
 
@@ -8707,15 +8679,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr "无法访问"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr "无法访问的主机数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr "无法访问的主机"
 
@@ -8728,7 +8700,7 @@ msgid "Unsaved changes modal"
 msgstr "未保存的修改 modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "启动时更新修订"
@@ -8810,7 +8782,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr "使用的容量"
 
@@ -8922,11 +8894,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr "变量"
 
@@ -8954,9 +8926,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr "详细程度"
 
@@ -9226,7 +9198,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "警告："
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "等待"
@@ -9260,14 +9232,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook 凭证"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr "Webhook 凭证"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook 密钥"
@@ -9275,7 +9247,7 @@ msgstr "Webhook 密钥"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook 服务"
@@ -9283,14 +9255,14 @@ msgstr "Webhook 服务"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr "Webhook 详情"
 
@@ -9327,7 +9299,7 @@ msgstr "周末日"
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr "欢迎使用 Ansible {brandName}！请登录。"
 
@@ -9384,18 +9356,18 @@ msgstr "未找到工作流批准。"
 msgid "Workflow Approvals"
 msgstr "工作流批准"
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "工作流作业"
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9548,18 +9520,18 @@ msgstr "放大"
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK 密钥"
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK url"
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9585,10 +9557,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr "取消删除"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "命令"
@@ -9608,7 +9576,7 @@ msgstr "确认解除关联"
 #~ msgid "controller instance"
 #~ msgstr "控制器实例"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr "复制到剪贴板被禁用"
 
@@ -9630,14 +9598,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9680,19 +9648,19 @@ msgstr "此处。"
 msgid "hosts"
 msgstr "主机"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr "实例数"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr "实例组使用的容量"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr "实例主机名"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr "实例类型"
 
@@ -9799,11 +9767,6 @@ msgstr "选择详细程度"
 msgid "social login"
 msgstr "社交登录"
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "系统"
@@ -9848,7 +9811,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9876,17 +9839,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9939,10 +9898,6 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr}（按 <0>{username}</0>）"
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
-msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -18,7 +18,7 @@ msgstr "（限制为前 10）"
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr "（启动时提示）"
 
@@ -26,11 +26,11 @@ msgstr "（启动时提示）"
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr "* 此字段将使用指定的凭证从外部 secret 管理系统检索。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr "- 启用并发作业"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr "- 启用 Webhook"
 
@@ -185,8 +185,8 @@ msgstr "帐户令牌"
 msgid "Action"
 msgstr "操作"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -214,7 +214,7 @@ msgstr "操作"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "操作"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -237,7 +237,7 @@ msgstr "操作"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr "活动"
 
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "作业作业类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "允许分支覆写"
@@ -572,6 +572,10 @@ msgstr "于 {0} - {1} 批准"
 msgid "April"
 msgstr "4 月"
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
 #~ msgstr "您确定要删除以下 {0} 吗？"
@@ -608,7 +612,6 @@ msgstr "您确定要从 {1} 中删除访问 {0} 吗？这样做会影响团队�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "您确定要从 {username} 中删除 {0} 吗？"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "您确定要提交取消此作业的请求吗？"
@@ -618,7 +621,7 @@ msgstr "您确定要提交取消此作业的请求吗？"
 msgid "Arguments"
 msgstr "参数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr "工件"
 
@@ -657,7 +660,7 @@ msgstr "授权代码过期"
 msgid "Authorization grant type"
 msgstr "授权授予类型"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr "Auto"
 
@@ -728,7 +731,7 @@ msgstr "返回到调度"
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -830,9 +833,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "缓存超时"
@@ -868,8 +875,6 @@ msgstr "缓存超时（秒）"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -892,17 +897,25 @@ msgstr "缓存超时（秒）"
 msgid "Cancel"
 msgstr "取消"
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "取消作业"
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -942,18 +955,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "取消同步"
+#~ msgid "Cancel sync"
+#~ msgstr "取消同步"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "取消同步进程"
+#~ msgid "Cancel sync process"
+#~ msgstr "取消同步进程"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "取消同步源"
+#~ msgid "Cancel sync source"
+#~ msgstr "取消同步源"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
+msgstr ""
+
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -1043,7 +1062,7 @@ msgstr "选择通知类型"
 msgid "Choose a Playbook Directory"
 msgstr "选择 Playbook 目录"
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr "选择源控制类型"
 
@@ -1103,7 +1122,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "选择将获得新角色的资源类型。例如，如果您想为一组用户添加新角色，请选择用户并点击下一步。您可以选择下一步中的具体资源。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "清理"
@@ -1184,9 +1203,9 @@ msgstr "云"
 msgid "Collapse"
 msgstr "折叠"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "命令"
@@ -1211,7 +1230,7 @@ msgstr "命令"
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr "并发作业"
 
@@ -1223,6 +1242,14 @@ msgstr "确认删除"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "确认密码"
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
+msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1252,7 +1279,7 @@ msgstr "确认全部恢复"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr "容器组"
 
@@ -1291,7 +1318,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1340,7 +1367,7 @@ msgstr "复制清单"
 msgid "Copy Notification Template"
 msgstr "复制通知模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "复制项目"
 
@@ -1348,7 +1375,7 @@ msgstr "复制项目"
 msgid "Copy Template"
 msgstr "复制模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "将完整修订复制到剪贴板。"
 
@@ -1360,8 +1387,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr "创建"
 
@@ -1508,14 +1535,14 @@ msgstr "创建用户令牌"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1534,7 +1561,7 @@ msgstr "已创建"
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1630,7 +1657,7 @@ msgstr "凭证密码"
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1638,7 +1665,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "未找到凭证类型。"
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1653,9 +1680,9 @@ msgstr "未找到凭证类型。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr "凭证"
@@ -1673,10 +1700,10 @@ msgid "Custom pod spec"
 msgstr "自定义 pod 规格"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1773,7 +1800,7 @@ msgstr "定义系统级的特性和功能"
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1785,16 +1812,16 @@ msgstr "定义系统级的特性和功能"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1809,7 +1836,7 @@ msgstr "删除所有组和主机"
 msgid "Delete Credential"
 msgstr "删除凭证"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1830,9 +1857,9 @@ msgstr "删除主机"
 msgid "Delete Inventory"
 msgstr "删除清单"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "删除作业"
 
@@ -1848,7 +1875,7 @@ msgstr "删除通知"
 msgid "Delete Organization"
 msgstr "删除机构"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "删除项目"
 
@@ -1880,7 +1907,7 @@ msgstr "删除用户令牌"
 msgid "Delete Workflow Approval"
 msgstr "删除工作流批准"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr "删除工作流作业模板"
 
@@ -1911,7 +1938,7 @@ msgid "Delete inventory source"
 msgstr "删除清单源"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "更新时删除"
 
@@ -2008,7 +2035,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -2030,16 +2057,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2122,7 +2149,7 @@ msgstr "目标频道或用户"
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2230,7 +2257,7 @@ msgstr "解除关联角色！"
 msgid "Disassociate?"
 msgstr "解除关联？"
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2252,8 +2279,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "下载输出"
 
@@ -2298,7 +2325,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2307,14 +2334,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2323,8 +2350,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2344,8 +2371,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2440,8 +2467,8 @@ msgstr "编辑通知模板"
 msgid "Edit Organization"
 msgstr "编辑机构"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "编辑项目"
 
@@ -2455,7 +2482,7 @@ msgstr "编辑问题"
 msgid "Edit Schedule"
 msgstr "编辑调度"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "编辑源"
 
@@ -2525,16 +2552,16 @@ msgid "Edit this node"
 msgstr "编辑此节点"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "已经过"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "过期的时间"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "作业运行所经过的时间"
 
@@ -2552,11 +2579,11 @@ msgstr "电子邮件选项"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr "启用并发作业"
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr "启用事实缓存"
 
@@ -2569,14 +2596,14 @@ msgstr "启用 HTTPS 证书验证"
 msgid "Enable Privilege Escalation"
 msgstr "启用权限升级"
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr "启用 Webhook"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr "为此工作流作业模板启用 Webhook。"
 
@@ -2601,7 +2628,7 @@ msgstr "启用权限升级"
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "为您的 {brandName} 应用启用简化的登录"
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr "为此模板启用 Webhook。"
 
@@ -2620,7 +2647,7 @@ msgstr "启用的值"
 msgid "Enabled Variable"
 msgstr "启用的变量"
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2810,11 +2837,11 @@ msgstr "使用 JSON 或 YAML 语法输入变量。使用单选按钮在两者之
 #~ msgid "Environment"
 #~ msgstr "环境"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2844,9 +2871,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2869,6 +2896,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2884,8 +2912,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2893,7 +2920,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2902,7 +2929,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2968,6 +2995,10 @@ msgstr "Subversion SCM 源控制 URL 示例包括："
 msgid "Examples include:"
 msgstr "示例包括：："
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr "无论父节点的最后状态如何都执行。"
@@ -2984,7 +3015,7 @@ msgstr "当父节点具有成功状态时执行。"
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -3006,7 +3037,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr "执行节点"
 
@@ -3074,7 +3105,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "过期于 {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "解释"
@@ -3089,9 +3120,9 @@ msgid "Extra variables"
 msgstr "额外变量"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "完成："
 
@@ -3104,19 +3135,19 @@ msgstr "完成："
 msgid "Facts"
 msgstr "事实"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "失败"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "失败的主机计数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "失败的主机"
 
@@ -3150,13 +3181,28 @@ msgstr "关联角色失败"
 msgid "Failed to associate."
 msgstr "关联失败。"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "取消清单源同步失败。"
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "取消清单源同步失败。"
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3170,7 +3216,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "复制清单失败。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "复制项目失败。"
 
@@ -3253,7 +3299,7 @@ msgstr "删除一个或多个清单源失败。"
 msgid "Failed to delete one or more job templates."
 msgstr "删除一个或多个作业模板失败。"
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "删除一个或多个作业失败。"
 
@@ -3301,7 +3347,7 @@ msgstr "无法删除一个或多个工作流批准。"
 msgid "Failed to delete organization."
 msgstr "删除机构失败。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "删除项目失败。"
 
@@ -3334,7 +3380,7 @@ msgstr "删除用户失败。"
 msgid "Failed to delete workflow approval."
 msgstr "删除工作流批准失败。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr "删除工作流任务模板失败。"
 
@@ -3374,7 +3420,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr "获取自定义登录配置设置失败。系统默认设置会被显示。"
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr "启动作业失败。"
@@ -3395,7 +3441,7 @@ msgstr "获取节点凭证失败。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "同步清单源失败。"
 
@@ -3422,6 +3468,10 @@ msgstr "切换通知失败。"
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
 msgstr "切换调度失败。"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
+msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
 msgid "Failed to update survey."
@@ -3486,12 +3536,12 @@ msgstr "上传文件被拒绝。请选择单个 .json 文件。"
 msgid "File, directory or script"
 msgstr "文件、目录或脚本"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "完成时间"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "完成"
@@ -3561,7 +3611,7 @@ msgstr "有关详情请参阅"
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr "分叉"
 
@@ -3608,7 +3658,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3669,7 +3719,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3787,11 +3837,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr "主机配置键"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "主机计数"
 
@@ -3874,7 +3924,7 @@ msgstr "此作业的主机状态信息不可用。"
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "主机"
@@ -3900,7 +3950,7 @@ msgstr "小时"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4004,7 +4054,7 @@ msgstr ""
 #~ msgid "If checked, any hosts and groups that were previously present on the external source but are now removed will be removed from the Tower inventory. Hosts and groups that were not managed by the inventory source will be promoted to the next manually created group or if there is no manually created group to promote them into, they will be left in the \"all\" default group for the inventory."
 #~ msgstr "如果选中，以前存在于外部源上的但现已被删除的任何主机和组都将从 Tower 清单中删除。不由清单源管理的主机和组将提升到下一个手动创建的组，如果没有手动创建组来提升它们，则它们将保留在清单的“all”默认组中。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4021,7 +4071,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4036,7 +4086,7 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "如果启用，显示 Ansible 任务所做的更改（在支持的情况下）。这等同于 Ansible 的 --diff 模式。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4046,11 +4096,11 @@ msgstr ""
 #~ msgid "If enabled, simultaneous runs of this job template will be allowed."
 #~ msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "如果启用，将允许同时运行此工作流作业模板。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4087,14 +4137,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -4140,12 +4191,12 @@ msgid "Input configuration"
 msgstr "输入配置"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -4153,7 +4204,16 @@ msgid "Insights Credential"
 msgstr "Insights 凭证"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4168,7 +4228,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "实例过滤器"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr "实例组"
 
@@ -4252,7 +4312,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "无法复制含有源的清单"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4275,11 +4335,11 @@ msgstr "无法复制含有源的清单"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr "清单"
 
@@ -4295,13 +4355,17 @@ msgstr "清单文件"
 msgid "Inventory ID"
 msgstr "清单 ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "清单源同步"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4310,11 +4374,11 @@ msgstr "清单源同步"
 msgid "Inventory Sources"
 msgstr "清单源"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr "清单同步"
 
@@ -4366,9 +4430,9 @@ msgid "Items per page"
 msgstr "每页的项"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "作业 ID："
 
@@ -4393,26 +4457,27 @@ msgstr "1 月"
 msgid "Job"
 msgstr "作业"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "作业删除错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr "作业分片"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr "作业分片"
 
@@ -4425,19 +4490,19 @@ msgstr "作业状态"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr "作业标签"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "作业模板"
@@ -4462,14 +4527,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr "作业类型"
@@ -4488,8 +4553,8 @@ msgstr "作业状态图标签页"
 msgid "Job templates"
 msgstr "作业模板"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4595,19 +4660,19 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "标签名称"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr "标签"
 
@@ -4615,7 +4680,7 @@ msgstr "标签"
 msgid "Last"
 msgstr "最后"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4638,10 +4703,10 @@ msgstr "最近登陆"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4681,7 +4746,7 @@ msgstr "最后作业运行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "最后修改"
 
@@ -4690,7 +4755,7 @@ msgstr "最后修改"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4700,8 +4765,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr "启动"
 
@@ -4736,12 +4801,16 @@ msgstr "启动工作流"
 msgid "Launched By"
 msgstr "启动者"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "启动者（用户名）"
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4772,15 +4841,15 @@ msgstr "小于或等于比较。"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr "限制"
@@ -4840,16 +4909,16 @@ msgstr "查找类型"
 msgid "Lookup typeahead"
 msgstr "查找 typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "最新同步"
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr "机器凭证"
 
@@ -4866,10 +4935,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr "管理作业"
 
@@ -4895,14 +4964,14 @@ msgstr "未找到管理作业。"
 msgid "Management jobs"
 msgstr "管理作业"
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手动"
@@ -5008,7 +5077,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr "修改"
@@ -5024,7 +5093,7 @@ msgstr "修改"
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -5119,9 +5188,9 @@ msgstr "多项选择选项"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5144,8 +5213,8 @@ msgstr "多项选择选项"
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5239,7 +5308,7 @@ msgstr "多项选择选项"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5265,13 +5334,13 @@ msgstr "多项选择选项"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5279,7 +5348,7 @@ msgstr "多项选择选项"
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5325,7 +5394,7 @@ msgstr "永不更新"
 msgid "Never expires"
 msgstr "永不过期"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新"
@@ -5593,7 +5662,7 @@ msgstr "10 月"
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr "关"
 
@@ -5611,7 +5680,7 @@ msgstr "关"
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr "于"
 
@@ -5649,8 +5718,8 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "选项详情"
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5676,12 +5745,12 @@ msgstr "（可选）选择要用来向 Webhook 服务发回状态更新的凭证
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr "选项"
 
@@ -5712,15 +5781,15 @@ msgstr "选项"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5835,7 +5904,7 @@ msgstr "传递额外的命令行更改。有两个 ansible 命令行参数："
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5843,7 +5912,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr "向 playbook 传递额外的命令行变量。这是 ansible-playbook 的 -e 或 --extra-vars 命令行参数。使用 YAML 或 JSON 提供键/值对。示例语法请参阅 Ansible Tower 文档。"
 
@@ -5872,7 +5941,7 @@ msgstr "过去两周"
 msgid "Past week"
 msgstr "过去一周"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "待处理"
@@ -5897,7 +5966,7 @@ msgstr "个人访问令牌"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "play 数量"
 
@@ -5906,13 +5975,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5921,15 +5990,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook 目录"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr "Playbook 运行"
 
@@ -5948,7 +6017,7 @@ msgstr "Playbook 名称"
 msgid "Playbook run"
 msgstr "Playbook 运行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Play"
 
@@ -5985,7 +6054,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr "选择的日数字应介于 1 到 31 之间。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr "请选择一个清单或者选中“启动时提示”选项。"
 
@@ -6072,7 +6141,7 @@ msgstr "预览"
 msgid "Private key passphrase"
 msgstr "私钥密码"
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr "权限升级"
 
@@ -6080,17 +6149,17 @@ msgstr "权限升级"
 msgid "Privilege escalation password"
 msgstr "权限升级密码"
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6098,7 +6167,7 @@ msgid "Project"
 msgstr "项目"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "项目基本路径"
@@ -6107,6 +6176,11 @@ msgstr "项目基本路径"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
 msgstr "项目同步"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
@@ -6163,7 +6237,7 @@ msgstr "提示的值"
 msgid "Prompts"
 msgstr "提示"
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6209,26 +6283,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr "部署回调 URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr "置备回调详情"
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr "置备回调"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6243,6 +6321,10 @@ msgstr "RADIUS"
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
 msgstr "RADIUS 设置"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
+msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
 msgid "Read"
@@ -6272,7 +6354,7 @@ msgstr "接收者列表"
 msgid "Recipient list"
 msgstr "接收者列表"
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6316,7 +6398,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6339,7 +6421,7 @@ msgstr "刷新令牌过期"
 msgid "Regions"
 msgstr "区域"
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6353,16 +6435,16 @@ msgstr "仅导入主机名与这个正则表达式匹配的主机。该过滤器
 msgid "Related Groups"
 msgstr "相关组"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "重新启动"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "重新启动作业"
 
@@ -6379,12 +6461,12 @@ msgstr "重新启动失败的主机"
 msgid "Relaunch on"
 msgstr "重新启动于"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "使用主机参数重新启动"
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6493,10 +6575,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6545,9 +6627,9 @@ msgstr "恢复设置"
 msgid "Revert to factory default."
 msgstr "恢复到工厂默认值。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "修订"
 
@@ -6618,7 +6700,7 @@ msgstr "运行于"
 msgid "Run type"
 msgstr "运行类型"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6633,7 +6715,7 @@ msgid "Running Jobs"
 msgstr "运行作业"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr "运行作业"
 
@@ -6668,9 +6750,9 @@ msgid "START"
 msgstr "开始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "状态："
 
@@ -6807,7 +6889,7 @@ msgstr "秒"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "秒"
 
@@ -6815,7 +6897,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "在左侧查看错误"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6973,7 +7055,7 @@ msgstr "为此字段选择有效日期和时间"
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -7005,11 +7087,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr "为工作流选择清单。此清单应用于提示清单的所有作业模板节点。"
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7079,7 +7161,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "选择要运行此清单的实例组。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7101,7 +7183,7 @@ msgstr "选择要在访问远程主机时用来运行命令的凭证。选择包
 #~ msgid "Select the custom Python virtual environment for this inventory source sync to run on."
 #~ msgstr "选择要运行此清单源同步的自定义 Python 虚拟环境。"
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -7109,7 +7191,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -7145,7 +7227,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "选择此主机要属于的清单。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr "选择要由此作业执行的 playbook。"
 
@@ -7185,7 +7267,7 @@ msgstr "选择 {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7220,7 +7302,7 @@ msgid "Service account JSON file"
 msgstr "服务账户 JSON 文件"
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr "为这个字段设置值"
 
@@ -7289,7 +7371,7 @@ msgstr "显示"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr "显示更改"
 
@@ -7360,9 +7442,9 @@ msgstr "简单键选择"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr "跳过标签"
 
@@ -7375,7 +7457,7 @@ msgstr "跳过标签"
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7460,8 +7542,10 @@ msgstr "源"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr "源控制分支"
@@ -7471,41 +7555,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "源控制分支/标签/提交"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "源控制凭证"
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr "源控制凭证类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "源控制 Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "源控制类型"
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr "源控制 URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr "源控制更新"
 
@@ -7517,8 +7601,8 @@ msgstr "源电话号码"
 msgid "Source Variables"
 msgstr "源变量"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr "源工作流作业"
 
@@ -7605,8 +7689,8 @@ msgstr "标准输出标签页"
 msgid "Start"
 msgstr "开始"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "开始时间"
 
@@ -7624,32 +7708,32 @@ msgstr "开始消息"
 msgid "Start message body"
 msgstr "开始消息正文"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "启动同步进程"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "启动同步源"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "已开始"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7712,7 +7796,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7736,13 +7820,13 @@ msgstr "成功信息"
 msgid "Success message body"
 msgstr "成功消息正文"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "成功复制至剪贴板！"
 
@@ -7782,14 +7866,14 @@ msgstr "问卷调查预览 modal"
 msgid "Survey questions"
 msgstr "可选的问卷调查问题"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同步"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7808,7 +7892,7 @@ msgstr "同步所有源"
 msgid "Sync error"
 msgstr "同步错误"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "修订版本同步"
 
@@ -7862,7 +7946,7 @@ msgstr "制表符"
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7905,7 +7989,7 @@ msgstr "目标 URL"
 msgid "Task"
 msgstr "任务"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "任务计数"
 
@@ -7913,7 +7997,7 @@ msgstr "任务计数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "任务"
 
@@ -8035,7 +8119,7 @@ msgstr ""
 #~ msgid "The amount of time (in seconds) before the email notification stops trying to reach the host and times out. Ranges from 1 to 120 seconds."
 #~ msgstr "电子邮件通知停止尝试到达主机并超时之前所经过的时间（以秒为单位）。范围为 1 秒到 120 秒。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8068,6 +8152,10 @@ msgstr ""
 #~ msgid "The first fetches all references. The second fetches the Github pull request number 62, in this example the branch needs to be \"pull/62/head\"."
 #~ msgstr "第一个获取所有引用。第二个获取 Github 拉取请求号 62，在本示例中，分支需要为 \"pull/62/head\"。"
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -8079,7 +8167,7 @@ msgstr ""
 #~ msgid "The maximum number of hosts allowed to be managed by this organization. Value defaults to 0 which means no limit. Refer to the Ansible documentation for more details."
 #~ msgstr "允许由此机构管理的最大主机数。默认值为 0，表示无限制。请参阅 Ansible 文档以了解更多详情。"
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8106,8 +8194,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr "用于将字段保留为清单中的目标主机的模式。留空、所有和 * 将针对清单中的所有主机。您可以找到有关 Ansible 主机模式的更多信息"
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -8239,6 +8327,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -8247,13 +8342,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8354,7 +8449,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8397,7 +8492,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr "此工作流没有配置任何节点。"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8453,7 +8548,7 @@ msgstr "超时"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr "超时"
 
@@ -8565,7 +8660,7 @@ msgid "Total Nodes"
 msgstr "节点总数"
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr "作业总数"
 
@@ -8574,7 +8669,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8607,9 +8702,9 @@ msgstr "周二"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8629,12 +8724,12 @@ msgstr "Twilio"
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8642,7 +8737,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8655,7 +8750,7 @@ msgstr "类型"
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr "类型详情"
 
@@ -8665,7 +8760,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr "不可用"
 
@@ -8679,15 +8774,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "无法访问"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "无法访问的主机数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "无法访问的主机"
 
@@ -8700,7 +8795,7 @@ msgid "Unsaved changes modal"
 msgstr "未保存的修改 modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "启动时更新修订"
@@ -8782,7 +8877,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr "使用的容量"
 
@@ -8894,11 +8989,11 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr "变量"
 
@@ -8926,9 +9021,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr "详细程度"
 
@@ -9198,7 +9293,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "警告："
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "等待"
@@ -9232,14 +9327,14 @@ msgstr "Webhook"
 msgid "Webhook Credential"
 msgstr "Webhook 凭证"
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr "Webhook 凭证"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr "Webhook 密钥"
@@ -9247,7 +9342,7 @@ msgstr "Webhook 密钥"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr "Webhook 服务"
@@ -9255,14 +9350,14 @@ msgstr "Webhook 服务"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr "Webhook 详情"
 
@@ -9356,18 +9451,18 @@ msgstr "未找到工作流批准。"
 msgid "Workflow Approvals"
 msgstr "工作流批准"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "工作流作业"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9520,18 +9615,18 @@ msgstr "放大"
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK 密钥"
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK url"
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9557,6 +9652,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr "取消删除"
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr "命令"
@@ -9576,7 +9675,7 @@ msgstr "确认解除关联"
 #~ msgid "controller instance"
 #~ msgstr "控制器实例"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "复制到剪贴板被禁用"
 
@@ -9598,14 +9697,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9648,19 +9747,19 @@ msgstr "此处。"
 msgid "hosts"
 msgstr "主机"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr "实例数"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr "实例组使用的容量"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr "实例主机名"
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr "实例类型"
 
@@ -9767,6 +9866,11 @@ msgstr "选择详细程度"
 msgid "social login"
 msgstr "社交登录"
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr "系统"
@@ -9811,7 +9915,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9839,13 +9943,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9898,6 +10006,10 @@ msgstr ""
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
 msgstr "{dateStr}（按 <0>{username}</0>）"
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
+msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192
 msgid "{intervalValue, plural, one {day} other {days}}"

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -211,7 +211,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -219,7 +219,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -234,7 +234,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
 msgid "Activity"
 msgstr ""
 
@@ -403,7 +403,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -538,6 +538,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:83
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: components/DeleteButton/DeleteButton.jsx:128
 msgid "Are you sure you want to delete:"
 msgstr ""
@@ -570,7 +574,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -580,7 +583,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:349
 msgid "Artifacts"
 msgstr ""
 
@@ -619,7 +622,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
 msgid "Auto"
 msgstr ""
 
@@ -690,7 +693,7 @@ msgstr ""
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:39
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:73
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:39
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:57
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:54
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:90
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:63
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:110
@@ -784,9 +787,13 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
+msgid "CPU {0}"
+msgstr ""
+
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -822,8 +829,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -846,17 +851,25 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
+msgid "Cancel Sync"
+msgstr ""
+
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -896,18 +909,24 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
+#~ msgid "Cancel sync source"
+#~ msgstr ""
+
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
+msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
@@ -989,7 +1008,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:220
+#: screens/Project/shared/ProjectForm.jsx:219
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1045,7 +1064,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1126,9 +1145,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:81
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1137,7 +1156,7 @@ msgstr ""
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:576
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1148,6 +1167,14 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:65
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:69
+msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1178,7 +1205,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Container Group"
 msgstr ""
 
@@ -1213,7 +1240,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:440
+#: screens/Template/shared/JobTemplateForm.jsx:441
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1257,7 +1284,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1265,7 +1292,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1277,8 +1304,8 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:381
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
+#: screens/Template/shared/JobTemplateForm.jsx:382
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
 msgid "Create"
 msgstr ""
 
@@ -1425,14 +1452,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:326
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1451,7 +1478,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:129
+#: components/Lookup/ProjectLookup.jsx:128
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1543,7 +1570,7 @@ msgstr ""
 msgid "Credential to authenticate with Kubernetes or OpenShift. Must be of type \"Kubernetes/OpenShift API Bearer Token\". If left blank, the underlying Pod's service account will be used."
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:148
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:163
 msgid "Credential to authenticate with a protected container registry."
 msgstr ""
 
@@ -1551,7 +1578,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1566,9 +1593,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:264
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:349
+#: screens/Template/shared/JobTemplateForm.jsx:350
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1586,10 +1613,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1686,7 +1713,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1698,16 +1725,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:399
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1722,7 +1749,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1735,9 +1762,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobDetail/JobDetail.jsx:395
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1753,7 +1780,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -1785,7 +1812,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1816,7 +1843,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -1909,7 +1936,7 @@ msgstr ""
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:32
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:62
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:150
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:126
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
 #: screens/Host/HostDetail/HostDetail.jsx:81
 #: screens/Host/HostList/HostList.jsx:152
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:78
@@ -1931,16 +1958,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
-#: screens/Project/shared/ProjectForm.jsx:176
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
+#: screens/Project/shared/ProjectForm.jsx:175
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2023,7 +2050,7 @@ msgstr ""
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:54
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:46
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:46
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:64
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:61
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:70
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.jsx:117
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.jsx:46
@@ -2131,7 +2158,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:456
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2149,8 +2176,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2186,7 +2213,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2195,14 +2222,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2211,8 +2238,8 @@ msgstr ""
 #: screens/Setting/GitHub/GitHubDetail/GitHubDetail.jsx:147
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:80
 #: screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.jsx:84
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:97
-#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:101
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:94
+#: screens/Setting/Jobs/JobsDetail/JobsDetail.jsx:98
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:161
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.jsx:165
 #: screens/Setting/Logging/LoggingDetail/LoggingDetail.jsx:101
@@ -2232,8 +2259,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2328,8 +2355,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2343,7 +2370,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2413,16 +2440,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2440,11 +2467,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:583
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2457,14 +2484,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:557
-#: screens/Template/shared/JobTemplateForm.jsx:560
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
+#: screens/Template/shared/JobTemplateForm.jsx:558
+#: screens/Template/shared/JobTemplateForm.jsx:561
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2489,7 +2516,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:563
+#: screens/Template/shared/JobTemplateForm.jsx:564
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2516,7 +2543,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:543
+#: screens/Template/shared/JobTemplateForm.jsx:544
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2670,11 +2697,11 @@ msgstr ""
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2704,9 +2731,9 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
-#: components/LaunchButton/LaunchButton.jsx:171
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
+#: components/LaunchButton/LaunchButton.jsx:173
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:205
@@ -2729,6 +2756,7 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2744,8 +2772,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2753,7 +2780,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2762,7 +2789,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2828,6 +2855,10 @@ msgstr ""
 msgid "Examples include:"
 msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:108
+msgid "Examples:"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.jsx:48
 msgid "Execute regardless of the parent node's final state."
 msgstr ""
@@ -2844,7 +2875,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
 msgid "Execution Environment"
 msgstr ""
 
@@ -2866,7 +2897,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:227
 msgid "Execution Node"
 msgstr ""
 
@@ -2934,7 +2965,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -2949,9 +2980,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -2964,19 +2995,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3010,12 +3041,27 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
+
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:388
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3030,7 +3076,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3113,7 +3159,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3161,7 +3207,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3194,7 +3240,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3234,7 +3280,7 @@ msgid "Failed to fetch custom login configuration settings.  System defaults wil
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.jsx:113
-#: components/LaunchButton/LaunchButton.jsx:174
+#: components/LaunchButton/LaunchButton.jsx:176
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:130
 msgid "Failed to launch job."
 msgstr ""
@@ -3255,7 +3301,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3281,6 +3327,10 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
+msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3346,12 +3396,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3416,7 +3466,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:400
+#: screens/Template/shared/JobTemplateForm.jsx:401
 msgid "Forks"
 msgstr ""
 
@@ -3463,7 +3513,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3524,7 +3574,7 @@ msgstr ""
 msgid "Globally Available"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:132
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:147
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
@@ -3642,11 +3692,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:616
+#: screens/Template/shared/JobTemplateForm.jsx:617
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3729,7 +3779,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3755,7 +3805,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3849,7 +3899,7 @@ msgid ""
 "default group for the inventory."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:534
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3862,7 +3912,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:474
+#: screens/Template/shared/JobTemplateForm.jsx:475
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -3873,17 +3923,17 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:578
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:585
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3916,14 +3966,15 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:138
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:157
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.jsx:62
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:88
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:107
 msgid "Image"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:98
-msgid "Image name"
-msgstr ""
+#~ msgid "Image name"
+#~ msgstr ""
 
 #: screens/Job/JobOutput/JobOutput.jsx:653
 msgid "Including File"
@@ -3965,12 +4016,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights Analytics"
-msgstr ""
+#~ msgid "Insights Analytics"
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights Analytics dashboard"
-msgstr ""
+#~ msgid "Insights Analytics dashboard"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -3978,7 +4029,16 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-msgid "Insights analytics"
+#~ msgid "Insights analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
+msgid "Insights for Ansible"
+msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
+msgid "Insights for Ansible dashboard"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -3993,7 +4053,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:230
 msgid "Instance Group"
 msgstr ""
 
@@ -4077,7 +4137,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4100,11 +4160,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:160
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 msgid "Inventory"
 msgstr ""
 
@@ -4120,12 +4180,16 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:176
 msgid "Inventory Source"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4135,11 +4199,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4191,9 +4255,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4218,26 +4282,27 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:386
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:243
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:454
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid "Job Slicing"
 msgstr ""
 
@@ -4250,19 +4315,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:292
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:494
+#: screens/Template/shared/JobTemplateForm.jsx:495
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:126
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4287,14 +4352,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:156
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4313,8 +4378,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4420,19 +4485,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:277
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
-#: screens/Template/shared/JobTemplateForm.jsx:367
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
+#: screens/Template/shared/JobTemplateForm.jsx:368
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
 msgid "Labels"
 msgstr ""
 
@@ -4440,7 +4505,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4463,10 +4528,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:330
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4506,7 +4571,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4515,7 +4580,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4525,8 +4590,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
 msgid "Launch"
 msgstr ""
 
@@ -4561,12 +4626,16 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights Analytics"
+#~ msgid "Learn more about Insights Analytics"
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
+msgid "Learn more about Insights for Ansible"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4597,15 +4666,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:221
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:416
+#: screens/Template/shared/JobTemplateForm.jsx:417
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4665,16 +4734,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:249
 msgid "Machine Credential"
 msgstr ""
 
@@ -4691,10 +4760,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:82
 msgid "Management Job"
 msgstr ""
 
@@ -4720,14 +4789,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:112
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -4825,7 +4894,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -4841,7 +4910,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:125
+#: components/Lookup/ProjectLookup.jsx:124
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -4936,9 +5005,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -4961,8 +5030,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:105
-#: components/Lookup/ProjectLookup.jsx:135
+#: components/Lookup/ProjectLookup.jsx:104
+#: components/Lookup/ProjectLookup.jsx:134
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5056,7 +5125,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5082,13 +5151,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
-#: screens/Project/shared/ProjectForm.jsx:168
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
+#: screens/Project/shared/ProjectForm.jsx:167
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5096,7 +5165,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5142,7 +5211,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5390,7 +5459,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "Off"
 msgstr ""
 
@@ -5408,7 +5477,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:480
+#: screens/Template/shared/JobTemplateForm.jsx:481
 msgid "On"
 msgstr ""
 
@@ -5446,8 +5515,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:370
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
+#: screens/Template/shared/JobTemplateForm.jsx:371
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5468,12 +5537,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
-#: screens/Template/shared/JobTemplateForm.jsx:526
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
+#: screens/Template/shared/JobTemplateForm.jsx:527
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
 msgid "Options"
 msgstr ""
 
@@ -5504,15 +5573,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5627,7 +5696,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:389
+#: screens/Template/shared/JobTemplateForm.jsx:390
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5635,7 +5704,7 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
@@ -5664,7 +5733,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5689,7 +5758,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5698,13 +5767,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:220
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:330
+#: screens/Template/shared/JobTemplateForm.jsx:331
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Check"
 msgstr ""
 
@@ -5713,15 +5782,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:80
 msgid "Playbook Run"
 msgstr ""
 
@@ -5740,7 +5809,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -5777,7 +5846,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:746
+#: screens/Template/shared/JobTemplateForm.jsx:748
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -5860,7 +5929,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:532
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -5868,17 +5937,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
-#: components/Lookup/ProjectLookup.jsx:86
-#: components/Lookup/ProjectLookup.jsx:91
-#: components/Lookup/ProjectLookup.jsx:144
+#: components/JobList/JobListItem.jsx:196
+#: components/Lookup/ProjectLookup.jsx:85
+#: components/Lookup/ProjectLookup.jsx:90
+#: components/Lookup/ProjectLookup.jsx:143
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
+#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -5886,7 +5955,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -5894,6 +5963,11 @@ msgstr ""
 #: components/Workflow/WorkflowLegend.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:104
 msgid "Project Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:55
@@ -5951,7 +6025,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:419
+#: screens/Template/shared/JobTemplateForm.jsx:420
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -5987,26 +6061,30 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
+#~ msgstr ""
+
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:603
+#: screens/Template/shared/JobTemplateForm.jsx:604
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:598
+#: screens/Template/shared/JobTemplateForm.jsx:599
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:537
-#: screens/Template/shared/JobTemplateForm.jsx:540
+#: screens/Template/shared/JobTemplateForm.jsx:538
+#: screens/Template/shared/JobTemplateForm.jsx:541
 msgid "Provisioning Callbacks"
 msgstr ""
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:88
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:113
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:128
 msgid "Pull"
 msgstr ""
 
@@ -6020,6 +6098,10 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
+msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6050,7 +6132,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:117
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6094,7 +6176,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:409
+#: screens/Template/shared/JobTemplateForm.jsx:410
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6113,7 +6195,7 @@ msgstr ""
 msgid "Regions"
 msgstr ""
 
-#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:141
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:156
 msgid "Registry credential"
 msgstr ""
 
@@ -6127,16 +6209,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
+#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6153,12 +6235,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6263,10 +6345,10 @@ msgid ""
 "The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6315,9 +6397,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6388,7 +6470,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6403,7 +6485,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
 msgid "Running jobs"
 msgstr ""
 
@@ -6438,9 +6520,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6577,7 +6659,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6585,7 +6667,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6739,7 +6821,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:101
+#: screens/Project/shared/ProjectForm.jsx:100
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -6771,11 +6853,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:198
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:352
+#: screens/Template/shared/JobTemplateForm.jsx:353
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6837,7 +6919,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:489
+#: screens/Template/shared/JobTemplateForm.jsx:490
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -6855,7 +6937,7 @@ msgstr ""
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -6863,7 +6945,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:196
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -6890,7 +6972,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:333
+#: screens/Template/shared/JobTemplateForm.jsx:334
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -6926,7 +7008,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -6961,7 +7043,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:97
+#: screens/Project/shared/ProjectForm.jsx:96
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7030,7 +7112,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:471
+#: screens/Template/shared/JobTemplateForm.jsx:472
 msgid "Show Changes"
 msgstr ""
 
@@ -7101,9 +7183,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:310
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:510
+#: screens/Template/shared/JobTemplateForm.jsx:511
 msgid "Skip Tags"
 msgstr ""
 
@@ -7116,7 +7198,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:513
+#: screens/Template/shared/JobTemplateForm.jsx:514
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7196,8 +7278,10 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Job/JobDetail/JobDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7207,41 +7291,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:211
+#: screens/Project/shared/ProjectForm.jsx:210
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:121
+#: components/Lookup/ProjectLookup.jsx:120
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Source Control Update"
 msgstr ""
 
@@ -7253,8 +7337,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:148
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7333,8 +7417,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7352,32 +7436,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:112
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7440,7 +7524,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7464,13 +7548,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7510,14 +7594,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7536,7 +7620,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7590,7 +7674,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:497
+#: screens/Template/shared/JobTemplateForm.jsx:498
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7628,7 +7712,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7636,7 +7720,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -7754,7 +7838,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:466
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -7775,6 +7859,10 @@ msgid ""
 "the branch needs to be \"pull/62/head\"."
 msgstr ""
 
+#: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:105
+msgid "The full image location, including the container registry, image name, and version tag."
+msgstr ""
+
 #: screens/Organization/shared/OrganizationForm.jsx:75
 msgid ""
 "The maximum number of hosts allowed to be managed by this organization.\n"
@@ -7782,7 +7870,7 @@ msgid ""
 "documentation for more details."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:403
+#: screens/Template/shared/JobTemplateForm.jsx:404
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -7805,8 +7893,8 @@ msgid "The pattern used to target hosts in the inventory. Leaving the field blan
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:103
-msgid "The registry location where the container is stored."
-msgstr ""
+#~ msgid "The registry location where the container is stored."
+#~ msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:123
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:126
@@ -7930,6 +8018,13 @@ msgstr ""
 #~ "Insights Analytics to subscribers."
 #~ msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Software and to provide\n"
+"Red Hat Insights for Ansible."
+msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
 "This data is used to enhance\n"
@@ -7938,13 +8033,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Tower Software and to provide\n"
-"Insights Analytics to Tower subscribers."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Tower Software and to provide\n"
+#~ "Insights Analytics to Tower subscribers."
+#~ msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8045,7 +8140,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8084,7 +8179,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8132,7 +8227,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:464
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid "Timeout"
 msgstr ""
 
@@ -8244,7 +8339,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
 msgid "Total jobs"
 msgstr ""
 
@@ -8253,7 +8348,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8286,9 +8381,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
-#: components/Lookup/ProjectLookup.jsx:110
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
+#: components/Lookup/ProjectLookup.jsx:109
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8308,12 +8403,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8321,7 +8416,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8334,7 +8429,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:243
+#: screens/Project/shared/ProjectForm.jsx:242
 msgid "Type Details"
 msgstr ""
 
@@ -8344,7 +8439,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
 msgid "Unavailable"
 msgstr ""
 
@@ -8358,15 +8453,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8379,7 +8474,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8455,7 +8550,7 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
 msgid "Used capacity"
 msgstr ""
 
@@ -8567,11 +8662,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
-#: screens/Template/shared/JobTemplateForm.jsx:387
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
+#: screens/Template/shared/JobTemplateForm.jsx:388
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
 msgid "Variables"
 msgstr ""
 
@@ -8599,9 +8694,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:222
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:437
+#: screens/Template/shared/JobTemplateForm.jsx:438
 msgid "Verbosity"
 msgstr ""
 
@@ -8871,7 +8966,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -8905,14 +9000,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -8920,7 +9015,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -8928,14 +9023,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:629
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
+#: screens/Template/shared/JobTemplateForm.jsx:630
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
 msgid "Webhook details"
 msgstr ""
 
@@ -9019,18 +9114,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:83
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:136
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9183,18 +9278,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:726
+#: screens/Template/shared/JobTemplateForm.jsx:728
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:723
+#: screens/Template/shared/JobTemplateForm.jsx:725
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9220,6 +9315,10 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
+msgid "capacity adjustment"
+msgstr ""
+
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9239,7 +9338,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9261,14 +9360,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9307,19 +9406,19 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
 msgid "instance type"
 msgstr ""
 
@@ -9430,6 +9529,11 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
+#: screens/Template/shared/JobTemplateForm.jsx:320
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
+msgid "source control branch"
+msgstr ""
+
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9474,7 +9578,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9502,13 +9606,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9560,6 +9668,10 @@ msgstr ""
 
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
+msgstr ""
+
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
+msgid "{forks, plural, one {# fork} other {# forks}}"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: zu\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:90
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:153
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:92
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:91
 msgid "(Prompt on launch)"
 msgstr ""
 
@@ -27,11 +27,11 @@ msgstr ""
 msgid "* This field will be retrieved from an external secret management system using the specified credential."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:60
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:59
 msgid "- Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:65
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:64
 msgid "- Enable Webhooks"
 msgstr ""
 
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:226
-#: components/JobList/JobListItem.jsx:87
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:85
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -211,7 +211,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -219,7 +219,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:171
+#: screens/Project/ProjectList/ProjectListItem.jsx:170
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -234,7 +234,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:78
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:34
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:119
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:118
 msgid "Activity"
 msgstr ""
 
@@ -403,7 +403,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -522,20 +522,20 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:48
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:59
 msgid "Approved"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:42
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:52
+msgid "Approved - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:49
 msgid "Approved by {0} - {1}"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:83
-msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
 #: components/DeleteButton/DeleteButton.jsx:128
@@ -570,6 +570,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:441
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -579,7 +580,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:349
+#: screens/Job/JobDetail/JobDetail.jsx:357
 msgid "Artifacts"
 msgstr ""
 
@@ -618,7 +619,7 @@ msgstr ""
 msgid "Authorization grant type"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
 msgid "Auto"
 msgstr ""
 
@@ -783,13 +784,9 @@ msgstr ""
 msgid "By default, we collect and transmit analytics data on the serice usage to Red Hat. There are two categories of data collected by the service. For more information, see <0>this Tower documentation page</0>. Uncheck the following boxes to disable this feature."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:184
-msgid "CPU {0}"
-msgstr ""
-
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -825,6 +822,8 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
+#: screens/Job/JobDetail/JobDetail.jsx:392
+#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -847,25 +846,17 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
-msgid "Cancel Inventory Source Sync"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:49
+#: screens/Job/JobDetail/JobDetail.jsx:417
+#: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
-msgid "Cancel Sync"
-msgstr ""
-
+#: screens/Job/JobDetail/JobDetail.jsx:425
+#: screens/Job/JobDetail/JobDetail.jsx:428
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -905,27 +896,21 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-#~ msgid "Cancel sync"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-#~ msgid "Cancel sync process"
-#~ msgstr ""
-
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-#~ msgid "Cancel sync source"
-#~ msgstr ""
-
-#: components/JobList/JobListItem.jsx:97
-#: screens/Job/JobDetail/JobDetail.jsx:387
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
-msgid "Cancel {0}"
+msgid "Cancel sync"
 msgstr ""
 
-#: components/JobList/JobList.jsx:211
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
+msgid "Cancel sync process"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
+msgid "Cancel sync source"
+msgstr ""
+
+#: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:20
 msgid "Canceled"
 msgstr ""
 
@@ -1004,7 +989,7 @@ msgstr ""
 msgid "Choose a Playbook Directory"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:219
+#: screens/Project/shared/ProjectForm.jsx:220
 msgid "Choose a Source Control Type"
 msgstr ""
 
@@ -1036,6 +1021,13 @@ msgid ""
 "information about each option."
 msgstr ""
 
+#: screens/Template/Survey/SurveyQuestionForm.jsx:37
+#~ msgid ""
+#~ "Choose an answer type or format you want as the prompt for the user.\n"
+#~ "Refer to the Documentation for more additional\n"
+#~ "information about each option."
+#~ msgstr ""
+
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:142
 msgid "Choose an email option"
 msgstr ""
@@ -1053,7 +1045,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1086,10 +1078,6 @@ msgstr ""
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.jsx:150
 msgid "Click to create a new link to this node."
 msgstr ""
-
-#: components/FormField/TextAndCheckboxField.jsx:86
-#~ msgid "Click to select this answer as a default answer."
-#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.jsx:114
 msgid "Click to toggle default value"
@@ -1138,9 +1126,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:191
-#: components/JobList/JobListItem.jsx:36
-#: screens/Job/JobDetail/JobDetail.jsx:81
+#: components/JobList/JobList.jsx:187
+#: components/JobList/JobListItem.jsx:34
+#: screens/Job/JobDetail/JobDetail.jsx:96
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1149,7 +1137,7 @@ msgstr ""
 msgid "Compliant"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:577
+#: screens/Template/shared/JobTemplateForm.jsx:576
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1160,14 +1148,6 @@ msgstr ""
 
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:65
-msgid "Confirm cancel job"
-msgstr ""
-
-#: components/JobCancelButton/JobCancelButton.jsx:69
-msgid "Confirm cancellation"
 msgstr ""
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
@@ -1198,7 +1178,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:244
 msgid "Container Group"
 msgstr ""
 
@@ -1233,11 +1213,16 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:441
+#: screens/Template/shared/JobTemplateForm.jsx:440
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
 msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:69
+#~ msgid "Controller"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:208
 msgid "Convergence"
@@ -1272,7 +1257,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:211
+#: screens/Project/ProjectList/ProjectListItem.jsx:196
 msgid "Copy Project"
 msgstr ""
 
@@ -1280,7 +1265,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:165
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1292,10 +1277,15 @@ msgstr ""
 #~ msgid "Copyright 2019 Red Hat, Inc."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:382
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:225
+#: screens/Template/shared/JobTemplateForm.jsx:381
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:224
 msgid "Create"
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:14
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:24
+#~ msgid "Create Execution environments"
+#~ msgstr ""
 
 #: screens/Application/Applications.jsx:26
 #: screens/Application/Applications.jsx:35
@@ -1435,14 +1425,14 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:326
+#: screens/Job/JobDetail/JobDetail.jsx:334
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:191
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
 #: screens/User/UserDetail/UserDetail.jsx:77
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:63
 #: screens/User/UserTokenList/UserTokenList.jsx:134
@@ -1461,7 +1451,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:167
 #: components/Lookup/MultiCredentialsLookup.jsx:184
 #: components/Lookup/OrganizationLookup.jsx:111
-#: components/Lookup/ProjectLookup.jsx:128
+#: components/Lookup/ProjectLookup.jsx:129
 #: components/NotificationList/NotificationList.jsx:206
 #: components/Schedule/ScheduleList/ScheduleList.jsx:197
 #: components/TemplateList/TemplateList.jsx:215
@@ -1561,7 +1551,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:212
+#: components/JobList/JobListItem.jsx:196
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1576,9 +1566,9 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:264
+#: screens/Job/JobDetail/JobDetail.jsx:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
-#: screens/Template/shared/JobTemplateForm.jsx:350
+#: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
 msgid "Credentials"
 msgstr ""
@@ -1596,10 +1586,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:131
+#: screens/Project/ProjectList/ProjectListItem.jsx:130
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1673,7 +1663,7 @@ msgstr ""
 msgid "Default answer"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:81
+#: screens/Template/Survey/SurveyQuestionForm.jsx:85
 #~ msgid "Default choice must be answered from the choices listed."
 #~ msgstr ""
 
@@ -1696,7 +1686,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:127
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:284
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:124
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:137
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:138
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:111
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:137
@@ -1708,16 +1698,16 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:399
+#: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
 #: screens/Template/Survey/SurveyList.jsx:104
 #: screens/Template/Survey/SurveyToolbar.jsx:73
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:249
 #: screens/User/UserDetail/UserDetail.jsx:99
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:218
@@ -1732,7 +1722,7 @@ msgstr ""
 msgid "Delete Credential"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:130
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:131
 msgid "Delete Execution Environment"
 msgstr ""
 
@@ -1745,9 +1735,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
+#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
 msgid "Delete Job"
 msgstr ""
 
@@ -1763,7 +1753,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
 msgid "Delete Project"
 msgstr ""
 
@@ -1795,7 +1785,7 @@ msgstr ""
 msgid "Delete Workflow Approval"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:251
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:243
 msgid "Delete Workflow Job Template"
 msgstr ""
 
@@ -1826,7 +1816,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 msgid "Delete on Update"
 msgstr ""
 
@@ -1873,11 +1863,15 @@ msgstr ""
 msgid "Deletion error"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:33
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:38
 msgid "Denied"
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:27
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:31
+msgid "Denied - {0}.  See the Activity Stream for more information."
+msgstr ""
+
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:28
 msgid "Denied by {0} - {1}"
 msgstr ""
 
@@ -1937,16 +1931,16 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:230
-#: screens/Project/shared/ProjectForm.jsx:175
+#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
 #: screens/Team/shared/TeamForm.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:174
 #: screens/Template/Survey/SurveyQuestionForm.jsx:166
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:115
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:166
 #: screens/Template/shared/JobTemplateForm.jsx:221
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:120
@@ -2137,7 +2131,7 @@ msgstr ""
 msgid "Disassociate?"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:456
+#: screens/Template/shared/JobTemplateForm.jsx:455
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2155,8 +2149,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
 msgid "Download Output"
 msgstr ""
 
@@ -2168,7 +2162,7 @@ msgstr ""
 msgid "E-mail options"
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:212
+#: screens/Template/Survey/SurveyQuestionForm.jsx:220
 #~ msgid "Each answer choice must be on a separate line."
 #~ msgstr ""
 
@@ -2192,7 +2186,7 @@ msgstr ""
 #: screens/Application/ApplicationDetails/ApplicationDetails.jsx:116
 #: screens/Credential/CredentialDetail/CredentialDetail.jsx:271
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:109
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:124
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:125
 #: screens/Host/HostDetail/HostDetail.jsx:113
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:97
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:110
@@ -2201,14 +2195,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2238,8 +2232,8 @@ msgstr ""
 #: screens/Team/TeamDetail/TeamDetail.jsx:55
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:365
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:367
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:227
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:229
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:219
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:221
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:208
 #: screens/User/UserDetail/UserDetail.jsx:88
 msgid "Edit"
@@ -2334,8 +2328,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:197
-#: screens/Project/ProjectList/ProjectListItem.jsx:202
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 msgid "Edit Project"
 msgstr ""
 
@@ -2349,7 +2343,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
 msgid "Edit Source"
 msgstr ""
 
@@ -2419,16 +2413,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2446,11 +2440,11 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:64
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:30
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:134
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:261
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:584
+#: screens/Template/shared/JobTemplateForm.jsx:583
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2463,14 +2457,14 @@ msgstr ""
 msgid "Enable Privilege Escalation"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:558
-#: screens/Template/shared/JobTemplateForm.jsx:561
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:241
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:244
+#: screens/Template/shared/JobTemplateForm.jsx:557
+#: screens/Template/shared/JobTemplateForm.jsx:560
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:240
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:243
 msgid "Enable Webhook"
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:247
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:246
 msgid "Enable Webhook for this workflow job template."
 msgstr ""
 
@@ -2495,7 +2489,7 @@ msgstr ""
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:564
+#: screens/Template/shared/JobTemplateForm.jsx:563
 msgid "Enable webhook for this template."
 msgstr ""
 
@@ -2522,7 +2516,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:544
+#: screens/Template/shared/JobTemplateForm.jsx:543
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {BrandName}\n"
@@ -2571,9 +2565,17 @@ msgstr ""
 msgid "Enter injectors using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:49
+#~ msgid "Enter injectors using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
+
 #: screens/CredentialType/shared/CredentialTypeForm.jsx:38
 msgid "Enter inputs using either JSON or YAML syntax. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/CredentialType/shared/CredentialTypeForm.jsx:39
+#~ msgid "Enter inputs using either JSON or YAML syntax. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Inventory/shared/SmartInventoryForm.jsx:97
 msgid ""
@@ -2582,9 +2584,20 @@ msgid ""
 "Ansible Tower documentation for example syntax."
 msgstr ""
 
+#: screens/Inventory/shared/SmartInventoryForm.jsx:100
+#~ msgid ""
+#~ "Enter inventory variables using either JSON or YAML syntax.\n"
+#~ "Use the radio button to toggle between the two. Refer to the\n"
+#~ "documentation for example syntax."
+#~ msgstr ""
+
 #: screens/Inventory/shared/InventoryForm.jsx:84
 msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the Ansible Tower documentation for example syntax"
 msgstr ""
+
+#: screens/Inventory/shared/InventoryForm.jsx:85
+#~ msgid "Enter inventory variables using either JSON or YAML syntax. Use the radio button to toggle between the two. Refer to the documentation for example syntax"
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:193
 msgid "Enter one Annotation Tag per line, without commas."
@@ -2657,11 +2670,11 @@ msgstr ""
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr ""
 
-#: components/JobList/JobList.jsx:210
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:148
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.jsx:223
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:119
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:133
@@ -2691,8 +2704,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:281
-#: components/JobList/JobList.jsx:292
+#: components/JobList/JobList.jsx:276
+#: components/JobList/JobList.jsx:287
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2716,7 +2729,6 @@ msgstr ""
 #: screens/Host/HostGroups/HostGroupsList.jsx:245
 #: screens/Host/HostList/HostList.jsx:222
 #: screens/InstanceGroup/Instances/InstanceList.jsx:230
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:229
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:146
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:76
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.jsx:265
@@ -2732,7 +2744,8 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2740,7 +2753,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2749,7 +2762,7 @@ msgstr ""
 #: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:265
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:167
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:182
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.jsx:307
@@ -2831,7 +2844,7 @@ msgstr ""
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.jsx:26
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:152
 #: components/Lookup/ExecutionEnvironmentLookup.jsx:174
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:143
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:135
 msgid "Execution Environment"
 msgstr ""
 
@@ -2853,7 +2866,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Execution Node"
 msgstr ""
 
@@ -2868,6 +2881,11 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironment.jsx:82
 msgid "Execution environment not found."
 msgstr ""
+
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:13
+#: screens/ExecutionEnvironment/ExecutionEnvironments.jsx:23
+#~ msgid "Execution environments"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:23
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.jsx:26
@@ -2912,11 +2930,11 @@ msgid "Expires on UTC"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:34
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:11
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:240
+#: components/JobList/JobListItem.jsx:224
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -2931,9 +2949,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
-#: screens/Project/ProjectList/ProjectListItem.jsx:76
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
+#: screens/Project/ProjectList/ProjectListItem.jsx:75
 msgid "FINISHED:"
 msgstr ""
 
@@ -2946,19 +2964,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:209
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
 msgid "Failed Hosts"
 msgstr ""
 
@@ -2992,32 +3010,12 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
-msgid "Failed to cancel Inventory Source Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:181
-msgid "Failed to cancel Project Sync"
-msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#~ msgid "Failed to cancel Project Update"
-#~ msgstr ""
-
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-#~ msgid "Failed to cancel inventory source sync."
-#~ msgstr ""
-
-#: components/JobList/JobList.jsx:295
-msgid "Failed to cancel one or more jobs."
+msgid "Failed to cancel inventory source sync."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:98
-#: screens/Job/JobDetail/JobDetail.jsx:388
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
-msgid "Failed to cancel {0}"
+#: components/JobList/JobList.jsx:290
+msgid "Failed to cancel one or more jobs."
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3032,7 +3030,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:219
+#: screens/Project/ProjectList/ProjectListItem.jsx:204
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3115,7 +3113,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:284
+#: components/JobList/JobList.jsx:279
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3163,7 +3161,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3196,7 +3194,7 @@ msgstr ""
 msgid "Failed to delete workflow approval."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:268
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:260
 msgid "Failed to delete workflow job template."
 msgstr ""
 
@@ -3257,7 +3255,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3283,10 +3281,6 @@ msgstr ""
 
 #: components/Schedule/ScheduleToggle/ScheduleToggle.jsx:71
 msgid "Failed to toggle schedule."
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:233
-msgid "Failed to update capacity adjustment."
 msgstr ""
 
 #: screens/Template/TemplateSurvey.jsx:133
@@ -3352,12 +3346,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:225
-#: components/JobList/JobListItem.jsx:84
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:82
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:123
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3422,7 +3416,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:185
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:132
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:219
-#: screens/Template/shared/JobTemplateForm.jsx:401
+#: screens/Template/shared/JobTemplateForm.jsx:400
 msgid "Forks"
 msgstr ""
 
@@ -3469,7 +3463,7 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:113
+#: components/Lookup/ProjectLookup.jsx:114
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
 #: screens/Project/ProjectList/ProjectList.jsx:150
@@ -3648,11 +3642,11 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:139
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:227
-#: screens/Template/shared/JobTemplateForm.jsx:617
+#: screens/Template/shared/JobTemplateForm.jsx:616
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Host Count"
 msgstr ""
 
@@ -3735,7 +3729,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3761,7 +3755,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3831,7 +3825,7 @@ msgid ""
 "on the external source."
 msgstr ""
 
-#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:125
+#: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:126
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:135
 #~ msgid ""
 #~ "If checked, any hosts and groups that were\n"
@@ -3855,7 +3849,7 @@ msgid ""
 "default group for the inventory."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:534
+#: screens/Template/shared/JobTemplateForm.jsx:533
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3868,7 +3862,7 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:475
+#: screens/Template/shared/JobTemplateForm.jsx:474
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -3879,17 +3873,17 @@ msgstr ""
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:578
+#: screens/Template/shared/JobTemplateForm.jsx:577
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:260
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:259
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:585
+#: screens/Template/shared/JobTemplateForm.jsx:584
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3971,12 +3965,12 @@ msgid "Input configuration"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-#~ msgid "Insights Analytics"
-#~ msgstr ""
+msgid "Insights Analytics"
+msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-#~ msgid "Insights Analytics dashboard"
-#~ msgstr ""
+msgid "Insights Analytics dashboard"
+msgstr ""
 
 #: screens/Inventory/shared/InventoryForm.jsx:71
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:33
@@ -3984,16 +3978,7 @@ msgid "Insights Credential"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#~ msgid "Insights analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:82
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:83
-msgid "Insights for Ansible"
-msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:122
-msgid "Insights for Ansible dashboard"
+msgid "Insights analytics"
 msgstr ""
 
 #: components/Lookup/HostFilterLookup.jsx:107
@@ -4008,7 +3993,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:238
 msgid "Instance Group"
 msgstr ""
 
@@ -4092,7 +4077,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:164
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4115,11 +4100,11 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:160
+#: screens/Job/JobDetail/JobDetail.jsx:175
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:148
 msgid "Inventory"
 msgstr ""
 
@@ -4135,20 +4120,12 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-#~ msgid "Inventory Source Error"
-#~ msgstr ""
-
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
-msgstr ""
-
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
-msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4158,11 +4135,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:34
+#: components/JobList/JobList.jsx:185
+#: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4214,9 +4191,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
-#: screens/Project/ProjectList/ProjectListItem.jsx:69
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
+#: screens/Project/ProjectList/ProjectListItem.jsx:68
 msgid "JOB ID:"
 msgstr ""
 
@@ -4241,27 +4218,26 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:386
+#: screens/Job/JobDetail/JobDetail.jsx:449
+#: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:460
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:243
+#: screens/Job/JobDetail/JobDetail.jsx:251
 msgid "Job Slice"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:138
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:224
-#: screens/Template/shared/JobTemplateForm.jsx:455
+#: screens/Template/shared/JobTemplateForm.jsx:454
 msgid "Job Slicing"
 msgstr ""
 
@@ -4274,19 +4250,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:292
+#: screens/Job/JobDetail/JobDetail.jsx:300
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
-#: screens/Template/shared/JobTemplateForm.jsx:495
+#: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:148
+#: components/JobList/JobListItem.jsx:132
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:126
+#: screens/Job/JobDetail/JobDetail.jsx:141
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4311,14 +4287,14 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
+#: components/JobList/JobList.jsx:181
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:156
+#: screens/Job/JobDetail/JobDetail.jsx:171
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:153
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
 msgid "Job Type"
 msgstr ""
@@ -4337,8 +4313,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:243
+#: components/JobList/JobList.jsx:164
+#: components/JobList/JobList.jsx:239
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4444,19 +4420,19 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:177
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:225
+#: components/JobList/JobListItem.jsx:209
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:277
+#: screens/Job/JobDetail/JobDetail.jsx:285
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:203
-#: screens/Template/shared/JobTemplateForm.jsx:368
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:211
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
+#: screens/Template/shared/JobTemplateForm.jsx:367
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:210
 msgid "Labels"
 msgstr ""
 
@@ -4464,7 +4440,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
 msgid "Last Job Status"
 msgstr ""
 
@@ -4487,10 +4463,10 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:330
+#: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4530,7 +4506,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:257
+#: screens/Project/ProjectList/ProjectListItem.jsx:242
 msgid "Last modified"
 msgstr ""
 
@@ -4539,7 +4515,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:262
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 msgid "Last used"
 msgstr ""
 
@@ -4549,8 +4525,8 @@ msgstr ""
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:57
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:371
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:380
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:233
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:242
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:225
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:234
 msgid "Launch"
 msgstr ""
 
@@ -4585,16 +4561,12 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:193
 msgid "Launched By (Username)"
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-#~ msgid "Learn more about Insights Analytics"
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:131
-msgid "Learn more about Insights for Ansible"
+msgid "Learn more about Insights Analytics"
 msgstr ""
 
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.jsx:77
@@ -4625,15 +4597,15 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:215
+#: components/JobList/JobList.jsx:211
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:221
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
-#: screens/Template/shared/JobTemplateForm.jsx:417
+#: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
 msgid "Limit"
 msgstr ""
@@ -4693,16 +4665,16 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
-#: screens/Project/ProjectList/ProjectListItem.jsx:67
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
+#: screens/Project/ProjectList/ProjectListItem.jsx:66
 msgid "MOST RECENT SYNC"
 msgstr ""
 
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:249
+#: screens/Job/JobDetail/JobDetail.jsx:257
 msgid "Machine Credential"
 msgstr ""
 
@@ -4719,10 +4691,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:192
-#: components/JobList/JobListItem.jsx:37
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:82
+#: screens/Job/JobDetail/JobDetail.jsx:97
 msgid "Management Job"
 msgstr ""
 
@@ -4748,14 +4720,14 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:112
+#: components/Lookup/ProjectLookup.jsx:113
 #: components/PromptDetail/PromptProjectDetail.jsx:76
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:161
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:154
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -4853,7 +4825,7 @@ msgstr ""
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:119
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:115
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:143
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:196
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
 #: screens/User/UserTokenList/UserTokenList.jsx:138
 msgid "Modified"
 msgstr ""
@@ -4869,7 +4841,7 @@ msgstr ""
 #: components/Lookup/InventoryLookup.jsx:171
 #: components/Lookup/MultiCredentialsLookup.jsx:188
 #: components/Lookup/OrganizationLookup.jsx:115
-#: components/Lookup/ProjectLookup.jsx:124
+#: components/Lookup/ProjectLookup.jsx:125
 #: components/NotificationList/NotificationList.jsx:210
 #: components/Schedule/ScheduleList/ScheduleList.jsx:201
 #: components/TemplateList/TemplateList.jsx:219
@@ -4964,9 +4936,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:172
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:70
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:217
+#: components/JobList/JobListItem.jsx:68
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -4989,8 +4961,8 @@ msgstr ""
 #: components/Lookup/MultiCredentialsLookup.jsx:194
 #: components/Lookup/OrganizationLookup.jsx:106
 #: components/Lookup/OrganizationLookup.jsx:121
-#: components/Lookup/ProjectLookup.jsx:104
-#: components/Lookup/ProjectLookup.jsx:134
+#: components/Lookup/ProjectLookup.jsx:105
+#: components/Lookup/ProjectLookup.jsx:135
 #: components/NotificationList/NotificationList.jsx:181
 #: components/NotificationList/NotificationList.jsx:218
 #: components/NotificationList/NotificationListItem.jsx:25
@@ -5084,7 +5056,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5110,13 +5082,13 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:122
-#: screens/Project/shared/ProjectForm.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
 #: screens/Team/TeamList/TeamList.jsx:129
@@ -5124,7 +5096,7 @@ msgstr ""
 #: screens/Team/TeamList/TeamListItem.jsx:33
 #: screens/Team/shared/TeamForm.jsx:35
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:173
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:114
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:113
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:81
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.jsx:104
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.jsx:83
@@ -5166,11 +5138,11 @@ msgid "Never Updated"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:44
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:13
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:12
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:200
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5418,7 +5390,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:94
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:53
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "Off"
 msgstr ""
 
@@ -5436,7 +5408,7 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.jsx:93
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
 #: screens/Template/Survey/SurveyToolbar.jsx:52
-#: screens/Template/shared/JobTemplateForm.jsx:481
+#: screens/Template/shared/JobTemplateForm.jsx:480
 msgid "On"
 msgstr ""
 
@@ -5474,8 +5446,8 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:371
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:214
+#: screens/Template/shared/JobTemplateForm.jsx:370
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:213
 msgid ""
 "Optional labels that describe this job template,\n"
 "such as 'dev' or 'test'. Labels can be used to group and filter\n"
@@ -5496,12 +5468,12 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:188
-#: screens/Template/shared/JobTemplateForm.jsx:527
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:238
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
+#: screens/Template/shared/JobTemplateForm.jsx:526
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:237
 msgid "Options"
 msgstr ""
 
@@ -5532,15 +5504,15 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
-#: screens/Project/ProjectList/ProjectListItem.jsx:236
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
+#: screens/Project/ProjectList/ProjectListItem.jsx:221
+#: screens/Project/ProjectList/ProjectListItem.jsx:232
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:178
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:188
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:124
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:123
 #: screens/User/UserTeams/UserTeamList.jsx:183
 #: screens/User/UserTeams/UserTeamList.jsx:242
 #: screens/User/UserTeams/UserTeamListItem.jsx:23
@@ -5655,7 +5627,7 @@ msgstr ""
 #~ "Ansible Tower documentation for example syntax."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:390
+#: screens/Template/shared/JobTemplateForm.jsx:389
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5663,9 +5635,13 @@ msgid ""
 "documentation for example syntax."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:235
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:234
 msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:242
+#~ msgid "Pass extra command line variables to the playbook. This is the -e or --extra-vars command line parameter for ansible-playbook. Provide key/value pairs using either YAML or JSON. Refer to the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/Login/Login.jsx:179
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:73
@@ -5688,7 +5664,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:201
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5713,7 +5689,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Play Count"
 msgstr ""
 
@@ -5722,13 +5698,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:220
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:331
+#: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Check"
 msgstr ""
 
@@ -5737,15 +5713,15 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:190
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:186
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:80
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Playbook Run"
 msgstr ""
 
@@ -5764,7 +5740,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Plays"
 msgstr ""
 
@@ -5801,7 +5777,7 @@ msgstr ""
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:748
+#: screens/Template/shared/JobTemplateForm.jsx:746
 msgid "Please select an Inventory or check the Prompt on Launch option."
 msgstr ""
 
@@ -5840,6 +5816,14 @@ msgstr ""
 #~ "examples."
 #~ msgstr ""
 
+#: components/Lookup/HostFilterLookup.jsx:288
+#~ msgid ""
+#~ "Populate the hosts for this inventory by using a search\n"
+#~ "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
+#~ "Refer to the documentation for further syntax and\n"
+#~ "examples."
+#~ msgstr ""
+
 #: components/Lookup/HostFilterLookup.jsx:287
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
@@ -5866,18 +5850,6 @@ msgstr ""
 msgid "Press Enter to edit. Press ESC to stop editing."
 msgstr ""
 
-#: screens/Template/Survey/SurveyQuestionForm.jsx:223
-#~ msgid "Press Enter to get additional inputs."
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional inputs. Refer to the"
-#~ msgstr ""
-
-#: screens/Template/Survey/SurveyQuestionForm.jsx:229
-#~ msgid "Press Enter to get additional {num} inputs. Refer to the"
-#~ msgstr ""
-
 #: components/LaunchPrompt/steps/usePreviewStep.jsx:23
 #: screens/Template/Survey/SurveyList.jsx:160
 #: screens/Template/Survey/SurveyList.jsx:162
@@ -5888,7 +5860,7 @@ msgstr ""
 msgid "Private key passphrase"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:533
+#: screens/Template/shared/JobTemplateForm.jsx:532
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -5896,17 +5868,17 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
-#: components/Lookup/ProjectLookup.jsx:85
-#: components/Lookup/ProjectLookup.jsx:90
-#: components/Lookup/ProjectLookup.jsx:143
+#: components/JobList/JobListItem.jsx:180
+#: components/Lookup/ProjectLookup.jsx:86
+#: components/Lookup/ProjectLookup.jsx:91
+#: components/Lookup/ProjectLookup.jsx:144
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:87
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:116
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:188
 #: screens/Job/JobDetail/JobDetail.jsx:203
+#: screens/Job/JobDetail/JobDetail.jsx:218
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -5914,7 +5886,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -5924,19 +5896,9 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:178
-msgid "Project Sync Error"
-msgstr ""
-
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
-
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
-#: screens/Project/ProjectList/ProjectListItem.jsx:179
-#~ msgid "Project Update Error"
-#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -5989,7 +5951,7 @@ msgstr ""
 msgid "Prompts"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:420
+#: screens/Template/shared/JobTemplateForm.jsx:419
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:163
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6025,25 +5987,21 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-#~ msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
-#~ msgstr ""
-
-#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:94
-msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights for Ansible."
+msgid "Provide your Red Hat or Red Hat Satellite credentials to enable Insights Analytics."
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:142
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:229
-#: screens/Template/shared/JobTemplateForm.jsx:604
+#: screens/Template/shared/JobTemplateForm.jsx:603
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:599
+#: screens/Template/shared/JobTemplateForm.jsx:598
 msgid "Provisioning Callback details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:538
-#: screens/Template/shared/JobTemplateForm.jsx:541
+#: screens/Template/shared/JobTemplateForm.jsx:537
+#: screens/Template/shared/JobTemplateForm.jsx:540
 msgid "Provisioning Callbacks"
 msgstr ""
 
@@ -6062,10 +6020,6 @@ msgstr ""
 
 #: screens/Setting/SettingList.jsx:76
 msgid "RADIUS settings"
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:201
-msgid "RAM {0}"
 msgstr ""
 
 #: screens/User/shared/UserTokenForm.jsx:76
@@ -6096,7 +6050,7 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:116
+#: components/Lookup/ProjectLookup.jsx:117
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
 #: screens/Project/ProjectList/ProjectList.jsx:153
@@ -6140,7 +6094,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:410
+#: screens/Template/shared/JobTemplateForm.jsx:409
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6173,16 +6127,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:129
+#: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:367
 #: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
+#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:110
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
+#: components/JobList/JobListItem.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6199,12 +6153,12 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:109
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
+#: components/JobList/JobListItem.jsx:93
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:115
+#: components/Lookup/ProjectLookup.jsx:116
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
 #: screens/Project/ProjectList/ProjectList.jsx:152
@@ -6309,10 +6263,10 @@ msgid ""
 "The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:75
-#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
+#: screens/Job/JobDetail/JobDetail.jsx:434
+#: screens/Job/JobDetail/JobDetail.jsx:437
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6361,9 +6315,9 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:156
+#: screens/Project/ProjectList/ProjectListItem.jsx:155
 msgid "Revision"
 msgstr ""
 
@@ -6434,7 +6388,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:203
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6449,7 +6403,7 @@ msgid "Running Jobs"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:73
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:170
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:91
 msgid "Running jobs"
 msgstr ""
 
@@ -6484,9 +6438,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
-#: screens/Project/ProjectList/ProjectListItem.jsx:72
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
+#: screens/Project/ProjectList/ProjectListItem.jsx:71
 msgid "STATUS:"
 msgstr ""
 
@@ -6623,7 +6577,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 msgid "Seconds"
 msgstr ""
 
@@ -6631,7 +6585,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -6785,7 +6739,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.jsx:24
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:61
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:444
-#: screens/Project/shared/ProjectForm.jsx:100
+#: screens/Project/shared/ProjectForm.jsx:101
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.jsx:18
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:40
 #: screens/Team/shared/TeamForm.jsx:20
@@ -6817,11 +6771,11 @@ msgstr ""
 msgid "Select an inventory for the workflow. This inventory is applied to all job template nodes that prompt for an inventory."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:197
+#: screens/Project/shared/ProjectForm.jsx:198
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:353
+#: screens/Template/shared/JobTemplateForm.jsx:352
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6883,7 +6837,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:490
+#: screens/Template/shared/JobTemplateForm.jsx:489
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -6901,7 +6855,7 @@ msgstr ""
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr ""
 
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:204
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:203
 msgid "Select the default execution environment for this organization to run on."
 msgstr ""
 
@@ -6909,7 +6863,7 @@ msgstr ""
 msgid "Select the default execution environment for this organization."
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:196
+#: screens/Project/shared/ProjectForm.jsx:197
 msgid "Select the default execution environment for this project."
 msgstr ""
 
@@ -6936,7 +6890,7 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:334
+#: screens/Template/shared/JobTemplateForm.jsx:333
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
@@ -6972,7 +6926,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:120
+#: screens/Project/ProjectList/ProjectListItem.jsx:119
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7007,7 +6961,7 @@ msgid "Service account JSON file"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceForm.jsx:55
-#: screens/Project/shared/ProjectForm.jsx:96
+#: screens/Project/shared/ProjectForm.jsx:97
 msgid "Set a value for this field"
 msgstr ""
 
@@ -7076,7 +7030,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:136
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:314
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:223
-#: screens/Template/shared/JobTemplateForm.jsx:472
+#: screens/Template/shared/JobTemplateForm.jsx:471
 msgid "Show Changes"
 msgstr ""
 
@@ -7147,9 +7101,9 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:310
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
-#: screens/Template/shared/JobTemplateForm.jsx:511
+#: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
 msgstr ""
 
@@ -7162,7 +7116,7 @@ msgstr ""
 #~ "of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:514
+#: screens/Template/shared/JobTemplateForm.jsx:513
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7242,10 +7196,8 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Job/JobDetail/JobDetail.jsx:215
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:137
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
 msgstr ""
@@ -7255,41 +7207,41 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
 
-#: screens/Project/shared/ProjectForm.jsx:210
+#: screens/Project/shared/ProjectForm.jsx:211
 msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:120
+#: components/Lookup/ProjectLookup.jsx:121
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:184
+#: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:78
+#: screens/Job/JobDetail/JobDetail.jsx:93
 msgid "Source Control Update"
 msgstr ""
 
@@ -7301,8 +7253,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:170
-#: screens/Job/JobDetail/JobDetail.jsx:148
+#: components/JobList/JobListItem.jsx:154
+#: screens/Job/JobDetail/JobDetail.jsx:163
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7337,6 +7289,12 @@ msgid ""
 "Specify HTTP Headers in JSON format. Refer to\n"
 "the Ansible Tower documentation for example syntax."
 msgstr ""
+
+#: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:478
+#~ msgid ""
+#~ "Specify HTTP Headers in JSON format. Refer to\n"
+#~ "the documentation for example syntax."
+#~ msgstr ""
 
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:392
 msgid ""
@@ -7375,8 +7333,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:224
-#: components/JobList/JobListItem.jsx:83
+#: components/JobList/JobList.jsx:220
+#: components/JobList/JobListItem.jsx:81
 msgid "Start Time"
 msgstr ""
 
@@ -7394,32 +7352,32 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:122
+#: screens/Job/JobDetail/JobDetail.jsx:137
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:79
+#: components/JobList/JobList.jsx:197
+#: components/JobList/JobList.jsx:218
+#: components/JobList/JobListItem.jsx:77
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:112
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:140
+#: screens/Project/ProjectList/ProjectListItem.jsx:139
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7482,7 +7440,7 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.jsx:114
+#: components/Lookup/ProjectLookup.jsx:115
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
 #: screens/Project/ProjectList/ProjectList.jsx:151
@@ -7506,13 +7464,13 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:208
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:167
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7552,14 +7510,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:173
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7578,7 +7536,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:160
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "Sync for revision"
 msgstr ""
 
@@ -7632,7 +7590,7 @@ msgstr ""
 #~ "the usage of tags."
 #~ msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:498
+#: screens/Template/shared/JobTemplateForm.jsx:497
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7670,7 +7628,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Task Count"
 msgstr ""
 
@@ -7678,7 +7636,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 msgid "Tasks"
 msgstr ""
 
@@ -7796,7 +7754,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:466
+#: screens/Template/shared/JobTemplateForm.jsx:465
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -7824,7 +7782,7 @@ msgid ""
 "documentation for more details."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:404
+#: screens/Template/shared/JobTemplateForm.jsx:403
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -7884,7 +7842,7 @@ msgstr ""
 msgid "There was a problem logging in. Please try again."
 msgstr ""
 
-#: screens/Login/Login.jsx:120
+#: screens/Login/Login.jsx:130
 #~ msgid "There was a problem signing in. Please try again."
 #~ msgstr ""
 
@@ -7958,12 +7916,19 @@ msgstr ""
 msgid "This credential type is currently being used by some credentials and cannot be deleted"
 msgstr ""
 
+#: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and help\n"
+#~ "streamline customer experience and success."
+#~ msgstr ""
+
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-msgid ""
-"This data is used to enhance\n"
-"future releases of the Software and to provide\n"
-"Red Hat Insights for Ansible."
-msgstr ""
+#~ msgid ""
+#~ "This data is used to enhance\n"
+#~ "future releases of the Software and to provide\n"
+#~ "Insights Analytics to subscribers."
+#~ msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:73
 msgid ""
@@ -7973,13 +7938,13 @@ msgid ""
 msgstr ""
 
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.jsx:85
-#~ msgid ""
-#~ "This data is used to enhance\n"
-#~ "future releases of the Tower Software and to provide\n"
-#~ "Insights Analytics to Tower subscribers."
-#~ msgstr ""
+msgid ""
+"This data is used to enhance\n"
+"future releases of the Tower Software and to provide\n"
+"Insights Analytics to Tower subscribers."
+msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:135
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:136
 msgid "This execution environment is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8080,7 +8045,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8119,7 +8084,7 @@ msgstr ""
 msgid "This workflow does not have any nodes configured."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:255
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:247
 msgid "This workflow job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8158,7 +8123,7 @@ msgid ""
 "inventory sync will be performed."
 msgstr ""
 
-#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:17
+#: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:16
 msgid "Timed out"
 msgstr ""
 
@@ -8167,7 +8132,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:115
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:222
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:169
-#: screens/Template/shared/JobTemplateForm.jsx:465
+#: screens/Template/shared/JobTemplateForm.jsx:464
 msgid "Timeout"
 msgstr ""
 
@@ -8279,7 +8244,7 @@ msgid "Total Nodes"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:74
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:174
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:95
 msgid "Total jobs"
 msgstr ""
 
@@ -8288,7 +8253,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8321,9 +8286,9 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:223
-#: components/JobList/JobListItem.jsx:82
-#: components/Lookup/ProjectLookup.jsx:109
+#: components/JobList/JobList.jsx:219
+#: components/JobList/JobListItem.jsx:80
+#: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
 #: components/PromptDetail/PromptDetail.jsx:112
@@ -8343,12 +8308,12 @@ msgstr ""
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:55
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.jsx:239
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:68
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:159
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:80
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8356,7 +8321,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:152
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8369,7 +8334,7 @@ msgstr ""
 
 #: screens/Credential/shared/TypeInputsSubForm.jsx:25
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.jsx:44
-#: screens/Project/shared/ProjectForm.jsx:242
+#: screens/Project/shared/ProjectForm.jsx:243
 msgid "Type Details"
 msgstr ""
 
@@ -8379,7 +8344,7 @@ msgstr ""
 
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:84
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:48
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:111
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:57
 msgid "Unavailable"
 msgstr ""
 
@@ -8393,15 +8358,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8414,7 +8379,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -8483,10 +8448,14 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr ""
 
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:72
+#~ msgid "Use custom messages to change the content of notifications sent when a job starts, succeeds, or fails. Use curly braces to access information about the job:"
+#~ msgstr ""
+
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:75
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:83
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:44
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:107
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:53
 msgid "Used capacity"
 msgstr ""
 
@@ -8598,11 +8567,11 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:347
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:218
-#: screens/Template/shared/JobTemplateForm.jsx:388
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:233
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
+#: screens/Template/shared/JobTemplateForm.jsx:387
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:232
 msgid "Variables"
 msgstr ""
 
@@ -8630,9 +8599,9 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:222
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
-#: screens/Template/shared/JobTemplateForm.jsx:438
+#: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
 msgstr ""
 
@@ -8902,7 +8871,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:202
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -8936,14 +8905,14 @@ msgstr ""
 msgid "Webhook Credential"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:177
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
 msgid "Webhook Credentials"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:153
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:78
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:246
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:173
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:165
 #: screens/Template/shared/WebhookSubForm.jsx:179
 msgid "Webhook Key"
 msgstr ""
@@ -8951,7 +8920,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:146
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:77
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:236
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:164
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:156
 #: screens/Template/shared/WebhookSubForm.jsx:131
 msgid "Webhook Service"
 msgstr ""
@@ -8959,14 +8928,14 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:149
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:81
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:242
-#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:169
+#: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:161
 #: screens/Template/shared/WebhookSubForm.jsx:163
 #: screens/Template/shared/WebhookSubForm.jsx:173
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:630
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:269
+#: screens/Template/shared/JobTemplateForm.jsx:629
+#: screens/Template/shared/WorkflowJobTemplateForm.jsx:268
 msgid "Webhook details"
 msgstr ""
 
@@ -9003,7 +8972,7 @@ msgstr ""
 msgid "Welcome to Ansible {brandName}!"
 msgstr ""
 
-#: screens/Login/Login.jsx:142
+#: screens/Login/Login.jsx:152
 #~ msgid "Welcome to Ansible {brandName}! Please Sign In."
 #~ msgstr ""
 
@@ -9050,18 +9019,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
-#: components/JobList/JobListItem.jsx:38
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:83
+#: screens/Job/JobDetail/JobDetail.jsx:98
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:158
+#: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:136
+#: screens/Job/JobDetail/JobDetail.jsx:151
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9214,18 +9183,18 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:728
+#: screens/Template/shared/JobTemplateForm.jsx:726
 #: screens/Template/shared/WebhookSubForm.jsx:152
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:725
+#: screens/Template/shared/JobTemplateForm.jsx:723
 #: screens/Template/shared/WebhookSubForm.jsx:142
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Host/HostGroups/HostGroupItem.jsx:45
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:214
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:108
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.jsx:68
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.jsx:58
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.jsx:35
@@ -9251,10 +9220,6 @@ msgstr ""
 msgid "cancel delete"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:180
-msgid "capacity adjustment"
-msgstr ""
-
 #: components/AdHocCommands/AdHocDetailsStep.jsx:240
 msgid "command"
 msgstr ""
@@ -9274,7 +9239,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:158
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9296,14 +9261,14 @@ msgid "documentation"
 msgstr ""
 
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:105
-#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:120
+#: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx:121
 #: screens/Host/HostDetail/HostDetail.jsx:109
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.jsx:93
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:106
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"
@@ -9342,25 +9307,31 @@ msgstr ""
 msgid "hosts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:166
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:87
 msgid "instance counts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:207
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:101
 msgid "instance group used capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:155
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:76
 msgid "instance host name"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:158
+#: screens/InstanceGroup/Instances/InstanceListItem.jsx:79
 msgid "instance type"
 msgstr ""
 
 #: components/Lookup/HostListItem.jsx:30
 msgid "inventory"
 msgstr ""
+
+#: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.jsx:51
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.jsx:59
+#: screens/Job/JobDetail/JobDetail.jsx:119
+#~ msgid "isolated instance"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:23
 msgid "items"
@@ -9401,6 +9372,10 @@ msgstr ""
 #: components/AdHocCommands/AdHocDetailsStep.jsx:238
 msgid "option to the"
 msgstr ""
+
+#: screens/NotificationTemplate/shared/CustomMessagesSubForm.jsx:84
+#~ msgid "or attributes of the job such as"
+#~ msgstr ""
 
 #: components/Pagination/Pagination.jsx:24
 msgid "page"
@@ -9455,11 +9430,6 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.jsx:320
-#: screens/Template/shared/WorkflowJobTemplateForm.jsx:193
-msgid "source control branch"
-msgstr ""
-
 #: screens/ActivityStream/ActivityStreamListItem.jsx:30
 msgid "system"
 msgstr ""
@@ -9504,7 +9474,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:249
+#: components/JobList/JobList.jsx:245
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
@@ -9532,17 +9502,13 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
-
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-#~ msgstr ""
+msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
@@ -9594,10 +9560,6 @@ msgstr ""
 
 #: components/DetailList/UserDateDetail.jsx:23
 msgid "{dateStr} by <0>{username}</0>"
-msgstr ""
-
-#: screens/InstanceGroup/Instances/InstanceListItem.jsx:187
-msgid "{forks, plural, one {# fork} other {# forks}}"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:192

--- a/awx/ui_next/src/screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx
+++ b/awx/ui_next/src/screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { t } from '@lingui/macro';
 import { Label, Tooltip } from '@patternfly/react-core';
 import { CheckIcon, InfoCircleIcon } from '@patternfly/react-icons';
@@ -24,9 +23,15 @@ function WorkflowApprovalStatus({ workflowApproval }) {
   if (workflowApproval.status === 'failed' && workflowApproval.failed) {
     return (
       <Tooltip
-        content={t`Denied by ${
-          workflowApproval.summary_fields.approved_or_denied_by.username
-        } - ${formatDateString(workflowApproval.finished)}`}
+        content={
+          workflowApproval.summary_fields?.approved_or_denied_by?.username
+            ? t`Denied by ${
+                workflowApproval.summary_fields.approved_or_denied_by.username
+              } - ${formatDateString(workflowApproval.finished)}`
+            : t`Denied - ${formatDateString(
+                workflowApproval.finished
+              )}.  See the Activity Stream for more information.`
+        }
         position="top"
       >
         <Label variant="outline" color="red" icon={<InfoCircleIcon />}>
@@ -39,9 +44,15 @@ function WorkflowApprovalStatus({ workflowApproval }) {
   if (workflowApproval.status === 'successful') {
     return (
       <Tooltip
-        content={t`Approved by ${
-          workflowApproval.summary_fields.approved_or_denied_by.username
-        } - ${formatDateString(workflowApproval.finished)}`}
+        content={
+          workflowApproval.summary_fields?.approved_or_denied_by?.username
+            ? t`Approved by ${
+                workflowApproval.summary_fields.approved_or_denied_by.username
+              } - ${formatDateString(workflowApproval.finished)}`
+            : t`Approved - ${formatDateString(
+                workflowApproval.finished
+              )}.  See the Activity Stream for more information.`
+        }
         position="top"
       >
         <Label variant="outline" color="green" icon={<CheckIcon />}>


### PR DESCRIPTION
##### SUMMARY
link #9163 

The tooltip on the status labels for completed workflow approvals attempts to show the username of the user that acted on it.  If that user has been deleted then the key is not present in the object.  This would cause the page to crash.

To fix this, I conditionally show a different string when the username is not available.  If a user wants to see which deleted user acted on the approval they'll have to go to the activity stream.

<img width="474" alt="Screen Shot 2021-04-22 at 9 59 23 AM" src="https://user-images.githubusercontent.com/9889020/115727254-6eb58380-a351-11eb-96e4-85d38213ab85.png">

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
