### PR TITLE
Fix typos

### DIFF
--- a/awx/ui_next/src/locales/en/messages.po
+++ b/awx/ui_next/src/locales/en/messages.po
@@ -361,7 +361,7 @@ msgstr "Add resource type"
 msgid "Add smart inventory"
 msgstr "Add smart inventory"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr "Add team permissions"
 
@@ -885,8 +885,8 @@ msgstr "Cache timeout (seconds)"
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr ""
 
@@ -2192,7 +2192,7 @@ msgstr "Disable SSL verification"
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr "Disassociate"
@@ -2218,12 +2218,12 @@ msgstr "Disassociate related group(s)?"
 msgid "Disassociate related team(s)?"
 msgstr "Disassociate related team(s)?"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr "Disassociate role"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr "Disassociate role!"
@@ -2900,7 +2900,7 @@ msgstr "Error saving the workflow!"
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3305,7 +3305,7 @@ msgstr "Failed to delete project."
 msgid "Failed to delete role"
 msgstr "Failed to delete role"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr "Failed to delete role."
@@ -3676,19 +3676,19 @@ msgstr "Globally Available"
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr "Globally available execution environment can not be reassigned to a specific Organization"
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr "I agree to the End User License Agreement"
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr "ID"
 
@@ -4402,7 +4402,7 @@ msgstr "Item Skipped"
 msgid "Items"
 msgstr "Items"
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr ""
 
@@ -5889,7 +5889,7 @@ msgstr "Pagerduty Subdomain"
 msgid "Pagerduty subdomain"
 msgstr "Pagerduty subdomain"
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr ""
 
@@ -6584,6 +6584,11 @@ msgstr "Request subscription"
 msgid "Required"
 msgstr "Required"
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr "Resource Name"
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr "Resource deleted"
@@ -6693,8 +6698,9 @@ msgstr "Revision #"
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6950,7 +6956,7 @@ msgstr "See errors on the left"
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr ""
@@ -7981,7 +7987,7 @@ msgstr "Sync for revision"
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -8003,7 +8009,7 @@ msgstr "System Auditor"
 msgid "System Warning"
 msgstr "System Warning"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr "System administrators have unrestricted access to all resources."
@@ -8104,7 +8110,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr ""
 
@@ -8411,7 +8417,7 @@ msgstr "This action will delete the following:"
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "This action will disassociate all roles for this user from the selected teams."
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr "This action will disassociate the following role from {0}:"
@@ -8855,7 +8861,8 @@ msgstr "Twilio"
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9802,7 +9809,7 @@ msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr "confirm disassociate"
 
@@ -9919,7 +9926,7 @@ msgstr "instance type"
 msgid "inventory"
 msgstr "inventory"
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr ""
 
@@ -9963,15 +9970,15 @@ msgstr "of"
 msgid "option to the"
 msgstr "option to the"
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr "page"
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr ""
 
@@ -9981,16 +9988,16 @@ msgid "relaunch jobs"
 msgstr "relaunch jobs"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr "resource name"
+#~ msgid "resource name"
+#~ msgstr "resource name"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr "resource role"
+#~ msgid "resource role"
+#~ msgstr "resource role"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr "resource type"
+#~ msgid "resource type"
+#~ msgstr "resource type"
 
 #: src/pages/Organizations/components/OrganizationEdit.jsx:22
 #~ msgid "save/cancel and go back to view"
@@ -10100,13 +10107,17 @@ msgstr "{0, plural, one {This execution environment is currently being used by o
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/es/messages.po
+++ b/awx/ui_next/src/locales/es/messages.po
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Add smart inventory"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr ""
 
@@ -844,8 +844,8 @@ msgstr ""
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1588,7 +1588,7 @@ msgstr ""
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr ""
 
@@ -2110,7 +2110,7 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr ""
@@ -2136,12 +2136,12 @@ msgstr ""
 msgid "Disassociate related team(s)?"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr ""
@@ -2784,7 +2784,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3189,7 +3189,7 @@ msgstr ""
 msgid "Failed to delete role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr ""
@@ -3553,19 +3553,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr ""
 
@@ -3782,7 +3782,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr ""
 
@@ -4237,7 +4237,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr ""
 
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "Pagerduty subdomain"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr ""
 
@@ -6324,6 +6324,11 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr ""
@@ -6431,8 +6436,9 @@ msgstr ""
 msgid "Rocket.Chat"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6688,7 +6694,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr ""
