### PR TITLE
Fix CSP error on Safari

### DIFF
--- a/awx/ui_next/public/installing.html
+++ b/awx/ui_next/public/installing.html
@@ -5,7 +5,7 @@
       <title>{{ title }}</title>
       <meta
          http-equiv="Content-Security-Policy"
-         content="default-src 'self'; connect-src 'self' ws: wss:; style-src 'self' 'nonce-{{ csp_nonce }}'; script-src 'self' 'nonce-{{ csp_nonce }}' *.pendo.io; img-src 'self' *.pendo.io data:;"
+         content="default-src 'self'; connect-src 'self' ws: wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'nonce-{{ csp_nonce }}' *.pendo.io; img-src 'self' *.pendo.io data:;"
          />
       <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
This was causing:

```
[Error] Refused to execute a script because its hash, its nonce, or
'unsafe-inline' does not appear in the script-src directive of the Content
Security Policy. (migrations_notran, line 16)
```
