### PR TITLE
Make Workflow Surveys Idempotent

### DIFF
--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -809,7 +809,7 @@ def main():
         existing_spec = None
         if existing_item:
             spec_endpoint = existing_item.get('related', {}).get('survey_spec')
-            existing_spec = module.get_endpoint(spec_endpoint)
+            existing_spec = module.get_endpoint(spec_endpoint)['json']
         if new_spec != existing_spec:
             module.json_output['changed'] = True
             if existing_item and module.has_encrypted_values(existing_spec):

--- a/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
@@ -300,6 +300,124 @@
     that:
       - "result is changed"
 
+- name: Add Survey to Copied workflow job template
+  tower_workflow_job_template:
+    name: "copy_{{ wfjt_name }}"
+    organization: Default
+    survey_spec:
+      name: Basic Survey
+      description: Basic Survey
+      spec:
+        - question_description: Name
+          min: 0
+          default: ''
+          max: 128
+          required: true
+          choices: ''
+          new_question: true
+          variable: basic_name
+          question_name: Basic Name
+          type: text
+        - question_description: Choosing yes or no.
+          min: 0
+          default: 'yes'
+          max: 0
+          required: true
+          choices: |-
+            yes
+            no
+          new_question: true
+          variable: option_true_false
+          question_name: Choose yes or no?
+          type: multiplechoice
+        - question_description: ''
+          min: 0
+          default: ''
+          max: 0
+          required: true
+          choices: |-
+            group1
+            group2
+            group3
+          new_question: true
+          variable: target_groups
+          question_name: 'Select Group:'
+          type: multiselect
+        - question_name: password
+          question_description: ''
+          required: true
+          type: password
+          variable: password
+          min: 0
+          max: 1024
+          default: ''
+          choices: ''
+          new_question: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Re add survey to workflow job template expected not changed.
+  tower_workflow_job_template:
+    name: "copy_{{ wfjt_name }}"
+    organization: Default
+    survey_spec:
+      name: Basic Survey
+      description: Basic Survey
+      spec:
+        - question_description: Name
+          min: 0
+          default: ''
+          max: 128
+          required: true
+          choices: ''
+          new_question: true
+          variable: basic_name
+          question_name: Basic Name
+          type: text
+        - question_description: Choosing yes or no.
+          min: 0
+          default: 'yes'
+          max: 0
+          required: true
+          choices: |-
+            yes
+            no
+          new_question: true
+          variable: option_true_false
+          question_name: Choose yes or no?
+          type: multiplechoice
+        - question_description: ''
+          min: 0
+          default: ''
+          max: 0
+          required: true
+          choices: |-
+            group1
+            group2
+            group3
+          new_question: true
+          variable: target_groups
+          question_name: 'Select Group:'
+          type: multiselect
+        - question_name: password
+          question_description: ''
+          required: true
+          type: password
+          variable: password
+          min: 0
+          max: 1024
+          default: ''
+          choices: ''
+          new_question: true
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
 - name: Delete copied workflow job template
   tower_workflow_job_template:
     name: "copy_{{ wfjt_name }}"


### PR DESCRIPTION
##### SUMMARY
Update the Workflow survey check to be in line with job template check. 
Resolving issue #7554
Found that it was returning json/status_code, and needed to reference json output.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
awx_collection

##### AWX VERSION
```
19.0.0
```