### PR TITLE
close db and cache connection in new threads

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -95,6 +95,7 @@ from awx.main.utils import (
     get_awx_version,
     deepmerge,
     parse_yaml_or_json,
+    cleanup_new_process,
 )
 from awx.main.utils.execution_environments import get_default_execution_environment, get_default_pod_spec
 from awx.main.utils.ansible import read_ansible_config
@@ -2972,6 +2973,7 @@ class AWXReceptorJob:
 
     # Spawned in a thread so Receptor can start reading before we finish writing, we
     # write our payload to the left side of our socketpair.
+    @cleanup_new_process
     def transmit(self, _socket):
         if not settings.IS_K8S and self.work_type == 'local':
             self.runner_params['only_transmit_kwargs'] = True
@@ -2981,6 +2983,7 @@ class AWXReceptorJob:
         # Socket must be shutdown here, or the reader will hang forever.
         _socket.shutdown(socket.SHUT_WR)
 
+    @cleanup_new_process
     def processor(self, resultfile):
         return ansible_runner.interface.run(
             streamer='process',
@@ -3022,6 +3025,7 @@ class AWXReceptorJob:
 
         return work_type
 
+    @cleanup_new_process
     def cancel_watcher(self, processor_future):
         while True:
             if processor_future.done():


### PR DESCRIPTION
It's not safe to share or re-use django db connections nor django cache connections across new threads nor processes.