@@ -7663,7 +7669,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7681,7 +7687,7 @@ msgstr ""
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr ""
@@ -7768,7 +7774,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr ""
 
@@ -8046,7 +8052,7 @@ msgstr ""
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr ""
@@ -8471,7 +8477,8 @@ msgstr ""
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9385,7 +9392,7 @@ msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr ""
 
@@ -9490,7 +9497,7 @@ msgstr ""
 msgid "inventory"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr ""
 
@@ -9530,15 +9537,15 @@ msgstr ""
 msgid "option to the"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr ""
 
@@ -9548,16 +9555,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr ""
+#~ msgid "resource name"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr ""
+#~ msgid "resource role"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr ""
+#~ msgid "resource type"
+#~ msgstr ""
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9655,13 +9662,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/fr/messages.po
+++ b/awx/ui_next/src/locales/fr/messages.po
@@ -341,7 +341,7 @@ msgstr "Ajouter un type de ressource"
 msgid "Add smart inventory"
 msgstr "Ajouter un inventaire smart"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr "Ajouter les permissions de l'équipe"
 
@@ -874,8 +874,8 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1652,7 +1652,7 @@ msgstr "Informations d’identification"
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr "Page actuelle"
 
@@ -2174,7 +2174,7 @@ msgstr "Désactiver la vérification SSL"
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr "Dissocier"
@@ -2200,12 +2200,12 @@ msgstr "Dissocier le(s) groupe(s) lié(s) ?"
 msgid "Disassociate related team(s)?"
 msgstr "Dissocier la ou les équipes liées ?"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr "Dissocier le rôle"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr "Dissocier le rôle !"
@@ -2864,7 +2864,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3269,7 +3269,7 @@ msgstr "N'a pas réussi à supprimer le projet."
 msgid "Failed to delete role"
 msgstr "N'a pas réussi à supprimer le rôle"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr "N'a pas réussi à supprimer le rôle."
@@ -3633,19 +3633,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr "Allez à la première page"
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr "Allez à la dernière page de la liste"
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr "Allez à la page suivante de la liste"
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr "Obtenir la page précédente"
 
@@ -3862,7 +3862,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr "ID"
 
@@ -4317,7 +4317,7 @@ msgstr ""
 msgid "Items"
 msgstr "Éléments"
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr "Éléments par page"
 
@@ -5759,7 +5759,7 @@ msgstr "Sous-domaine Pagerduty"
 msgid "Pagerduty subdomain"
 msgstr "Sous-domaine Pagerduty"
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr "Pagination"
 
@@ -6400,6 +6400,11 @@ msgstr ""
 msgid "Required"
 msgstr "Obligatoire"
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr "Ressource supprimée"
@@ -6507,8 +6512,9 @@ msgstr "Révision n°"
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6764,7 +6770,7 @@ msgstr "Voir les erreurs sur la gauche"
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr "Sélectionner"
@@ -7757,7 +7763,7 @@ msgstr "Synchronisation pour la révision"
 msgid "System"
 msgstr "Système"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7775,7 +7781,7 @@ msgstr "Auditeur système"
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr "Les administrateurs système ont un accès illimité à toutes les ressources."
@@ -7862,7 +7868,7 @@ msgid "Team"
 msgstr "Équipe"
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr "Rôles d’équipe"
 
@@ -8144,7 +8150,7 @@ msgstr "Cette action supprimera les éléments suivants :"
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "Cette action permettra de dissocier tous les rôles de cet utilisateur des équipes sélectionnées."
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr "Cette action permettra de dissocier le rôle suivant de  {brandName} :"
@@ -8569,7 +8575,8 @@ msgstr "Twilio"
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9492,7 +9499,7 @@ msgid "confirm delete"
 msgstr "confirmer supprimer"
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr "confirmer dissocier"
 
@@ -9599,7 +9606,7 @@ msgstr "inventaire"
 #~ msgid "isolated instance"
 #~ msgstr "cas isolé"
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr "éléments"
 
@@ -9639,15 +9646,15 @@ msgstr "de"
 msgid "option to the"
 msgstr "l'option à la"
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr "page"
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr "pages"
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr "par page"
 
@@ -9657,16 +9664,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr "nom de la ressource"
+#~ msgid "resource name"
+#~ msgstr "nom de la ressource"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr "rôle de ressource"
+#~ msgid "resource role"
+#~ msgstr "rôle de ressource"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr "type de ressource"
+#~ msgid "resource type"
+#~ msgstr "type de ressource"
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9764,13 +9771,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/ja/messages.po
+++ b/awx/ui_next/src/locales/ja/messages.po
@@ -341,7 +341,7 @@ msgstr "リソースタイプの追加"
 msgid "Add smart inventory"
 msgstr "スマートインベントリーの追加"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr "チームパーミッションの追加"
 
