### PR TITLE
Make date consistent on tooltip display

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
@@ -20,6 +20,7 @@ import styled from 'styled-components';
 
 import StatusIcon from '../../../components/StatusIcon';
 import InventorySourceSyncButton from '../shared/InventorySourceSyncButton';
+import { formatDateString } from '../../../util/dates';
 
 const ExclamationTriangleIcon = styled(PFExclamationTriangleIcon)`
   color: var(--pf-global--warning-color--100);
@@ -46,7 +47,7 @@ function InventorySourceListItem({
         </div>
         {job.finished && (
           <div>
-            {t`FINISHED:`} {job.finished}
+            {t`FINISHED:`} {formatDateString(job.finished)}
           </div>
         )}
       </>


### PR DESCRIPTION
Make date consistent on tooltip to display info about job.
There are 3 places that define similar function on the code basis. Make
them consistent in how to display date.

Search for `generateLastJobTooltip` on code basis.

