### PR TITLE
Display Edit/Delete on EE details page as per last API changes

### DIFF
--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.jsx
@@ -113,33 +113,31 @@ function ExecutionEnvironmentDetails({ executionEnvironment }) {
           dataCy="execution-environment-modified"
         />
       </DetailList>
-      {!managedByTower && (
-        <CardActionsRow>
-          {summary_fields.user_capabilities?.edit && (
-            <Button
-              ouiaId="execution-environment-detail-edit-button"
-              aria-label={t`edit`}
-              component={Link}
-              to={`/execution_environments/${id}/edit`}
-            >
-              {t`Edit`}
-            </Button>
-          )}
-          {summary_fields.user_capabilities?.delete && (
-            <DeleteButton
-              name={image}
-              modalTitle={t`Delete Execution Environment`}
-              onConfirm={deleteExecutionEnvironment}
-              isDisabled={isLoading}
-              ouiaId="delete-button"
-              deleteDetailsRequests={deleteDetailsRequests}
-              deleteMessage={t`This execution environment is currently being used by other resources. Are you sure you want to delete it?`}
-            >
-              {t`Delete`}
-            </DeleteButton>
-          )}
-        </CardActionsRow>
-      )}
+      <CardActionsRow>
+        {summary_fields.user_capabilities?.edit && (
+          <Button
+            ouiaId="execution-environment-detail-edit-button"
+            aria-label={t`edit`}
+            component={Link}
+            to={`/execution_environments/${id}/edit`}
+          >
+            {t`Edit`}
+          </Button>
+        )}
+        {summary_fields.user_capabilities?.delete && (
+          <DeleteButton
+            name={image}
+            modalTitle={t`Delete Execution Environment`}
+            onConfirm={deleteExecutionEnvironment}
+            isDisabled={isLoading}
+            ouiaId="delete-button"
+            deleteDetailsRequests={deleteDetailsRequests}
+            deleteMessage={t`This execution environment is currently being used by other resources. Are you sure you want to delete it?`}
+          >
+            {t`Delete`}
+          </DeleteButton>
+        )}
+      </CardActionsRow>
 
       {error && (
         <AlertModal

--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.jsx
@@ -153,7 +153,7 @@ describe('<ExecutionEnvironmentDetails/>', () => {
     expect(history.location.pathname).toBe('/execution_environments');
   });
 
-  test('should not render action buttons to ee managed by tower', async () => {
+  test('should render action buttons to ee managed by tower', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <ExecutionEnvironmentDetails
@@ -185,9 +185,9 @@ describe('<ExecutionEnvironmentDetails/>', () => {
     expect(dates).toHaveLength(2);
     expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);
     expect(dates.at(1).prop('date')).toEqual(executionEnvironment.modified);
-    expect(wrapper.find('Button[aria-label="edit"]')).toHaveLength(0);
+    expect(wrapper.find('Button[aria-label="edit"]')).toHaveLength(1);
 
-    expect(wrapper.find('Button[aria-label="Delete"]')).toHaveLength(0);
+    expect(wrapper.find('Button[aria-label="Delete"]')).toHaveLength(1);
   });
 
   test('should have proper number of delete detail requests', async () => {


### PR DESCRIPTION
Display Edit/Delete buttons on details page for EE managed by tower.

See: https://github.com/ansible/awx/issues/10078
