### PR TITLE
add notification error to notification template list view

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4374,7 +4374,7 @@ class NotificationTemplateSerializer(BaseSerializer):
         return res
 
     def _recent_notifications(self, obj):
-        return [{'id': x.id, 'status': x.status, 'created': x.created} for x in obj.notifications.all().order_by('-created')[:5]]
+        return [{'id': x.id, 'status': x.status, 'created': x.created, 'error': x.error} for x in obj.notifications.all().order_by('-created')[:5]]
 
     def get_summary_fields(self, obj):
         d = super(NotificationTemplateSerializer, self).get_summary_fields(obj)


### PR DESCRIPTION
In support of https://github.com/ansible/awx/issues/8853

Updates `/api/v2/notification_templates` to include the `error` field for `summary_fields -> recent_notifications`

![image](https://user-images.githubusercontent.com/4440360/116928228-a35af200-ac11-11eb-8d67-e8b760b965fb.png)