### PR TITLE
Fix unit-test styling warning

### DIFF
--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.jsx
@@ -87,7 +87,7 @@ function AdHocCommandsWizard({
         <AdHocExecutionEnvironmentStep organizationId={organizationId} />
       ),
       // Removed this line when https://github.com/patternfly/patternfly-react/issues/5729 is fixed
-      stepNavItemProps: { style: { 'white-space': 'nowrap' } },
+      stepNavItemProps: { style: { whiteSpace: 'nowrap' } },
       enableNext: true,
       nextButtonText: t`Next`,
       canJumpTo: currentStepId >= 2,


### PR DESCRIPTION
Fix unit-test styling warning.

```console.error
      Warning: Unsupported style property white-space. Did you mean
      whiteSpace?
```

Style still valid after change:

<img width="253" alt="image" src="https://user-images.githubusercontent.com/9053044/116881364-2ddf2980-abf1-11eb-9ab7-b177901d58aa.png">

