### PR TITLE
Add more fields to .only since they get referenced

### DIFF
--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -511,7 +511,7 @@ class JobEvent(BasePlaybookEvent):
 
             from awx.main.models import Host, JobHostSummary  # circular import
 
-            all_hosts = Host.objects.filter(pk__in=self.host_map.values()).only('id', 'name', 'last_job_id', 'last_job_host_summary_id')
+            all_hosts = Host.objects.filter(pk__in=self.host_map.values()).only('id', 'name')
             existing_host_ids = set(h.id for h in all_hosts)
 
             summaries = dict()

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -511,7 +511,7 @@ class JobEvent(BasePlaybookEvent):
 
             from awx.main.models import Host, JobHostSummary  # circular import
 
-            all_hosts = Host.objects.filter(pk__in=self.host_map.values()).only('id')
+            all_hosts = Host.objects.filter(pk__in=self.host_map.values()).only('id', 'name', 'last_job_id', 'last_job_host_summary_id')
             existing_host_ids = set(h.id for h in all_hosts)
 
             summaries = dict()


### PR DESCRIPTION
##### SUMMARY
Fixes a performance bottleneck when saving playbook_on_stats for jobs that use `--limit` against a small number of hosts while it has a large number in the inventory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
'tis the problem with `.only()`, that _only_ the developer who wrote the queryset remembers that the other fields cannot be referenced except at the cost of another query

https://github.com/ansible/awx/pull/7352/files
