### PR TITLE
Adds Job Cancel Button

### DIFF
--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -1,0 +1,99 @@
+import React, { useCallback, useState } from 'react';
+import { t } from '@lingui/macro';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { getJobModel } from '../../util/jobs';
+import useRequest, { useDismissableError } from '../../util/useRequest';
+import AlertModal from '../AlertModal';
+import ErrorDetail from '../ErrorDetail';
+
+function JobCancelButton({
+  job = {},
+  errorTitle,
+  title,
+  showIconButton,
+  errorMessage,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { error: cancelError, request: cancelJob } = useRequest(
+    useCallback(async () => {
+      setIsOpen(false);
+      await getJobModel(job.type).cancel(job.id);
+    }, [job.id, job.type]),
+    {}
+  );
+  const { error, dismissError: dismissCancelError } = useDismissableError(
+    cancelError
+  );
+
+  return (
+    <>
+      <Tooltip content={title}>
+        {showIconButton ? (
+          <Button
+            aria-label={title}
+            ouiaId="cancel job"
+            onClick={setIsOpen}
+            variant="plain"
+          >
+            <MinusCircleIcon />
+          </Button>
+        ) : (
+          <Button
+            aria-label={title}
+            variant="secondary"
+            ouiaId="cancel job"
+            onClick={setIsOpen}
+          >{t`Cancel Sync`}</Button>
+        )}
+      </Tooltip>
+      {isOpen && (
+        <AlertModal
+          isOpen={isOpen}
+          variant="danger"
+          onClose={() => setIsOpen(false)}
+          title={title}
+          label={title}
+          actions={[
+            <Button
+              id="cancel-job-confirm-button"
+              key="delete"
+              variant="danger"
+              aria-label={t`Confirm cancel job`}
+              ouiaId="confirm cancel job"
+              onClick={cancelJob}
+            >
+              {t`Confirm cancellation`}
+            </Button>,
+            <Button
+              id="cancel-job-return-button"
+              key="cancel"
+              ouiaId="return"
+              aria-label={t`Return`}
+              variant="secondary"
+              onClick={() => setIsOpen(false)}
+            >
+              {t`Return`}
+            </Button>,
+          ]}
+        >
+          {t`Are you sure you want to submit the request to cancel this job?`}
+        </AlertModal>
+      )}
+      {error && (
+        <AlertModal
+          isOpen={error}
+          variant="danger"
+          onClose={dismissCancelError}
+          title={errorTitle}
+          label={errorTitle}
+        >
+          {errorMessage}
+          <ErrorDetail error={error} />
+        </AlertModal>
+      )}
+    </>
+  );
+}
+
+export default JobCancelButton;

--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -33,7 +33,7 @@ function JobCancelButton({
           <Button
             aria-label={title}
             ouiaId="cancel job"
-            onClick={setIsOpen}
+            onClick={() => setIsOpen(true)}
             variant="plain"
           >
             <MinusCircleIcon />
@@ -43,7 +43,7 @@ function JobCancelButton({
             aria-label={title}
             variant="secondary"
             ouiaId="cancel job"
-            onClick={setIsOpen}
+            onClick={() => setIsOpen(true)}
           >{t`Cancel Sync`}</Button>
         )}
       </Tooltip>
@@ -77,7 +77,7 @@ function JobCancelButton({
             </Button>,
           ]}
         >
-          {t`Are you sure you want to submit the request to cancel this job?`}
+          {t`Are you sure you want to cancel this job?`}
         </AlertModal>
       )}
       {error && (

--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -13,6 +13,7 @@ function JobCancelButton({
   title,
   showIconButton,
   errorMessage,
+  buttonText,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const { error: cancelError, request: cancelJob } = useRequest(
@@ -44,7 +45,9 @@ function JobCancelButton({
             variant="secondary"
             ouiaId="cancel job"
             onClick={() => setIsOpen(true)}
-          >{t`Cancel Sync`}</Button>
+          >
+            {buttonText || t`Cancel Job`}
+          </Button>
         )}
       </Tooltip>
       {isOpen && (

--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -43,7 +43,7 @@ function JobCancelButton({
           <Button
             aria-label={title}
             variant="secondary"
-            ouiaId="cancel job"
+            ouiaId="cancel-job-button"
             onClick={() => setIsOpen(true)}
           >
             {buttonText || t`Cancel Job`}

--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -32,7 +32,7 @@ function JobCancelButton({
         {showIconButton ? (
           <Button
             aria-label={title}
-            ouiaId="cancel job"
+            ouiaId="cancel-job-button"
             onClick={() => setIsOpen(true)}
             variant="plain"
           >
@@ -60,7 +60,7 @@ function JobCancelButton({
               key="delete"
               variant="danger"
               aria-label={t`Confirm cancel job`}
-              ouiaId="confirm cancel job"
+              ouiaId="cancel-job-confirm-button"
               onClick={cancelJob}
             >
               {t`Confirm cancellation`}

--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.test.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.test.jsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import {
+  ProjectUpdatesAPI,
+  AdHocCommandsAPI,
+  SystemJobsAPI,
+  WorkflowJobsAPI,
+  JobsAPI,
+} from '../../api';
+import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import JobCancelButton from './JobCancelButton';
+
+jest.mock('../../api');
+
+describe('<JobCancelButton/>', () => {
+  let wrapper;
+
+  test('should render properly', () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'project_update' }}
+          errorTitle="Error"
+          title="Title"
+        />
+      );
+    });
+    expect(wrapper.length).toBe(1);
+    expect(wrapper.find('MinusCircleIcon').length).toBe(0);
+  });
+  test('should render icon button', () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'project_update' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    expect(wrapper.find('MinusCircleIcon').length).toBe(1);
+  });
+  test('should call api', async () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'project_update' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    expect(ProjectUpdatesAPI.cancel).toBeCalledWith(1);
+  });
+  test('should throw error', async () => {
+    ProjectUpdatesAPI.cancel.mockRejectedValue(
+      new Error({
+        response: {
+          config: {
+            method: 'post',
+            url: '/api/v2/projectupdates',
+          },
+          data: 'An error occurred',
+          status: 403,
+        },
+      })
+    );
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 'a', type: 'project_update' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    wrapper.update();
+    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    expect(wrapper.find('AlertModal[title="Title"]').length).toBe(0);
+  });
+
+  test('should cancel Ad Hoc Command job', async () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'ad_hoc_command' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    expect(AdHocCommandsAPI.cancel).toBeCalledWith(1);
+  });
+
+  test('should cancel system job', async () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'system_job' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    expect(SystemJobsAPI.cancel).toBeCalledWith(1);
+  });
+
+  test('should cancel workflow job', async () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'workflow_job' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    expect(WorkflowJobsAPI.cancel).toBeCalledWith(1);
+  });
+  test('should cancel workflow job', async () => {
+    act(() => {
+      wrapper = mountWithContexts(
+        <JobCancelButton
+          job={{ id: 1, type: 'hakunah_matata' }}
+          errorTitle="Error"
+          title="Title"
+          showIconButton
+        />
+      );
+    });
+    await act(async () => wrapper.find('Button').prop('onClick')(true));
+    wrapper.update();
+
+    expect(wrapper.find('AlertModal').length).toBe(1);
+    await act(() =>
+      wrapper.find('Button#cancel-job-confirm-button').prop('onClick')()
+    );
+    expect(JobsAPI.cancel).toBeCalledWith(1);
+  });
+});

--- a/awx/ui_next/src/components/JobCancelButton/index.js
+++ b/awx/ui_next/src/components/JobCancelButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './JobCancelButton';

--- a/awx/ui_next/src/components/JobList/JobList.jsx
+++ b/awx/ui_next/src/components/JobList/JobList.jsx
@@ -12,6 +12,8 @@ import useRequest, {
   useDeleteItems,
   useDismissableError,
 } from '../../util/useRequest';
+import { useConfig } from '../../contexts/Config';
+
 import { isJobRunning, getJobModel } from '../../util/jobs';
 import { getQSConfig, parseQueryString } from '../../util/qs';
 import JobListItem from './JobListItem';
@@ -31,6 +33,8 @@ function JobList({ defaultParams, showTypeColumn = false }) {
     },
     ['id', 'page', 'page_size']
   );
+
+  const { me } = useConfig();
 
   const [selected, setSelected] = useState([]);
   const location = useLocation();
@@ -261,6 +265,7 @@ function JobList({ defaultParams, showTypeColumn = false }) {
             <JobListItem
               key={job.id}
               job={job}
+              isSuperUser={me?.is_superuser}
               showTypeColumn={showTypeColumn}
               onSelect={() => handleSelect(job)}
               isSelected={selected.some(row => row.id === job.id)}

--- a/awx/ui_next/src/components/JobList/JobListItem.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.jsx
@@ -15,6 +15,7 @@ import CredentialChip from '../CredentialChip';
 import ExecutionEnvironmentDetail from '../ExecutionEnvironmentDetail';
 import { formatDateString } from '../../util/dates';
 import { JOB_TYPE_URL_SEGMENTS } from '../../constants';
+import JobCancelButton from '../JobCancelButton';
 
 const Dash = styled.span``;
 function JobListItem({
@@ -23,6 +24,7 @@ function JobListItem({
   isSelected,
   onSelect,
   showTypeColumn = false,
+  isSuperUser = false,
 }) {
   const labelId = `check-action-${job.id}`;
   const [isExpanded, setIsExpanded] = useState(false);
@@ -83,6 +85,20 @@ function JobListItem({
           {job.finished ? formatDateString(job.finished) : ''}
         </Td>
         <ActionsTd dataLabel={t`Actions`}>
+          <ActionItem
+            visible={
+              ['pending', 'waiting', 'running'].includes(job.status) &&
+              (job.type === 'system_job' ? isSuperUser : true)
+            }
+          >
+            <JobCancelButton
+              job={job}
+              errorTitle={t`Job Cancel Error`}
+              title={t`Cancel ${job.name}`}
+              errorMessage={t`Failed to cancel ${job.name}`}
+              showIconButton
+            />
+          </ActionItem>
           <ActionItem
             visible={
               job.type !== 'system_job' &&

--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Are you sure you want to submit the request to cancel this job?"
@@ -625,7 +625,7 @@ msgstr "Are you sure you want to submit the request to cancel this job?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr "Artifacts"
 
@@ -879,8 +879,6 @@ msgstr "Cache timeout (seconds)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -907,8 +905,8 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr "Cancel Inventory Source Sync"
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -923,8 +921,8 @@ msgstr "Cancel Project Sync"
 msgid "Cancel Sync"
 msgstr "Cancel Sync"
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -975,6 +973,7 @@ msgstr "Cancel subscription edit"
 #~ msgid "Cancel sync source"
 #~ msgstr "Cancel sync source"
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr "Cancel {0}"
@@ -1220,7 +1219,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Command"
@@ -1278,7 +1277,7 @@ msgstr "Confirm revert all"
 msgid "Confirm selection"
 msgstr "Confirm selection"
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr "Container Group"
 
@@ -1529,7 +1528,7 @@ msgstr "Create user token"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1674,7 +1673,7 @@ msgstr "Credential type not found."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1806,7 +1805,7 @@ msgstr "Define system-level features and functions"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1851,7 +1850,7 @@ msgstr "Delete Host"
 msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2912,8 +2911,7 @@ msgstr "Error saving the workflow!"
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -3034,7 +3032,7 @@ msgstr "Execution Environment"
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr "Execution Node"
 
@@ -3195,6 +3193,7 @@ msgstr "Failed to cancel Project Sync"
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr "Failed to cancel {0}"
@@ -3532,7 +3531,7 @@ msgstr "File, directory or script"
 msgid "Finish Time"
 msgstr "Finish Time"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Finished"
@@ -4249,7 +4248,7 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Instance Filters"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr "Instance Group"
 
@@ -4356,7 +4355,7 @@ msgstr "Inventories with sources cannot be copied"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4381,7 +4380,7 @@ msgstr "Inventory ID"
 #~ msgid "Inventory Scripts"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr "Inventory Source"
 
@@ -4408,7 +4407,7 @@ msgstr "Inventory Sources"
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr "Inventory Sync"
 
@@ -4487,21 +4486,22 @@ msgstr "January"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Job Delete Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr "Job Slice"
 
@@ -4520,7 +4520,7 @@ msgstr "Job Status"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4532,7 +4532,7 @@ msgstr "Job Tags"
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Job Template"
@@ -4562,7 +4562,7 @@ msgstr "Job Templates with credentials that prompt for passwords cannot be selec
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4702,7 +4702,7 @@ msgstr "Label Name"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4737,7 +4737,7 @@ msgstr "Last Login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4877,7 +4877,7 @@ msgstr "Less than or equal to comparison."
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4952,7 +4952,7 @@ msgstr "MOST RECENT SYNC"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr "Machine Credential"
 
@@ -4972,7 +4972,7 @@ msgstr "Managed nodes"
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr "Management Job"
 
@@ -6054,13 +6054,13 @@ msgid "Play Started"
 msgstr "Play Started"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr "Playbook Check"
 
@@ -6077,7 +6077,7 @@ msgstr "Playbook Directory"
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr "Playbook Run"
 
@@ -6263,8 +6263,8 @@ msgstr "Privilege escalation password"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6555,8 +6555,8 @@ msgstr "Related Groups"
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "Relaunch"
@@ -6699,8 +6699,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6749,7 +6749,7 @@ msgstr "Revert settings"
 msgid "Revert to factory default."
 msgstr "Revert to factory default."
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7587,7 +7587,7 @@ msgstr "Simple key select"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7741,7 +7741,7 @@ msgstr "Source Control URL"
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr "Source Control Update"
 
@@ -7754,7 +7754,7 @@ msgid "Source Variables"
 msgstr "Source Variables"
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr "Source Workflow Job"
 
@@ -7862,7 +7862,7 @@ msgstr "Start sync process"
 msgid "Start sync source"
 msgstr "Start sync source"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7875,7 +7875,7 @@ msgstr "Started"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -9185,7 +9185,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -9217,7 +9217,7 @@ msgstr "Verbose"
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9653,7 +9653,7 @@ msgstr "Workflow Approvals"
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Workflow Job"
@@ -9661,7 +9661,7 @@ msgstr "Workflow Job"
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -242,7 +242,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -949,16 +949,16 @@ msgid "Cancel subscription edit"
 msgstr "Cancel subscription edit"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "Cancel sync"
+#~ msgid "Cancel sync"
+#~ msgstr "Cancel sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "Cancel sync process"
+#~ msgid "Cancel sync process"
+#~ msgstr "Cancel sync process"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "Cancel sync source"
+#~ msgid "Cancel sync source"
+#~ msgstr "Cancel sync source"
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3146,13 +3146,26 @@ msgstr "Failed to associate role"
 msgid "Failed to associate."
 msgstr "Failed to associate."
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
+msgstr "Failed to cancel Inventory Source Sync"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr "Failed to cancel Project Update"
+
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "Failed to cancel inventory source sync."
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "Failed to cancel inventory source sync."
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
+msgstr "Failed to cancel {0}"
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3391,7 +3404,7 @@ msgstr "Failed to retrieve node credentials."
 msgid "Failed to send test notification."
 msgstr "Failed to send test notification."
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "Failed to sync inventory source."
 
@@ -3734,7 +3747,7 @@ msgstr "Group"
 msgid "Group details"
 msgstr "Group details"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr "Group type"
 
@@ -4339,6 +4352,10 @@ msgstr "Inventory ID"
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
 msgstr "Inventory Source"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
+msgstr "Inventory Source Error"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
@@ -6232,6 +6249,11 @@ msgstr "Project Sync"
 msgid "Project Update"
 msgstr "Project Update"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr "Project Update Error"
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr "Project not found."
@@ -6631,6 +6653,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -7073,7 +7097,7 @@ msgid "Select a row to approve"
 msgstr "Select a row to approve"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7454,7 +7478,7 @@ msgstr "Show"
 msgid "Show Changes"
 msgstr "Show Changes"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr "Show all groups"
 
@@ -7467,7 +7491,7 @@ msgstr "Show changes"
 msgid "Show less"
 msgstr "Show less"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr "Show only root groups"
 
@@ -7788,11 +7812,11 @@ msgstr "Start message"
 msgid "Start message body"
 msgstr "Start message body"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "Start sync process"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "Start sync source"
 

--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -205,8 +205,8 @@ msgstr "Account token"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -575,7 +575,7 @@ msgstr "Approved by {0} - {1}"
 msgid "April"
 msgstr "April"
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr "Are you sure you want to cancel this job?"
 
@@ -615,7 +615,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Are you sure you want to submit the request to cancel this job?"
@@ -625,7 +624,7 @@ msgstr "Are you sure you want to submit the request to cancel this job?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr "Artifacts"
 
@@ -905,8 +904,7 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr "Cancel Inventory Source Sync"
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -917,12 +915,10 @@ msgstr "Cancel Job"
 msgid "Cancel Project Sync"
 msgstr "Cancel Project Sync"
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr "Cancel Sync"
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -973,12 +969,13 @@ msgstr "Cancel subscription edit"
 #~ msgid "Cancel sync source"
 #~ msgstr "Cancel sync source"
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr "Cancel {0}"
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1217,9 +1214,9 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Command"
@@ -1241,11 +1238,11 @@ msgstr "Confirm Delete"
 msgid "Confirm Password"
 msgstr "Confirm Password"
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr "Confirm cancel job"
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr "Confirm cancellation"
 
@@ -1277,7 +1274,7 @@ msgstr "Confirm revert all"
 msgid "Confirm selection"
 msgstr "Confirm selection"
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr "Container Group"
 
@@ -1528,7 +1525,7 @@ msgstr "Create user token"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1658,7 +1655,7 @@ msgstr "Credential to authenticate with a protected container registry."
 msgid "Credential type not found."
 msgstr "Credential type not found."
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1673,7 +1670,7 @@ msgstr "Credential type not found."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1805,10 +1802,10 @@ msgstr "Define system-level features and functions"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1850,9 +1847,9 @@ msgstr "Delete Host"
 msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "Delete Job"
 
@@ -1868,7 +1865,7 @@ msgstr "Delete Notification"
 msgid "Delete Organization"
 msgstr "Delete Organization"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "Delete Project"
 
@@ -2283,8 +2280,8 @@ msgstr "Documentation."
 msgid "Done"
 msgstr "Done"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "Download Output"
 
@@ -2561,16 +2558,16 @@ msgid "Edit this node"
 msgstr "Edit this node"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Elapsed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "Elapsed Time"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "Elapsed time that the job ran"
 
@@ -2837,7 +2834,7 @@ msgstr "Enter variables using either JSON or YAML syntax. Use the radio button t
 #~ msgid "Environment"
 #~ msgstr "Environment"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2871,8 +2868,8 @@ msgstr "Error saving the workflow!"
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2919,7 +2916,7 @@ msgstr "Error saving the workflow!"
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3032,7 +3029,7 @@ msgstr "Execution Environment"
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr "Execution Node"
 
@@ -3095,7 +3092,7 @@ msgstr "Expires on UTC"
 msgid "Expires on {0}"
 msgstr "Expires on {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explanation"
@@ -3125,19 +3122,19 @@ msgstr "FINISHED:"
 msgid "Facts"
 msgstr "Facts"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "Failed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "Failed Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "Failed Hosts"
 
@@ -3189,12 +3186,13 @@ msgstr "Failed to cancel Project Sync"
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr "Failed to cancel inventory source sync."
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr "Failed to cancel {0}"
 
@@ -3293,7 +3291,7 @@ msgstr "Failed to delete one or more inventory sources."
 msgid "Failed to delete one or more job templates."
 msgstr "Failed to delete one or more job templates."
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "Failed to delete one or more jobs."
 
@@ -3341,7 +3339,7 @@ msgstr "Failed to delete one or more workflow approval."
 msgid "Failed to delete organization."
 msgstr "Failed to delete organization."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "Failed to delete project."
 
@@ -3526,12 +3524,12 @@ msgstr "File upload rejected. Please select a single .json file."
 msgid "File, directory or script"
 msgstr "File, directory or script"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "Finish Time"
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Finished"
@@ -3838,7 +3836,7 @@ msgstr "Host Async OK"
 msgid "Host Config Key"
 msgstr "Host Config Key"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "Host Count"
 
@@ -3921,7 +3919,7 @@ msgstr "Host status information for this job is unavailable."
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hosts"
@@ -3947,7 +3945,7 @@ msgstr "Hour"
 msgid "I agree to the End User License Agreement"
 msgstr "I agree to the End User License Agreement"
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4248,7 +4246,7 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Instance Filters"
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr "Instance Group"
 
@@ -4332,7 +4330,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Inventories with sources cannot be copied"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4355,7 +4353,7 @@ msgstr "Inventories with sources cannot be copied"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4380,7 +4378,7 @@ msgstr "Inventory ID"
 #~ msgid "Inventory Scripts"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr "Inventory Source"
 
@@ -4403,11 +4401,11 @@ msgstr "Inventory Source Sync Error"
 msgid "Inventory Sources"
 msgstr "Inventory Sources"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr "Inventory Sync"
 
@@ -4486,22 +4484,21 @@ msgstr "January"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Job Delete Error"
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr "Job Slice"
 
@@ -4520,19 +4517,19 @@ msgstr "Job Status"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "Job Tags"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Job Template"
@@ -4557,12 +4554,12 @@ msgstr "Job Templates with a missing inventory or project cannot be selected whe
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4583,8 +4580,8 @@ msgstr "Job status graph tab"
 msgid "Job templates"
 msgstr "Job templates"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4694,15 +4691,15 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "Label Name"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4737,7 +4734,7 @@ msgstr "Last Login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4835,7 +4832,7 @@ msgstr "Launch workflow"
 msgid "Launched By"
 msgstr "Launched By"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "Launched By (Username)"
 
@@ -4871,13 +4868,13 @@ msgstr "Less than or equal to comparison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4952,7 +4949,7 @@ msgstr "MOST RECENT SYNC"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr "Machine Credential"
 
@@ -4969,10 +4966,10 @@ msgstr "Managed by Tower"
 msgid "Managed nodes"
 msgstr "Managed nodes"
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr "Management Job"
 
@@ -5235,9 +5232,9 @@ msgstr "Multiple Choice Options"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5441,7 +5438,7 @@ msgstr "Never Updated"
 msgid "Never expires"
 msgstr "Never expires"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "New"
@@ -6016,7 +6013,7 @@ msgstr "Past two weeks"
 msgid "Past week"
 msgstr "Past week"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "Pending"
@@ -6045,7 +6042,7 @@ msgstr "Personal access token"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "Play Count"
 
@@ -6054,13 +6051,13 @@ msgid "Play Started"
 msgstr "Play Started"
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr "Playbook Check"
 
@@ -6074,10 +6071,10 @@ msgstr "Playbook Complete"
 msgid "Playbook Directory"
 msgstr "Playbook Directory"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr "Playbook Run"
 
@@ -6096,7 +6093,7 @@ msgstr "Playbook name"
 msgid "Playbook run"
 msgstr "Playbook run"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Plays"
 
@@ -6254,7 +6251,7 @@ msgstr "Privilege Escalation"
 msgid "Privilege escalation password"
 msgstr "Privilege escalation password"
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6263,8 +6260,8 @@ msgstr "Privilege escalation password"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6553,16 +6550,16 @@ msgstr "Regular expression where only matching host names will be imported. The 
 msgid "Related Groups"
 msgstr "Related Groups"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "Relaunch Job"
 
@@ -6579,8 +6576,8 @@ msgstr "Relaunch failed hosts"
 msgid "Relaunch on"
 msgstr "Relaunch on"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "Relaunch using host parameters"
 
@@ -6695,12 +6692,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6749,7 +6744,7 @@ msgstr "Revert settings"
 msgid "Revert to factory default."
 msgstr "Revert to factory default."
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6822,7 +6817,7 @@ msgstr "Run on"
 msgid "Run type"
 msgstr "Run type"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -7019,7 +7014,7 @@ msgstr "Seconds"
 msgid "See errors on the left"
 msgstr "See errors on the left"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7587,7 +7582,7 @@ msgstr "Simple key select"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7738,10 +7733,10 @@ msgstr "Source Control Type"
 msgid "Source Control URL"
 msgstr "Source Control URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr "Source Control Update"
 
@@ -7753,8 +7748,8 @@ msgstr "Source Phone Number"
 msgid "Source Variables"
 msgstr "Source Variables"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr "Source Workflow Job"
 
@@ -7835,8 +7830,8 @@ msgstr "Standard out tab"
 msgid "Start"
 msgstr "Start"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "Start Time"
 
@@ -7862,20 +7857,20 @@ msgstr "Start sync process"
 msgid "Start sync source"
 msgstr "Start sync source"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Started"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7972,7 +7967,7 @@ msgstr "Success message"
 msgid "Success message body"
 msgstr "Success message body"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -8159,7 +8154,7 @@ msgstr "Target URL"
 msgid "Task"
 msgstr "Task"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "Task Count"
 
@@ -8167,7 +8162,7 @@ msgstr "Task Count"
 msgid "Task Started"
 msgstr "Task Started"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -8625,7 +8620,7 @@ msgstr "This job template is currently being used by other resources. Are you su
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "This organization is currently being by other resources. Are you sure you want to delete it?"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This project is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8891,8 +8886,8 @@ msgstr "Tuesday"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8926,7 +8921,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8963,15 +8958,15 @@ msgid "Unlimited"
 msgstr "Unlimited"
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "Unreachable"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "Unreachable Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "Unreachable Hosts"
 
@@ -9185,7 +9180,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -9217,7 +9212,7 @@ msgstr "Verbose"
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9489,7 +9484,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "WARNING:"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "Waiting"
@@ -9650,18 +9645,18 @@ msgstr "Workflow Approval not found."
 msgid "Workflow Approvals"
 msgstr "Workflow Approvals"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Workflow Job"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -10145,7 +10140,7 @@ msgstr "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 

--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -234,7 +234,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -434,7 +434,7 @@ msgid "All job types"
 msgstr "All job types"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Allow Branch Override"
@@ -574,6 +574,10 @@ msgstr "Approved by {0} - {1}"
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "April"
+
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr "Are you sure you want to cancel this job?"
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -839,7 +843,7 @@ msgstr "By default, we collect and transmit analytics data on the serice usage t
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Cache Timeout"
@@ -899,14 +903,25 @@ msgstr "Cache timeout (seconds)"
 msgid "Cancel"
 msgstr ""
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr "Cancel Inventory Source Sync"
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Cancel Job"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr "Cancel Project Sync"
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
+msgstr "Cancel Sync"
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
 #: screens/Job/JobDetail/JobDetail.jsx:428
@@ -959,6 +974,10 @@ msgstr "Cancel subscription edit"
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr "Cancel sync source"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr "Cancel {0}"
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1114,7 +1133,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choose the type of resource that will be receiving new roles.  For example, if you'd like to add new roles to a set of users please choose Users and click Next.  You'll be able to select the specific resources in the next step."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Clean"
@@ -1222,6 +1241,14 @@ msgstr "Confirm Delete"
 #: screens/User/shared/UserForm.jsx:91
 msgid "Confirm Password"
 msgstr "Confirm Password"
+
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr "Confirm cancel job"
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr "Confirm cancellation"
 
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
@@ -1335,7 +1362,7 @@ msgstr "Copy Inventory"
 msgid "Copy Notification Template"
 msgstr "Copy Notification Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "Copy Project"
 
@@ -1343,7 +1370,7 @@ msgstr "Copy Project"
 msgid "Copy Template"
 msgstr "Copy Template"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "Copy full revision to clipboard."
 
@@ -1506,7 +1533,7 @@ msgstr "Create user token"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1667,10 +1694,10 @@ msgid "Custom pod spec"
 msgstr "Custom pod spec"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr "Custom virtual environment {0} must be replaced by an execution environment."
 
@@ -1782,7 +1809,7 @@ msgstr "Define system-level features and functions"
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1825,8 +1852,8 @@ msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr "Delete Job"
 
@@ -1842,7 +1869,7 @@ msgstr "Delete Notification"
 msgid "Delete Organization"
 msgstr "Delete Organization"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr "Delete Project"
 
@@ -1905,7 +1932,7 @@ msgid "Delete inventory source"
 msgstr "Delete inventory source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "Delete on Update"
 
@@ -2032,9 +2059,9 @@ msgstr "Deprecated"
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2257,8 +2284,8 @@ msgstr "Documentation."
 msgid "Done"
 msgstr "Done"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr "Download Output"
 
@@ -2317,14 +2344,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2450,8 +2477,8 @@ msgstr "Edit Notification Template"
 msgid "Edit Organization"
 msgstr "Edit Organization"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "Edit Project"
 
@@ -2465,7 +2492,7 @@ msgstr "Edit Question"
 msgid "Edit Schedule"
 msgstr "Edit Schedule"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "Edit Source"
 
@@ -2535,16 +2562,16 @@ msgid "Edit this node"
 msgstr "Edit this node"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Elapsed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr "Elapsed Time"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr "Elapsed time that the job ran"
 
@@ -2894,7 +2921,7 @@ msgstr "Error saving the workflow!"
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3085,9 +3112,9 @@ msgid "Extra variables"
 msgstr "Extra variables"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "FINISHED:"
 
@@ -3104,15 +3131,15 @@ msgstr "Facts"
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr "Failed"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr "Failed Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr "Failed Hosts"
 
@@ -3146,14 +3173,19 @@ msgstr "Failed to associate role"
 msgid "Failed to associate."
 msgstr "Failed to associate."
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr "Failed to cancel Inventory Source Sync"
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
+msgstr "Failed to cancel Project Sync"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
 #: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
-msgstr "Failed to cancel Project Update"
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr "Failed to cancel Project Update"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3163,7 +3195,7 @@ msgstr "Failed to cancel Project Update"
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr "Failed to cancel {0}"
 
@@ -3179,7 +3211,7 @@ msgstr "Failed to copy execution environment"
 msgid "Failed to copy inventory."
 msgstr "Failed to copy inventory."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "Failed to copy project."
 
@@ -3310,7 +3342,7 @@ msgstr "Failed to delete one or more workflow approval."
 msgid "Failed to delete organization."
 msgstr "Failed to delete organization."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr "Failed to delete project."
 
@@ -3747,7 +3779,7 @@ msgstr "Group"
 msgid "Group details"
 msgstr "Group details"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr "Group type"
 
@@ -3807,7 +3839,7 @@ msgstr "Host Async OK"
 msgid "Host Config Key"
 msgstr "Host Config Key"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr "Host Count"
 
@@ -3890,7 +3922,7 @@ msgstr "Host status information for this job is unavailable."
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hosts"
@@ -4354,12 +4386,16 @@ msgid "Inventory Source"
 msgstr "Inventory Source"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr "Inventory Source Error"
+#~ msgid "Inventory Source Error"
+#~ msgstr "Inventory Source Error"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Inventory Source Sync"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr "Inventory Source Sync Error"
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4424,9 +4460,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "JOB ID:"
 
@@ -4455,6 +4491,7 @@ msgstr "Job"
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
@@ -4677,7 +4714,7 @@ msgstr "Labels"
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr "Last Job Status"
 
@@ -4703,7 +4740,7 @@ msgstr "Last Login"
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4743,7 +4780,7 @@ msgstr "Last job run"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "Last modified"
 
@@ -4752,7 +4789,7 @@ msgstr "Last modified"
 msgid "Last name"
 msgstr "Last name"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr "Last used"
 
@@ -4906,9 +4943,9 @@ msgstr "Lookup type"
 msgid "Lookup typeahead"
 msgstr "Lookup typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "MOST RECENT SYNC"
 
@@ -4966,9 +5003,9 @@ msgstr "Management jobs"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manual"
@@ -5318,7 +5355,7 @@ msgstr "Multiple Choice Options"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5344,12 +5381,12 @@ msgstr "Multiple Choice Options"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5779,7 +5816,7 @@ msgstr "Optionally select the credential to use to send status updates back to t
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5815,9 +5852,9 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -6008,7 +6045,7 @@ msgstr "Personal access token"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr "Play Count"
 
@@ -6032,7 +6069,7 @@ msgid "Playbook Complete"
 msgstr "Playbook Complete"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook Directory"
@@ -6059,7 +6096,7 @@ msgstr "Playbook name"
 msgid "Playbook run"
 msgstr "Playbook run"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr "Plays"
 
@@ -6235,7 +6272,7 @@ msgid "Project"
 msgstr "Project"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Project Base Path"
@@ -6245,14 +6282,19 @@ msgstr "Project Base Path"
 msgid "Project Sync"
 msgstr "Project Sync"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr "Project Sync Error"
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "Project Update"
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr "Project Update Error"
+#~ msgid "Project Update Error"
+#~ msgstr "Project Update Error"
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6515,12 +6557,12 @@ msgstr "Related Groups"
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "Relaunch"
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr "Relaunch Job"
 
@@ -6538,7 +6580,7 @@ msgid "Relaunch on"
 msgstr "Relaunch on"
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr "Relaunch using host parameters"
 
@@ -6653,8 +6695,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6709,7 +6751,7 @@ msgstr "Revert to factory default."
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "Revision"
 
@@ -6830,9 +6872,9 @@ msgid "START"
 msgstr "START"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "STATUS:"
 
@@ -6969,7 +7011,7 @@ msgstr "Second"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "Seconds"
 
@@ -7097,7 +7139,7 @@ msgid "Select a row to approve"
 msgstr "Select a row to approve"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7370,7 +7412,7 @@ msgstr "Select {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7478,7 +7520,7 @@ msgstr "Show"
 msgid "Show Changes"
 msgstr "Show Changes"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr "Show all groups"
 
@@ -7491,7 +7533,7 @@ msgstr "Show changes"
 msgid "Show less"
 msgstr "Show less"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr "Show only root groups"
 
@@ -7654,7 +7696,7 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7665,7 +7707,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Source Control Branch/Tag/Commit"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Source Control Credential"
@@ -7675,13 +7717,13 @@ msgid "Source Control Credential Type"
 msgstr "Source Control Credential Type"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Source Control Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "Source Control Type"
 
@@ -7689,7 +7731,7 @@ msgstr "Source Control Type"
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7832,12 +7874,12 @@ msgstr "Started"
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7936,7 +7978,7 @@ msgstr "Success message body"
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "Successfully copied to clipboard!"
 
@@ -7976,14 +8018,14 @@ msgstr "Survey preview modal"
 msgid "Survey questions"
 msgstr "Survey questions"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -8002,7 +8044,7 @@ msgstr "Sync all sources"
 msgid "Sync error"
 msgstr "Sync error"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "Sync for revision"
 
@@ -8117,7 +8159,7 @@ msgstr "Target URL"
 msgid "Task"
 msgstr "Task"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr "Task Count"
 
@@ -8125,7 +8167,7 @@ msgstr "Task Count"
 msgid "Task Started"
 msgstr "Task Started"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -8583,7 +8625,7 @@ msgstr "This job template is currently being used by other resources. Are you su
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "This organization is currently being by other resources. Are you sure you want to delete it?"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This project is currently being used by other resources. Are you sure you want to delete it?"
 
@@ -8816,7 +8858,7 @@ msgid "Track submodules"
 msgstr "Track submodules"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr "Track submodules latest commit on branch"
 
@@ -8876,7 +8918,7 @@ msgstr "Twilio"
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8921,15 +8963,15 @@ msgid "Unlimited"
 msgstr "Unlimited"
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr "Unreachable"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr "Unreachable Host Count"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr "Unreachable Hosts"
 
@@ -8942,7 +8984,7 @@ msgid "Unsaved changes modal"
 msgstr "Unsaved changes modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Update Revision on Launch"
@@ -9846,7 +9888,7 @@ msgstr "confirm disassociate"
 #~ msgid "controller instance"
 #~ msgstr "controller instance"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "copy to clipboard disabled"
 
@@ -9883,7 +9925,7 @@ msgstr "documentation"
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -546,7 +546,7 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -582,7 +582,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -592,7 +591,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr ""
 
@@ -864,8 +863,7 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -876,12 +874,10 @@ msgstr ""
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -932,12 +928,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1157,9 +1154,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1181,11 +1178,11 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1217,7 +1214,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr ""
 
@@ -1458,7 +1455,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1588,7 +1585,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1603,7 +1600,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1735,10 +1732,10 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1780,9 +1777,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1798,7 +1795,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -2198,8 +2195,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2471,16 +2468,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2721,7 +2718,7 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2755,8 +2752,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2803,7 +2800,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2916,7 +2913,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr ""
 
@@ -2979,7 +2976,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -3009,19 +3006,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3073,12 +3070,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3177,7 +3175,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3225,7 +3223,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3410,12 +3408,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3715,7 +3713,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3798,7 +3796,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3824,7 +3822,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4088,7 +4086,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr ""
 
@@ -4172,7 +4170,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4195,7 +4193,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4215,7 +4213,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4238,11 +4236,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4321,22 +4319,21 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr ""
 
@@ -4355,19 +4352,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4392,12 +4389,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4418,8 +4415,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4525,15 +4522,15 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4568,7 +4565,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4666,7 +4663,7 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
@@ -4702,13 +4699,13 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4779,7 +4776,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr ""
 
@@ -4796,10 +4793,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr ""
 
@@ -5049,9 +5046,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5255,7 +5252,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5798,7 +5795,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5823,7 +5820,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5832,13 +5829,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5852,10 +5849,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr ""
 
@@ -5874,7 +5871,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -6010,7 +6007,7 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6019,8 +6016,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6293,16 +6290,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6319,8 +6316,8 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6433,12 +6430,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6487,7 +6482,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6560,7 +6555,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6757,7 +6752,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7293,7 +7288,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7430,10 +7425,10 @@ msgstr ""
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr ""
 
@@ -7445,8 +7440,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7523,8 +7518,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7550,20 +7545,20 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7654,7 +7649,7 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7823,7 +7818,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7831,7 +7826,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -8254,7 +8249,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8507,8 +8502,8 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8542,7 +8537,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8579,15 +8574,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8790,7 +8785,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8822,7 +8817,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9094,7 +9089,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9247,18 +9242,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9700,7 +9695,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -411,7 +411,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -858,13 +858,24 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
@@ -918,6 +929,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1054,7 +1069,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1163,6 +1178,14 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr ""
@@ -1269,7 +1292,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1277,7 +1300,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1436,7 +1459,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1597,10 +1620,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1712,7 +1735,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1755,8 +1778,8 @@ msgid "Delete Inventory"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr ""
 
@@ -1772,7 +1795,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr ""
 
@@ -1835,7 +1858,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -1950,9 +1973,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2172,8 +2195,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr ""
 
@@ -2227,14 +2250,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2360,8 +2383,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2375,7 +2398,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2445,16 +2468,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2778,7 +2801,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2969,9 +2992,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -2988,15 +3011,15 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3030,14 +3053,19 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3047,7 +3075,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3063,7 +3091,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3194,7 +3222,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3624,7 +3652,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr ""
 
@@ -3684,7 +3712,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr ""
 
@@ -3767,7 +3795,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -4189,11 +4217,15 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4259,9 +4291,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4290,6 +4322,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
@@ -4508,7 +4541,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4534,7 +4567,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4574,7 +4607,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4583,7 +4616,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4733,9 +4766,9 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
@@ -4793,9 +4826,9 @@ msgstr ""
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -5132,7 +5165,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5158,12 +5191,12 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5569,7 +5602,7 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5605,9 +5638,9 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5786,7 +5819,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr ""
 
@@ -5810,7 +5843,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
@@ -5837,7 +5870,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr ""
 
@@ -5991,7 +6024,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6001,14 +6034,19 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6255,12 +6293,12 @@ msgstr ""
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6278,7 +6316,7 @@ msgid "Relaunch on"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6391,8 +6429,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6447,7 +6485,7 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6568,9 +6606,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6707,7 +6745,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6829,7 +6867,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7076,7 +7114,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7184,7 +7222,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr ""
 
@@ -7197,7 +7235,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr ""
 
@@ -7346,7 +7384,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7357,7 +7395,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
@@ -7367,13 +7405,13 @@ msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
@@ -7381,7 +7419,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7520,12 +7558,12 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7618,7 +7656,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7658,14 +7696,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7684,7 +7722,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7781,7 +7819,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr ""
 
@@ -7789,7 +7827,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr ""
 
@@ -8212,7 +8250,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8432,7 +8470,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8492,7 +8530,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8537,15 +8575,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8558,7 +8596,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -9425,7 +9463,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9454,7 +9492,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -546,6 +546,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: components/DeleteButton/DeleteButton.jsx:128
 msgid "Are you sure you want to delete:"
 msgstr ""
@@ -578,7 +582,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -588,7 +592,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr ""
 
@@ -834,8 +838,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -862,8 +864,8 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -878,8 +880,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -930,6 +932,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1156,7 +1159,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1214,7 +1217,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr ""
 
@@ -1455,7 +1458,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1600,7 +1603,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1732,7 +1735,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1777,7 +1780,7 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2792,8 +2795,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2914,7 +2916,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr ""
 
@@ -3075,6 +3077,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3412,7 +3415,7 @@ msgstr ""
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -4085,7 +4088,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr ""
 
@@ -4192,7 +4195,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4212,7 +4215,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4239,7 +4242,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4318,21 +4321,22 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr ""
 
@@ -4351,7 +4355,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4363,7 +4367,7 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4393,7 +4397,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4529,7 +4533,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4564,7 +4568,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4704,7 +4708,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4775,7 +4779,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr ""
 
@@ -4795,7 +4799,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr ""
 
@@ -5828,13 +5832,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5851,7 +5855,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr ""
 
@@ -6015,8 +6019,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6291,8 +6295,8 @@ msgstr ""
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
@@ -6433,8 +6437,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6483,7 +6487,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7289,7 +7293,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7429,7 +7433,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr ""
 
@@ -7442,7 +7446,7 @@ msgid "Source Variables"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7546,7 +7550,7 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7559,7 +7563,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8786,7 +8790,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8818,7 +8822,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9246,7 +9250,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
@@ -9254,7 +9258,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -908,16 +908,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr ""
+#~ msgid "Cancel sync source"
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3030,12 +3030,25 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3275,7 +3288,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3611,7 +3624,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr ""
 
@@ -4173,6 +4186,10 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -5988,6 +6005,11 @@ msgstr ""
 msgid "Project Update"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr ""
@@ -6369,6 +6391,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6805,7 +6829,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7160,7 +7184,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr ""
 
@@ -7173,7 +7197,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr ""
 
@@ -7476,11 +7500,11 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -185,8 +185,8 @@ msgstr "Token de compte"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -568,7 +568,7 @@ msgstr "Approuvé par {0} - {1}"
 msgid "April"
 msgstr "Avril"
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -608,7 +608,6 @@ msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès à {1}?  Cela risque
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès de {1} ?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
@@ -618,7 +617,7 @@ msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr "Artefacts"
 
@@ -894,8 +893,7 @@ msgstr "Annuler"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -906,12 +904,10 @@ msgstr "Annuler Job"
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -962,12 +958,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "Annuler la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1195,9 +1192,9 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr "Effondrement"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Commande"
@@ -1235,11 +1232,11 @@ msgstr "Confirmer Effacer"
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1271,7 +1268,7 @@ msgstr "Confirmer annuler tout"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr "Groupe de conteneurs"
 
@@ -1522,7 +1519,7 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1652,7 +1649,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "Type d'informations d’identification non trouvé."
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1667,7 +1664,7 @@ msgstr "Type d'informations d’identification non trouvé."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1799,10 +1796,10 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1844,9 +1841,9 @@ msgstr "Supprimer l'hôte"
 msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "Supprimer Job"
 
@@ -1862,7 +1859,7 @@ msgstr "Supprimer la notification"
 msgid "Delete Organization"
 msgstr "Supprimer l'organisation"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "Suppression du projet"
 
@@ -2262,8 +2259,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "Télécharger la sortie"
 
@@ -2535,16 +2532,16 @@ msgid "Edit this node"
 msgstr "Modifier ce nœud"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "Temps écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "Temps écoulé (en secondes) pendant lequel la tâche s'est exécutée."
 
@@ -2801,7 +2798,7 @@ msgstr "Entrez les variables avec la syntaxe JSON ou YAML. Utilisez le bouton ra
 #~ msgid "Environment"
 #~ msgstr "Environnement"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2835,8 +2832,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2883,7 +2880,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2996,7 +2993,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr "Nœud d'exécution"
 
@@ -3059,7 +3056,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "Arrive à expiration le {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "Explication"
@@ -3089,19 +3086,19 @@ msgstr "TERMINÉ :"
 msgid "Facts"
 msgstr "Faits"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "Échec"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "Échec du comptage des hôtes"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "Échec Hôtes"
 
@@ -3153,12 +3150,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3257,7 +3255,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs sources d'inventaire."
 msgid "Failed to delete one or more job templates."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles de Jobs."
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs."
 
@@ -3305,7 +3303,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs approbations de flux de tr
 msgid "Failed to delete organization."
 msgstr "N'a pas réussi à supprimer l'organisation."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "N'a pas réussi à supprimer le projet."
 
@@ -3490,12 +3488,12 @@ msgstr "Téléchargement de fichier rejeté. Veuillez sélectionner un seul fich
 msgid "File, directory or script"
 msgstr "Fichier, répertoire ou script"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "Heure de Fin"
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Terminé"
@@ -3795,7 +3793,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "Clé de configuration de l’hôte"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "Nombre d'hôtes"
 
@@ -3878,7 +3876,7 @@ msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas dis
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hôtes"
@@ -3904,7 +3902,7 @@ msgstr "Heure"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4168,7 +4166,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "Filtres de l'instance"
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr "Groupe d'instance"
 
@@ -4252,7 +4250,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4275,7 +4273,7 @@ msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4295,7 +4293,7 @@ msgstr "Fichier d'inventaire"
 msgid "Inventory ID"
 msgstr "ID Inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4318,11 +4316,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "Sources d'inventaire"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr "Sync Inventaires"
 
@@ -4401,22 +4399,21 @@ msgstr "Janvier"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Erreur de suppression d’un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr "Découpage de job"
 
@@ -4435,19 +4432,19 @@ msgstr "Statut Job"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "Balises Job"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Modèle de Job"
@@ -4472,12 +4469,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4498,8 +4495,8 @@ msgstr "Onglet Graphique de l'état des Jobs"
 msgid "Job templates"
 msgstr "Modèles de Jobs"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4605,15 +4602,15 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "Nom du label"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4648,7 +4645,7 @@ msgstr "Dernière connexion"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4746,7 +4743,7 @@ msgstr "Lancer le flux de travail"
 msgid "Launched By"
 msgstr "Lancé par"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "Lancé par (Nom d'utilisateur)"
 
@@ -4782,13 +4779,13 @@ msgstr "Moins ou égal à la comparaison."
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4859,7 +4856,7 @@ msgstr "DERNIÈRE SYNCHRONISATION"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr "Informations d’identification de la machine"
 
@@ -4876,10 +4873,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr "Job de gestion"
 
@@ -5129,9 +5126,9 @@ msgstr "Options à choix multiples."
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5335,7 +5332,7 @@ msgstr "Jamais mis à jour"
 msgid "Never expires"
 msgstr "N'expire jamais"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "Nouveau"
@@ -5878,7 +5875,7 @@ msgstr "Les deux dernières semaines"
 msgid "Past week"
 msgstr "La semaine dernière"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "En attente"
@@ -5903,7 +5900,7 @@ msgstr "Jeton d'accès personnel"
 msgid "Play"
 msgstr "Lancer"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "Compte de jeux"
 
@@ -5912,13 +5909,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5932,10 +5929,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr "Répertoire de playbook"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr "Exécution du playbook"
 
@@ -5954,7 +5951,7 @@ msgstr "Nom du playbook"
 msgid "Playbook run"
 msgstr "Exécution du playbook"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Lancements"
 
@@ -6090,7 +6087,7 @@ msgstr "Élévation des privilèges"
 msgid "Privilege escalation password"
 msgstr "Mot de passe pour l’élévation des privilèges"
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6099,8 +6096,8 @@ msgstr "Mot de passe pour l’élévation des privilèges"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6369,16 +6366,16 @@ msgstr "Expression régulière où seuls les noms d'hôtes correspondants seront
 msgid "Related Groups"
 msgstr "Groupes liés"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "Relancer le Job"
 
@@ -6395,8 +6392,8 @@ msgstr "Relancer les hôtes défaillants"
 msgid "Relaunch on"
 msgstr "Relancer sur"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "Relancer en utilisant les paramètres de l'hôte"
 
@@ -6509,12 +6506,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6563,7 +6558,7 @@ msgstr "Inverser les paramètres"
 msgid "Revert to factory default."
 msgstr "Revenir à la valeur usine par défaut."
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6636,7 +6631,7 @@ msgstr "Continuer"
 msgid "Run type"
 msgstr "Type d’exécution"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6833,7 +6828,7 @@ msgstr "Secondes"
 msgid "See errors on the left"
 msgstr "Voir les erreurs sur la gauche"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7378,7 +7373,7 @@ msgstr "Sélection par simple pression d'une touche"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7520,10 +7515,10 @@ msgstr "Type de Contrôle de la source"
 msgid "Source Control URL"
 msgstr "URL Contrôle de la source"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr "Mise à jour du Contrôle de la source"
 
@@ -7535,8 +7530,8 @@ msgstr "Numéro de téléphone de la source"
 msgid "Source Variables"
 msgstr "Variables Source"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr "Flux de travail Source"
 
@@ -7617,8 +7612,8 @@ msgstr "Onglet Standard Out"
 msgid "Start"
 msgstr "Démarrer"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "Heure Début"
 
@@ -7644,20 +7639,20 @@ msgstr "Démarrer le processus de synchronisation"
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "Démarré"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7748,7 +7743,7 @@ msgstr "Message de réussite"
 msgid "Success message body"
 msgstr "Corps du message de réussite"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7917,7 +7912,7 @@ msgstr "URL cible"
 msgid "Task"
 msgstr "Tâche"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "Nombre de tâches"
 
@@ -7925,7 +7920,7 @@ msgstr "Nombre de tâches"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "Tâches"
 
@@ -8352,7 +8347,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8605,8 +8600,8 @@ msgstr "Mardi"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8640,7 +8635,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8677,15 +8672,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "Hôte inaccessible"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "Nombre d'hôtes inaccessibles"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "Hôtes inaccessibles"
 
@@ -8892,7 +8887,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8924,7 +8919,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9196,7 +9191,7 @@ msgstr "Visualiseur"
 msgid "WARNING:"
 msgstr "AVERTISSEMENT :"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "En attente"
@@ -9354,18 +9349,18 @@ msgstr "Approbation du flux de travail non trouvée."
 msgid "Workflow Approvals"
 msgstr "Approbations des flux de travail"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Job de flux de travail"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9809,7 +9804,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -608,7 +608,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès à {1}?  Cela risque
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {0} l’accès de {1} ?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
@@ -618,7 +618,7 @@ msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr "Artefacts"
 
@@ -868,8 +868,6 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -896,8 +894,8 @@ msgstr "Annuler"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -912,8 +910,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -964,6 +962,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "Annuler la source de synchronisation"
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1198,7 +1197,7 @@ msgstr "Effondrement"
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "Commande"
@@ -1272,7 +1271,7 @@ msgstr "Confirmer annuler tout"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr "Groupe de conteneurs"
 
@@ -1523,7 +1522,7 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1668,7 +1667,7 @@ msgstr "Type d'informations d’identification non trouvé."
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1800,7 +1799,7 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1845,7 +1844,7 @@ msgstr "Supprimer l'hôte"
 msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2876,8 +2875,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2998,7 +2996,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr "Nœud d'exécution"
 
@@ -3159,6 +3157,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3496,7 +3495,7 @@ msgstr "Fichier, répertoire ou script"
 msgid "Finish Time"
 msgstr "Heure de Fin"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "Terminé"
@@ -4169,7 +4168,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "Filtres de l'instance"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr "Groupe d'instance"
 
@@ -4276,7 +4275,7 @@ msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4296,7 +4295,7 @@ msgstr "Fichier d'inventaire"
 msgid "Inventory ID"
 msgstr "ID Inventaire"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4323,7 +4322,7 @@ msgstr "Sources d'inventaire"
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr "Sync Inventaires"
 
@@ -4402,21 +4401,22 @@ msgstr "Janvier"
 msgid "Job"
 msgstr "Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "Erreur de suppression d’un Job"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr "Découpage de job"
 
@@ -4435,7 +4435,7 @@ msgstr "Statut Job"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4447,7 +4447,7 @@ msgstr "Balises Job"
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "Modèle de Job"
@@ -4477,7 +4477,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4613,7 +4613,7 @@ msgstr "Nom du label"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4648,7 +4648,7 @@ msgstr "Dernière connexion"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4788,7 +4788,7 @@ msgstr "Moins ou égal à la comparaison."
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4859,7 +4859,7 @@ msgstr "DERNIÈRE SYNCHRONISATION"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr "Informations d’identification de la machine"
 
@@ -4879,7 +4879,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr "Job de gestion"
 
@@ -5912,13 +5912,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5935,7 +5935,7 @@ msgstr "Répertoire de playbook"
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr "Exécution du playbook"
 
@@ -6099,8 +6099,8 @@ msgstr "Mot de passe pour l’élévation des privilèges"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6371,8 +6371,8 @@ msgstr "Groupes liés"
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "Relancer"
@@ -6513,8 +6513,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6563,7 +6563,7 @@ msgstr "Inverser les paramètres"
 msgid "Revert to factory default."
 msgstr "Revenir à la valeur usine par défaut."
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7378,7 +7378,7 @@ msgstr "Sélection par simple pression d'une touche"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7523,7 +7523,7 @@ msgstr "URL Contrôle de la source"
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr "Mise à jour du Contrôle de la source"
 
@@ -7536,7 +7536,7 @@ msgid "Source Variables"
 msgstr "Variables Source"
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr "Flux de travail Source"
 
@@ -7644,7 +7644,7 @@ msgstr "Démarrer le processus de synchronisation"
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7657,7 +7657,7 @@ msgstr "Démarré"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8892,7 +8892,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8924,7 +8924,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9357,7 +9357,7 @@ msgstr "Approbations des flux de travail"
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "Job de flux de travail"
@@ -9365,7 +9365,7 @@ msgstr "Job de flux de travail"
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -214,7 +214,7 @@ msgstr "Action"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "Action"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "Tous les types de tâche"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "Autoriser le remplacement de la branche"
@@ -567,6 +567,10 @@ msgstr "Approuvé par {0} - {1}"
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "Avril"
+
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -828,7 +832,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "Expiration Délai d’attente du cache"
@@ -888,14 +892,25 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 msgid "Cancel"
 msgstr "Annuler"
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "Annuler Job"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
+msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
 #: screens/Job/JobDetail/JobDetail.jsx:428
@@ -948,6 +963,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr "Annuler la source de synchronisation"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1092,7 +1111,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "Choisissez le type de ressource qui recevra de nouveaux rôles.  Par exemple, si vous souhaitez ajouter de nouveaux rôles à un ensemble d'utilisateurs, veuillez choisir Utilisateurs et cliquer sur Suivant.  Vous pourrez sélectionner les ressources spécifiques dans l'étape suivante."
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "Nettoyer"
@@ -1217,6 +1236,14 @@ msgstr "Confirmer Effacer"
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr "Confirmer la suppression"
@@ -1333,7 +1360,7 @@ msgstr "Copier l'inventaire"
 msgid "Copy Notification Template"
 msgstr "Copie du modèle de notification"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "Copier le projet"
 
@@ -1341,7 +1368,7 @@ msgstr "Copier le projet"
 msgid "Copy Template"
 msgstr "Copier le modèle"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "Copier la révision complète dans le Presse-papiers."
 
@@ -1500,7 +1527,7 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1661,10 +1688,10 @@ msgid "Custom pod spec"
 msgstr "Spécifications des pods personnalisés"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1776,7 +1803,7 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1819,8 +1846,8 @@ msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr "Supprimer Job"
 
@@ -1836,7 +1863,7 @@ msgstr "Supprimer la notification"
 msgid "Delete Organization"
 msgstr "Supprimer l'organisation"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr "Suppression du projet"
 
@@ -1899,7 +1926,7 @@ msgid "Delete inventory source"
 msgstr "Supprimer la source de l'inventaire"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "Supprimer lors de la mise à jour"
 
@@ -2014,9 +2041,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2236,8 +2263,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr "Télécharger la sortie"
 
@@ -2291,14 +2318,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2424,8 +2451,8 @@ msgstr "Modèle de notification de modification"
 msgid "Edit Organization"
 msgstr "Modifier l'organisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "Modifier le projet"
 
@@ -2439,7 +2466,7 @@ msgstr "Modifier la question"
 msgid "Edit Schedule"
 msgstr "Modifier la programmation"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "Modifier la source"
 
@@ -2509,16 +2536,16 @@ msgid "Edit this node"
 msgstr "Modifier ce nœud"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "Écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr "Temps écoulé"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr "Temps écoulé (en secondes) pendant lequel la tâche s'est exécutée."
 
@@ -2858,7 +2885,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3049,9 +3076,9 @@ msgid "Extra variables"
 msgstr "Variables supplémentaires"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "TERMINÉ :"
 
@@ -3068,15 +3095,15 @@ msgstr "Faits"
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr "Échec"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr "Échec du comptage des hôtes"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr "Échec Hôtes"
 
@@ -3110,14 +3137,19 @@ msgstr "N'a pas réussi à associer le rôle"
 msgid "Failed to associate."
 msgstr "N'a pas réussi à associer."
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3127,7 +3159,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3143,7 +3175,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "N'a pas réussi à copier l'inventaire."
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "Le projet n'a pas été copié."
 
@@ -3274,7 +3306,7 @@ msgstr "N'a pas réussi à supprimer une ou plusieurs approbations de flux de tr
 msgid "Failed to delete organization."
 msgstr "N'a pas réussi à supprimer l'organisation."
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr "N'a pas réussi à supprimer le projet."
 
@@ -3704,7 +3736,7 @@ msgstr "Groupe"
 msgid "Group details"
 msgstr "Détails du groupe"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr "Type de groupe"
 
@@ -3764,7 +3796,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "Clé de configuration de l’hôte"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr "Nombre d'hôtes"
 
@@ -3847,7 +3879,7 @@ msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas dis
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "Hôtes"
@@ -4269,12 +4301,16 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "Sync Source d’inventaire"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4339,9 +4375,9 @@ msgid "Items per page"
 msgstr "Éléments par page"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "ID JOB :"
 
@@ -4370,6 +4406,7 @@ msgstr "Job"
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
@@ -4588,7 +4625,7 @@ msgstr "Libellés"
 msgid "Last"
 msgstr "Dernier"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4614,7 +4651,7 @@ msgstr "Dernière connexion"
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4654,7 +4691,7 @@ msgstr "Dernière exécution du Job"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "Dernière modification"
 
@@ -4663,7 +4700,7 @@ msgstr "Dernière modification"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4813,9 +4850,9 @@ msgstr "Type de recherche"
 msgid "Lookup typeahead"
 msgstr "Recherche par type"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "DERNIÈRE SYNCHRONISATION"
 
@@ -4873,9 +4910,9 @@ msgstr "Jobs de gestion"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "Manuel"
@@ -5212,7 +5249,7 @@ msgstr "Options à choix multiples."
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5238,12 +5275,12 @@ msgstr "Options à choix multiples."
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5649,7 +5686,7 @@ msgstr "En option, sélectionnez les informations d'identification à utiliser p
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5685,9 +5722,9 @@ msgstr "Options"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5866,7 +5903,7 @@ msgstr "Jeton d'accès personnel"
 msgid "Play"
 msgstr "Lancer"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr "Compte de jeux"
 
@@ -5890,7 +5927,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Répertoire de playbook"
@@ -5917,7 +5954,7 @@ msgstr "Nom du playbook"
 msgid "Playbook run"
 msgstr "Exécution du playbook"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr "Lancements"
 
@@ -6071,7 +6108,7 @@ msgid "Project"
 msgstr "Projet"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "Chemin de base du projet"
@@ -6081,14 +6118,19 @@ msgstr "Chemin de base du projet"
 msgid "Project Sync"
 msgstr "Sync Projet"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "Mise à jour du projet"
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6331,12 +6373,12 @@ msgstr "Groupes liés"
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "Relancer"
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr "Relancer le Job"
 
@@ -6354,7 +6396,7 @@ msgid "Relaunch on"
 msgstr "Relancer sur"
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr "Relancer en utilisant les paramètres de l'hôte"
 
@@ -6467,8 +6509,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6523,7 +6565,7 @@ msgstr "Revenir à la valeur usine par défaut."
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "Révision"
 
@@ -6644,9 +6686,9 @@ msgid "START"
 msgstr "DÉMARRER"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "ÉTAT :"
 
@@ -6783,7 +6825,7 @@ msgstr "Deuxième"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "Secondes"
 
@@ -6905,7 +6947,7 @@ msgid "Select a row to approve"
 msgstr "Sélectionnez une ligne à approuver"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr "Sélectionnez une ligne à supprimer"
 
@@ -7161,7 +7203,7 @@ msgstr "Sélectionnez {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7269,7 +7311,7 @@ msgstr "Afficher"
 msgid "Show Changes"
 msgstr "Afficher les modifications"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr "Afficher tous les groupes"
 
@@ -7282,7 +7324,7 @@ msgstr "Afficher les modifications"
 msgid "Show less"
 msgstr "Afficher moins de détails"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr "Afficher uniquement les groupes racines"
 
@@ -7436,7 +7478,7 @@ msgstr "Source"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7447,7 +7489,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "Branche/ Balise / Commit du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "Identifiant Contrôle de la source"
@@ -7457,13 +7499,13 @@ msgid "Source Control Credential Type"
 msgstr "Type d’Identifiant du Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "Refspec Contrôle de la source"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "Type de Contrôle de la source"
 
@@ -7471,7 +7513,7 @@ msgstr "Type de Contrôle de la source"
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7614,12 +7656,12 @@ msgstr "Démarré"
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7712,7 +7754,7 @@ msgstr "Corps du message de réussite"
 msgid "Successful"
 msgstr "Réussi"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "Copie réussie dans le presse-papiers !"
 
@@ -7752,14 +7794,14 @@ msgstr "Aperçu de l'enquête modale"
 msgid "Survey questions"
 msgstr "Questions de l'enquête"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "Sync"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7778,7 +7820,7 @@ msgstr "Synchroniser toutes les sources"
 msgid "Sync error"
 msgstr "Erreur de synchronisation"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "Synchronisation pour la révision"
 
@@ -7875,7 +7917,7 @@ msgstr "URL cible"
 msgid "Task"
 msgstr "Tâche"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr "Nombre de tâches"
 
@@ -7883,7 +7925,7 @@ msgstr "Nombre de tâches"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr "Tâches"
 
@@ -8310,7 +8352,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8530,7 +8572,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8590,7 +8632,7 @@ msgstr "Twilio"
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8635,15 +8677,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr "Hôte inaccessible"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr "Nombre d'hôtes inaccessibles"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr "Hôtes inaccessibles"
 
@@ -8656,7 +8698,7 @@ msgid "Unsaved changes modal"
 msgstr "Annuler les modifications non enregistrées"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "Mettre à jour Révision au lancement"
@@ -9532,7 +9574,7 @@ msgstr "confirmer dissocier"
 #~ msgid "controller instance"
 #~ msgstr "instance de contrôleur"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "copie dans le presse-papiers désactivée"
 
@@ -9561,7 +9603,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -938,16 +938,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "Annuler sync"
+#~ msgid "Cancel sync"
+#~ msgstr "Annuler sync"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "Annuler le processus de synchronisation"
+#~ msgid "Cancel sync process"
+#~ msgstr "Annuler le processus de synchronisation"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "Annuler la source de synchronisation"
+#~ msgid "Cancel sync source"
+#~ msgstr "Annuler la source de synchronisation"
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3110,13 +3110,26 @@ msgstr "N'a pas réussi à associer le rôle"
 msgid "Failed to associate."
 msgstr "N'a pas réussi à associer."
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3355,7 +3368,7 @@ msgstr "Impossible de récupérer les informations d'identification des nœuds."
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "Impossible de synchroniser la source de l'inventaire."
 
@@ -3691,7 +3704,7 @@ msgstr "Groupe"
 msgid "Group details"
 msgstr "Détails du groupe"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr "Type de groupe"
 
@@ -4253,6 +4266,10 @@ msgstr "ID Inventaire"
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -6068,6 +6085,11 @@ msgstr "Sync Projet"
 msgid "Project Update"
 msgstr "Mise à jour du projet"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr "Projet non trouvé."
@@ -6445,6 +6467,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6881,7 +6905,7 @@ msgid "Select a row to approve"
 msgstr "Sélectionnez une ligne à approuver"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr "Sélectionnez une ligne à supprimer"
 
@@ -7245,7 +7269,7 @@ msgstr "Afficher"
 msgid "Show Changes"
 msgstr "Afficher les modifications"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr "Afficher tous les groupes"
 
@@ -7258,7 +7282,7 @@ msgstr "Afficher les modifications"
 msgid "Show less"
 msgstr "Afficher moins de détails"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr "Afficher uniquement les groupes racines"
 
@@ -7570,11 +7594,11 @@ msgstr "Message de départ"
 msgid "Start message body"
 msgstr "Démarrer le corps du message"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "Démarrer le processus de synchronisation"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -938,16 +938,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "同期の取り消し"
+#~ msgid "Cancel sync"
+#~ msgstr "同期の取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "同期プロセスの取り消し"
+#~ msgid "Cancel sync process"
+#~ msgstr "同期プロセスの取り消し"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "同期プロセスの取り消し"
+#~ msgid "Cancel sync source"
+#~ msgstr "同期プロセスの取り消し"
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3106,13 +3106,26 @@ msgstr "ロールの関連付けに失敗しました"
 msgid "Failed to associate."
 msgstr "関連付けに失敗しました。"
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "インベントリーソースの同期をキャンセルできませんでした。"
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "インベントリーソースの同期をキャンセルできませんでした。"
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3351,7 +3364,7 @@ msgstr "ノード認証情報を取得できませんでした。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "インベントリーソースを同期できませんでした。"
 
@@ -3687,7 +3700,7 @@ msgstr "グループ"
 msgid "Group details"
 msgstr "グループの詳細"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr "グループタイプ"
 
@@ -4249,6 +4262,10 @@ msgstr "インベントリー ID"
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -6064,6 +6081,11 @@ msgstr "プロジェクトの同期"
 msgid "Project Update"
 msgstr "プロジェクトの更新"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr "プロジェクトが見つかりません。"
@@ -6441,6 +6463,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6877,7 +6901,7 @@ msgid "Select a row to approve"
 msgstr "承認する行の選択"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr "削除する行の選択"
 
@@ -7241,7 +7265,7 @@ msgstr "表示"
 msgid "Show Changes"
 msgstr "変更の表示"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr "すべてのグループの表示"
 
@@ -7254,7 +7278,7 @@ msgstr "変更の表示"
 msgid "Show less"
 msgstr "簡易表示"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr "root グループのみを表示"
 
@@ -7566,11 +7590,11 @@ msgstr "開始メッセージ"
 msgid "Start message body"
 msgstr "開始メッセージのボディー"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "同期プロセスの開始"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -185,8 +185,8 @@ msgstr "アカウントトークン"
 msgid "Action"
 msgstr "アクション"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -568,7 +568,7 @@ msgstr "{0} - {1} により承認済"
 msgid "April"
 msgstr "4 月"
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -608,7 +608,6 @@ msgstr "{1} から {0} のアクセスを削除しますか? これを行うと�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "{username} からの {0} のアクセスを削除してもよろしいですか?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "このジョブをキャンセルする要求を送信してよろしいですか?"
@@ -618,7 +617,7 @@ msgstr "このジョブをキャンセルする要求を送信してよろしい
 msgid "Arguments"
 msgstr "引数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr "アーティファクト"
 
@@ -894,8 +893,7 @@ msgstr "取り消し"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -906,12 +904,10 @@ msgstr "ジョブの取り消し"
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -962,12 +958,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "同期プロセスの取り消し"
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1195,9 +1192,9 @@ msgstr "クラウド"
 msgid "Collapse"
 msgstr "折りたたむ"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "コマンド"
@@ -1235,11 +1232,11 @@ msgstr "削除の確認"
 msgid "Confirm Password"
 msgstr "パスワードの確認"
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1271,7 +1268,7 @@ msgstr "すべて元に戻すことを確認"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr "コンテナーグループ"
 
@@ -1522,7 +1519,7 @@ msgstr "ユーザートークンの作成"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1652,7 +1649,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "認証情報タイプが見つかりません。"
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1667,7 +1664,7 @@ msgstr "認証情報タイプが見つかりません。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1799,10 +1796,10 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1844,9 +1841,9 @@ msgstr "ホストの削除"
 msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "ジョブの削除"
 
@@ -1862,7 +1859,7 @@ msgstr "通知の削除"
 msgid "Delete Organization"
 msgstr "組織の削除"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "プロジェクトの削除"
 
@@ -2262,8 +2259,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "出力のダウンロード"
 
@@ -2535,16 +2532,16 @@ msgid "Edit this node"
 msgstr "このノードの編集"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "ジョブ実行の経過時間"
 
@@ -2797,7 +2794,7 @@ msgstr "JSON または YAML 構文のいずれかを使用して変数を入力�
 #~ msgid "Environment"
 #~ msgstr "環境"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2831,8 +2828,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2879,7 +2876,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2992,7 +2989,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr "実行ノード"
 
@@ -3055,7 +3052,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "{0} の有効期限"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "説明"
@@ -3085,19 +3082,19 @@ msgstr "終了日時:"
 msgid "Facts"
 msgstr "ファクト"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "失敗"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "失敗したホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "失敗したホスト"
 
@@ -3149,12 +3146,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr "インベントリーソースの同期をキャンセルできませんでした。"
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3253,7 +3251,7 @@ msgstr "1 つ以上のインベントリーリソースを削除できません�
 msgid "Failed to delete one or more job templates."
 msgstr "1 つ以上のジョブテンプレートを削除できませんでした"
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "1 つ以上のジョブを削除できませんでした。"
 
@@ -3301,7 +3299,7 @@ msgstr "1 つ以上のワークフロー承認を削除できませんでした�
 msgid "Failed to delete organization."
 msgstr "組織を削除できませんでした。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "プロジェクトを削除できませんでした。"
 
@@ -3486,12 +3484,12 @@ msgstr "ファイルのアップロードが拒否されました。単一の .j
 msgid "File, directory or script"
 msgstr "ファイル、ディレクトリー、またはスクリプト"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "終了時間"
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "終了日時"
@@ -3791,7 +3789,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "ホスト設定キー"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "ホスト数"
 
@@ -3874,7 +3872,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3900,7 +3898,7 @@ msgstr "時間"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4164,7 +4162,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "インスタンスフィルター"
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr "インスタンスグループ"
 
@@ -4248,7 +4246,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "ソースを含むインベントリーはコピーできません。"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4271,7 +4269,7 @@ msgstr "ソースを含むインベントリーはコピーできません。"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4291,7 +4289,7 @@ msgstr "インベントリーファイル"
 msgid "Inventory ID"
 msgstr "インベントリー ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4314,11 +4312,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "インベントリーソース"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr "インベントリー同期"
 
@@ -4397,22 +4395,21 @@ msgstr "1 月"
 msgid "Job"
 msgstr "ジョブ"
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "ジョブ削除エラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr "ジョブスライス"
 
@@ -4431,19 +4428,19 @@ msgstr "ジョブステータス"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "ジョブタグ"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "ジョブテンプレート"
@@ -4468,12 +4465,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4494,8 +4491,8 @@ msgstr "ジョブステータスのグラフタブ"
 msgid "Job templates"
 msgstr "ジョブテンプレート"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4601,15 +4598,15 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "ラベル名"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4644,7 +4641,7 @@ msgstr "前回のログイン"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4742,7 +4739,7 @@ msgstr "ワークフローの起動"
 msgid "Launched By"
 msgstr "起動者"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "起動者 (ユーザー名)"
 
@@ -4778,13 +4775,13 @@ msgstr "Less than or equal to の比較条件"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4855,7 +4852,7 @@ msgstr "直近の同期"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr "マシンの認証情報"
 
@@ -4872,10 +4869,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr "管理ジョブ"
 
@@ -5125,9 +5122,9 @@ msgstr "複数の選択オプション"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5331,7 +5328,7 @@ msgstr "未更新"
 msgid "Never expires"
 msgstr "期限切れなし"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新規"
@@ -5874,7 +5871,7 @@ msgstr "過去 2 週間"
 msgid "Past week"
 msgstr "過去 1 週間"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "保留中"
@@ -5899,7 +5896,7 @@ msgstr "パーソナルアクセストークン"
 msgid "Play"
 msgstr "プレイ"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "再生回数"
 
@@ -5908,13 +5905,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5928,10 +5925,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr "Playbook ディレクトリー"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr "Playbook 実行"
 
@@ -5950,7 +5947,7 @@ msgstr "Playbook 名"
 msgid "Playbook run"
 msgstr "Playbook 実行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "プレイ"
 
@@ -6086,7 +6083,7 @@ msgstr "権限昇格"
 msgid "Privilege escalation password"
 msgstr "権限昇格のパスワード"
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6095,8 +6092,8 @@ msgstr "権限昇格のパスワード"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6365,16 +6362,16 @@ msgstr "一致するホスト名のみがインポートされる正規表現。
 msgid "Related Groups"
 msgstr "関連するグループ"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "再起動"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "ジョブの再起動"
 
@@ -6391,8 +6388,8 @@ msgstr "失敗したホストの再起動"
 msgid "Relaunch on"
 msgstr "再起動時"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "ホストパラメーターを使用した再起動"
 
@@ -6505,12 +6502,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6559,7 +6554,7 @@ msgstr "設定を元に戻す"
 msgid "Revert to factory default."
 msgstr "工場出荷時のデフォルトに戻します。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6632,7 +6627,7 @@ msgstr "実行:"
 msgid "Run type"
 msgstr "実行タイプ"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6829,7 +6824,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "左側のエラーを参照してください"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7374,7 +7369,7 @@ msgstr "簡易キー選択"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7516,10 +7511,10 @@ msgstr "ソースコントロールのタイプ"
 msgid "Source Control URL"
 msgstr "ソースコントロールの URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr "ソースコントロールの更新"
 
@@ -7531,8 +7526,8 @@ msgstr "発信元の電話番号"
 msgid "Source Variables"
 msgstr "ソース変数"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr "ソースワークフローのジョブ"
 
@@ -7613,8 +7608,8 @@ msgstr "標準出力タブ"
 msgid "Start"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "開始時間"
 
@@ -7640,20 +7635,20 @@ msgstr "同期プロセスの開始"
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "開始"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7744,7 +7739,7 @@ msgstr "成功メッセージ"
 msgid "Success message body"
 msgstr "成功メッセージボディー"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7913,7 +7908,7 @@ msgstr "ターゲット URL"
 msgid "Task"
 msgstr "タスク"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "タスク数"
 
@@ -7921,7 +7916,7 @@ msgstr "タスク数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "タスク"
 
@@ -8348,7 +8343,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8601,8 +8596,8 @@ msgstr "火曜"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8636,7 +8631,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8673,15 +8668,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "到達不能"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "到達不能なホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "到達不能なホスト"
 
@@ -8888,7 +8883,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8920,7 +8915,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9192,7 +9187,7 @@ msgstr "ビジュアライザー"
 msgid "WARNING:"
 msgstr "警告:"
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "待機中"
@@ -9350,18 +9345,18 @@ msgstr "ワークフローの承認が見つかりません。"
 msgid "Workflow Approvals"
 msgstr "ワークフローの承認"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "ワークフロージョブ"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9805,7 +9800,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -608,7 +608,7 @@ msgstr "{1} から {0} のアクセスを削除しますか? これを行うと�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "{username} からの {0} のアクセスを削除してもよろしいですか?"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "このジョブをキャンセルする要求を送信してよろしいですか?"
@@ -618,7 +618,7 @@ msgstr "このジョブをキャンセルする要求を送信してよろしい
 msgid "Arguments"
 msgstr "引数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr "アーティファクト"
 
@@ -868,8 +868,6 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -896,8 +894,8 @@ msgstr "取り消し"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -912,8 +910,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -964,6 +962,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "同期プロセスの取り消し"
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1198,7 +1197,7 @@ msgstr "折りたたむ"
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "コマンド"
@@ -1272,7 +1271,7 @@ msgstr "すべて元に戻すことを確認"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr "コンテナーグループ"
 
@@ -1523,7 +1522,7 @@ msgstr "ユーザートークンの作成"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1668,7 +1667,7 @@ msgstr "認証情報タイプが見つかりません。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1800,7 +1799,7 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1845,7 +1844,7 @@ msgstr "ホストの削除"
 msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2872,8 +2871,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2994,7 +2992,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr "実行ノード"
 
@@ -3155,6 +3153,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3492,7 +3491,7 @@ msgstr "ファイル、ディレクトリー、またはスクリプト"
 msgid "Finish Time"
 msgstr "終了時間"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "終了日時"
@@ -4165,7 +4164,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "インスタンスフィルター"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr "インスタンスグループ"
 
@@ -4272,7 +4271,7 @@ msgstr "ソースを含むインベントリーはコピーできません。"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4292,7 +4291,7 @@ msgstr "インベントリーファイル"
 msgid "Inventory ID"
 msgstr "インベントリー ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4319,7 +4318,7 @@ msgstr "インベントリーソース"
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr "インベントリー同期"
 
@@ -4398,21 +4397,22 @@ msgstr "1 月"
 msgid "Job"
 msgstr "ジョブ"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "ジョブ削除エラー"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr "ジョブスライス"
 
@@ -4431,7 +4431,7 @@ msgstr "ジョブステータス"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4443,7 +4443,7 @@ msgstr "ジョブタグ"
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "ジョブテンプレート"
@@ -4473,7 +4473,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4609,7 +4609,7 @@ msgstr "ラベル名"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4644,7 +4644,7 @@ msgstr "前回のログイン"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4784,7 +4784,7 @@ msgstr "Less than or equal to の比較条件"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4855,7 +4855,7 @@ msgstr "直近の同期"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr "マシンの認証情報"
 
@@ -4875,7 +4875,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr "管理ジョブ"
 
@@ -5908,13 +5908,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5931,7 +5931,7 @@ msgstr "Playbook ディレクトリー"
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr "Playbook 実行"
 
@@ -6095,8 +6095,8 @@ msgstr "権限昇格のパスワード"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6367,8 +6367,8 @@ msgstr "関連するグループ"
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "再起動"
@@ -6509,8 +6509,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6559,7 +6559,7 @@ msgstr "設定を元に戻す"
 msgid "Revert to factory default."
 msgstr "工場出荷時のデフォルトに戻します。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7374,7 +7374,7 @@ msgstr "簡易キー選択"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7519,7 +7519,7 @@ msgstr "ソースコントロールの URL"
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr "ソースコントロールの更新"
 
@@ -7532,7 +7532,7 @@ msgid "Source Variables"
 msgstr "ソース変数"
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr "ソースワークフローのジョブ"
 
@@ -7640,7 +7640,7 @@ msgstr "同期プロセスの開始"
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7653,7 +7653,7 @@ msgstr "開始"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8888,7 +8888,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8920,7 +8920,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9353,7 +9353,7 @@ msgstr "ワークフローの承認"
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "ワークフロージョブ"
@@ -9361,7 +9361,7 @@ msgstr "ワークフロージョブ"
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -214,7 +214,7 @@ msgstr "アクション"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "アクション"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "すべてのジョブタイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "ブランチの上書き許可"
@@ -567,6 +567,10 @@ msgstr "{0} - {1} により承認済"
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "4 月"
+
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -828,7 +832,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "キャッシュタイムアウト"
@@ -888,14 +892,25 @@ msgstr "キャッシュのタイムアウト (秒)"
 msgid "Cancel"
 msgstr "取り消し"
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "ジョブの取り消し"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
+msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
 #: screens/Job/JobDetail/JobDetail.jsx:428
@@ -948,6 +963,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr "同期プロセスの取り消し"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1092,7 +1111,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "新しいロールを受け取るリソースのタイプを選択します。たとえば、一連のユーザーに新しいロールを追加する場合は、ユーザーを選択して次へをクリックしてください。次のステップで特定のリソースを選択できるようになります。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "クリーニング"
@@ -1217,6 +1236,14 @@ msgstr "削除の確認"
 msgid "Confirm Password"
 msgstr "パスワードの確認"
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr "削除の確認"
@@ -1333,7 +1360,7 @@ msgstr "インベントリーのコピー"
 msgid "Copy Notification Template"
 msgstr "通知テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "プロジェクトのコピー"
 
@@ -1341,7 +1368,7 @@ msgstr "プロジェクトのコピー"
 msgid "Copy Template"
 msgstr "テンプレートのコピー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "完全なリビジョンをクリップボードにコピーします。"
 
@@ -1500,7 +1527,7 @@ msgstr "ユーザートークンの作成"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1661,10 +1688,10 @@ msgid "Custom pod spec"
 msgstr "カスタム Pod 仕様"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1776,7 +1803,7 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1819,8 +1846,8 @@ msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr "ジョブの削除"
 
@@ -1836,7 +1863,7 @@ msgstr "通知の削除"
 msgid "Delete Organization"
 msgstr "組織の削除"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr "プロジェクトの削除"
 
@@ -1899,7 +1926,7 @@ msgid "Delete inventory source"
 msgstr "インベントリーソースの削除"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "更新時のデプロイ"
 
@@ -2014,9 +2041,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2236,8 +2263,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr "出力のダウンロード"
 
@@ -2291,14 +2318,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2424,8 +2451,8 @@ msgstr "通知テンプレートの編集"
 msgid "Edit Organization"
 msgstr "組織の編集"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "プロジェクトの編集"
 
@@ -2439,7 +2466,7 @@ msgstr "質問の編集"
 msgid "Edit Schedule"
 msgstr "スケジュールの編集"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "ソースの編集"
 
@@ -2509,16 +2536,16 @@ msgid "Edit this node"
 msgstr "このノードの編集"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr "経過時間"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr "ジョブ実行の経過時間"
 
@@ -2854,7 +2881,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3045,9 +3072,9 @@ msgid "Extra variables"
 msgstr "追加変数"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "終了日時:"
 
@@ -3064,15 +3091,15 @@ msgstr "ファクト"
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr "失敗"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr "失敗したホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr "失敗したホスト"
 
@@ -3106,14 +3133,19 @@ msgstr "ロールの関連付けに失敗しました"
 msgid "Failed to associate."
 msgstr "関連付けに失敗しました。"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3123,7 +3155,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3139,7 +3171,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "インベントリーをコピーできませんでした。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "プロジェクトをコピーできませんでした。"
 
@@ -3270,7 +3302,7 @@ msgstr "1 つ以上のワークフロー承認を削除できませんでした�
 msgid "Failed to delete organization."
 msgstr "組織を削除できませんでした。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr "プロジェクトを削除できませんでした。"
 
@@ -3700,7 +3732,7 @@ msgstr "グループ"
 msgid "Group details"
 msgstr "グループの詳細"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr "グループタイプ"
 
@@ -3760,7 +3792,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "ホスト設定キー"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr "ホスト数"
 
@@ -3843,7 +3875,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -4265,12 +4297,16 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "インベントリーソース同期"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4335,9 +4371,9 @@ msgid "Items per page"
 msgstr "ページ別の項目"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "ジョブ ID:"
 
@@ -4366,6 +4402,7 @@ msgstr "ジョブ"
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
@@ -4584,7 +4621,7 @@ msgstr "ラベル"
 msgid "Last"
 msgstr "最終"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4610,7 +4647,7 @@ msgstr "前回のログイン"
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4650,7 +4687,7 @@ msgstr "最後のジョブ実行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "最終更新日"
 
@@ -4659,7 +4696,7 @@ msgstr "最終更新日"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4809,9 +4846,9 @@ msgstr "ルックアップタイプ"
 msgid "Lookup typeahead"
 msgstr "ルックアップの先行入力"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "直近の同期"
 
@@ -4869,9 +4906,9 @@ msgstr "管理ジョブ"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手動"
@@ -5208,7 +5245,7 @@ msgstr "複数の選択オプション"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5234,12 +5271,12 @@ msgstr "複数の選択オプション"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5645,7 +5682,7 @@ msgstr "必要に応じて、ステータスの更新を Webhook サービスに
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5681,9 +5718,9 @@ msgstr "オプション"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5862,7 +5899,7 @@ msgstr "パーソナルアクセストークン"
 msgid "Play"
 msgstr "プレイ"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr "再生回数"
 
@@ -5886,7 +5923,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook ディレクトリー"
@@ -5913,7 +5950,7 @@ msgstr "Playbook 名"
 msgid "Playbook run"
 msgstr "Playbook 実行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr "プレイ"
 
@@ -6067,7 +6104,7 @@ msgid "Project"
 msgstr "プロジェクト"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "プロジェクトのベースパス"
@@ -6077,14 +6114,19 @@ msgstr "プロジェクトのベースパス"
 msgid "Project Sync"
 msgstr "プロジェクトの同期"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "プロジェクトの更新"
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6327,12 +6369,12 @@ msgstr "関連するグループ"
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "再起動"
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr "ジョブの再起動"
 
@@ -6350,7 +6392,7 @@ msgid "Relaunch on"
 msgstr "再起動時"
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr "ホストパラメーターを使用した再起動"
 
@@ -6463,8 +6505,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6519,7 +6561,7 @@ msgstr "工場出荷時のデフォルトに戻します。"
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "リビジョン"
 
@@ -6640,9 +6682,9 @@ msgid "START"
 msgstr "開始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "ステータス:"
 
@@ -6779,7 +6821,7 @@ msgstr "第 2"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "秒"
 
@@ -6901,7 +6943,7 @@ msgid "Select a row to approve"
 msgstr "承認する行の選択"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr "削除する行の選択"
 
@@ -7157,7 +7199,7 @@ msgstr "{0} の選択"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7265,7 +7307,7 @@ msgstr "表示"
 msgid "Show Changes"
 msgstr "変更の表示"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr "すべてのグループの表示"
 
@@ -7278,7 +7320,7 @@ msgstr "変更の表示"
 msgid "Show less"
 msgstr "簡易表示"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr "root グループのみを表示"
 
@@ -7432,7 +7474,7 @@ msgstr "ソース"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7443,7 +7485,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "ソースコントロールブランチ/タグ/コミット"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "ソースコントロール認証情報"
@@ -7453,13 +7495,13 @@ msgid "Source Control Credential Type"
 msgstr "ソースコントロール認証情報タイプ"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "ソースコントロールの Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "ソースコントロールのタイプ"
 
@@ -7467,7 +7509,7 @@ msgstr "ソースコントロールのタイプ"
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7610,12 +7652,12 @@ msgstr "開始"
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7708,7 +7750,7 @@ msgstr "成功メッセージボディー"
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "クリップボードへのコピーに成功しました!"
 
@@ -7748,14 +7790,14 @@ msgstr "Survey プレビューモーダル"
 msgid "Survey questions"
 msgstr "Survey の質問"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同期"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7774,7 +7816,7 @@ msgstr "すべてのソースの同期"
 msgid "Sync error"
 msgstr "同期エラー"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "リビジョンの同期"
 
@@ -7871,7 +7913,7 @@ msgstr "ターゲット URL"
 msgid "Task"
 msgstr "タスク"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr "タスク数"
 
@@ -7879,7 +7921,7 @@ msgstr "タスク数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr "タスク"
 
@@ -8306,7 +8348,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8526,7 +8568,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8586,7 +8628,7 @@ msgstr "Twilio"
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8631,15 +8673,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr "到達不能"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr "到達不能なホスト数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr "到達不能なホスト"
 
@@ -8652,7 +8694,7 @@ msgid "Unsaved changes modal"
 msgstr "保存されていない変更モーダル"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "起動時のリビジョン更新"
@@ -9528,7 +9570,7 @@ msgstr "関連付けの解除の確認"
 #~ msgid "controller instance"
 #~ msgstr "コントローラインスタンス"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "クリップボードへのコピーが無効"
 
@@ -9557,7 +9599,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -186,8 +186,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -546,7 +546,7 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -582,7 +582,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -592,7 +591,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr ""
 
@@ -864,8 +863,7 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -876,12 +874,10 @@ msgstr ""
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -932,12 +928,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1157,9 +1154,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1181,11 +1178,11 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1217,7 +1214,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr ""
 
@@ -1458,7 +1455,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1588,7 +1585,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1603,7 +1600,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1735,10 +1732,10 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1780,9 +1777,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1798,7 +1795,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -2198,8 +2195,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2471,16 +2468,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2721,7 +2718,7 @@ msgstr ""
 #~ msgid "Environment"
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2755,8 +2752,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2803,7 +2800,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2916,7 +2913,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr ""
 
@@ -2979,7 +2976,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -3009,19 +3006,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3073,12 +3070,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3177,7 +3175,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3225,7 +3223,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3410,12 +3408,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3715,7 +3713,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3798,7 +3796,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3824,7 +3822,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4088,7 +4086,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr ""
 
@@ -4172,7 +4170,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4195,7 +4193,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4215,7 +4213,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4238,11 +4236,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4321,22 +4319,21 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr ""
 
@@ -4355,19 +4352,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4392,12 +4389,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4418,8 +4415,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4525,15 +4522,15 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4568,7 +4565,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4666,7 +4663,7 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
@@ -4702,13 +4699,13 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4779,7 +4776,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr ""
 
@@ -4796,10 +4793,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr ""
 
@@ -5049,9 +5046,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5255,7 +5252,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5798,7 +5795,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5823,7 +5820,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5832,13 +5829,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5852,10 +5849,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr ""
 
@@ -5874,7 +5871,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -6010,7 +6007,7 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6019,8 +6016,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6293,16 +6290,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6319,8 +6316,8 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6433,12 +6430,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6487,7 +6482,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6560,7 +6555,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6757,7 +6752,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7293,7 +7288,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7430,10 +7425,10 @@ msgstr ""
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr ""
 
@@ -7445,8 +7440,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7523,8 +7518,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7550,20 +7545,20 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7654,7 +7649,7 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7823,7 +7818,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7831,7 +7826,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -8254,7 +8249,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8507,8 +8502,8 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8542,7 +8537,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8579,15 +8574,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8790,7 +8785,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8822,7 +8817,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9094,7 +9089,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9247,18 +9242,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9700,7 +9695,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -215,7 +215,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -223,7 +223,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -411,7 +411,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -858,13 +858,24 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
@@ -918,6 +929,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1054,7 +1069,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1163,6 +1178,14 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr ""
@@ -1269,7 +1292,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1277,7 +1300,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1436,7 +1459,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1597,10 +1620,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1712,7 +1735,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1755,8 +1778,8 @@ msgid "Delete Inventory"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr ""
 
@@ -1772,7 +1795,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr ""
 
@@ -1835,7 +1858,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -1950,9 +1973,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2172,8 +2195,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr ""
 
@@ -2227,14 +2250,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2360,8 +2383,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2375,7 +2398,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2445,16 +2468,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2778,7 +2801,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2969,9 +2992,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -2988,15 +3011,15 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3030,14 +3053,19 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3047,7 +3075,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3063,7 +3091,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3194,7 +3222,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3624,7 +3652,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr ""
 
@@ -3684,7 +3712,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr ""
 
@@ -3767,7 +3795,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -4189,11 +4217,15 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4259,9 +4291,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4290,6 +4322,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
@@ -4508,7 +4541,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4534,7 +4567,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4574,7 +4607,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4583,7 +4616,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4733,9 +4766,9 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
@@ -4793,9 +4826,9 @@ msgstr ""
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -5132,7 +5165,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5158,12 +5191,12 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5569,7 +5602,7 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5605,9 +5638,9 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5786,7 +5819,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr ""
 
@@ -5810,7 +5843,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
@@ -5837,7 +5870,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr ""
 
@@ -5991,7 +6024,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -6001,14 +6034,19 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6255,12 +6293,12 @@ msgstr ""
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6278,7 +6316,7 @@ msgid "Relaunch on"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6391,8 +6429,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6447,7 +6485,7 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6568,9 +6606,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6707,7 +6745,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6829,7 +6867,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7076,7 +7114,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7184,7 +7222,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr ""
 
@@ -7197,7 +7235,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr ""
 
@@ -7346,7 +7384,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7357,7 +7395,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
@@ -7367,13 +7405,13 @@ msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
@@ -7381,7 +7419,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7520,12 +7558,12 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7618,7 +7656,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7658,14 +7696,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7684,7 +7722,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7781,7 +7819,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr ""
 
@@ -7789,7 +7827,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr ""
 
@@ -8212,7 +8250,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8432,7 +8470,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8492,7 +8530,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8537,15 +8575,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8558,7 +8596,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -9425,7 +9463,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9454,7 +9492,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -546,6 +546,10 @@ msgstr ""
 msgid "April"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
+
 #: components/DeleteButton/DeleteButton.jsx:128
 msgid "Are you sure you want to delete:"
 msgstr ""
@@ -578,7 +582,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -588,7 +592,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr ""
 
@@ -834,8 +838,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -862,8 +864,8 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -878,8 +880,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -930,6 +932,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1156,7 +1159,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1214,7 +1217,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr ""
 
@@ -1455,7 +1458,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1600,7 +1603,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1732,7 +1735,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1777,7 +1780,7 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2792,8 +2795,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2914,7 +2916,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr ""
 
@@ -3075,6 +3077,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3412,7 +3415,7 @@ msgstr ""
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -4085,7 +4088,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr ""
 
@@ -4192,7 +4195,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4212,7 +4215,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4239,7 +4242,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4318,21 +4321,22 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr ""
 
@@ -4351,7 +4355,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4363,7 +4367,7 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4393,7 +4397,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4529,7 +4533,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4564,7 +4568,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4704,7 +4708,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4775,7 +4779,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr ""
 
@@ -4795,7 +4799,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr ""
 
@@ -5828,13 +5832,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5851,7 +5855,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr ""
 
@@ -6015,8 +6019,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6291,8 +6295,8 @@ msgstr ""
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
@@ -6433,8 +6437,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6483,7 +6487,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7289,7 +7293,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7429,7 +7433,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr ""
 
@@ -7442,7 +7446,7 @@ msgid "Source Variables"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7546,7 +7550,7 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7559,7 +7563,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8786,7 +8790,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8818,7 +8822,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9246,7 +9250,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
@@ -9254,7 +9258,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -908,16 +908,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr ""
+#~ msgid "Cancel sync source"
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3030,12 +3030,25 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3275,7 +3288,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3611,7 +3624,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr ""
 
@@ -4173,6 +4186,10 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -5988,6 +6005,11 @@ msgstr ""
 msgid "Project Update"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr ""
@@ -6369,6 +6391,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6805,7 +6829,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7160,7 +7184,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr ""
 
@@ -7173,7 +7197,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr ""
 
@@ -7476,11 +7500,11 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -938,16 +938,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr "取消同步"
+#~ msgid "Cancel sync"
+#~ msgstr "取消同步"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr "取消同步进程"
+#~ msgid "Cancel sync process"
+#~ msgstr "取消同步进程"
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr "取消同步源"
+#~ msgid "Cancel sync source"
+#~ msgstr "取消同步源"
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -3106,13 +3106,26 @@ msgstr "关联角色失败"
 msgid "Failed to associate."
 msgstr "关联失败。"
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
-msgstr "取消清单源同步失败。"
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr "取消清单源同步失败。"
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
+msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
 msgid "Failed to copy credential."
@@ -3351,7 +3364,7 @@ msgstr "获取节点凭证失败。"
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr "同步清单源失败。"
 
@@ -3687,7 +3700,7 @@ msgstr "组"
 msgid "Group details"
 msgstr "组详情"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr "组类型"
 
@@ -4249,6 +4262,10 @@ msgstr "清单 ID"
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -6064,6 +6081,11 @@ msgstr "项目同步"
 msgid "Project Update"
 msgstr "项目更新"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr "未找到项目。"
@@ -6441,6 +6463,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6877,7 +6901,7 @@ msgid "Select a row to approve"
 msgstr "选择要批准的行"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr "选择要删除的行"
 
@@ -7241,7 +7265,7 @@ msgstr "显示"
 msgid "Show Changes"
 msgstr "显示更改"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr "显示所有组"
 
@@ -7254,7 +7278,7 @@ msgstr "显示更改"
 msgid "Show less"
 msgstr "显示更少"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr "只显示 root 组"
 
@@ -7566,11 +7590,11 @@ msgstr "开始消息"
 msgid "Start message body"
 msgstr "开始消息正文"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr "启动同步进程"
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr "启动同步源"
 

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -185,8 +185,8 @@ msgstr "帐户令牌"
 msgid "Action"
 msgstr "操作"
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -568,7 +568,7 @@ msgstr "于 {0} - {1} 批准"
 msgid "April"
 msgstr "4 月"
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -608,7 +608,6 @@ msgstr "您确定要从 {1} 中删除访问 {0} 吗？这样做会影响团队�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "您确定要从 {username} 中删除 {0} 吗？"
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "您确定要提交取消此作业的请求吗？"
@@ -618,7 +617,7 @@ msgstr "您确定要提交取消此作业的请求吗？"
 msgid "Arguments"
 msgstr "参数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr "工件"
 
@@ -894,8 +893,7 @@ msgstr "取消"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -906,12 +904,10 @@ msgstr "取消作业"
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -962,12 +958,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "取消同步源"
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1195,9 +1192,9 @@ msgstr "云"
 msgid "Collapse"
 msgstr "折叠"
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "命令"
@@ -1235,11 +1232,11 @@ msgstr "确认删除"
 msgid "Confirm Password"
 msgstr "确认密码"
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1271,7 +1268,7 @@ msgstr "确认全部恢复"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr "容器组"
 
@@ -1522,7 +1519,7 @@ msgstr "创建用户令牌"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1652,7 +1649,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr "未找到凭证类型。"
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1667,7 +1664,7 @@ msgstr "未找到凭证类型。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1799,10 +1796,10 @@ msgstr "定义系统级的特性和功能"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1844,9 +1841,9 @@ msgstr "删除主机"
 msgid "Delete Inventory"
 msgstr "删除清单"
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr "删除作业"
 
@@ -1862,7 +1859,7 @@ msgstr "删除通知"
 msgid "Delete Organization"
 msgstr "删除机构"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr "删除项目"
 
@@ -2262,8 +2259,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr "下载输出"
 
@@ -2535,16 +2532,16 @@ msgid "Edit this node"
 msgstr "编辑此节点"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "已经过"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr "过期的时间"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr "作业运行所经过的时间"
 
@@ -2797,7 +2794,7 @@ msgstr "使用 JSON 或 YAML 语法输入变量。使用单选按钮在两者之
 #~ msgid "Environment"
 #~ msgstr "环境"
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2831,8 +2828,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2879,7 +2876,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2992,7 +2989,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr "执行节点"
 
@@ -3055,7 +3052,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr "过期于 {0}"
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr "解释"
@@ -3085,19 +3082,19 @@ msgstr "完成："
 msgid "Facts"
 msgstr "事实"
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr "失败"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr "失败的主机计数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr "失败的主机"
 
@@ -3149,12 +3146,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr "取消清单源同步失败。"
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3253,7 +3251,7 @@ msgstr "删除一个或多个清单源失败。"
 msgid "Failed to delete one or more job templates."
 msgstr "删除一个或多个作业模板失败。"
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr "删除一个或多个作业失败。"
 
@@ -3301,7 +3299,7 @@ msgstr "无法删除一个或多个工作流批准。"
 msgid "Failed to delete organization."
 msgstr "删除机构失败。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr "删除项目失败。"
 
@@ -3486,12 +3484,12 @@ msgstr "上传文件被拒绝。请选择单个 .json 文件。"
 msgid "File, directory or script"
 msgstr "文件、目录或脚本"
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr "完成时间"
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "完成"
@@ -3791,7 +3789,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "主机配置键"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr "主机计数"
 
@@ -3874,7 +3872,7 @@ msgstr "此作业的主机状态信息不可用。"
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "主机"
@@ -3900,7 +3898,7 @@ msgstr "小时"
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -4164,7 +4162,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "实例过滤器"
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr "实例组"
 
@@ -4248,7 +4246,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr "无法复制含有源的清单"
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4271,7 +4269,7 @@ msgstr "无法复制含有源的清单"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4291,7 +4289,7 @@ msgstr "清单文件"
 msgid "Inventory ID"
 msgstr "清单 ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4314,11 +4312,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr "清单源"
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr "清单同步"
 
@@ -4397,22 +4395,21 @@ msgstr "1 月"
 msgid "Job"
 msgstr "作业"
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "作业删除错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr "作业分片"
 
@@ -4431,19 +4428,19 @@ msgstr "作业状态"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr "作业标签"
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "作业模板"
@@ -4468,12 +4465,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4494,8 +4491,8 @@ msgstr "作业状态图标签页"
 msgid "Job templates"
 msgstr "作业模板"
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4601,15 +4598,15 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr "标签名称"
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4644,7 +4641,7 @@ msgstr "最近登陆"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4742,7 +4739,7 @@ msgstr "启动工作流"
 msgid "Launched By"
 msgstr "启动者"
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr "启动者（用户名）"
 
@@ -4778,13 +4775,13 @@ msgstr "小于或等于比较。"
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4855,7 +4852,7 @@ msgstr "最新同步"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr "机器凭证"
 
@@ -4872,10 +4869,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr "管理作业"
 
@@ -5125,9 +5122,9 @@ msgstr "多项选择选项"
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5331,7 +5328,7 @@ msgstr "永不更新"
 msgid "Never expires"
 msgstr "永不过期"
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr "新"
@@ -5874,7 +5871,7 @@ msgstr "过去两周"
 msgid "Past week"
 msgstr "过去一周"
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr "待处理"
@@ -5899,7 +5896,7 @@ msgstr "个人访问令牌"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr "play 数量"
 
@@ -5908,13 +5905,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5928,10 +5925,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr "Playbook 目录"
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr "Playbook 运行"
 
@@ -5950,7 +5947,7 @@ msgstr "Playbook 名称"
 msgid "Playbook run"
 msgstr "Playbook 运行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr "Play"
 
@@ -6086,7 +6083,7 @@ msgstr "权限升级"
 msgid "Privilege escalation password"
 msgstr "权限升级密码"
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -6095,8 +6092,8 @@ msgstr "权限升级密码"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6365,16 +6362,16 @@ msgstr "仅导入主机名与这个正则表达式匹配的主机。该过滤器
 msgid "Related Groups"
 msgstr "相关组"
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr "重新启动"
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr "重新启动作业"
 
@@ -6391,8 +6388,8 @@ msgstr "重新启动失败的主机"
 msgid "Relaunch on"
 msgstr "重新启动于"
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr "使用主机参数重新启动"
 
@@ -6505,12 +6502,10 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6559,7 +6554,7 @@ msgstr "恢复设置"
 msgid "Revert to factory default."
 msgstr "恢复到工厂默认值。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6632,7 +6627,7 @@ msgstr "运行于"
 msgid "Run type"
 msgstr "运行类型"
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6829,7 +6824,7 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "在左侧查看错误"
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7374,7 +7369,7 @@ msgstr "简单键选择"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7516,10 +7511,10 @@ msgstr "源控制类型"
 msgid "Source Control URL"
 msgstr "源控制 URL"
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr "源控制更新"
 
@@ -7531,8 +7526,8 @@ msgstr "源电话号码"
 msgid "Source Variables"
 msgstr "源变量"
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr "源工作流作业"
 
@@ -7613,8 +7608,8 @@ msgstr "标准输出标签页"
 msgid "Start"
 msgstr "开始"
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr "开始时间"
 
@@ -7640,20 +7635,20 @@ msgstr "启动同步进程"
 msgid "Start sync source"
 msgstr "启动同步源"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr "已开始"
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7744,7 +7739,7 @@ msgstr "成功信息"
 msgid "Success message body"
 msgstr "成功消息正文"
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7913,7 +7908,7 @@ msgstr "目标 URL"
 msgid "Task"
 msgstr "任务"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr "任务计数"
 
@@ -7921,7 +7916,7 @@ msgstr "任务计数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr "任务"
 
@@ -8348,7 +8343,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8601,8 +8596,8 @@ msgstr "周二"
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8636,7 +8631,7 @@ msgstr "Twilio"
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8673,15 +8668,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr "无法访问"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr "无法访问的主机数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr "无法访问的主机"
 
@@ -8888,7 +8883,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8920,7 +8915,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9192,7 +9187,7 @@ msgstr "Visualizer"
 msgid "WARNING:"
 msgstr "警告："
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr "等待"
@@ -9350,18 +9345,18 @@ msgstr "未找到工作流批准。"
 msgid "Workflow Approvals"
 msgstr "工作流批准"
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "工作流作业"
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9805,7 +9800,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -608,7 +608,7 @@ msgstr "您确定要从 {1} 中删除访问 {0} 吗？这样做会影响团队�
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "您确定要从 {username} 中删除 {0} 吗？"
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "您确定要提交取消此作业的请求吗？"
@@ -618,7 +618,7 @@ msgstr "您确定要提交取消此作业的请求吗？"
 msgid "Arguments"
 msgstr "参数"
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr "工件"
 
@@ -868,8 +868,6 @@ msgstr "缓存超时（秒）"
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -896,8 +894,8 @@ msgstr "取消"
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -912,8 +910,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -964,6 +962,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr "取消同步源"
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1198,7 +1197,7 @@ msgstr "折叠"
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr "命令"
@@ -1272,7 +1271,7 @@ msgstr "确认全部恢复"
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr "容器组"
 
@@ -1523,7 +1522,7 @@ msgstr "创建用户令牌"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1668,7 +1667,7 @@ msgstr "未找到凭证类型。"
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1800,7 +1799,7 @@ msgstr "定义系统级的特性和功能"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1845,7 +1844,7 @@ msgstr "删除主机"
 msgid "Delete Inventory"
 msgstr "删除清单"
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2872,8 +2871,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2994,7 +2992,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr "执行节点"
 
@@ -3155,6 +3153,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3492,7 +3491,7 @@ msgstr "文件、目录或脚本"
 msgid "Finish Time"
 msgstr "完成时间"
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr "完成"
@@ -4165,7 +4164,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr "实例过滤器"
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr "实例组"
 
@@ -4272,7 +4271,7 @@ msgstr "无法复制含有源的清单"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4292,7 +4291,7 @@ msgstr "清单文件"
 msgid "Inventory ID"
 msgstr "清单 ID"
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4319,7 +4318,7 @@ msgstr "清单源"
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr "清单同步"
 
@@ -4398,21 +4397,22 @@ msgstr "1 月"
 msgid "Job"
 msgstr "作业"
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr "作业删除错误"
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr "作业分片"
 
@@ -4431,7 +4431,7 @@ msgstr "作业状态"
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4443,7 +4443,7 @@ msgstr "作业标签"
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr "作业模板"
@@ -4473,7 +4473,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4609,7 +4609,7 @@ msgstr "标签名称"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4644,7 +4644,7 @@ msgstr "最近登陆"
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4784,7 +4784,7 @@ msgstr "小于或等于比较。"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4855,7 +4855,7 @@ msgstr "最新同步"
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr "机器凭证"
 
@@ -4875,7 +4875,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr "管理作业"
 
@@ -5908,13 +5908,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr "Playbook"
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5931,7 +5931,7 @@ msgstr "Playbook 目录"
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr "Playbook 运行"
 
@@ -6095,8 +6095,8 @@ msgstr "权限升级密码"
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6367,8 +6367,8 @@ msgstr "相关组"
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "重新启动"
@@ -6509,8 +6509,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6559,7 +6559,7 @@ msgstr "恢复设置"
 msgid "Revert to factory default."
 msgstr "恢复到工厂默认值。"
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7374,7 +7374,7 @@ msgstr "简单键选择"
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7519,7 +7519,7 @@ msgstr "源控制 URL"
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr "源控制更新"
 
@@ -7532,7 +7532,7 @@ msgid "Source Variables"
 msgstr "源变量"
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr "源工作流作业"
 
@@ -7640,7 +7640,7 @@ msgstr "启动同步进程"
 msgid "Start sync source"
 msgstr "启动同步源"
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7653,7 +7653,7 @@ msgstr "已开始"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8888,7 +8888,7 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8920,7 +8920,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9353,7 +9353,7 @@ msgstr "工作流批准"
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr "工作流作业"
@@ -9361,7 +9361,7 @@ msgstr "工作流作业"
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -214,7 +214,7 @@ msgstr "操作"
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -222,7 +222,7 @@ msgstr "操作"
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -415,7 +415,7 @@ msgid "All job types"
 msgstr "作业作业类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr "允许分支覆写"
@@ -567,6 +567,10 @@ msgstr "于 {0} - {1} 批准"
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
 msgstr "4 月"
+
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
+msgstr ""
 
 #: src/screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:116
 #~ msgid "Are you sure you want to delete the {0} below?"
@@ -828,7 +832,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr "缓存超时"
@@ -888,14 +892,25 @@ msgstr "缓存超时（秒）"
 msgid "Cancel"
 msgstr "取消"
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
 msgstr "取消作业"
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
+msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
 #: screens/Job/JobDetail/JobDetail.jsx:428
@@ -948,6 +963,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr "取消同步源"
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1092,7 +1111,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr "选择将获得新角色的资源类型。例如，如果您想为一组用户添加新角色，请选择用户并点击下一步。您可以选择下一步中的具体资源。"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr "清理"
@@ -1217,6 +1236,14 @@ msgstr "确认删除"
 msgid "Confirm Password"
 msgstr "确认密码"
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr "确认删除"
@@ -1333,7 +1360,7 @@ msgstr "复制清单"
 msgid "Copy Notification Template"
 msgstr "复制通知模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr "复制项目"
 
@@ -1341,7 +1368,7 @@ msgstr "复制项目"
 msgid "Copy Template"
 msgstr "复制模板"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr "将完整修订复制到剪贴板。"
 
@@ -1500,7 +1527,7 @@ msgstr "创建用户令牌"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1661,10 +1688,10 @@ msgid "Custom pod spec"
 msgstr "自定义 pod 规格"
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1776,7 +1803,7 @@ msgstr "定义系统级的特性和功能"
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1819,8 +1846,8 @@ msgid "Delete Inventory"
 msgstr "删除清单"
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr "删除作业"
 
@@ -1836,7 +1863,7 @@ msgstr "删除通知"
 msgid "Delete Organization"
 msgstr "删除机构"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr "删除项目"
 
@@ -1899,7 +1926,7 @@ msgid "Delete inventory source"
 msgstr "删除清单源"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr "更新时删除"
 
@@ -2014,9 +2041,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2236,8 +2263,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr "下载输出"
 
@@ -2291,14 +2318,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2424,8 +2451,8 @@ msgstr "编辑通知模板"
 msgid "Edit Organization"
 msgstr "编辑机构"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr "编辑项目"
 
@@ -2439,7 +2466,7 @@ msgstr "编辑问题"
 msgid "Edit Schedule"
 msgstr "编辑调度"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr "编辑源"
 
@@ -2509,16 +2536,16 @@ msgid "Edit this node"
 msgstr "编辑此节点"
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr "已经过"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr "过期的时间"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr "作业运行所经过的时间"
 
@@ -2854,7 +2881,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -3045,9 +3072,9 @@ msgid "Extra variables"
 msgstr "额外变量"
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr "完成："
 
@@ -3064,15 +3091,15 @@ msgstr "事实"
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr "失败"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr "失败的主机计数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr "失败的主机"
 
@@ -3106,14 +3133,19 @@ msgstr "关联角色失败"
 msgid "Failed to associate."
 msgstr "关联失败。"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -3123,7 +3155,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3139,7 +3171,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr "复制清单失败。"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr "复制项目失败。"
 
@@ -3270,7 +3302,7 @@ msgstr "无法删除一个或多个工作流批准。"
 msgid "Failed to delete organization."
 msgstr "删除机构失败。"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr "删除项目失败。"
 
@@ -3700,7 +3732,7 @@ msgstr "组"
 msgid "Group details"
 msgstr "组详情"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr "组类型"
 
@@ -3760,7 +3792,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr "主机配置键"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr "主机计数"
 
@@ -3843,7 +3875,7 @@ msgstr "此作业的主机状态信息不可用。"
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr "主机"
@@ -4265,12 +4297,16 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
 msgstr "清单源同步"
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
+msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:184
@@ -4335,9 +4371,9 @@ msgid "Items per page"
 msgstr "每页的项"
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr "作业 ID："
 
@@ -4366,6 +4402,7 @@ msgstr "作业"
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
@@ -4584,7 +4621,7 @@ msgstr "标签"
 msgid "Last"
 msgstr "最后"
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4610,7 +4647,7 @@ msgstr "最近登陆"
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4650,7 +4687,7 @@ msgstr "最后作业运行"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr "最后修改"
 
@@ -4659,7 +4696,7 @@ msgstr "最后修改"
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4809,9 +4846,9 @@ msgstr "查找类型"
 msgid "Lookup typeahead"
 msgstr "查找 typeahead"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr "最新同步"
 
@@ -4869,9 +4906,9 @@ msgstr "管理作业"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr "手动"
@@ -5208,7 +5245,7 @@ msgstr "多项选择选项"
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5234,12 +5271,12 @@ msgstr "多项选择选项"
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5645,7 +5682,7 @@ msgstr "（可选）选择要用来向 Webhook 服务发回状态更新的凭证
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5681,9 +5718,9 @@ msgstr "选项"
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5862,7 +5899,7 @@ msgstr "个人访问令牌"
 msgid "Play"
 msgstr "Play"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr "play 数量"
 
@@ -5886,7 +5923,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr "Playbook 目录"
@@ -5913,7 +5950,7 @@ msgstr "Playbook 名称"
 msgid "Playbook run"
 msgstr "Playbook 运行"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr "Play"
 
@@ -6067,7 +6104,7 @@ msgid "Project"
 msgstr "项目"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr "项目基本路径"
@@ -6077,14 +6114,19 @@ msgstr "项目基本路径"
 msgid "Project Sync"
 msgstr "项目同步"
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr "项目更新"
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6327,12 +6369,12 @@ msgstr "相关组"
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr "重新启动"
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr "重新启动作业"
 
@@ -6350,7 +6392,7 @@ msgid "Relaunch on"
 msgstr "重新启动于"
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr "使用主机参数重新启动"
 
@@ -6463,8 +6505,8 @@ msgstr ""
 #~ msgid "Retrieve the enabled state from the given dict of host variables. The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 #~ msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6519,7 +6561,7 @@ msgstr "恢复到工厂默认值。"
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr "修订"
 
@@ -6640,9 +6682,9 @@ msgid "START"
 msgstr "开始"
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr "状态："
 
@@ -6779,7 +6821,7 @@ msgstr "秒"
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr "秒"
 
@@ -6901,7 +6943,7 @@ msgid "Select a row to approve"
 msgstr "选择要批准的行"
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr "选择要删除的行"
 
@@ -7157,7 +7199,7 @@ msgstr "选择 {0}"
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7265,7 +7307,7 @@ msgstr "显示"
 msgid "Show Changes"
 msgstr "显示更改"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr "显示所有组"
 
@@ -7278,7 +7320,7 @@ msgstr "显示更改"
 msgid "Show less"
 msgstr "显示更少"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr "只显示 root 组"
 
@@ -7432,7 +7474,7 @@ msgstr "源"
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7443,7 +7485,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr "源控制分支/标签/提交"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr "源控制凭证"
@@ -7453,13 +7495,13 @@ msgid "Source Control Credential Type"
 msgstr "源控制凭证类型"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr "源控制 Refspec"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr "源控制类型"
 
@@ -7467,7 +7509,7 @@ msgstr "源控制类型"
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7610,12 +7652,12 @@ msgstr "已开始"
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7708,7 +7750,7 @@ msgstr "成功消息正文"
 msgid "Successful"
 msgstr "成功"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr "成功复制至剪贴板！"
 
@@ -7748,14 +7790,14 @@ msgstr "问卷调查预览 modal"
 msgid "Survey questions"
 msgstr "可选的问卷调查问题"
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr "同步"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7774,7 +7816,7 @@ msgstr "同步所有源"
 msgid "Sync error"
 msgstr "同步错误"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr "修订版本同步"
 
@@ -7871,7 +7913,7 @@ msgstr "目标 URL"
 msgid "Task"
 msgstr "任务"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr "任务计数"
 
@@ -7879,7 +7921,7 @@ msgstr "任务计数"
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr "任务"
 
@@ -8306,7 +8348,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8526,7 +8568,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8586,7 +8628,7 @@ msgstr "Twilio"
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8631,15 +8673,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr "无法访问"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr "无法访问的主机数"
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr "无法访问的主机"
 
@@ -8652,7 +8694,7 @@ msgid "Unsaved changes modal"
 msgstr "未保存的修改 modal"
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr "启动时更新修订"
@@ -9528,7 +9570,7 @@ msgstr "确认解除关联"
 #~ msgid "controller instance"
 #~ msgstr "控制器实例"
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr "复制到剪贴板被禁用"
 
@@ -9557,7 +9599,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: zu\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n
+"PO-Revision-Date: \n\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
@@ -211,7 +211,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:206
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:108
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:220
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:94
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:104
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.jsx:73
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:199
@@ -219,7 +219,7 @@ msgstr ""
 #: screens/Organization/OrganizationList/OrganizationList.jsx:160
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:68
 #: screens/Project/ProjectList/ProjectList.jsx:177
-#: screens/Project/ProjectList/ProjectListItem.jsx:170
+#: screens/Project/ProjectList/ProjectListItem.jsx:171
 #: screens/Team/TeamList/TeamList.jsx:156
 #: screens/Team/TeamList/TeamListItem.jsx:47
 #: screens/User/UserList/UserList.jsx:166
@@ -403,7 +403,7 @@ msgid "All job types"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:48
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:79
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:80
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:105
 msgid "Allow Branch Override"
 msgstr ""
@@ -532,6 +532,10 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.jsx:127
 msgid "April"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:80
+msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
 #: components/DeleteButton/DeleteButton.jsx:128
@@ -782,7 +786,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:102
 #: components/PromptDetail/PromptProjectDetail.jsx:95
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:165
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:123
 msgid "Cache Timeout"
 msgstr ""
@@ -842,13 +846,24 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:104
+msgid "Cancel Inventory Source Sync"
+msgstr ""
+
 #: screens/Job/JobDetail/JobDetail.jsx:417
 #: screens/Job/JobDetail/JobDetail.jsx:418
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:187
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:191
 msgid "Cancel Job"
+msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:208
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Cancel Project Sync"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:47
+msgid "Cancel Sync"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:425
@@ -902,6 +917,10 @@ msgstr ""
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
 #~ msgid "Cancel sync source"
 #~ msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+msgid "Cancel {0}"
+msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -1034,7 +1053,7 @@ msgid "Choose the type of resource that will be receiving new roles.  For exampl
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:40
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:71
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:71
 msgid "Clean"
 msgstr ""
@@ -1143,6 +1162,14 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:62
+msgid "Confirm cancel job"
+msgstr ""
+
+#: components/JobCancelButton/JobCancelButton.jsx:66
+msgid "Confirm cancellation"
+msgstr ""
+
 #: components/ResourceAccessList/DeleteRoleConfirmationModal.jsx:27
 msgid "Confirm delete"
 msgstr ""
@@ -1245,7 +1272,7 @@ msgstr ""
 msgid "Copy Notification Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:196
+#: screens/Project/ProjectList/ProjectListItem.jsx:211
 msgid "Copy Project"
 msgstr ""
 
@@ -1253,7 +1280,7 @@ msgstr ""
 msgid "Copy Template"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:165
+#: screens/Project/ProjectList/ProjectListItem.jsx:166
 msgid "Copy full revision to clipboard."
 msgstr ""
 
@@ -1412,7 +1439,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:181
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:182
 #: screens/Team/TeamDetail/TeamDetail.jsx:43
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:263
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:183
@@ -1569,10 +1596,10 @@ msgid "Custom pod spec"
 msgstr ""
 
 #: components/TemplateList/TemplateListItem.jsx:144
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:72
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:54
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:130
+#: screens/Project/ProjectList/ProjectListItem.jsx:131
 msgid "Custom virtual environment {0} must be replaced by an execution environment."
 msgstr ""
 
@@ -1684,7 +1711,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:408
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:217
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1719,8 +1746,8 @@ msgid "Delete Inventory"
 msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:404
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:202
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:206
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
 msgstr ""
 
@@ -1736,7 +1763,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:211
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
 msgid "Delete Project"
 msgstr ""
 
@@ -1799,7 +1826,7 @@ msgid "Delete inventory source"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:41
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:72
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:73
 msgid "Delete on Update"
 msgstr ""
 
@@ -1910,9 +1937,9 @@ msgstr ""
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:95
 #: screens/Organization/OrganizationList/OrganizationList.jsx:141
 #: screens/Organization/shared/OrganizationForm.jsx:67
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:132
 #: screens/Project/ProjectList/ProjectList.jsx:142
-#: screens/Project/ProjectList/ProjectListItem.jsx:215
+#: screens/Project/ProjectList/ProjectListItem.jsx:230
 #: screens/Project/shared/ProjectForm.jsx:176
 #: screens/Team/TeamDetail/TeamDetail.jsx:34
 #: screens/Team/TeamList/TeamList.jsx:134
@@ -2128,8 +2155,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:173
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:178
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
 msgid "Download Output"
 msgstr ""
 
@@ -2174,14 +2201,14 @@ msgstr ""
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:60
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:99
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:269
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:118
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:150
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:341
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:132
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:151
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:155
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:199
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:200
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:88
 #: screens/Setting/ActivityStream/ActivityStreamDetail/ActivityStreamDetail.jsx:92
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.jsx:80
@@ -2307,8 +2334,8 @@ msgstr ""
 msgid "Edit Organization"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-#: screens/Project/ProjectList/ProjectListItem.jsx:187
+#: screens/Project/ProjectList/ProjectListItem.jsx:197
+#: screens/Project/ProjectList/ProjectListItem.jsx:202
 msgid "Edit Project"
 msgstr ""
 
@@ -2322,7 +2349,7 @@ msgstr ""
 msgid "Edit Schedule"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:106
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:122
 msgid "Edit Source"
 msgstr ""
 
@@ -2392,16 +2419,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:129
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:128
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:130
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2713,7 +2740,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2904,9 +2931,9 @@ msgid "Extra variables"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:35
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:42
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:96
-#: screens/Project/ProjectList/ProjectListItem.jsx:75
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:43
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:97
+#: screens/Project/ProjectList/ProjectListItem.jsx:76
 msgid "FINISHED:"
 msgstr ""
 
@@ -2923,15 +2950,15 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:117
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:116
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:118
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
 msgid "Failed Hosts"
 msgstr ""
 
@@ -2965,14 +2992,19 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:103
 msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:209
-#: screens/Project/ProjectList/ProjectListItem.jsx:182
-msgid "Failed to cancel Project Update"
+#: screens/Project/ProjectList/ProjectListItem.jsx:181
+msgid "Failed to cancel Project Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+#~ msgid "Failed to cancel Project Update"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
 #~ msgid "Failed to cancel inventory source sync."
@@ -2982,7 +3014,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -2998,7 +3030,7 @@ msgstr ""
 msgid "Failed to copy inventory."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:204
+#: screens/Project/ProjectList/ProjectListItem.jsx:219
 msgid "Failed to copy project."
 msgstr ""
 
@@ -3129,7 +3161,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:229
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3554,7 +3586,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
 msgid "Group type"
 msgstr ""
 
@@ -3614,7 +3646,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
 msgid "Host Count"
 msgstr ""
 
@@ -3697,7 +3729,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -4093,11 +4125,15 @@ msgid "Inventory Source"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
-msgid "Inventory Source Error"
-msgstr ""
+#~ msgid "Inventory Source Error"
+#~ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
 msgid "Inventory Source Sync"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:102
+msgid "Inventory Source Sync Error"
 msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:165
@@ -4163,9 +4199,9 @@ msgid "Items per page"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:28
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:35
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:89
-#: screens/Project/ProjectList/ProjectListItem.jsx:68
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:36
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:90
+#: screens/Project/ProjectList/ProjectListItem.jsx:69
 msgid "JOB ID:"
 msgstr ""
 
@@ -4194,6 +4230,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:450
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
@@ -4412,7 +4449,7 @@ msgstr ""
 msgid "Last"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:115
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:116
 msgid "Last Job Status"
 msgstr ""
 
@@ -4438,7 +4475,7 @@ msgstr ""
 #: screens/Job/JobDetail/JobDetail.jsx:338
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:186
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:187
 #: screens/Team/TeamDetail/TeamDetail.jsx:44
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:268
 #: screens/User/UserTokenDetail/UserTokenDetail.jsx:69
@@ -4478,7 +4515,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:257
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:137
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:51
-#: screens/Project/ProjectList/ProjectListItem.jsx:242
+#: screens/Project/ProjectList/ProjectListItem.jsx:257
 msgid "Last modified"
 msgstr ""
 
@@ -4487,7 +4524,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:247
+#: screens/Project/ProjectList/ProjectListItem.jsx:262
 msgid "Last used"
 msgstr ""
 
@@ -4637,9 +4674,9 @@ msgstr ""
 msgid "Lookup typeahead"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:33
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:87
-#: screens/Project/ProjectList/ProjectListItem.jsx:66
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:34
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:88
+#: screens/Project/ProjectList/ProjectListItem.jsx:67
 msgid "MOST RECENT SYNC"
 msgstr ""
 
@@ -4697,9 +4734,9 @@ msgstr ""
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.jsx:82
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:149
-#: screens/Project/ProjectList/ProjectListItem.jsx:153
+#: screens/Project/ProjectList/ProjectListItem.jsx:154
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:89
 msgid "Manual"
 msgstr ""
@@ -5028,7 +5065,7 @@ msgstr ""
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.jsx:181
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:194
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:217
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:63
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:64
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:97
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:31
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:67
@@ -5054,12 +5091,12 @@ msgstr ""
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:66
 #: screens/Organization/OrganizationTeams/OrganizationTeamList.jsx:81
 #: screens/Organization/shared/OrganizationForm.jsx:59
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:130
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:131
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:120
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:147
 #: screens/Project/ProjectList/ProjectList.jsx:137
 #: screens/Project/ProjectList/ProjectList.jsx:173
-#: screens/Project/ProjectList/ProjectListItem.jsx:121
+#: screens/Project/ProjectList/ProjectListItem.jsx:122
 #: screens/Project/shared/ProjectForm.jsx:168
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:139
 #: screens/Team/TeamDetail/TeamDetail.jsx:33
@@ -5440,7 +5477,7 @@ msgstr ""
 #: screens/Credential/shared/TypeInputsSubForm.jsx:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.jsx:61
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:245
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:163
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:164
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:260
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:180
@@ -5476,9 +5513,9 @@ msgstr ""
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:107
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:55
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:65
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:134
-#: screens/Project/ProjectList/ProjectListItem.jsx:221
-#: screens/Project/ProjectList/ProjectListItem.jsx:232
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:135
+#: screens/Project/ProjectList/ProjectListItem.jsx:236
+#: screens/Project/ProjectList/ProjectListItem.jsx:247
 #: screens/Team/TeamDetail/TeamDetail.jsx:36
 #: screens/Team/TeamList/TeamList.jsx:155
 #: screens/Team/TeamList/TeamListItem.jsx:38
@@ -5657,7 +5694,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
 msgid "Play Count"
 msgstr ""
 
@@ -5681,7 +5718,7 @@ msgid "Playbook Complete"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:103
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:178
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:179
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:85
 msgid "Playbook Directory"
 msgstr ""
@@ -5708,7 +5745,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
 msgid "Plays"
 msgstr ""
 
@@ -5858,7 +5895,7 @@ msgid "Project"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:100
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:175
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:176
 #: screens/Project/shared/ProjectSubForms/ManualSubForm.jsx:63
 msgid "Project Base Path"
 msgstr ""
@@ -5868,14 +5905,19 @@ msgstr ""
 msgid "Project Sync"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:178
+msgid "Project Sync Error"
+msgstr ""
+
 #: components/Workflow/WorkflowNodeHelp.jsx:55
 msgid "Project Update"
 msgstr ""
 
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:207
 #: screens/Project/ProjectList/ProjectListItem.jsx:179
-msgid "Project Update Error"
-msgstr ""
+#~ msgid "Project Update Error"
+#~ msgstr ""
 
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
@@ -6108,12 +6150,12 @@ msgstr ""
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
 #: screens/Job/JobDetail/JobDetail.jsx:375
 #: screens/Job/JobDetail/JobDetail.jsx:383
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:161
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:141
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6131,7 +6173,7 @@ msgid "Relaunch on"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:140
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6240,8 +6282,8 @@ msgid ""
 "The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:71
-#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:72
+#: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6296,7 +6338,7 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:227
 #: screens/Project/ProjectList/ProjectList.jsx:176
-#: screens/Project/ProjectList/ProjectListItem.jsx:155
+#: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
 msgstr ""
 
@@ -6417,9 +6459,9 @@ msgid "START"
 msgstr ""
 
 #: components/Sparkline/Sparkline.jsx:31
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:38
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:92
-#: screens/Project/ProjectList/ProjectListItem.jsx:71
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:39
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:93
+#: screens/Project/ProjectList/ProjectListItem.jsx:72
 msgid "STATUS:"
 msgstr ""
 
@@ -6556,7 +6598,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptInventorySourceDetail.jsx:103
 #: components/PromptDetail/PromptProjectDetail.jsx:96
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:166
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:167
 msgid "Seconds"
 msgstr ""
 
@@ -6674,7 +6716,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
 msgid "Select a row to delete"
 msgstr ""
 
@@ -6905,7 +6947,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:77
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:104
 #: screens/Organization/OrganizationList/OrganizationListItem.jsx:42
-#: screens/Project/ProjectList/ProjectListItem.jsx:119
+#: screens/Project/ProjectList/ProjectListItem.jsx:120
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.jsx:253
 #: screens/Team/TeamList/TeamListItem.jsx:31
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:57
@@ -7013,7 +7055,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
 msgid "Show all groups"
 msgstr ""
 
@@ -7026,7 +7068,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show only root groups"
 msgstr ""
 
@@ -7175,7 +7217,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:79
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:75
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:309
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:217
 #: screens/Template/shared/JobTemplateForm.jsx:308
 msgid "Source Control Branch"
@@ -7186,7 +7228,7 @@ msgid "Source Control Branch/Tag/Commit"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:83
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:153
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:154
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:57
 msgid "Source Control Credential"
 msgstr ""
@@ -7196,13 +7238,13 @@ msgid "Source Control Credential Type"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:80
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:150
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:151
 #: screens/Project/shared/ProjectSubForms/GitSubForm.jsx:50
 msgid "Source Control Refspec"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:75
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:145
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:146
 msgid "Source Control Type"
 msgstr ""
 
@@ -7210,7 +7252,7 @@ msgstr ""
 #: components/PromptDetail/PromptProjectDetail.jsx:78
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:148
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:149
 #: screens/Project/ProjectList/ProjectList.jsx:157
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:18
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:97
@@ -7345,12 +7387,12 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:79
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
 #: screens/Job/JobDetail/JobDetail.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
-#: screens/Project/ProjectList/ProjectListItem.jsx:139
+#: screens/Project/ProjectList/ProjectListItem.jsx:140
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:49
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:108
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:230
@@ -7443,7 +7485,7 @@ msgstr ""
 msgid "Successful"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:166
+#: screens/Project/ProjectList/ProjectListItem.jsx:167
 msgid "Successfully copied to clipboard!"
 msgstr ""
 
@@ -7483,14 +7525,14 @@ msgstr ""
 msgid "Survey questions"
 msgstr ""
 
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:96
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:78
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:111
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:43
 #: screens/Project/shared/ProjectSyncButton.jsx:55
 msgid "Sync"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:173
+#: screens/Project/ProjectList/ProjectListItem.jsx:187
 #: screens/Project/shared/ProjectSyncButton.jsx:39
 #: screens/Project/shared/ProjectSyncButton.jsx:50
 msgid "Sync Project"
@@ -7509,7 +7551,7 @@ msgstr ""
 msgid "Sync error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:159
+#: screens/Project/ProjectList/ProjectListItem.jsx:160
 msgid "Sync for revision"
 msgstr ""
 
@@ -7601,7 +7643,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
 msgid "Task Count"
 msgstr ""
 
@@ -7609,7 +7651,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
 msgid "Tasks"
 msgstr ""
 
@@ -8004,7 +8046,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:215
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8212,7 +8254,7 @@ msgid "Track submodules"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:43
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:74
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:75
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
@@ -8272,7 +8314,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryList.jsx:204
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:93
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:219
-#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:92
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:93
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:105
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:198
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:114
@@ -8317,15 +8359,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:107
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:106
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:108
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8338,7 +8380,7 @@ msgid "Unsaved changes modal"
 msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.jsx:46
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:77
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:78
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:97
 msgid "Update Revision on Launch"
 msgstr ""
@@ -9194,7 +9236,7 @@ msgstr ""
 #~ msgid "controller instance"
 #~ msgstr ""
 
-#: screens/Project/ProjectList/ProjectListItem.jsx:158
+#: screens/Project/ProjectList/ProjectListItem.jsx:159
 msgid "copy to clipboard disabled"
 msgstr ""
 
@@ -9223,7 +9265,7 @@ msgstr ""
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:95
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:266
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:147
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:195
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:196
 #: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.jsx:154
 #: screens/User/UserDetail/UserDetail.jsx:84
 msgid "edit"

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -8,7 +8,7 @@ msgstr ""
 "Language: zu\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: \n
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
@@ -892,16 +892,16 @@ msgid "Cancel subscription edit"
 msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:66
-msgid "Cancel sync"
-msgstr ""
+#~ msgid "Cancel sync"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:58
-msgid "Cancel sync process"
-msgstr ""
+#~ msgid "Cancel sync process"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSyncButton.jsx:62
-msgid "Cancel sync source"
-msgstr ""
+#~ msgid "Cancel sync source"
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:207
 #: components/Workflow/WorkflowNodeHelp.jsx:95
@@ -2965,12 +2965,25 @@ msgstr ""
 msgid "Failed to associate."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
-msgid "Failed to cancel inventory source sync."
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:126
+msgid "Failed to cancel Inventory Source Sync"
 msgstr ""
+
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:209
+#: screens/Project/ProjectList/ProjectListItem.jsx:182
+msgid "Failed to cancel Project Update"
+msgstr ""
+
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:100
+#~ msgid "Failed to cancel inventory source sync."
+#~ msgstr ""
 
 #: components/JobList/JobList.jsx:290
 msgid "Failed to cancel one or more jobs."
+msgstr ""
+
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
+msgid "Failed to cancel {0}"
 msgstr ""
 
 #: screens/Credential/CredentialList/CredentialListItem.jsx:85
@@ -3210,7 +3223,7 @@ msgstr ""
 msgid "Failed to send test notification."
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:89
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:54
 msgid "Failed to sync inventory source."
 msgstr ""
 
@@ -3541,7 +3554,7 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:122
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:121
 msgid "Group type"
 msgstr ""
 
@@ -4077,6 +4090,10 @@ msgstr ""
 
 #: screens/Job/JobDetail/JobDetail.jsx:191
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Inventory/InventorySources/InventorySourceListItem.jsx:125
+msgid "Inventory Source Error"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:92
@@ -5855,6 +5872,11 @@ msgstr ""
 msgid "Project Update"
 msgstr ""
 
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:207
+#: screens/Project/ProjectList/ProjectListItem.jsx:179
+msgid "Project Update Error"
+msgstr ""
+
 #: screens/Project/Project.jsx:139
 msgid "Project not found."
 msgstr ""
@@ -6218,6 +6240,8 @@ msgid ""
 "The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 msgstr ""
 
+#: components/JobCancelButton/JobCancelButton.jsx:71
+#: components/JobCancelButton/JobCancelButton.jsx:75
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
 #: screens/Job/JobDetail/JobDetail.jsx:434
@@ -6650,7 +6674,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedDataList/ToolbarDeleteButton.jsx:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:100
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:99
 msgid "Select a row to delete"
 msgstr ""
 
@@ -6989,7 +7013,7 @@ msgstr ""
 msgid "Show Changes"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:127
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
 msgid "Show all groups"
 msgstr ""
 
@@ -7002,7 +7026,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.jsx:125
 msgid "Show only root groups"
 msgstr ""
 
@@ -7301,11 +7325,11 @@ msgstr ""
 msgid "Start message body"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:70
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:35
 msgid "Start sync process"
 msgstr ""
 
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:74
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:39
 msgid "Start sync source"
 msgstr ""
 

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -182,8 +182,8 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.jsx:222
-#: components/JobList/JobListItem.jsx:85
+#: components/JobList/JobList.jsx:226
+#: components/JobList/JobListItem.jsx:87
 #: components/Schedule/ScheduleList/ScheduleList.jsx:172
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:111
 #: components/TemplateList/TemplateList.jsx:230
@@ -534,7 +534,7 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:80
+#: components/JobCancelButton/JobCancelButton.jsx:83
 msgid "Are you sure you want to cancel this job?"
 msgstr ""
 
@@ -570,7 +570,6 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -580,7 +579,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:358
+#: screens/Job/JobDetail/JobDetail.jsx:341
 msgid "Artifacts"
 msgstr ""
 
@@ -848,8 +847,7 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:415
-#: screens/Job/JobDetail/JobDetail.jsx:416
+#: components/JobCancelButton/JobCancelButton.jsx:49
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -860,12 +858,10 @@ msgstr ""
 msgid "Cancel Project Sync"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:47
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:210
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:423
-#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -916,12 +912,13 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:394
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
+#: components/JobList/JobListItem.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:379
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:138
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:207
+#: components/JobList/JobList.jsx:211
 #: components/Workflow/WorkflowNodeHelp.jsx:95
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:176
 #: screens/WorkflowApproval/shared/WorkflowApprovalStatus.jsx:21
@@ -1137,9 +1134,9 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.jsx:187
-#: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: components/JobList/JobList.jsx:191
+#: components/JobList/JobListItem.jsx:36
+#: screens/Job/JobDetail/JobDetail.jsx:80
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1161,11 +1158,11 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:62
+#: components/JobCancelButton/JobCancelButton.jsx:65
 msgid "Confirm cancel job"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:66
+#: components/JobCancelButton/JobCancelButton.jsx:69
 msgid "Confirm cancellation"
 msgstr ""
 
@@ -1197,7 +1194,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:245
+#: screens/Job/JobDetail/JobDetail.jsx:228
 msgid "Container Group"
 msgstr ""
 
@@ -1434,7 +1431,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:335
+#: screens/Job/JobDetail/JobDetail.jsx:318
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1560,7 +1557,7 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:196
+#: components/JobList/JobListItem.jsx:212
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:193
 #: components/LaunchPrompt/steps/useCredentialsStep.jsx:64
 #: components/Lookup/MultiCredentialsLookup.jsx:131
@@ -1575,7 +1572,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:273
+#: screens/Job/JobDetail/JobDetail.jsx:256
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1707,10 +1704,10 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:406
+#: screens/Job/JobDetail/JobDetail.jsx:391
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:226
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:227
 #: screens/Project/shared/ProjectSubForms/SharedFields.jsx:77
 #: screens/Team/TeamDetail/TeamDetail.jsx:66
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:396
@@ -1744,9 +1741,9 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:402
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
+#: screens/Job/JobDetail/JobDetail.jsx:387
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:196
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:200
 msgid "Delete Job"
 msgstr ""
 
@@ -1762,7 +1759,7 @@ msgstr ""
 msgid "Delete Organization"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:220
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:221
 msgid "Delete Project"
 msgstr ""
 
@@ -2154,8 +2151,8 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:175
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:180
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:185
 msgid "Download Output"
 msgstr ""
 
@@ -2418,16 +2415,16 @@ msgid "Edit this node"
 msgstr ""
 
 #: components/Workflow/WorkflowNodeHelp.jsx:146
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:123
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:126
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:181
 msgid "Elapsed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:122
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:125
 msgid "Elapsed Time"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:124
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:127
 msgid "Elapsed time that the job ran"
 msgstr ""
 
@@ -2656,7 +2653,7 @@ msgstr ""
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr ""
 
-#: components/JobList/JobList.jsx:206
+#: components/JobList/JobList.jsx:210
 #: components/Workflow/WorkflowNodeHelp.jsx:92
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.jsx:133
 #: screens/CredentialType/CredentialTypeList/CredentialTypeList.jsx:210
@@ -2690,8 +2687,8 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.jsx:57
 #: components/HostToggle/HostToggle.jsx:70
 #: components/InstanceToggle/InstanceToggle.jsx:61
-#: components/JobList/JobList.jsx:276
-#: components/JobList/JobList.jsx:287
+#: components/JobList/JobList.jsx:281
+#: components/JobList/JobList.jsx:292
 #: components/LaunchButton/LaunchButton.jsx:171
 #: components/LaunchPrompt/LaunchPrompt.jsx:73
 #: components/NotificationList/NotificationList.jsx:246
@@ -2738,7 +2735,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:163
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:177
 #: screens/Organization/OrganizationList/OrganizationList.jsx:210
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:234
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:235
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:197
 #: screens/Project/ProjectList/ProjectList.jsx:236
 #: screens/Project/shared/ProjectSyncButton.jsx:62
@@ -2851,7 +2848,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:236
+#: screens/Job/JobDetail/JobDetail.jsx:219
 msgid "Execution Node"
 msgstr ""
 
@@ -2914,7 +2911,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:224
+#: components/JobList/JobListItem.jsx:240
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:129
 msgid "Explanation"
 msgstr ""
@@ -2944,19 +2941,19 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.jsx:205
+#: components/JobList/JobList.jsx:209
 #: components/Workflow/WorkflowNodeHelp.jsx:89
 #: screens/Dashboard/shared/ChartTooltip.jsx:66
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:47
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:111
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:114
 msgid "Failed"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:113
 msgid "Failed Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:112
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:115
 msgid "Failed Hosts"
 msgstr ""
 
@@ -3008,12 +3005,13 @@ msgstr ""
 #~ msgid "Failed to cancel inventory source sync."
 #~ msgstr ""
 
-#: components/JobList/JobList.jsx:290
+#: components/JobList/JobList.jsx:295
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:395
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
+#: components/JobList/JobListItem.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:380
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:139
 msgid "Failed to cancel {0}"
 msgstr ""
 
@@ -3112,7 +3110,7 @@ msgstr ""
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.jsx:279
+#: components/JobList/JobList.jsx:284
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
@@ -3160,7 +3158,7 @@ msgstr ""
 msgid "Failed to delete organization."
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:237
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:238
 msgid "Failed to delete project."
 msgstr ""
 
@@ -3345,12 +3343,12 @@ msgstr ""
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.jsx:221
-#: components/JobList/JobListItem.jsx:82
+#: components/JobList/JobList.jsx:225
+#: components/JobList/JobListItem.jsx:84
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:139
+#: screens/Job/JobDetail/JobDetail.jsx:122
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3645,7 +3643,7 @@ msgstr ""
 msgid "Host Config Key"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:94
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:97
 msgid "Host Count"
 msgstr ""
 
@@ -3728,7 +3726,7 @@ msgstr ""
 #: screens/Inventory/InventoryHosts/InventoryHostList.jsx:151
 #: screens/Inventory/SmartInventory.jsx:71
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.jsx:62
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:95
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:98
 #: util/getRelatedResourceDeleteDetails.js:129
 msgid "Hosts"
 msgstr ""
@@ -3754,7 +3752,7 @@ msgstr ""
 msgid "I agree to the End User License Agreement"
 msgstr ""
 
-#: components/JobList/JobList.jsx:173
+#: components/JobList/JobList.jsx:177
 #: components/Lookup/HostFilterLookup.jsx:82
 #: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
@@ -3992,7 +3990,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:239
+#: screens/Job/JobDetail/JobDetail.jsx:222
 msgid "Instance Group"
 msgstr ""
 
@@ -4076,7 +4074,7 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.jsx:28
-#: components/JobList/JobListItem.jsx:164
+#: components/JobList/JobListItem.jsx:180
 #: components/LaunchPrompt/steps/InventoryStep.jsx:107
 #: components/LaunchPrompt/steps/useInventoryStep.jsx:53
 #: components/Lookup/InventoryLookup.jsx:85
@@ -4099,7 +4097,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:176
+#: screens/Job/JobDetail/JobDetail.jsx:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4119,7 +4117,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:192
+#: screens/Job/JobDetail/JobDetail.jsx:175
 msgid "Inventory Source"
 msgstr ""
 
@@ -4142,11 +4140,11 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.jsx:185
-#: components/JobList/JobListItem.jsx:32
+#: components/JobList/JobList.jsx:189
+#: components/JobList/JobListItem.jsx:34
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:78
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4225,22 +4223,21 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:393
-#: screens/Job/JobDetail/JobDetail.jsx:447
-#: screens/Job/JobDetail/JobDetail.jsx:448
+#: components/JobList/JobListItem.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:378
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:137
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:458
+#: screens/Job/JobDetail/JobDetail.jsx:400
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:252
+#: screens/Job/JobDetail/JobDetail.jsx:235
 msgid "Job Slice"
 msgstr ""
 
@@ -4259,19 +4256,19 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:301
+#: screens/Job/JobDetail/JobDetail.jsx:284
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:132
+#: components/JobList/JobListItem.jsx:148
 #: components/TemplateList/TemplateList.jsx:206
 #: components/Workflow/WorkflowLegend.jsx:92
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:142
+#: screens/Job/JobDetail/JobDetail.jsx:125
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4296,12 +4293,12 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:181
+#: components/JobList/JobList.jsx:185
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:108
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:172
+#: screens/Job/JobDetail/JobDetail.jsx:155
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4322,8 +4319,8 @@ msgstr ""
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.jsx:164
-#: components/JobList/JobList.jsx:239
+#: components/JobList/JobList.jsx:168
+#: components/JobList/JobList.jsx:243
 #: routeConfig.jsx:37
 #: screens/ActivityStream/ActivityStream.jsx:148
 #: screens/Dashboard/shared/LineChart.jsx:69
@@ -4429,15 +4426,15 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.jsx:177
+#: components/JobList/JobList.jsx:181
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:209
+#: components/JobList/JobListItem.jsx:225
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:286
+#: screens/Job/JobDetail/JobDetail.jsx:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4472,7 +4469,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:339
+#: screens/Job/JobDetail/JobDetail.jsx:322
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4570,7 +4567,7 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.jsx:193
+#: components/JobList/JobList.jsx:197
 msgid "Launched By (Username)"
 msgstr ""
 
@@ -4606,13 +4603,13 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocDetailsStep.jsx:164
 #: components/AdHocCommands/AdHocDetailsStep.jsx:165
-#: components/JobList/JobList.jsx:211
+#: components/JobList/JobList.jsx:215
 #: components/LaunchPrompt/steps/OtherPromptsStep.jsx:35
 #: components/PromptDetail/PromptDetail.jsx:186
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:213
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4683,7 +4680,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:258
+#: screens/Job/JobDetail/JobDetail.jsx:241
 msgid "Machine Credential"
 msgstr ""
 
@@ -4700,10 +4697,10 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.jsx:188
-#: components/JobList/JobListItem.jsx:35
+#: components/JobList/JobList.jsx:192
+#: components/JobList/JobListItem.jsx:37
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:81
 msgid "Management Job"
 msgstr ""
 
@@ -4945,9 +4942,9 @@ msgstr ""
 #: components/AssociateModal/AssociateModal.jsx:140
 #: components/AssociateModal/AssociateModal.jsx:155
 #: components/HostForm/HostForm.jsx:85
-#: components/JobList/JobList.jsx:168
-#: components/JobList/JobList.jsx:217
-#: components/JobList/JobListItem.jsx:68
+#: components/JobList/JobList.jsx:172
+#: components/JobList/JobList.jsx:221
+#: components/JobList/JobListItem.jsx:70
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:171
 #: components/LaunchPrompt/steps/CredentialsStep.jsx:186
 #: components/LaunchPrompt/steps/InventoryStep.jsx:86
@@ -5151,7 +5148,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.jsx:200
+#: components/JobList/JobList.jsx:204
 #: components/Workflow/WorkflowNodeHelp.jsx:74
 msgid "New"
 msgstr ""
@@ -5669,7 +5666,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:205
 #: components/Workflow/WorkflowNodeHelp.jsx:77
 msgid "Pending"
 msgstr ""
@@ -5694,7 +5691,7 @@ msgstr ""
 msgid "Play"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:82
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:85
 msgid "Play Count"
 msgstr ""
 
@@ -5703,13 +5700,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:212
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Check"
 msgstr ""
 
@@ -5723,10 +5720,10 @@ msgstr ""
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.jsx:186
-#: components/JobList/JobListItem.jsx:33
+#: components/JobList/JobList.jsx:190
+#: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:79
 msgid "Playbook Run"
 msgstr ""
 
@@ -5745,7 +5742,7 @@ msgstr ""
 msgid "Playbook run"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:83
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:86
 msgid "Plays"
 msgstr ""
 
@@ -5877,7 +5874,7 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:180
+#: components/JobList/JobListItem.jsx:196
 #: components/Lookup/ProjectLookup.jsx:86
 #: components/Lookup/ProjectLookup.jsx:91
 #: components/Lookup/ProjectLookup.jsx:144
@@ -5886,8 +5883,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:204
-#: screens/Job/JobDetail/JobDetail.jsx:219
+#: screens/Job/JobDetail/JobDetail.jsx:187
+#: screens/Job/JobDetail/JobDetail.jsx:202
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6146,16 +6143,16 @@ msgstr ""
 msgid "Related Groups"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:113
+#: components/JobList/JobListItem.jsx:129
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:376
-#: screens/Job/JobDetail/JobDetail.jsx:384
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:359
+#: screens/Job/JobDetail/JobDetail.jsx:367
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:168
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:94
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:143
+#: components/JobList/JobListItem.jsx:110
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:148
 msgid "Relaunch Job"
 msgstr ""
 
@@ -6172,8 +6169,8 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:93
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:142
+#: components/JobList/JobListItem.jsx:109
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:147
 msgid "Relaunch using host parameters"
 msgstr ""
 
@@ -6282,12 +6279,10 @@ msgid ""
 "The enabled variable may be specified using dot notation, e.g: 'foo.bar'"
 msgstr ""
 
-#: components/JobCancelButton/JobCancelButton.jsx:72
-#: components/JobCancelButton/JobCancelButton.jsx:76
+#: components/JobCancelButton/JobCancelButton.jsx:75
+#: components/JobCancelButton/JobCancelButton.jsx:79
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:432
-#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6336,7 +6331,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:211
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -6409,7 +6404,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.jsx:203
+#: components/JobList/JobList.jsx:207
 #: components/TemplateList/TemplateListItem.jsx:105
 #: components/Workflow/WorkflowNodeHelp.jsx:83
 msgid "Running"
@@ -6606,7 +6601,7 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:66
+#: components/JobList/JobListItem.jsx:68
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
 #: components/Pagination/Pagination.jsx:32
@@ -7122,7 +7117,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:319
+#: screens/Job/JobDetail/JobDetail.jsx:302
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7259,10 +7254,10 @@ msgstr ""
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.jsx:184
-#: components/JobList/JobListItem.jsx:31
+#: components/JobList/JobList.jsx:188
+#: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:77
 msgid "Source Control Update"
 msgstr ""
 
@@ -7274,8 +7269,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:164
+#: components/JobList/JobListItem.jsx:170
+#: screens/Job/JobDetail/JobDetail.jsx:147
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7348,8 +7343,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.jsx:220
-#: components/JobList/JobListItem.jsx:81
+#: components/JobList/JobList.jsx:224
+#: components/JobList/JobListItem.jsx:83
 msgid "Start Time"
 msgstr ""
 
@@ -7375,20 +7370,20 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:121
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.jsx:197
-#: components/JobList/JobList.jsx:218
-#: components/JobList/JobListItem.jsx:77
+#: components/JobList/JobList.jsx:201
+#: components/JobList/JobList.jsx:222
+#: components/JobList/JobListItem.jsx:79
 #: screens/Inventory/InventoryList/InventoryList.jsx:203
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:128
+#: screens/Job/JobDetail/JobDetail.jsx:111
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -7479,7 +7474,7 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.jsx:204
+#: components/JobList/JobList.jsx:208
 #: components/Workflow/WorkflowNodeHelp.jsx:86
 #: screens/Dashboard/shared/ChartTooltip.jsx:59
 msgid "Successful"
@@ -7643,7 +7638,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:88
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:91
 msgid "Task Count"
 msgstr ""
 
@@ -7651,7 +7646,7 @@ msgstr ""
 msgid "Task Started"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:89
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:92
 msgid "Tasks"
 msgstr ""
 
@@ -8046,7 +8041,7 @@ msgstr ""
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Project/ProjectDetail/ProjectDetail.jsx:224
+#: screens/Project/ProjectDetail/ProjectDetail.jsx:225
 msgid "This project is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8287,8 +8282,8 @@ msgstr ""
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.jsx:219
-#: components/JobList/JobListItem.jsx:80
+#: components/JobList/JobList.jsx:223
+#: components/JobList/JobListItem.jsx:82
 #: components/Lookup/ProjectLookup.jsx:110
 #: components/NotificationList/NotificationList.jsx:219
 #: components/NotificationList/NotificationListItem.jsx:30
@@ -8322,7 +8317,7 @@ msgstr ""
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:155
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
-#: screens/Project/ProjectList/ProjectListItem.jsx:152
+#: screens/Project/ProjectList/ProjectListItem.jsx:153
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
 #: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
@@ -8359,15 +8354,15 @@ msgid "Unlimited"
 msgstr ""
 
 #: screens/Job/JobOutput/shared/HostStatusBar.jsx:51
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:101
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:104
 msgid "Unreachable"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:100
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:103
 msgid "Unreachable Host Count"
 msgstr ""
 
-#: screens/Job/JobOutput/shared/OutputToolbar.jsx:102
+#: screens/Job/JobOutput/shared/OutputToolbar.jsx:105
 msgid "Unreachable Hosts"
 msgstr ""
 
@@ -8564,7 +8559,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:348
+#: screens/Job/JobDetail/JobDetail.jsx:331
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8596,7 +8591,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:231
+#: screens/Job/JobDetail/JobDetail.jsx:214
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -8868,7 +8863,7 @@ msgstr ""
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.jsx:202
+#: components/JobList/JobList.jsx:206
 #: components/Workflow/WorkflowNodeHelp.jsx:80
 msgid "Waiting"
 msgstr ""
@@ -9016,18 +9011,18 @@ msgstr ""
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.jsx:189
-#: components/JobList/JobListItem.jsx:36
+#: components/JobList/JobList.jsx:193
+#: components/JobList/JobListItem.jsx:38
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:99
+#: screens/Job/JobDetail/JobDetail.jsx:82
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.jsx:142
+#: components/JobList/JobListItem.jsx:158
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:152
+#: screens/Job/JobDetail/JobDetail.jsx:135
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111
@@ -9461,7 +9456,7 @@ msgstr ""
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.jsx:245
+#: components/JobList/JobList.jsx:249
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -570,7 +570,7 @@ msgstr ""
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:441
+#: screens/Job/JobDetail/JobDetail.jsx:439
 #: screens/Job/JobOutput/JobOutput.jsx:807
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
@@ -580,7 +580,7 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:357
+#: screens/Job/JobDetail/JobDetail.jsx:358
 msgid "Artifacts"
 msgstr ""
 
@@ -822,8 +822,6 @@ msgstr ""
 #: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx:101
 #: screens/Credential/shared/ExternalTestModal.jsx:98
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:107
-#: screens/Job/JobDetail/JobDetail.jsx:392
-#: screens/Job/JobDetail/JobDetail.jsx:397
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:63
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.jsx:66
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx:83
@@ -850,8 +848,8 @@ msgstr ""
 msgid "Cancel Inventory Source Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:417
-#: screens/Job/JobDetail/JobDetail.jsx:418
+#: screens/Job/JobDetail/JobDetail.jsx:415
+#: screens/Job/JobDetail/JobDetail.jsx:416
 #: screens/Job/JobOutput/JobOutput.jsx:783
 #: screens/Job/JobOutput/JobOutput.jsx:784
 msgid "Cancel Job"
@@ -866,8 +864,8 @@ msgstr ""
 msgid "Cancel Sync"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:425
-#: screens/Job/JobDetail/JobDetail.jsx:428
+#: screens/Job/JobDetail/JobDetail.jsx:423
+#: screens/Job/JobDetail/JobDetail.jsx:426
 #: screens/Job/JobOutput/JobOutput.jsx:791
 #: screens/Job/JobOutput/JobOutput.jsx:794
 msgid "Cancel job"
@@ -918,6 +916,7 @@ msgstr ""
 #~ msgid "Cancel sync source"
 #~ msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:394
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:134
 msgid "Cancel {0}"
 msgstr ""
@@ -1140,7 +1139,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:187
 #: components/JobList/JobListItem.jsx:34
-#: screens/Job/JobDetail/JobDetail.jsx:96
+#: screens/Job/JobDetail/JobDetail.jsx:97
 #: screens/Job/JobOutput/HostEventModal.jsx:135
 msgid "Command"
 msgstr ""
@@ -1198,7 +1197,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:244
+#: screens/Job/JobDetail/JobDetail.jsx:245
 msgid "Container Group"
 msgstr ""
 
@@ -1435,7 +1434,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:254
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:135
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:48
-#: screens/Job/JobDetail/JobDetail.jsx:334
+#: screens/Job/JobDetail/JobDetail.jsx:335
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:315
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:105
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.jsx:111
@@ -1576,7 +1575,7 @@ msgstr ""
 #: screens/Credential/CredentialList/CredentialList.jsx:175
 #: screens/Credential/Credentials.jsx:13
 #: screens/Credential/Credentials.jsx:23
-#: screens/Job/JobDetail/JobDetail.jsx:272
+#: screens/Job/JobDetail/JobDetail.jsx:273
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:275
 #: screens/Template/shared/JobTemplateForm.jsx:349
 #: util/getRelatedResourceDeleteDetails.js:97
@@ -1708,7 +1707,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:99
-#: screens/Job/JobDetail/JobDetail.jsx:408
+#: screens/Job/JobDetail/JobDetail.jsx:406
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:352
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:168
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:226
@@ -1745,7 +1744,7 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:404
+#: screens/Job/JobDetail/JobDetail.jsx:402
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:201
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:205
 msgid "Delete Job"
@@ -2731,8 +2730,7 @@ msgstr ""
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:258
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.jsx:169
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.jsx:146
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:86
-#: screens/Inventory/shared/InventorySourceSyncButton.jsx:97
+#: screens/Inventory/shared/InventorySourceSyncButton.jsx:51
 #: screens/Login/Login.jsx:191
 #: screens/ManagementJob/ManagementJobList/ManagementJobList.jsx:127
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:360
@@ -2853,7 +2851,7 @@ msgstr ""
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:235
+#: screens/Job/JobDetail/JobDetail.jsx:236
 msgid "Execution Node"
 msgstr ""
 
@@ -3014,6 +3012,7 @@ msgstr ""
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
+#: screens/Job/JobDetail/JobDetail.jsx:395
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:135
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3351,7 +3350,7 @@ msgstr ""
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:138
+#: screens/Job/JobDetail/JobDetail.jsx:139
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:171
 msgid "Finished"
 msgstr ""
@@ -3993,7 +3992,7 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:238
+#: screens/Job/JobDetail/JobDetail.jsx:239
 msgid "Instance Group"
 msgstr ""
 
@@ -4100,7 +4099,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.jsx:40
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.jsx:47
-#: screens/Job/JobDetail/JobDetail.jsx:175
+#: screens/Job/JobDetail/JobDetail.jsx:176
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:135
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:192
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:199
@@ -4120,7 +4119,7 @@ msgstr ""
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:191
+#: screens/Job/JobDetail/JobDetail.jsx:192
 msgid "Inventory Source"
 msgstr ""
 
@@ -4147,7 +4146,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:32
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:36
 #: components/Workflow/WorkflowLegend.jsx:100
-#: screens/Job/JobDetail/JobDetail.jsx:94
+#: screens/Job/JobDetail/JobDetail.jsx:95
 msgid "Inventory Sync"
 msgstr ""
 
@@ -4226,21 +4225,22 @@ msgstr ""
 msgid "Job"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:449
-#: screens/Job/JobDetail/JobDetail.jsx:450
+#: screens/Job/JobDetail/JobDetail.jsx:393
+#: screens/Job/JobDetail/JobDetail.jsx:447
+#: screens/Job/JobDetail/JobDetail.jsx:448
 #: screens/Job/JobOutput/JobOutput.jsx:826
 #: screens/Job/JobOutput/JobOutput.jsx:827
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:133
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:460
+#: screens/Job/JobDetail/JobDetail.jsx:458
 #: screens/Job/JobOutput/JobOutput.jsx:815
 #: screens/Job/JobOutput/JobOutput.jsx:816
 msgid "Job Delete Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:251
+#: screens/Job/JobDetail/JobDetail.jsx:252
 msgid "Job Slice"
 msgstr ""
 
@@ -4259,7 +4259,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:198
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:220
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:334
-#: screens/Job/JobDetail/JobDetail.jsx:300
+#: screens/Job/JobDetail/JobDetail.jsx:301
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:324
 #: screens/Template/shared/JobTemplateForm.jsx:494
 msgid "Job Tags"
@@ -4271,7 +4271,7 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.jsx:47
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.jsx:96
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:29
-#: screens/Job/JobDetail/JobDetail.jsx:141
+#: screens/Job/JobDetail/JobDetail.jsx:142
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:98
 msgid "Job Template"
 msgstr ""
@@ -4301,7 +4301,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:151
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:85
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:283
-#: screens/Job/JobDetail/JobDetail.jsx:171
+#: screens/Job/JobDetail/JobDetail.jsx:172
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:175
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:145
 #: screens/Template/shared/JobTemplateForm.jsx:226
@@ -4437,7 +4437,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:187
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:102
 #: components/TemplateList/TemplateListItem.jsx:306
-#: screens/Job/JobDetail/JobDetail.jsx:285
+#: screens/Job/JobDetail/JobDetail.jsx:286
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:291
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:195
 #: screens/Template/shared/JobTemplateForm.jsx:367
@@ -4472,7 +4472,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.jsx:114
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.jsx:43
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.jsx:86
-#: screens/Job/JobDetail/JobDetail.jsx:338
+#: screens/Job/JobDetail/JobDetail.jsx:339
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.jsx:320
 #: screens/Organization/OrganizationDetail/OrganizationDetail.jsx:110
 #: screens/Project/ProjectDetail/ProjectDetail.jsx:187
@@ -4612,7 +4612,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:133
 #: components/PromptDetail/PromptWFJobTemplateDetail.jsx:76
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:311
-#: screens/Job/JobDetail/JobDetail.jsx:229
+#: screens/Job/JobDetail/JobDetail.jsx:230
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:220
 #: screens/Template/shared/JobTemplateForm.jsx:416
 #: screens/Template/shared/WorkflowJobTemplateForm.jsx:160
@@ -4683,7 +4683,7 @@ msgstr ""
 #: components/AdHocCommands/AdHocCredentialStep.jsx:67
 #: components/AdHocCommands/AdHocCredentialStep.jsx:68
 #: components/AdHocCommands/AdHocCredentialStep.jsx:84
-#: screens/Job/JobDetail/JobDetail.jsx:257
+#: screens/Job/JobDetail/JobDetail.jsx:258
 msgid "Machine Credential"
 msgstr ""
 
@@ -4703,7 +4703,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:188
 #: components/JobList/JobListItem.jsx:35
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:39
-#: screens/Job/JobDetail/JobDetail.jsx:97
+#: screens/Job/JobDetail/JobDetail.jsx:98
 msgid "Management Job"
 msgstr ""
 
@@ -5703,13 +5703,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:131
-#: screens/Job/JobDetail/JobDetail.jsx:228
+#: screens/Job/JobDetail/JobDetail.jsx:229
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:218
 #: screens/Template/shared/JobTemplateForm.jsx:330
 msgid "Playbook"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Check"
 msgstr ""
 
@@ -5726,7 +5726,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:186
 #: components/JobList/JobListItem.jsx:33
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:37
-#: screens/Job/JobDetail/JobDetail.jsx:95
+#: screens/Job/JobDetail/JobDetail.jsx:96
 msgid "Playbook Run"
 msgstr ""
 
@@ -5886,8 +5886,8 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:124
 #: components/TemplateList/TemplateListItem.jsx:268
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:213
-#: screens/Job/JobDetail/JobDetail.jsx:203
-#: screens/Job/JobDetail/JobDetail.jsx:218
+#: screens/Job/JobDetail/JobDetail.jsx:204
+#: screens/Job/JobDetail/JobDetail.jsx:219
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.jsx:151
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:203
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:211
@@ -6148,8 +6148,8 @@ msgstr ""
 
 #: components/JobList/JobListItem.jsx:113
 #: components/LaunchButton/ReLaunchDropDown.jsx:81
-#: screens/Job/JobDetail/JobDetail.jsx:375
-#: screens/Job/JobDetail/JobDetail.jsx:383
+#: screens/Job/JobDetail/JobDetail.jsx:376
+#: screens/Job/JobDetail/JobDetail.jsx:384
 #: screens/Job/JobOutput/shared/OutputToolbar.jsx:163
 msgid "Relaunch"
 msgstr ""
@@ -6286,8 +6286,8 @@ msgstr ""
 #: components/JobCancelButton/JobCancelButton.jsx:76
 #: components/JobList/JobListCancelButton.jsx:159
 #: components/JobList/JobListCancelButton.jsx:162
-#: screens/Job/JobDetail/JobDetail.jsx:434
-#: screens/Job/JobDetail/JobDetail.jsx:437
+#: screens/Job/JobDetail/JobDetail.jsx:432
+#: screens/Job/JobDetail/JobDetail.jsx:435
 #: screens/Job/JobOutput/JobOutput.jsx:800
 #: screens/Job/JobOutput/JobOutput.jsx:803
 msgid "Return"
@@ -6336,7 +6336,7 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:227
+#: screens/Job/JobDetail/JobDetail.jsx:228
 #: screens/Project/ProjectList/ProjectList.jsx:176
 #: screens/Project/ProjectList/ProjectListItem.jsx:156
 msgid "Revision"
@@ -7122,7 +7122,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.jsx:221
 #: components/PromptDetail/PromptJobTemplateDetail.jsx:235
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:352
-#: screens/Job/JobDetail/JobDetail.jsx:318
+#: screens/Job/JobDetail/JobDetail.jsx:319
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:339
 #: screens/Template/shared/JobTemplateForm.jsx:510
 msgid "Skip Tags"
@@ -7262,7 +7262,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:184
 #: components/JobList/JobListItem.jsx:31
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:38
-#: screens/Job/JobDetail/JobDetail.jsx:93
+#: screens/Job/JobDetail/JobDetail.jsx:94
 msgid "Source Control Update"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid "Source Variables"
 msgstr ""
 
 #: components/JobList/JobListItem.jsx:154
-#: screens/Job/JobDetail/JobDetail.jsx:163
+#: screens/Job/JobDetail/JobDetail.jsx:164
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7375,7 +7375,7 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.jsx:137
+#: screens/Job/JobDetail/JobDetail.jsx:138
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.jsx:229
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.jsx:76
 msgid "Started"
@@ -7388,7 +7388,7 @@ msgstr ""
 #: screens/Inventory/InventoryList/InventoryListItem.jsx:88
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:218
 #: screens/Inventory/InventorySources/InventorySourceListItem.jsx:80
-#: screens/Job/JobDetail/JobDetail.jsx:127
+#: screens/Job/JobDetail/JobDetail.jsx:128
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.jsx:197
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.jsx:111
 #: screens/Project/ProjectList/ProjectList.jsx:174
@@ -8564,7 +8564,7 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.jsx:87
 #: screens/Inventory/shared/InventoryGroupForm.jsx:49
 #: screens/Inventory/shared/SmartInventoryForm.jsx:96
-#: screens/Job/JobDetail/JobDetail.jsx:347
+#: screens/Job/JobDetail/JobDetail.jsx:348
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:354
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:210
 #: screens/Template/shared/JobTemplateForm.jsx:387
@@ -8596,7 +8596,7 @@ msgstr ""
 #: components/Schedule/ScheduleDetail/ScheduleDetail.jsx:306
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.jsx:227
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.jsx:90
-#: screens/Job/JobDetail/JobDetail.jsx:230
+#: screens/Job/JobDetail/JobDetail.jsx:231
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:221
 #: screens/Template/shared/JobTemplateForm.jsx:437
 msgid "Verbosity"
@@ -9019,7 +9019,7 @@ msgstr ""
 #: components/JobList/JobList.jsx:189
 #: components/JobList/JobListItem.jsx:36
 #: components/Schedule/ScheduleList/ScheduleListItem.jsx:40
-#: screens/Job/JobDetail/JobDetail.jsx:98
+#: screens/Job/JobDetail/JobDetail.jsx:99
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:134
 msgid "Workflow Job"
 msgstr ""
@@ -9027,7 +9027,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:142
 #: components/Workflow/WorkflowNodeHelp.jsx:51
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.jsx:30
-#: screens/Job/JobDetail/JobDetail.jsx:151
+#: screens/Job/JobDetail/JobDetail.jsx:152
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.jsx:110
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.jsx:147
 #: util/getRelatedResourceDeleteDetails.js:111

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
@@ -92,11 +92,8 @@ function InventorySourceListItem({
         </Td>
         <Td dataLabel={t`Type`}>{label}</Td>
         <ActionsTd dataLabel={t`Actions`}>
-          <ActionItem
-            visible={source.summary_fields.user_capabilities.start}
-            tooltip={t`Sync`}
-          >
-            {['running', 'pending', 'waiting'].includes(source?.status) ? (
+          {['running', 'pending', 'waiting'].includes(source?.status) ? (
+            <ActionItem visible={source.summary_fields.user_capabilities.start}>
               <JobCancelButton
                 job={{
                   type: 'inventory_update',
@@ -107,10 +104,15 @@ function InventorySourceListItem({
                 title={t`Cancel Inventory Source Sync`}
                 showIconButton
               />
-            ) : (
+            </ActionItem>
+          ) : (
+            <ActionItem
+              visible={source.summary_fields.user_capabilities.start}
+              tooltip={t`Sync`}
+            >
               <InventorySourceSyncButton source={source} />
-            )}
-          </ActionItem>
+            </ActionItem>
+          )}
           <ActionItem
             visible={source.summary_fields.user_capabilities.edit}
             tooltip={t`Edit`}

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 
 import { ActionsTd, ActionItem } from '../../../components/PaginatedTable';
 import StatusIcon from '../../../components/StatusIcon';
+import JobCancelButton from '../../../components/JobCancelButton';
 import InventorySourceSyncButton from '../shared/InventorySourceSyncButton';
 import { formatDateString } from '../../../util/dates';
 
@@ -95,7 +96,20 @@ function InventorySourceListItem({
             visible={source.summary_fields.user_capabilities.start}
             tooltip={t`Sync`}
           >
-            <InventorySourceSyncButton source={source} />
+            {['running', 'pending', 'waiting'].includes(source?.status) ? (
+              <JobCancelButton
+                job={{
+                  type: 'inventory_update',
+                  id: source.summary_fields.last_job.id,
+                }}
+                errorTitle={t`Inventory Source Sync Error`}
+                errorMessage={t`Failed to cancel Inventory Source Sync`}
+                title={t`Cancel Inventory Source Sync`}
+                showIconButton
+              />
+            ) : (
+              <InventorySourceSyncButton source={source} />
+            )}
           </ActionItem>
           <ActionItem
             visible={source.summary_fields.user_capabilities.edit}

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.jsx
@@ -3,11 +3,11 @@ import React, { useCallback } from 'react';
 import { t } from '@lingui/macro';
 import PropTypes from 'prop-types';
 import { Button, Tooltip } from '@patternfly/react-core';
-import { SyncIcon, MinusCircleIcon } from '@patternfly/react-icons';
+import { SyncIcon } from '@patternfly/react-icons';
 import useRequest, { useDismissableError } from '../../../util/useRequest';
 import AlertModal from '../../../components/AlertModal/AlertModal';
 import ErrorDetail from '../../../components/ErrorDetail/ErrorDetail';
-import { InventoryUpdatesAPI, InventorySourcesAPI } from '../../../api';
+import { InventorySourcesAPI } from '../../../api';
 
 function InventorySourceSyncButton({ source, icon }) {
   const {
@@ -26,59 +26,24 @@ function InventorySourceSyncButton({ source, icon }) {
   );
 
   const {
-    isLoading: cancelSyncLoading,
-    error: cancelSyncError,
-    request: cancelSyncProcess,
-  } = useRequest(
-    useCallback(async () => {
-      const {
-        data: {
-          summary_fields: {
-            current_update: { id },
-          },
-        },
-      } = await InventorySourcesAPI.readDetail(source.id);
-
-      await InventoryUpdatesAPI.createSyncCancel(id);
-    }, [source.id])
-  );
-
-  const {
     error: startError,
     dismissError: dismissStartError,
   } = useDismissableError(startSyncError);
-  const {
-    error: cancelError,
-    dismissError: dismissCancelError,
-  } = useDismissableError(cancelSyncError);
 
   return (
     <>
-      {['running', 'pending', 'updating'].includes(source.status) ? (
-        <Tooltip content={t`Cancel sync process`} position="top">
-          <Button
-            ouiaId={`${source}-cancel-sync-button`}
-            isDisabled={cancelSyncLoading || startSyncLoading}
-            aria-label={t`Cancel sync source`}
-            variant={icon ? 'plain' : 'secondary'}
-            onClick={cancelSyncProcess}
-          >
-            {icon ? <MinusCircleIcon /> : t`Cancel sync`}
-          </Button>
-        </Tooltip>
-      ) : (
-        <Tooltip content={t`Start sync process`} position="top">
-          <Button
-            ouiaId={`${source}-sync-button`}
-            isDisabled={cancelSyncLoading || startSyncLoading}
-            aria-label={t`Start sync source`}
-            variant={icon ? 'plain' : 'secondary'}
-            onClick={startSyncProcess}
-          >
-            {icon ? <SyncIcon /> : t`Sync`}
-          </Button>
-        </Tooltip>
-      )}
+      <Tooltip content={t`Start sync process`} position="top">
+        <Button
+          ouiaId={`${source}-sync-button`}
+          isDisabled={startSyncLoading}
+          aria-label={t`Start sync source`}
+          variant={icon ? 'plain' : 'secondary'}
+          onClick={startSyncProcess}
+        >
+          {icon ? <SyncIcon /> : t`Sync`}
+        </Button>
+      </Tooltip>
+
       {startError && (
         <AlertModal
           isOpen={startError}
@@ -88,17 +53,6 @@ function InventorySourceSyncButton({ source, icon }) {
         >
           {t`Failed to sync inventory source.`}
           <ErrorDetail error={startError} />
-        </AlertModal>
-      )}
-      {cancelError && (
-        <AlertModal
-          isOpen={cancelError}
-          variant="error"
-          title={t`Error!`}
-          onClose={dismissCancelError}
-        >
-          {t`Failed to cancel inventory source sync.`}
-          <ErrorDetail error={cancelError} />
         </AlertModal>
       )}
     </>

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { InventoryUpdatesAPI, InventorySourcesAPI } from '../../../api';
+import { InventorySourcesAPI } from '../../../api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventorySourceSyncButton from './InventorySourceSyncButton';
 
@@ -36,17 +36,6 @@ describe('<InventorySourceSyncButton />', () => {
     ).toBe(false);
   });
 
-  test('should render cancel sync button', () => {
-    wrapper = mountWithContexts(
-      <InventorySourceSyncButton
-        source={{ status: 'pending', ...source }}
-        onSyncLoading={onSyncLoading}
-        onFetchSources={() => {}}
-      />
-    );
-    expect(wrapper.find('MinusCircleIcon').length).toBe(1);
-  });
-
   test('should start sync properly', async () => {
     InventorySourcesAPI.createSyncStart.mockResolvedValue({
       data: { status: 'pending' },
@@ -56,33 +45,6 @@ describe('<InventorySourceSyncButton />', () => {
       wrapper.find('Button[aria-label="Start sync source"]').simulate('click')
     );
     expect(InventorySourcesAPI.createSyncStart).toBeCalledWith(1);
-  });
-
-  test('should cancel sync properly', async () => {
-    InventorySourcesAPI.readDetail.mockResolvedValue({
-      data: { summary_fields: { current_update: { id: 120 } } },
-    });
-    InventoryUpdatesAPI.createSyncCancel.mockResolvedValue({
-      data: { status: '' },
-    });
-
-    wrapper = mountWithContexts(
-      <InventorySourceSyncButton
-        source={{ status: 'pending', ...source }}
-        onSyncLoading={onSyncLoading}
-        onFetchSources={() => {}}
-      />
-    );
-    expect(wrapper.find('Button[aria-label="Cancel sync source"]').length).toBe(
-      1
-    );
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Cancel sync source"]').simulate('click')
-    );
-
-    expect(InventorySourcesAPI.readDetail).toBeCalledWith(1);
-    expect(InventoryUpdatesAPI.createSyncCancel).toBeCalledWith(120);
   });
 
   test('should throw error on sync start properly', async () => {

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.jsx
@@ -24,6 +24,7 @@ import {
   ReLaunchDropDown,
 } from '../../../components/LaunchButton';
 import StatusIcon from '../../../components/StatusIcon';
+import JobCancelButton from '../../../components/JobCancelButton';
 import ExecutionEnvironmentDetail from '../../../components/ExecutionEnvironmentDetail';
 import { getJobModel, isJobRunning } from '../../../util/jobs';
 import { toTitleCase } from '../../../util/strings';
@@ -387,15 +388,12 @@ function JobDetail({ job }) {
           ))}
         {isJobRunning(job.status) &&
           job?.summary_fields?.user_capabilities?.start && (
-            <Button
-              variant="secondary"
-              aria-label={t`Cancel`}
-              isDisabled={isCancelling}
-              onClick={() => setShowCancelModal(true)}
-              ouiaId="job-detail-cancel-button"
-            >
-              {t`Cancel`}
-            </Button>
+            <JobCancelButton
+              job={job}
+              errorTitle={t`Job Cancel Error`}
+              title={t`Cancel ${job.name}`}
+              errorMessage={t`Failed to cancel ${job.name}`}
+            />
           )}
         {!isJobRunning(job.status) &&
           job?.summary_fields?.user_capabilities?.delete && (

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { createMemoryHistory } from 'history';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import { sleep } from '../../../../testUtils/testUtils';
 import JobDetail from './JobDetail';
@@ -14,6 +15,10 @@ describe('<JobDetail />', () => {
     expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
     expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
   }
+  afterEach(() => {
+    wrapper.unmount();
+    jest.clearAllMocks();
+  });
 
   test('should display details', () => {
     wrapper = mountWithContexts(
@@ -144,18 +149,15 @@ describe('<JobDetail />', () => {
   });
 
   test('DELETED is shown for required Job resources that have been deleted', () => {
-    wrapper = mountWithContexts(
-      <JobDetail
-        job={{
-          ...mockJobData,
-          summary_fields: {
-            ...mockJobData.summary_fields,
-            inventory: null,
-            project: null,
-          },
-        }}
-      />
-    );
+    const newMockData = {
+      ...mockJobData,
+      summary_fields: {
+        ...mockJobData.summary_fields,
+        inventory: null,
+        project: null,
+      },
+    };
+    wrapper = mountWithContexts(<JobDetail job={newMockData} />);
     const detail = wrapper.find('JobDetail');
     async function assertMissingDetail(label) {
       expect(detail.length).toBe(1);
@@ -176,5 +178,129 @@ describe('<JobDetail />', () => {
       />
     );
     assertDetail('Job Type', 'Playbook Check');
+  });
+
+  test('should not show cancel job button, not super user', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/settings/miscellaneous_system/edit'],
+    });
+
+    wrapper = mountWithContexts(
+      <JobDetail
+        job={{
+          ...mockJobData,
+          status: 'pending',
+          type: 'system_job',
+        }}
+      />,
+      {
+        context: {
+          router: {
+            history,
+          },
+          config: {
+            me: {
+              is_superuser: false,
+            },
+          },
+        },
+      }
+    );
+    expect(
+      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
+    ).toHaveLength(0);
+  });
+
+  test('should not show cancel job button, job completed', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/settings/miscellaneous_system/edit'],
+    });
+
+    wrapper = mountWithContexts(
+      <JobDetail
+        job={{
+          ...mockJobData,
+          status: 'success',
+          type: 'project_update',
+        }}
+      />,
+      {
+        context: {
+          router: {
+            history,
+          },
+          config: {
+            me: {
+              is_superuser: true,
+            },
+          },
+        },
+      }
+    );
+    expect(
+      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
+    ).toHaveLength(0);
+  });
+
+  test('should show cancel button, pending, super user', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/settings/miscellaneous_system/edit'],
+    });
+
+    wrapper = mountWithContexts(
+      <JobDetail
+        job={{
+          ...mockJobData,
+          status: 'pending',
+          type: 'system_job',
+        }}
+      />,
+      {
+        context: {
+          router: {
+            history,
+          },
+          config: {
+            me: {
+              is_superuser: true,
+            },
+          },
+        },
+      }
+    );
+    expect(
+      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
+    ).toHaveLength(1);
+  });
+
+  test('should show cancel button, pending, super project update, not super user', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/settings/miscellaneous_system/edit'],
+    });
+
+    wrapper = mountWithContexts(
+      <JobDetail
+        job={{
+          ...mockJobData,
+          status: 'pending',
+          type: 'project_update',
+        }}
+      />,
+      {
+        context: {
+          router: {
+            history,
+          },
+          config: {
+            me: {
+              is_superuser: false,
+            },
+          },
+        },
+      }
+    );
+    expect(
+      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
+    ).toHaveLength(1);
   });
 });

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { t } from '@lingui/macro';
 import { bool, shape, func } from 'prop-types';
 import {
-  MinusCircleIcon,
   DownloadIcon,
   RocketIcon,
   TrashAltIcon,
@@ -15,6 +14,7 @@ import {
   LaunchButton,
   ReLaunchDropDown,
 } from '../../../../components/LaunchButton';
+import JobCancelButton from '../../../../components/JobCancelButton';
 
 const BadgeGroup = styled.div`
   margin-left: 20px;
@@ -62,13 +62,7 @@ const OUTPUT_NO_COUNT_JOB_TYPES = [
   'inventory_update',
 ];
 
-const OutputToolbar = ({
-  job,
-  onDelete,
-  onCancel,
-  isDeleteDisabled,
-  jobStatus,
-}) => {
+const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
   const hideCounts = OUTPUT_NO_COUNT_JOB_TYPES.includes(job.type);
 
   const playCount = job?.playbook_counts?.play_count;
@@ -184,16 +178,13 @@ const OutputToolbar = ({
       )}
       {job.summary_fields.user_capabilities.start &&
         ['pending', 'waiting', 'running'].includes(jobStatus) && (
-          <Tooltip content={t`Cancel Job`}>
-            <Button
-              ouiaId="job-output-cancel-button"
-              variant="plain"
-              aria-label={t`Cancel Job`}
-              onClick={onCancel}
-            >
-              <MinusCircleIcon />
-            </Button>
-          </Tooltip>
+          <JobCancelButton
+            job={job}
+            errorTitle={t`Job Cancel Error`}
+            title={t`Job Cancel`}
+            errorMessage={t`Failed to cancel ${job.name}`}
+            showIconButton
+          />
         )}
       {job.summary_fields.user_capabilities.delete &&
         ['new', 'successful', 'failed', 'error', 'canceled'].includes(

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.jsx
@@ -126,8 +126,16 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
         </Tooltip>
       </BadgeGroup>
 
-      {job.type !== 'system_job' &&
-        job.summary_fields.user_capabilities?.start && (
+      {job.summary_fields.user_capabilities?.start &&
+        (['pending', 'waiting', 'running'].includes(jobStatus) ? (
+          <JobCancelButton
+            job={job}
+            errorTitle={t`Job Cancel Error`}
+            title={t`Cancel ${job.name}`}
+            errorMessage={t`Failed to cancel ${job.name}`}
+            showIconButton
+          />
+        ) : (
           <Tooltip
             content={
               job.status === 'failed' && job.type === 'job'
@@ -161,7 +169,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
               </LaunchButton>
             )}
           </Tooltip>
-        )}
+        ))}
 
       {job.related?.stdout && (
         <Tooltip content={t`Download Output`}>
@@ -176,7 +184,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
           </a>
         </Tooltip>
       )}
-      {job.summary_fields.user_capabilities.start &&
+      {/* {job.summary_fields.user_capabilities.start &&
         ['pending', 'waiting', 'running'].includes(jobStatus) && (
           <JobCancelButton
             job={job}
@@ -185,7 +193,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
             errorMessage={t`Failed to cancel ${job.name}`}
             showIconButton
           />
-        )}
+        )} */}
       {job.summary_fields.user_capabilities.delete &&
         ['new', 'successful', 'failed', 'error', 'canceled'].includes(
           jobStatus

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
@@ -219,7 +219,7 @@ function ProjectDetail({ project }) {
             name={name}
             modalTitle={t`Delete Project`}
             onConfirm={deleteProject}
-            isDisabled={isLoading}
+            isDisabled={isLoading || job?.status === 'running'}
             deleteDetailsRequests={deleteDetailsRequests}
             deleteMessage={t`This project is currently being used by other resources. Are you sure you want to delete it?`}
           >
@@ -227,7 +227,6 @@ function ProjectDetail({ project }) {
           </DeleteButton>
         )}
       </CardActionsRow>
-      {/* Update delete modal to show dependencies https://github.com/ansible/awx/issues/5546 */}
       {error && (
         <AlertModal
           isOpen={error}

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
@@ -207,6 +207,7 @@ function ProjectDetail({ project }) {
               errorTitle={t`Project Sync Error`}
               title={t`Cancel Project Sync`}
               errorMessage={t`Failed to cancel Project Sync`}
+              buttonText={t`Cancel Sync`}
             />
           ) : (
             <ProjectSyncButton

--- a/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectDetail/ProjectDetail.jsx
@@ -15,6 +15,7 @@ import {
   UserDateDetail,
 } from '../../../components/DetailList';
 import ErrorDetail from '../../../components/ErrorDetail';
+import JobCancelButton from '../../../components/JobCancelButton';
 import ExecutionEnvironmentDetail from '../../../components/ExecutionEnvironmentDetail';
 import CredentialChip from '../../../components/CredentialChip';
 import { ProjectsAPI } from '../../../api';
@@ -199,12 +200,20 @@ function ProjectDetail({ project }) {
             {t`Edit`}
           </Button>
         )}
-        {summary_fields.user_capabilities?.start && (
-          <ProjectSyncButton
-            projectId={project.id}
-            lastJobStatus={job && job.status}
-          />
-        )}
+        {summary_fields.user_capabilities?.start &&
+          (['running', 'pending', 'waiting'].includes(job?.status) ? (
+            <JobCancelButton
+              job={{ id: job.id, type: 'project_update' }}
+              errorTitle={t`Project Sync Error`}
+              title={t`Cancel Project Sync`}
+              errorMessage={t`Failed to cancel Project Sync`}
+            />
+          ) : (
+            <ProjectSyncButton
+              projectId={project.id}
+              lastJobStatus={job && job.status}
+            />
+          ))}
         {summary_fields.user_capabilities?.delete && (
           <DeleteButton
             name={name}

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -26,6 +26,7 @@ import { toTitleCase } from '../../../util/strings';
 import CopyButton from '../../../components/CopyButton';
 import ProjectSyncButton from '../shared/ProjectSyncButton';
 import { Project } from '../../../types';
+import JobCancelButton from '../../../components/JobCancelButton';
 
 const Label = styled.span`
   color: var(--pf-global--disabled-color--100);
@@ -172,10 +173,20 @@ function ProjectListItem({
             visible={project.summary_fields.user_capabilities.start}
             tooltip={t`Sync Project`}
           >
-            <ProjectSyncButton
-              projectId={project.id}
-              lastJobStatus={job && job.status}
-            />
+            {['running', 'pending', 'waiting'].includes(job?.status) ? (
+              <JobCancelButton
+                job={{ id: job.id, type: 'project_update' }}
+                errorTitle={t`Project Sync Error`}
+                title={t`Cancel Project Sync`}
+                showIconButton
+                errorMessage={t`Failed to cancel Project Sync`}
+              />
+            ) : (
+              <ProjectSyncButton
+                projectId={project.id}
+                lastJobStatus={job && job.status}
+              />
+            )}
           </ActionItem>
           <ActionItem
             visible={project.summary_fields.user_capabilities.edit}

--- a/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
+++ b/awx/ui_next/src/screens/Project/ProjectList/ProjectListItem.jsx
@@ -169,11 +169,10 @@ function ProjectListItem({
           />
         </Td>
         <ActionsTd dataLabel={t`Actions`}>
-          <ActionItem
-            visible={project.summary_fields.user_capabilities.start}
-            tooltip={t`Sync Project`}
-          >
-            {['running', 'pending', 'waiting'].includes(job?.status) ? (
+          {['running', 'pending', 'waiting'].includes(job?.status) ? (
+            <ActionItem
+              visible={project.summary_fields.user_capabilities.start}
+            >
               <JobCancelButton
                 job={{ id: job.id, type: 'project_update' }}
                 errorTitle={t`Project Sync Error`}
@@ -181,13 +180,18 @@ function ProjectListItem({
                 showIconButton
                 errorMessage={t`Failed to cancel Project Sync`}
               />
-            ) : (
+            </ActionItem>
+          ) : (
+            <ActionItem
+              visible={project.summary_fields.user_capabilities.start}
+              tooltip={t`Sync Project`}
+            >
               <ProjectSyncButton
                 projectId={project.id}
                 lastJobStatus={job && job.status}
               />
-            )}
-          </ActionItem>
+            </ActionItem>
+          )}
           <ActionItem
             visible={project.summary_fields.user_capabilities.edit}
             tooltip={t`Edit Project`}


### PR DESCRIPTION

##### SUMMARY
This addresses part of #10045 and adds a sync cancel button on the projects list.  It also expands the usage of that button to the Project details page, and the Inventory Source list.  It does this by introducing a new component called JobCancelButton, that basically takes the work of the job cancel button on the Output toolbar and refactors it slightly to make it useable in these other areas.  This button could also be used in the Inventory Source details page once we have websockets hooked up for that view and we can track the status of the sync. (https://github.com/ansible/awx/issues/9013)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION
![syncancel](https://user-images.githubusercontent.com/39280967/117157253-70893900-ad8c-11eb-835e-59171c6eb22f.gif)
