### PR TITLE
Fix to handle ask_* parameters correctly when set false

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -751,7 +751,7 @@ def main():
         'webhook_service',
     ):
         field_val = module.params.get(field_name)
-        if field_val:
+        if field_val is not None:
             new_fields[field_name] = field_val
 
     if 'extra_vars' in new_fields:

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -159,7 +159,25 @@
     extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
     labels:
       - "{{ lab1 }}"
+    ask_inventory_on_launch: true
+    ask_scm_branch_on_launch: true
+    ask_limit_on_launch: true
+    ask_variables_on_launch: true
   register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+# Turn off ask_ * settings to test that the issue/10057 has been fixed
+- name: Turn ask_* settings OFF
+  tower_workflow_job_template:
+    name: "{{ wfjt_name }}"
+    ask_inventory_on_launch: false
+    ask_scm_branch_on_launch: false
+    ask_limit_on_launch: false
+    ask_variables_on_launch: false
+    state: present
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY

Fixed the issue #10057 that the `ask_ *` parameter values has been ignored when set `false`.

* Fixes #10057 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - awx_collections

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
None