### PR TITLE
Add ouiaId to toolbar delete button

### DIFF
--- a/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
@@ -225,7 +225,7 @@ function ToolbarDeleteButton({
             key="add"
             isDisabled={isDisabled}
             isLoading={isLoading}
-            ouiaId="kebab-deleteButton"
+            ouiaId="deleteButton"
             spinnerAriaValueText={isLoading ? 'Loading' : undefined}
             component="button"
             onClick={() => {
@@ -241,7 +241,7 @@ function ToolbarDeleteButton({
             <Button
               variant="secondary"
               isLoading={isLoading}
-              ouiaId="kebab-deleteButton"
+              ouiaId="deleteButton"
               spinnerAriaValueText={isLoading ? 'Loading' : undefined}
               aria-label={t`Delete`}
               onClick={() => toggleModal(true)}

--- a/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
@@ -225,6 +225,7 @@ function ToolbarDeleteButton({
             key="add"
             isDisabled={isDisabled}
             isLoading={isLoading}
+            ouiaId="kebab-deleteButton"
             spinnerAriaValueText={isLoading ? 'Loading' : undefined}
             component="button"
             onClick={() => {
@@ -240,6 +241,7 @@ function ToolbarDeleteButton({
             <Button
               variant="secondary"
               isLoading={isLoading}
+              ouiaId="kebab-deleteButton"
               spinnerAriaValueText={isLoading ? 'Loading' : undefined}
               aria-label={t`Delete`}
               onClick={() => toggleModal(true)}

--- a/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
+++ b/awx/ui_next/src/components/PaginatedDataList/ToolbarDeleteButton.jsx
@@ -225,7 +225,7 @@ function ToolbarDeleteButton({
             key="add"
             isDisabled={isDisabled}
             isLoading={isLoading}
-            ouiaId="deleteButton"
+            ouiaId="delete-button"
             spinnerAriaValueText={isLoading ? 'Loading' : undefined}
             component="button"
             onClick={() => {
@@ -241,7 +241,7 @@ function ToolbarDeleteButton({
             <Button
               variant="secondary"
               isLoading={isLoading}
-              ouiaId="deleteButton"
+              ouiaId="delete-button"
               spinnerAriaValueText={isLoading ? 'Loading' : undefined}
               aria-label={t`Delete`}
               onClick={() => toggleModal(true)}

--- a/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryDetail/InventoryDetail.test.jsx
@@ -92,11 +92,11 @@ describe('<InventoryDetail />', () => {
     expectDetailToMatch(wrapper, 'Type', 'Inventory');
     const org = wrapper.find('Detail[label="Organization"]');
     expect(org.prop('value')).toMatchInlineSnapshot(`
-      <Link
+      <ForwardRef
         to="/organizations/1/details"
       >
         The Organization
-      </Link>
+      </ForwardRef>
     `);
     const vars = wrapper.find('VariablesDetail');
     expect(vars).toHaveLength(1);


### PR DESCRIPTION
In fixing UI tests, I came across an element that was missing testability. I added specific ouiaIds to this element, to override the automatically generated ones. This will make testability much easier for QE.

![image](https://user-images.githubusercontent.com/63685497/116284508-2801c800-a75b-11eb-93fc-9e2e5d183f13.png)
