### PR TITLE
Fix warning thrown about CodeDetail rows prop

### DIFF
--- a/awx/ui_next/src/components/DetailList/CodeDetail.jsx
+++ b/awx/ui_next/src/components/DetailList/CodeDetail.jsx
@@ -60,7 +60,7 @@ CodeDetail.propTypes = {
   label: node.isRequired,
   dataCy: string,
   helpText: string,
-  rows: oneOfType(number, string),
+  rows: oneOfType([number, string]),
   mode: oneOf(['javascript', 'yaml', 'jinja2']).isRequired,
 };
 CodeDetail.defaultProps = {


### PR DESCRIPTION
##### SUMMARY
Warning: 

```
  ● Console

    console.error
      Warning: Invalid argument supplied to oneOfType, expected an instance of array.

      61 |   dataCy: string,
      62 |   helpText: string,
    > 63 |   rows: oneOfType(number, string),
         |         ^
      64 |   mode: oneOf(['javascript', 'yaml', 'jinja2']).isRequired,
      65 | };
      66 | CodeDetail.defaultProps = {

      at printWarning (node_modules/prop-types/factoryWithTypeCheckers.js:23:15)
      at createUnionTypeChecker (node_modules/prop-types/factoryWithTypeCheckers.js:365:47)
      at Object.<anonymous> (src/components/DetailList/CodeDetail.jsx:63:9)
      at Object.<anonymous> (src/screens/Setting/shared/SettingDetail.jsx:5:1)
```