### PR TITLE
Remove source_script from tower_inventory_source integration test

### DIFF
--- a/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_inventory_source/tasks/main.yml
@@ -41,13 +41,12 @@
     that:
       - "result is changed"
 
-- name: Delete the inventory source with an invalid cred, source_project, sourece_script specified
+- name: Delete the inventory source with an invalid cred and source_project specified
   tower_inventory_source:
     name: "{{ result.id }}"
     inventory: "{{ openstack_inv }}"
     credential: "Does Not Exit"
     source_project: "Does Not Exist"
-    source_script: "Does Not Exist"
     state: absent
 
 - assert:


### PR DESCRIPTION
##### SUMMARY

`source_script` parameter is on longer available in the current version AWX API(#9822), so we need to remove it from the integration test of `tower_inventory_source` module

* Fixes #10104

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - awx_collections

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
None