### PR TITLE
Always resolve launching status

### DIFF
--- a/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
+++ b/awx/ui_next/src/components/LaunchButton/LaunchButton.jsx
@@ -78,6 +78,8 @@ function LaunchButton({ resource, children, history }) {
       }
     } catch (err) {
       setError(err);
+    } finally {
+      setIsLaunching(false);
     }
   };
 

--- a/awx/ui_next/src/components/LaunchButton/LaunchButton.test.jsx
+++ b/awx/ui_next/src/components/LaunchButton/LaunchButton.test.jsx
@@ -155,8 +155,7 @@ describe('LaunchButton', () => {
     const button = wrapper.find('button');
     await act(() => button.prop('onClick')());
     wrapper.update();
-
-    expect(wrapper.find('button').prop('disabled')).toEqual(true);
+    expect(wrapper.find('button').prop('disabled')).toEqual(false);
   });
 
   test('should relaunch job correctly', async () => {


### PR DESCRIPTION
##### SUMMARY
Resolves #10127 

Always resolve the launching status after any intermediate async activity that needs to occur while loading prompts, etc.