### PR TITLE
Wait for the database migrations before starting

### DIFF
--- a/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
@@ -13,4 +13,6 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
+wait-for-migrations
+
 supervisord -c /etc/supervisord_task.conf


### PR DESCRIPTION
cc: @shanemcd  @Spredzy 

##### SUMMARY
Before starting the `tower-task` container, we should wait for the database schema migrations to complete to avoid misleading users. 

This is much more evident on newer installations as the `tower-task` container will be noisy and populated with `SQL` errors which is a false positive due to the database being populated. 

See the https://github.com/ansible/awx-operator/issues/238 for more information


Fixes: https://github.com/ansible/awx-operator/issues/238

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