@@ -874,8 +874,8 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1652,7 +1652,7 @@ msgstr "認証情報"
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr "現在のページ"
 
@@ -2174,7 +2174,7 @@ msgstr "SSL 検証の無効化"
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr "関連付けの解除"
@@ -2200,12 +2200,12 @@ msgstr "関連するグループの関連付けを解除しますか?"
 msgid "Disassociate related team(s)?"
 msgstr "関連するチームの関連付けを解除しますか?"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr "ロールの関連付けの解除"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr "ロールの関連付けの解除!"
@@ -2860,7 +2860,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3265,7 +3265,7 @@ msgstr "プロジェクトを削除できませんでした。"
 msgid "Failed to delete role"
 msgstr "ロールを削除できませんでした。"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr "ロールを削除できませんでした。"
@@ -3629,19 +3629,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr "最初のページに移動"
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr "最後のページに移動"
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr "次のページに移動"
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr "前のページに移動"
 
@@ -3858,7 +3858,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr "ID"
 
@@ -4313,7 +4313,7 @@ msgstr ""
 msgid "Items"
 msgstr "項目"
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr "ページ別の項目"
 
@@ -5755,7 +5755,7 @@ msgstr "Pagerduty サブドメイン"
 msgid "Pagerduty subdomain"
 msgstr "Pagerduty サブドメイン"
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr "ページネーション"
 
@@ -6396,6 +6396,11 @@ msgstr ""
 msgid "Required"
 msgstr "必須"
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr "リソースが削除されました"
@@ -6503,8 +6508,9 @@ msgstr "リビジョン #"
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6760,7 +6766,7 @@ msgstr "左側のエラーを参照してください"
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr "選択"
@@ -7753,7 +7759,7 @@ msgstr "リビジョンの同期"
 msgid "System"
 msgstr "システム"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7771,7 +7777,7 @@ msgstr "システム監査者"
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr "システム管理者は、すべてのリソースに無制限にアクセスできます。"
@@ -7858,7 +7864,7 @@ msgid "Team"
 msgstr "チーム"
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr "チームロール"
 
@@ -8140,7 +8146,7 @@ msgstr "このアクションにより、以下が削除されます。"
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "このアクションにより、このユーザーのすべてのロールと選択したチームの関連付けが解除されます。"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr "このアクションにより、{0} から次のロールの関連付けが解除されます:"
@@ -8565,7 +8571,8 @@ msgstr "Twilio"
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9488,7 +9495,7 @@ msgid "confirm delete"
 msgstr "削除の確認"
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr "関連付けの解除の確認"
 
@@ -9595,7 +9602,7 @@ msgstr "インベントリー"
 #~ msgid "isolated instance"
 #~ msgstr "分離インスタンス"
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr "項目"
 
@@ -9635,15 +9642,15 @@ msgstr "/"
 msgid "option to the"
 msgstr "オプション"
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr "ページ"
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr "ページ"
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr "ページ別"
 
@@ -9653,16 +9660,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr "リソース名"
+#~ msgid "resource name"
+#~ msgstr "リソース名"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr "リソースロール"
+#~ msgid "resource role"
+#~ msgstr "リソースロール"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr "リソースタイプ"
+#~ msgid "resource type"
+#~ msgstr "リソースタイプ"
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9760,13 +9767,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/nl/messages.po
+++ b/awx/ui_next/src/locales/nl/messages.po
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Add smart inventory"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr ""
 
@@ -844,8 +844,8 @@ msgstr ""
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1588,7 +1588,7 @@ msgstr ""
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr ""
 
@@ -2110,7 +2110,7 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr ""
@@ -2136,12 +2136,12 @@ msgstr ""
 msgid "Disassociate related team(s)?"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr ""
@@ -2784,7 +2784,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3189,7 +3189,7 @@ msgstr ""
 msgid "Failed to delete role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr ""
@@ -3553,19 +3553,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr ""
 
@@ -3782,7 +3782,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr ""
 
@@ -4237,7 +4237,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr ""
 
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "Pagerduty subdomain"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr ""
 
@@ -6324,6 +6324,11 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr ""
@@ -6431,8 +6436,9 @@ msgstr ""
 msgid "Rocket.Chat"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6688,7 +6694,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr ""
