### PR TITLE
add custom_venv for backward compatibility

### DIFF
--- a/awx_collection/plugins/modules/tower_inventory_source.py
+++ b/awx_collection/plugins/modules/tower_inventory_source.py
@@ -72,6 +72,12 @@ options:
       description:
         - Execution Environment to use for the source.
       type: str
+    custom_virtualenv:
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+        - Only compatible with older versions of AWX/Tower
+        - Deprecated, will be removed in the future
+      type: str
     overwrite:
       description:
         - Delete child groups and hosts not found in source.
@@ -166,6 +172,7 @@ def main():
         host_filter=dict(),
         credential=dict(),
         execution_environment=dict(),
+        custom_virtualenv=dict(),
         organization=dict(),
         overwrite=dict(type='bool'),
         overwrite_vars=dict(type='bool'),
@@ -258,6 +265,7 @@ def main():
         'source_vars',
         'overwrite',
         'overwrite_vars',
+        'custom_virtualenv',
         'timeout',
         'verbosity',
         'update_on_launch',

--- a/awx_collection/plugins/modules/tower_job_template.py
+++ b/awx_collection/plugins/modules/tower_job_template.py
@@ -86,6 +86,12 @@ options:
       description:
         - Execution Environment to use for the JT.
       type: str
+    custom_virtualenv:
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+        - Only compatible with older versions of AWX/Tower
+        - Deprecated, will be removed in the future
+      type: str
     instance_groups:
       description:
         - list of Instance Groups for this Organization to run on.
@@ -371,6 +377,7 @@ def main():
         vault_credential=dict(),
         credentials=dict(type='list', elements='str'),
         execution_environment=dict(),
+        custom_virtualenv=dict(),
         instance_groups=dict(type="list", elements='str'),
         forks=dict(type='int'),
         limit=dict(),
@@ -495,6 +502,7 @@ def main():
         'become_enabled',
         'diff_mode',
         'allow_simultaneous',
+        'custom_virtualenv',
         'job_slice_count',
         'webhook_service',
     ):

--- a/awx_collection/plugins/modules/tower_organization.py
+++ b/awx_collection/plugins/modules/tower_organization.py
@@ -34,6 +34,12 @@ options:
       description:
         - Default Execution Environment to use for jobs owned by the Organization.
       type: str
+    custom_virtualenv:
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+        - Only compatible with older versions of AWX/Tower
+        - Deprecated, will be removed in the future
+      type: str
     max_hosts:
       description:
         - The max hosts allowed in this organizations
@@ -112,6 +118,7 @@ def main():
         name=dict(required=True),
         description=dict(),
         default_environment=dict(),
+        custom_virtualenv=dict(),
         max_hosts=dict(type='int', default="0"),
         instance_groups=dict(type="list", elements='str'),
         notification_templates_started=dict(type="list", elements='str'),
@@ -129,6 +136,7 @@ def main():
     name = module.params.get('name')
     description = module.params.get('description')
     default_ee = module.params.get('default_environment')
+    custom_virtualenv = module.params.get('custom_virtualenv')
     max_hosts = module.params.get('max_hosts')
     state = module.params.get('state')
 
@@ -183,6 +191,8 @@ def main():
         org_fields['description'] = description
     if default_ee is not None:
         org_fields['default_environment'] = module.resolve_name_to_id('execution_environments', default_ee)
+    if custom_virtualenv is not None:
+        org_fields['custom_virtualenv'] = custom_virtualenv
     if max_hosts is not None:
         org_fields['max_hosts'] = max_hosts
 

--- a/awx_collection/plugins/modules/tower_project.py
+++ b/awx_collection/plugins/modules/tower_project.py
@@ -113,6 +113,12 @@ options:
       description:
         - Default Execution Environment to use for jobs relating to the project.
       type: str
+    custom_virtualenv:
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+        - Only compatible with older versions of AWX/Tower
+        - Deprecated, will be removed in the future
+      type: str
     organization:
       description:
         - Name of organization for project.
@@ -262,6 +268,7 @@ def main():
         allow_override=dict(type='bool', aliases=['scm_allow_override']),
         timeout=dict(type='int', default=0, aliases=['job_timeout']),
         default_environment=dict(),
+        custom_virtualenv=dict(),
         organization=dict(),
         notification_templates_started=dict(type="list", elements='str'),
         notification_templates_success=dict(type="list", elements='str'),
@@ -286,6 +293,7 @@ def main():
     scm_update_on_launch = module.params.get('scm_update_on_launch')
     scm_update_cache_timeout = module.params.get('scm_update_cache_timeout')
     default_ee = module.params.get('default_environment')
+    custom_virtualenv = module.params.get('custom_virtualenv')
     organization = module.params.get('organization')
     state = module.params.get('state')
     wait = module.params.get('wait')


### PR DESCRIPTION
##### SUMMARY
As per #10055 , this is the proposal to add back custom virtual environments to the modules. With the understanding that they will not be tested. But to allow users of Ansible Tower 3.8 the ability to use newer features and bugfixes in awx.awx as applicable, without restorting to backporting these removals. Would expect these to remain for a time after Tower moves to Execution environments as teams/companies adopt the next version of tower. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - awx_collection


##### AWX VERSION
```
19.1.0
```
