### PR TITLE
add org search to labels

### DIFF
--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -544,13 +544,8 @@ def main():
     if labels is not None:
         association_fields['labels'] = []
         for item in labels:
-            association_fields['labels'].append(module.resolve_name_to_id('labels', item))
-    # Code to use once Issue #7567 is resolved
-    #            search_fields = {'name': item}
-    #            if organization:
-    #                search_fields['organization'] = organization_id
-    #            label_id = module.get_one('labels', **{'data': search_fields})
-    #            association_fields['labels'].append(label_id)
+            label_id = module.get_one('labels', name_or_id=item, **{'data': search_fields})
+            association_fields['labels'].append(label_id['id'])
 
     notifications_start = module.params.get('notification_templates_started')
     if notifications_start is not None:

--- a/awx_collection/plugins/modules/tower_workflow_job_template.py
+++ b/awx_collection/plugins/modules/tower_workflow_job_template.py
@@ -795,13 +795,8 @@ def main():
     if labels is not None:
         association_fields['labels'] = []
         for item in labels:
-            association_fields['labels'].append(module.resolve_name_to_id('labels', item))
-    # Code to use once Issue #7567 is resolved
-    #            search_fields = {'name': item}
-    #            if organization:
-    #                search_fields['organization'] = organization_id
-    #            label_id = module.get_one('labels', **{'data': search_fields})
-    #            association_fields['labels'].append(label_id)
+            label_id = module.get_one('labels', name_or_id=item, **{'data': search_fields})
+            association_fields['labels'].append(label_id['id'])
 
     on_change = None
     new_spec = module.params.get('survey_spec')

--- a/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_template/tasks/main.yml
@@ -5,6 +5,7 @@
 
 - name: generate random string for project
   set_fact:
+    org_name: "AWX-Collection-tests-tower_organization-org-{{ test_id }}"
     cred1: "AWX-Collection-tests-tower_job_template-cred1-{{ test_id }}"
     cred2: "AWX-Collection-tests-tower_job_template-cred2-{{ test_id }}"
     cred3: "AWX-Collection-tests-tower_job_template-cred3-{{ test_id }}"
@@ -15,6 +16,13 @@
     email_not: "AWX-Collection-tests-tower_job_template-email-not-{{ test_id }}"
     webhook_not: "AWX-Collection-tests-tower_notification_template-wehbook-not-{{ test_id }}"
     group_name1: "AWX-Collection-tests-tower_instance_group-group1-{{ test_id }}"
+
+- name: "Create a new organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    galaxy_credentials:
+      - Ansible Galaxy
+  register: result
 
 - name: Create a Demo Project
   tower_project:
@@ -44,10 +52,13 @@
     organization: Default
     kind: ssh
 
-- name: Create Label
+- name: Create Labels
   tower_label:
     name: "{{ lab1 }}"
-    organization: Default
+    organization: "{{ item }}"
+  loop:
+    - Default
+    - "{{ org_name }}"
 
 - name: Create an Instance Group
   tower_instance_group:
@@ -202,6 +213,7 @@
 - name: Create Job Template 2
   tower_job_template:
     name: "{{ jt2 }}"
+    organization: Default
     project: "{{ proj1 }}"
     inventory: Demo Inventory
     playbook: hello_world.yml
@@ -409,3 +421,9 @@
     name: "{{ webhook_not }}"
     organization: Default
     state: absent
+
+- name: "Remove the organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result

--- a/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_workflow_job_template/tasks/main.yml
@@ -5,6 +5,7 @@
 
 - name: Generate random names for test objects
   set_fact:
+    org_name: "AWX-Collection-tests-tower_organization-org-{{ test_id }}"
     scm_cred_name: "AWX-Collection-tests-tower_workflow_job_template-scm-cred-{{ test_id }}"
     demo_project_name: "AWX-Collection-tests-tower_workflow_job_template-proj-{{ test_id }}"
     jt1_name: "AWX-Collection-tests-tower_workflow_job_template-jt1-{{ test_id }}"
@@ -16,6 +17,13 @@
     webhook_not: "AWX-Collection-tests-tower_notification_template-wehbook-not-{{ test_id }}"
     project_inv: "AWX-Collection-tests-tower_inventory_source-inv-project-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
     project_inv_source: "AWX-Collection-tests-tower_inventory_source-inv-source-project-{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+- name: "Create a new organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    galaxy_credentials:
+      - Ansible Galaxy
+  register: result
 
 - name: Create an SCM Credential
   tower_credential:
@@ -55,10 +63,13 @@
     state: present
   register: result
 
-- name: Create Label
+- name: Create Labels
   tower_label:
     name: "{{ lab1 }}"
-    organization: Default
+    organization: "{{ item }}"
+  loop:
+    - Default
+    - "{{ org_name }}"
 
 - name: Create a Demo Project
   tower_project:
@@ -126,6 +137,7 @@
 - name: Add a Survey to second Job Template
   tower_job_template:
     name: "{{ jt2_name }}"
+    organization: Default
     project: "{{ demo_project_name }}"
     inventory: Demo Inventory
     playbook: hello_world.yml
@@ -142,6 +154,7 @@
 - name: Create a workflow job template
   tower_workflow_job_template:
     name: "{{ wfjt_name }}"
+    organization: Default
     inventory: Demo Inventory
     extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
     labels:
@@ -652,3 +665,9 @@
     name: "{{ webhook_not }}"
     organization: Default
     state: absent
+
+- name: "Remove the organization"
+  tower_organization:
+    name: "{{ org_name }}"
+    state: absent
+  register: result


### PR DESCRIPTION
##### SUMMARY
After having an issue with labels I saw that orgs were referenced, Remembering #7567 implemented the code to do the search for orgs so you can search for labels within an org, Tests include creating the same named label in two orgs, and the search not erroring out that it found two labels of that name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - awx_collection


##### AWX VERSION
```
19.0.0
```