@@ -7663,7 +7669,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7681,7 +7687,7 @@ msgstr ""
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr ""
@@ -7768,7 +7774,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr ""
 
@@ -8046,7 +8052,7 @@ msgstr ""
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr ""
@@ -8471,7 +8477,8 @@ msgstr ""
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9385,7 +9392,7 @@ msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr ""
 
@@ -9490,7 +9497,7 @@ msgstr ""
 msgid "inventory"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr ""
 
@@ -9530,15 +9537,15 @@ msgstr ""
 msgid "option to the"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr ""
 
@@ -9548,16 +9555,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr ""
+#~ msgid "resource name"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr ""
+#~ msgid "resource role"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr ""
+#~ msgid "resource type"
+#~ msgstr ""
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9655,13 +9662,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/zh/messages.po
+++ b/awx/ui_next/src/locales/zh/messages.po
@@ -341,7 +341,7 @@ msgstr "添加资源类型"
 msgid "Add smart inventory"
 msgstr "添加智能清单"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr "添加团队权限"
 
@@ -874,8 +874,8 @@ msgstr "缓存超时（秒）"
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1652,7 +1652,7 @@ msgstr "凭证"
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr "当前页"
 
@@ -2174,7 +2174,7 @@ msgstr "禁用 SSL 验证"
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr "解除关联"
@@ -2200,12 +2200,12 @@ msgstr "解除关联相关的组？"
 msgid "Disassociate related team(s)?"
 msgstr "解除关联相关的团队？"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr "解除关联角色"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr "解除关联角色！"
@@ -2860,7 +2860,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3265,7 +3265,7 @@ msgstr "删除项目失败。"
 msgid "Failed to delete role"
 msgstr "删除角色失败"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr "删除角色失败。"
@@ -3629,19 +3629,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr "前往第一页"
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr "进入最后页"
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr "进入下一页"
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr "进入上一页"
 
@@ -3858,7 +3858,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr "ID"
 
@@ -4313,7 +4313,7 @@ msgstr ""
 msgid "Items"
 msgstr "项"
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr "每页的项"
 
@@ -5755,7 +5755,7 @@ msgstr "Pagerduty 子域"
 msgid "Pagerduty subdomain"
 msgstr "Pagerduty 子域"
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr "分页"
 
@@ -6396,6 +6396,11 @@ msgstr ""
 msgid "Required"
 msgstr "必需"
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr "资源已删除"
@@ -6503,8 +6508,9 @@ msgstr "修订号"
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6760,7 +6766,7 @@ msgstr "在左侧查看错误"
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr "选择"
@@ -7753,7 +7759,7 @@ msgstr "修订版本同步"
 msgid "System"
 msgstr "系统"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7771,7 +7777,7 @@ msgstr "系统审核员"
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr "系统管理员对所有资源的访问权限是不受限制的。"
@@ -7858,7 +7864,7 @@ msgid "Team"
 msgstr "团队（team）"
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr "团队角色"
 
@@ -8140,7 +8146,7 @@ msgstr "此操作将删除以下内容："
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "此操作将从所选团队中解除该用户的所有角色。"
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr "此操作将从 {0} 中解除以下角色关联："
@@ -8565,7 +8571,8 @@ msgstr "Twilio"
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9488,7 +9495,7 @@ msgid "confirm delete"
 msgstr "确认删除"
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr "确认解除关联"
 
@@ -9595,7 +9602,7 @@ msgstr "清单（inventory）"
 #~ msgid "isolated instance"
 #~ msgstr "隔离的实例"
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr "项"
 
@@ -9635,15 +9642,15 @@ msgstr "的"
 msgid "option to the"
 msgstr "选项"
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr "页"
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr "页"
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr "按页面"
 
@@ -9653,16 +9660,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr "资源名称"
+#~ msgid "resource name"
+#~ msgstr "资源名称"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr "资源角色"
+#~ msgid "resource role"
+#~ msgstr "资源角色"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr "资源类型"
+#~ msgid "resource type"
+#~ msgstr "资源类型"
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9760,13 +9767,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/locales/zu/messages.po
+++ b/awx/ui_next/src/locales/zu/messages.po
@@ -338,7 +338,7 @@ msgstr ""
 msgid "Add smart inventory"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:168
+#: screens/Team/TeamRoles/TeamRolesList.jsx:171
 msgid "Add team permissions"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: screens/Setting/shared/RevertAllAlert.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:32
 #: screens/Setting/shared/RevertFormActionGroup.jsx:38
