### PR TITLE
Have the project update playbook warn if role/collection syncing is disabled

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -156,6 +156,21 @@
   name: Install content with ansible-galaxy command if necessary
   tasks:
 
+    - name: Check content sync settings
+      debug:
+        msg: "Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization."
+      when: not roles_enabled|bool and not collections_enabled|bool
+      tags:
+        - install_roles
+        - install_collections
+
+    - name:
+      meta: end_play
+      when: not roles_enabled|bool and not collections_enabled|bool
+      tags:
+        - install_roles
+        - install_collections
+
     - block:
         - name: fetch galaxy roles from requirements.(yml/yaml)
           command: >


### PR DESCRIPTION

In recent AWX, a galaxy credential (even a blank one for galaxy.ansible.com) is required to sync role/collection content. This is done so that server precedence can be properly set, and so that it can be configured to pull only from a private content host.

This does lead to bug reports where the credentials are not set, and users don't understand why their content is not syncing. This makes that more clear.

![Screenshot from 2021-04-30 16-04-52](https://user-images.githubusercontent.com/5208768/116749290-b7fb7800-a9ce-11eb-8492-71dfde80bf94.png)
