### PR TITLE
Break out the pre-commit hook into an explicit script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ black: reports
 	@(set -o pipefail && $@ $(BLACK_ARGS) awx awxkit awx_collection | tee reports/$@.report)
 
 .git/hooks/pre-commit:
-	@echo "[ -z \$$AWX_IGNORE_BLACK ] && (black --check \`git diff --cached --name-only --diff-filter=AM | grep -E '\.py$\'\` || (echo 'To fix this, run \`make black\` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && exit 1))" > .git/hooks/pre-commit
+	@echo "./pre-commit.sh" > .git/hooks/pre-commit
 	@chmod +x .git/hooks/pre-commit
 
 genschema: reports

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+if [ -z $AWX_IGNORE_BLACK ]
+then
+        black --check $(git diff --cached --name-only --diff-filter=AM | grep -E '\.py') || \
+        (echo 'To fix this, run `make black` to auto-format your code prior to commit, or set AWX_IGNORE_BLACK=1' && \
+        exit 1)
+fi


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This means that

- we don't have to be always updating the underlying .git/hooks/pre-commit file
- updates to the logic will just work automatically
- the logic of the conditional invocation of black has been fixed so that AWX_IGNORE_BLACK=1 should work correctly now

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