-#: screens/Team/TeamRoles/TeamRolesList.jsx:208
-#: screens/Team/TeamRoles/TeamRolesList.jsx:211
+#: screens/Team/TeamRoles/TeamRolesList.jsx:217
+#: screens/Team/TeamRoles/TeamRolesList.jsx:220
 #: screens/Template/Survey/SurveyList.jsx:116
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.jsx:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.jsx:39
@@ -1560,7 +1560,7 @@ msgstr ""
 msgid "Credentials that require passwords on launch are not permitted.  Please remove or replace the following credentials with a credential of the same type in order to proceed: {0}"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:34
+#: components/Pagination/Pagination.jsx:33
 msgid "Current page"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.jsx:92
 #: components/DisassociateButton/DisassociateButton.jsx:96
 #: components/DisassociateButton/DisassociateButton.jsx:116
-#: screens/Team/TeamRoles/TeamRolesList.jsx:202
+#: screens/Team/TeamRoles/TeamRolesList.jsx:211
 #: screens/User/UserRoles/UserRolesList.jsx:207
 msgid "Disassociate"
 msgstr ""
@@ -2096,12 +2096,12 @@ msgstr ""
 msgid "Disassociate related team(s)?"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:189
+#: screens/Team/TeamRoles/TeamRolesList.jsx:198
 #: screens/User/UserRoles/UserRolesList.jsx:194
 msgid "Disassociate role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:192
+#: screens/Team/TeamRoles/TeamRolesList.jsx:201
 #: screens/User/UserRoles/UserRolesList.jsx:197
 msgid "Disassociate role!"
 msgstr ""
@@ -2719,7 +2719,7 @@ msgstr ""
 #: screens/Project/shared/ProjectSyncButton.jsx:62
 #: screens/Team/TeamDetail/TeamDetail.jsx:74
 #: screens/Team/TeamList/TeamList.jsx:205
-#: screens/Team/TeamRoles/TeamRolesList.jsx:226
+#: screens/Team/TeamRoles/TeamRolesList.jsx:235
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.jsx:405
 #: screens/Template/TemplateSurvey.jsx:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.jsx:257
@@ -3124,7 +3124,7 @@ msgstr ""
 msgid "Failed to delete role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:229
+#: screens/Team/TeamRoles/TeamRolesList.jsx:238
 #: screens/User/UserRoles/UserRolesList.jsx:234
 msgid "Failed to delete role."
 msgstr ""
@@ -3483,19 +3483,19 @@ msgstr ""
 msgid "Globally available execution environment can not be reassigned to a specific Organization"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:29
+#: components/Pagination/Pagination.jsx:28
 msgid "Go to first page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:31
+#: components/Pagination/Pagination.jsx:30
 msgid "Go to last page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:32
+#: components/Pagination/Pagination.jsx:31
 msgid "Go to next page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:30
+#: components/Pagination/Pagination.jsx:29
 msgid "Go to previous page"
 msgstr ""
 
@@ -3712,7 +3712,7 @@ msgstr ""
 
 #: components/JobList/JobList.jsx:173
 #: components/Lookup/HostFilterLookup.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:152
+#: screens/Team/TeamRoles/TeamRolesList.jsx:155
 msgid "ID"
 msgstr ""
 
@@ -4141,7 +4141,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:27
+#: components/Pagination/Pagination.jsx:26
 msgid "Items per page"
 msgstr ""
 
@@ -5550,7 +5550,7 @@ msgstr ""
 msgid "Pagerduty subdomain"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:35
+#: components/Pagination/Pagination.jsx:34
 msgid "Pagination"
 msgstr ""
 
@@ -6177,6 +6177,11 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:12
+#: screens/Team/TeamRoles/TeamRolesList.jsx:180
+msgid "Resource Name"
+msgstr ""
+
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.jsx:194
 msgid "Resource deleted"
 msgstr ""
@@ -6280,8 +6285,9 @@ msgstr ""
 msgid "Rocket.Chat"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:40
-#: screens/Team/TeamRoles/TeamRolesList.jsx:145
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:20
+#: screens/Team/TeamRoles/TeamRolesList.jsx:148
+#: screens/Team/TeamRoles/TeamRolesList.jsx:182
 #: screens/User/UserList/UserList.jsx:165
 #: screens/User/UserList/UserListItem.jsx:69
 #: screens/User/UserRoles/UserRolesList.jsx:145
@@ -6537,7 +6543,7 @@ msgstr ""
 #: components/JobList/JobListItem.jsx:66
 #: components/Lookup/HostFilterLookup.jsx:318
 #: components/Lookup/Lookup.jsx:141
