### PR TITLE
Add instance_group to inventory update serializer

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2207,6 +2207,7 @@ class InventoryUpdateSerializer(UnifiedJobSerializer, InventorySourceOptionsSeri
             'org_host_limit_error',
             'source_project_update',
             'custom_virtualenv',
+            'instance_group',
             '-controller_node',
         )
 


### PR DESCRIPTION
##### SUMMARY
Inventory updates run remotely, in the execution plane. This adds the `instance_group` field to the inventory update serializer to help clarify this reality.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
