### PR TITLE
Avoid prop reference error when recreating survey

### DIFF
--- a/awx/ui_next/src/screens/Template/Survey/SurveyQuestionAdd.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyQuestionAdd.jsx
@@ -11,7 +11,7 @@ export default function SurveyQuestionAdd({ survey, updateSurvey }) {
   const handleSubmit = async question => {
     const formData = { ...question };
     try {
-      if (survey.spec?.some(q => q.variable === formData.variable)) {
+      if (survey?.spec?.some(q => q.variable === formData.variable)) {
         setFormError(
           new Error(
             `Survey already contains a question with variable named “${formData.variable}”`
@@ -41,9 +41,7 @@ export default function SurveyQuestionAdd({ survey, updateSurvey }) {
         formData.choices = choices.trim();
       }
       delete formData.formattedChoices;
-
-      const newSpec = survey.spec ? survey.spec.concat(formData) : [formData];
-
+      const newSpec = survey?.spec ? survey.spec.concat(formData) : [formData];
       await updateSurvey(newSpec);
       history.push(match.url.replace('/add', ''));
     } catch (err) {

--- a/awx/ui_next/src/screens/Template/TemplateSurvey.jsx
+++ b/awx/ui_next/src/screens/Template/TemplateSurvey.jsx
@@ -53,8 +53,8 @@ function TemplateSurvey({ template, canEdit }) {
   );
   const updateSurveySpec = spec => {
     updateSurvey({
-      name: survey.name || '',
-      description: survey.description || '',
+      name: survey?.name || '',
+      description: survey?.description || '',
       spec,
     });
   };


### PR DESCRIPTION
##### SUMMARY
For #9370 

The survey object is undefined when recreating a survey after deleting it. Add optional chaining on survey fields to avoid prop reference error.
