### PR TITLE
Fix tower_job_launch tags being passed to API

### DIFF
--- a/awx_collection/plugins/modules/tower_job_launch.py
+++ b/awx_collection/plugins/modules/tower_job_launch.py
@@ -176,21 +176,33 @@ def main():
     optional_args = {}
     # Extract our parameters
     name = module.params.get('name')
-    optional_args['job_type'] = module.params.get('job_type')
     inventory = module.params.get('inventory')
     organization = module.params.get('organization')
     credentials = module.params.get('credentials')
-    optional_args['limit'] = module.params.get('limit')
-    optional_args['tags'] = module.params.get('tags')
-    optional_args['extra_vars'] = module.params.get('extra_vars')
-    optional_args['scm_branch'] = module.params.get('scm_branch')
-    optional_args['skip_tags'] = module.params.get('skip_tags')
-    optional_args['verbosity'] = module.params.get('verbosity')
-    optional_args['diff_mode'] = module.params.get('diff_mode')
-    optional_args['credential_passwords'] = module.params.get('credential_passwords')
     wait = module.params.get('wait')
     interval = module.params.get('interval')
     timeout = module.params.get('timeout')
+
+    for field_name in (
+        'job_type',
+        'limit',
+        'extra_vars',
+        'scm_branch',
+        'verbosity',
+        'diff_mode',
+        'credential_passwords',
+    ):
+        field_val = module.params.get(field_name)
+        if field_val is not None:
+            optional_args[field_name] = field_val
+
+        # Special treatment of tags parameters
+        job_tags = module.params.get('tags')
+        if job_tags is not None:
+            optional_args['job_tags'] = ",".join(job_tags)
+        skip_tags = module.params.get('skip_tags')
+        if skip_tags is not None:
+            optional_args['skip_tags'] = ",".join(skip_tags)
 
     # Create a datastructure to pass into our job launch
     post_data = {}

--- a/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_job_launch/tasks/main.yml
@@ -48,6 +48,8 @@
     job_type: run
     ask_credential: true
     ask_inventory: true
+    ask_tags_on_launch: true
+    ask_skip_tags_on_launch: true
     state: present
   register: result
 
@@ -56,6 +58,10 @@
     job_template: "{{ jt_name1 }}"
     inventory: "Demo Inventory"
     credential: "Demo Credential"
+    tags:
+      - sometimes
+    skip_tags:
+      - always
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
#10008
Fix tower_job_launch tags being passed to API
Previously the wrong field was being used on the api to pass tags, also while the module accepts lists, the API does not, so it would error. Take a users list, and converts to comma separated string, in order to maintain status quo. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - awx_collection

##### AWX VERSION
```
19.1.0
```