### PR TITLE
Make the check_migrations command a direct alias of makemigration

### DIFF
--- a/awx/main/management/commands/check_migrations.py
+++ b/awx/main/management/commands/check_migrations.py
@@ -1,13 +1,5 @@
-from django.db import connections
-from django.db.backends.sqlite3.base import DatabaseWrapper
 from django.core.management.commands.makemigrations import Command as MakeMigrations
 
 
 class Command(MakeMigrations):
-    def execute(self, *args, **options):
-        settings = connections['default'].settings_dict.copy()
-        settings['ENGINE'] = 'sqlite3'
-        if 'application_name' in settings['OPTIONS']:
-            del settings['OPTIONS']['application_name']
-        connections['default'] = DatabaseWrapper(settings)
-        return MakeMigrations().execute(*args, **options)
+    pass


### PR DESCRIPTION
##### SUMMARY

Make the check_migrations command a direct alias of makemigration.

It already more or less was, but it previously did some machinations
around copying and modifying the database settings.  These on-the-fly
changes to the database connection no longer work after the
rearrangement of settings files, so let's just get rid of it.

Example, from running `make test`:

```
  py3: commands succeeded
  congratulations :)
awx-manage check_migrations --dry-run --check  -n 'missing_migration_file'
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 195, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/sqlite3/base.py", line 194, in get_new_connection
    conn = Database.connect(**conn_params)
sqlite3.OperationalError: unable to open database file
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 19.1.0
```