### PR TITLE
Intentionally drop job event websocket messages in excess of 30 per second (configurable)

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -345,6 +345,17 @@ register(
 )
 
 register(
+    'MAX_WEBSOCKET_EVENT_RATE',
+    field_class=fields.IntegerField,
+    min_value=0,
+    default=30,
+    label=_('Job Event Maximum Websocket Messages Per Second'),
+    help_text=_('Maximum number of messages to update the UI live job output with per second. Value of 0 means no limit.'),
+    category=_('Jobs'),
+    category_slug='jobs',
+)
+
+register(
     'SCHEDULE_MAX_JOBS',
     field_class=fields.IntegerField,
     min_value=1,

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -41,6 +41,7 @@ STANDARD_INVENTORY_UPDATE_ENV = {
 }
 CAN_CANCEL = ('new', 'pending', 'waiting', 'running')
 ACTIVE_STATES = CAN_CANCEL
+MINIMAL_EVENTS = set(['playbook_on_play_start', 'playbook_on_task_start', 'playbook_on_stats', 'EOF'])
 CENSOR_VALUE = '************'
 ENV_BLOCKLIST = frozenset(
     (

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -142,7 +142,8 @@ class CallbackBrokerWorker(BaseWorker):
                             logger.exception('Database Error Saving Job Event')
                 duration_to_save = time.perf_counter() - duration_to_save
                 for e in events:
-                    emit_event_detail(e)
+                    if not e.event_data.get('skip_websocket_message', False):
+                        emit_event_detail(e)
             self.buff = {}
             self.last_flush = time.time()
             # only update metrics if we saved events

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -142,7 +142,7 @@ class CallbackBrokerWorker(BaseWorker):
                             logger.exception('Database Error Saving Job Event')
                 duration_to_save = time.perf_counter() - duration_to_save
                 for e in events:
-                    if not e.event_data.get('skip_websocket_message', False):
+                    if not getattr(e, '_skip_websocket_message', False):
                         emit_event_detail(e)
             self.buff = {}
             self.last_flush = time.time()
@@ -208,7 +208,13 @@ class CallbackBrokerWorker(BaseWorker):
                         GuidMiddleware.set_guid('')
                     return
 
+                skip_websocket_message = body.pop('skip_websocket_message', False)
+
                 event = cls.create_from_data(**body)
+
+                if skip_websocket_message:
+                    event._skip_websocket_message = True
+
                 self.buff.setdefault(cls, []).append(event)
 
             retries = 0

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -17,6 +17,7 @@ from awx.api.versioning import reverse
 from awx.main import consumers
 from awx.main.managers import DeferJobCreatedManager
 from awx.main.fields import JSONField
+from awx.main.constants import MINIMAL_EVENTS
 from awx.main.models.base import CreatedModifiedModel
 from awx.main.utils import ignore_inventory_computed_fields, camelcase_to_underscore
 
@@ -55,9 +56,6 @@ def create_host_status_counts(event_data):
         host_status_counts[value] += 1
 
     return dict(host_status_counts)
-
-
-MINIMAL_EVENTS = set(['playbook_on_play_start', 'playbook_on_task_start', 'playbook_on_stats', 'EOF'])
 
 
 def emit_event_detail(event):

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -2,7 +2,8 @@
 
 import datetime
 import logging
-from collections import defaultdict
+from collections import defaultdict, deque
+import time
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -59,10 +60,33 @@ def create_host_status_counts(event_data):
 
 MINIMAL_EVENTS = set(['playbook_on_play_start', 'playbook_on_task_start', 'playbook_on_stats', 'EOF'])
 
+MAX_WEBSOCKET_EVENT_RATE = 30
+
+# TODO: these should be job-specific, this is the easy part, that is the hard part
+emit_times = deque(maxlen=MAX_WEBSOCKET_EVENT_RATE)
+
 
 def emit_event_detail(event):
+
+    # websocket rate limiting logic
     if settings.UI_LIVE_UPDATES_ENABLED is False and event.event not in MINIMAL_EVENTS:
         return
+    cpu_time = time.time()
+    if emit_times:
+        first_window_time = emit_times[0]
+        inverse_effective_rate = cpu_time - first_window_time
+        if inverse_effective_rate < 1.0:
+            if emit_times[0] != emit_times[-1]:
+                logger.info('Too many events chief, not broadcasting because that would be crazy')
+                # this is to smooth out jumpiness, we clear the events except for the last one
+                # that will enforce that we wait a full second before starting again
+                emit_times.clear()
+                emit_times.append(first_window_time)
+            return
+        elif emit_times[0] == emit_times[-1]:
+            logger.info('Starting a window of emit emission, will pause if I see too many')
+    emit_times.append(cpu_time)
+
     cls = event.__class__
     relation = {
         JobEvent: 'job_id',

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1174,17 +1174,6 @@ class BaseTask(object):
                     ]
                 )
 
-            logger.debug(
-                'Job {} event {} websocket send {}, queued: {}, rate - avg: {:.3f}, last: {:.3f}'.format(
-                    self.instance.id,
-                    event_data.get('counter', 0),
-                    should_emit,
-                    len(self.recent_event_timings),
-                    30.0 / (cpu_time - first_window_time),
-                    1.0 / (cpu_time - last_window_time),
-                )
-            )
-
             if should_emit:
                 self.recent_event_timings.append(cpu_time)
             else:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1160,7 +1160,9 @@ class BaseTask(object):
             # if last 30 events came in under 1 second ago
             if inverse_effective_rate < 1.0:
                 if self.recent_event_timings[0] != self.recent_event_timings[-1]:
-                    logger.info('Too many events chief, not broadcasting because that would be crazy')
+                    logger.info(
+                        'Too many events, skipping websocket {} broadcast for {} seconds'.format(self.instance.log_format, 1.0 - inverse_effective_rate)
+                    )
                     # this is to smooth out jumpiness, we clear the events except for the last one
                     # that will enforce that we wait a full second before starting again
                     self.recent_event_timings.clear()
@@ -1169,7 +1171,7 @@ class BaseTask(object):
                 event_data['event_data']['skip_websocket_message'] = True
             else:
                 if self.recent_event_timings[0] == self.recent_event_timings[-1]:
-                    logger.info('Starting a window of event emission, will pause if I see too many')
+                    logger.debug('Starting a window of event emission')
                 self.recent_event_timings.append(cpu_time)
         elif self.recent_event_timings.maxlen:
             self.recent_event_timings.append(time.time())

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1189,7 +1189,7 @@ class BaseTask(object):
                 self.recent_event_timings.append(cpu_time)
             else:
                 event_data.setdefault('event_data', {})
-                event_data['event_data']['skip_websocket_message'] = True
+                event_data['skip_websocket_message'] = True
 
         elif self.recent_event_timings.maxlen:
             self.recent_event_timings.append(time.time())

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1160,7 +1160,7 @@ class BaseTask(object):
 
             if event_data.get('event') in MINIMAL_EVENTS:
                 should_emit = True  # always send some types like playbook_on_stats
-            if event_data.get('stdout') == '' and event_data['start_line'] == event_data['end_line']:
+            elif event_data.get('stdout') == '' and event_data['start_line'] == event_data['end_line']:
                 should_emit = False  # exclude events with no output
             else:
                 should_emit = any(

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1169,7 +1169,8 @@ class BaseTask(object):
                     # that will enforce that we wait a full second before starting again
                     self.recent_event_timings.clear()
                     self.recent_event_timings.append(first_window_time)
-                event_data['skip_websocket_message'] = True
+                event_data.setdefault('event_data', {})
+                event_data['event_data']['skip_websocket_message'] = True
             else:
                 if self.recent_event_timings[0] == self.recent_event_timings[-1]:
                     logger.info('Starting a window of event emission, will pause if I see too many')

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1169,7 +1169,7 @@ class BaseTask(object):
 
             logger.debug(
                 'Event {} websocket send {}, queue {}, avg rate {}, last rate {}'.format(
-                    event_data['counter'],
+                    event_data.get('counter', 0),
                     should_emit,
                     len(self.recent_event_timings),
                     30.0 / (cpu_time - first_window_time),

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1160,8 +1160,8 @@ class BaseTask(object):
             # if last 30 events came in under 1 second ago
             if inverse_effective_rate < 1.0:
                 if self.recent_event_timings[0] != self.recent_event_timings[-1]:
-                    logger.info(
-                        'Too many events, skipping websocket {} broadcast for {} seconds'.format(self.instance.log_format, 1.0 - inverse_effective_rate)
+                    logger.debug(
+                        'Too many events, skipping job {} websocket broadcast for {:.4f} seconds'.format(self.instance.id, 1.0 - inverse_effective_rate)
                     )
                     # this is to smooth out jumpiness, we clear the events except for the last one
                     # that will enforce that we wait a full second before starting again

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -197,8 +197,9 @@ UI_LIVE_UPDATES_ENABLED = True
 # beyond this limit and the value will be removed
 MAX_EVENT_RES_DATA = 700000
 
-# Note: This setting may be overridden by database settings.
+# Note: These settings may be overridden by database settings.
 EVENT_STDOUT_MAX_BYTES_DISPLAY = 1024
+MAX_WEBSOCKET_EVENT_RATE = 30
 
 # The amount of time before a stdout file is expired and removed locally
 # Note that this can be recreated if the stdout is downloaded

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -301,10 +301,10 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const isMounted = useIsMounted();
   const scrollTop = useRef(0);
   const scrollHeight = useRef(0);
-  const currentlyLoading = useRef([]);
   const history = useHistory();
   const [contentError, setContentError] = useState(null);
   const [cssMap, setCssMap] = useState({});
+  const [currentlyLoading, setCurrentlyLoading] = useState([]);
   const [hasContentLoading, setHasContentLoading] = useState(true);
   const [hostEvent, setHostEvent] = useState({});
   const [isHostModalOpen, setIsHostModalOpen] = useState(false);
@@ -359,7 +359,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     if (listRef.current?.recomputeRowHeights) {
       listRef.current.recomputeRowHeights();
     }
-  }, [cssMap, remoteRowCount]);
+  }, [currentlyLoading, cssMap, remoteRowCount]);
 
   useEffect(() => {
     if (jobStatus && !isJobRunning(jobStatus)) {
@@ -427,7 +427,9 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
 
     if (isMounted.current) {
       setHasContentLoading(true);
-      currentlyLoading.current = currentlyLoading.current.concat(loadRange);
+      setCurrentlyLoading(prevCurrentlyLoading =>
+        prevCurrentlyLoading.concat(loadRange)
+      );
     }
 
     try {
@@ -493,8 +495,8 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     } finally {
       if (isMounted.current) {
         setHasContentLoading(false);
-        currentlyLoading.current = currentlyLoading.current.filter(
-          n => !loadRange.includes(n)
+        setCurrentlyLoading(prevCurrentlyLoading =>
+          prevCurrentlyLoading.filter(n => !loadRange.includes(n))
         );
         loadRange.forEach(n => {
           cache.clear(n);
@@ -507,7 +509,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     if (results[index]) {
       return true;
     }
-    return currentlyLoading.current.includes(index);
+    return currentlyLoading.includes(index);
   };
 
   const handleHostEventClick = hostEventToOpen => {
@@ -575,7 +577,9 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     );
 
     if (isMounted.current) {
-      currentlyLoading.current = currentlyLoading.current.concat(loadRange);
+      setCurrentlyLoading(prevCurrentlyLoading =>
+        prevCurrentlyLoading.concat(loadRange)
+      );
     }
 
     const params = {
@@ -602,8 +606,8 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
             ...prevCssMap,
             ...newResultsCssMap,
           }));
-          currentlyLoading.current = currentlyLoading.current.filter(
-            n => !loadRange.includes(n)
+          setCurrentlyLoading(prevCurrentlyLoading =>
+            prevCurrentlyLoading.filter(n => !loadRange.includes(n))
           );
           loadRange.forEach(n => {
             cache.clear(n);

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -183,11 +183,6 @@ const OutputWrapper = styled.div`
     Object.keys(cssMap).map(className => `.${className}{${cssMap[className]}}`)}
 `;
 
-const ListWrapper = styled(List)`
-  ${({ isFollowModeEnabled }) =>
-    isFollowModeEnabled ? `overflow: hidden !important;` : ''}
-`;
-
 const OutputFooter = styled.div`
   background-color: #ebebeb;
   border-right: 1px solid #d7d7d7;
@@ -315,7 +310,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [remoteRowCount, setRemoteRowCount] = useState(0);
   const [results, setResults] = useState({});
-  const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(false);
+  const [isFollowEnabled, setIsFollowModeEnabled] = useState(false);
 
   useEffect(() => {
     loadJobEvents();
@@ -610,7 +605,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   };
 
   const handleScrollLast = () => {
-    scrollToRow(remoteRowCount);
+    scrollToRow(remoteRowCount - 1);
   };
 
   const handleResize = ({ width }) => {
@@ -663,13 +658,25 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     history.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
-  const handleFollowToggle = () => setIsFollowModeEnabled(!isFollowModeEnabled);
+  const handleFollowToggle = () => {
+    if (isFollowEnabled) {
+      setIsFollowModeEnabled(false);
+    } else {
+      setIsFollowModeEnabled(true);
+      scrollToRow(remoteRowCount - 1);
+    }
+  };
+  const handleScroll = () => {
+    if (listRef?.current?.Grid?._renderedRowStopIndex < remoteRowCount - 1) {
+      setIsFollowModeEnabled(false);
+    }
+  };
 
   useEffect(() => {
-    if (isFollowModeEnabled) {
+    if (isFollowEnabled) {
       scrollToRow(remoteRowCount);
     }
-  }, [remoteRowCount, isFollowModeEnabled]);
+  }, [remoteRowCount, isFollowEnabled]);
 
   const renderSearchComponent = () => (
     <Search
@@ -778,8 +785,11 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
               </ToolbarItem>
             </ToolbarToggleGroup>
             {isJobRunning(job.status) ? (
-              <Button onClick={handleFollowToggle}>
-                {isFollowModeEnabled ? t`Unfollow` : t`Follow`}
+              <Button
+                variant={isFollowEnabled ? 'secondary' : 'primary'}
+                onClick={handleFollowToggle}
+              >
+                {isFollowEnabled ? t`Unfollow` : t`Follow`}
               </Button>
             ) : null}
           </SearchToolbarContent>
@@ -790,10 +800,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           onScrollNext={handleScrollNext}
           onScrollPrevious={handleScrollPrevious}
         />
-        <OutputWrapper
-          cssMap={cssMap}
-          isFollowModeEnabled={isFollowModeEnabled}
-        >
+        <OutputWrapper cssMap={cssMap} isFollowEnabled={isFollowEnabled}>
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
             loadMoreRows={loadMoreRows}
@@ -809,8 +816,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
                           <ContentLoading />
                         </div>
                       ) : (
-                        <ListWrapper
-                          isFollowModeEnabled={isFollowModeEnabled}
+                        <List
                           ref={ref => {
                             registerChild(ref);
                             listRef.current = ref;
@@ -824,6 +830,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
                           scrollToAlignment="start"
                           width={width || 1}
                           overscanRowCount={20}
+                          onScroll={handleScroll}
                         />
                       )}
                     </>

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -183,6 +183,11 @@ const OutputWrapper = styled.div`
     Object.keys(cssMap).map(className => `.${className}{${cssMap[className]}}`)}
 `;
 
+const ListWrapper = styled(List)`
+  ${({ isFollowModeEnabled }) =>
+    isFollowModeEnabled ? `overflow: hidden !important;` : ''}
+`;
+
 const OutputFooter = styled.div`
   background-color: #ebebeb;
   border-right: 1px solid #d7d7d7;
@@ -310,6 +315,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [remoteRowCount, setRemoteRowCount] = useState(0);
   const [results, setResults] = useState({});
+  const [isFollowModeEnabled, setIsFollowModeEnabled] = useState(false);
 
   useEffect(() => {
     loadJobEvents();
@@ -657,6 +663,14 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     history.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
+  const handleFollowToggle = () => setIsFollowModeEnabled(!isFollowModeEnabled);
+
+  useEffect(() => {
+    if (isFollowModeEnabled) {
+      scrollToRow(remoteRowCount);
+    }
+  }, [remoteRowCount, isFollowModeEnabled]);
+
   const renderSearchComponent = () => (
     <Search
       qsConfig={QS_CONFIG}
@@ -763,6 +777,11 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
                 )}
               </ToolbarItem>
             </ToolbarToggleGroup>
+            {isJobRunning(job.status) ? (
+              <Button onClick={handleFollowToggle}>
+                {isFollowModeEnabled ? t`Unfollow` : t`Follow`}
+              </Button>
+            ) : null}
           </SearchToolbarContent>
         </SearchToolbar>
         <PageControls
@@ -771,7 +790,10 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           onScrollNext={handleScrollNext}
           onScrollPrevious={handleScrollPrevious}
         />
-        <OutputWrapper cssMap={cssMap}>
+        <OutputWrapper
+          cssMap={cssMap}
+          isFollowModeEnabled={isFollowModeEnabled}
+        >
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
             loadMoreRows={loadMoreRows}
@@ -787,7 +809,8 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
                           <ContentLoading />
                         </div>
                       ) : (
-                        <List
+                        <ListWrapper
+                          isFollowModeEnabled={isFollowModeEnabled}
                           ref={ref => {
                             registerChild(ref);
                             listRef.current = ref;

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.jsx
@@ -359,7 +359,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     if (listRef.current?.recomputeRowHeights) {
       listRef.current.recomputeRowHeights();
     }
-  }, [currentlyLoading.current, cssMap, remoteRowCount]);
+  }, [cssMap, remoteRowCount]);
 
   useEffect(() => {
     if (jobStatus && !isJobRunning(jobStatus)) {
@@ -375,7 +375,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
         setTimeout(() => setIsFollowModeEnabled(false), 1000);
       }
     }
-  }, [jobStatus]);
+  }, [jobStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
     error: cancelError,


### PR DESCRIPTION
##### SUMMARY
The UI no longer follows the latest job events from websocket messages. Because of that, there's no reason to send messages for all events if the job event rate is high.

I used 30 because this is the number of events that I guesstimate will show in one page in the UI.

Needs the setting added in the UI.

This adds `skip_websocket_message` to event `event_data`. We could promote it to a top-level key for job events, if that is preferable aesthetically. Doing this allows us to test this feature without having to connect a websocket client. Ping @mabashian @chrismeyersfsu 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
 - UI


##### ADDITIONAL INFORMATION
Scenario walkthrough:

a job is producing 1,000 events per second. User launches it, the screen fills up in, say 1/4 of a second. The scrollbar indicates content beyond the bottom of the screen. Now, for 3/4ths of a second, the scrollbar stays still. After that, it updates the scrollbar to the current line number that the job is on. The scrollbar continues to update the length of the output effectively once per second.
