### PR TITLE
`console.warning` is not exists on browser

### DIFF
--- a/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
+++ b/awx/ui_next/src/components/CodeEditor/CodeEditor.jsx
@@ -84,7 +84,7 @@ function CodeEditor({
 }) {
   if (rows && typeof rows !== 'number' && rows !== 'auto') {
     // eslint-disable-next-line no-console
-    console.warning(
+    console.warn(
       `CodeEditor: Unexpected value for 'rows': ${rows}; expected number or 'auto'`
     );
   }


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fix typo error for `console.warn`
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

`console.warning` is not exists function in browser envirment.