-#: components/Pagination/Pagination.jsx:33
+#: components/Pagination/Pagination.jsx:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.jsx:89
 msgid "Select"
 msgstr ""
@@ -7488,7 +7494,7 @@ msgstr ""
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:125
+#: screens/Team/TeamRoles/TeamRolesList.jsx:128
 #: screens/User/UserDetail/UserDetail.jsx:42
 #: screens/User/UserList/UserListItem.jsx:19
 #: screens/User/UserRoles/UserRolesList.jsx:126
@@ -7506,7 +7512,7 @@ msgstr ""
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:128
+#: screens/Team/TeamRoles/TeamRolesList.jsx:131
 #: screens/User/UserRoles/UserRolesList.jsx:129
 msgid "System administrators have unrestricted access to all resources."
 msgstr ""
@@ -7588,7 +7594,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.jsx:82
-#: screens/Team/TeamRoles/TeamRolesList.jsx:141
+#: screens/Team/TeamRoles/TeamRolesList.jsx:144
 msgid "Team Roles"
 msgstr ""
 
@@ -7838,7 +7844,7 @@ msgstr ""
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.jsx:216
+#: screens/Team/TeamRoles/TeamRolesList.jsx:225
 #: screens/User/UserRoles/UserRolesList.jsx:221
 msgid "This action will disassociate the following role from {0}:"
 msgstr ""
@@ -8251,7 +8257,8 @@ msgstr ""
 #: screens/Project/ProjectList/ProjectList.jsx:146
 #: screens/Project/ProjectList/ProjectList.jsx:175
 #: screens/Project/ProjectList/ProjectListItem.jsx:152
-#: screens/Team/TeamRoles/TeamRoleListItem.jsx:30
+#: screens/Team/TeamRoles/TeamRoleListItem.jsx:17
+#: screens/Team/TeamRoles/TeamRolesList.jsx:181
 #: screens/Template/Survey/SurveyListItem.jsx:117
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.jsx:86
 #: screens/User/UserDetail/UserDetail.jsx:70
@@ -9154,7 +9161,7 @@ msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.jsx:113
-#: screens/Team/TeamRoles/TeamRolesList.jsx:199
+#: screens/Team/TeamRoles/TeamRolesList.jsx:208
 msgid "confirm disassociate"
 msgstr ""
 
@@ -9251,7 +9258,7 @@ msgstr ""
 msgid "inventory"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:24
+#: components/Pagination/Pagination.jsx:23
 msgid "items"
 msgstr ""
 
@@ -9291,15 +9298,15 @@ msgstr ""
 msgid "option to the"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:25
+#: components/Pagination/Pagination.jsx:24
 msgid "page"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:26
+#: components/Pagination/Pagination.jsx:25
 msgid "pages"
 msgstr ""
 
-#: components/Pagination/Pagination.jsx:28
+#: components/Pagination/Pagination.jsx:27
 msgid "per page"
 msgstr ""
 
@@ -9309,16 +9316,16 @@ msgid "relaunch jobs"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:21
-msgid "resource name"
-msgstr ""
+#~ msgid "resource name"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:36
-msgid "resource role"
-msgstr ""
+#~ msgid "resource role"
+#~ msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.jsx:26
-msgid "resource type"
-msgstr ""
+#~ msgid "resource type"
+#~ msgstr ""
 
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.jsx:41
 msgid "scope"
@@ -9416,13 +9423,17 @@ msgstr ""
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
+#: screens/Inventory/InventoryList/InventoryList.jsx:225
+msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+msgstr ""
+
 #: screens/Inventory/InventorySources/InventorySourceList.jsx:187
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
 #: screens/Inventory/InventoryList/InventoryList.jsx:225
-msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
-msgstr ""
+#~ msgid "{0, plural, one {This invetory is currently being used by some temeplates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
+#~ msgstr ""
 
 #: screens/Organization/OrganizationList/OrganizationList.jsx:181
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"

--- a/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryList/InventoryList.jsx
@@ -224,7 +224,7 @@ function InventoryList() {
                   deleteMessage={
                     <Plural
                       value={selected.length}
-                      one="This invetory is currently being used by some temeplates. Are you sure you want to delete it?"
+                      one="This inventory is currently being used by some templates. Are you sure you want to delete it?"
                       other="Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?"
                     />
                   }


### PR DESCRIPTION
Fix typos

I had to run `npm run extract-strings` since the typos were present on the Plural component.