### PR TITLE
Container groups registry creds

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -842,7 +842,7 @@ class BaseTask(object):
                     username = cred.get_input('username')
                     password = cred.get_input('password')
                     token = "{}:{}".format(username, password)
-                    auth_data = {'auths': {host: {'auth': b64encode(token.encode('ascii')).decode()}}}
+                    auth_data = {'auths': {host: {'auth': b64encode(token.encode('UTF-8')).decode('UTF-8')}}}
                     authfile.write(json.dumps(auth_data, indent=4))
                 params["container_options"].append(f'--authfile={authfile.name}')
             else:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3074,6 +3074,11 @@ class AWXReceptorJob:
         pod_spec['spec']['containers'][0]['image'] = ee.image
         pod_spec['spec']['containers'][0]['args'] = ['ansible-runner', 'worker', '--private-data-dir=/runner']
 
+        # Enforce EE Pull Policy
+        pull_options = {"always": "Always", "missing": "IfNotPresent", "never": "Never"}
+        if self.task and self.task.instance.execution_environment:
+            pod_spec['spec']['containers'][0]['imagePullPolicy'] = pull_options[self.task.instance.execution_environment.pull]
+
         if self.task:
             pod_spec['metadata'] = deepmerge(
                 pod_spec.get('metadata', {}),

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -51,7 +51,7 @@ def construct_rsyslog_conf_template(settings=settings):
         # urlparse requires '//' to be provided if scheme is not specified
         original_parsed = urlparse.urlsplit(host)
         if (not original_parsed.scheme and not host.startswith('//')) or original_parsed.hostname is None:
-            host = '%s://%s' % (scheme, host) if scheme else '//%s' % host
+            host = '%s://%s' % (scheme, host)
         parsed = urlparse.urlsplit(host)
 
         host = escape_quotes(parsed.hostname)

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -47,11 +47,10 @@ def construct_rsyslog_conf_template(settings=settings):
         return tmpl
 
     if protocol.startswith('http'):
-        scheme = 'https'
         # urlparse requires '//' to be provided if scheme is not specified
         original_parsed = urlparse.urlsplit(host)
         if (not original_parsed.scheme and not host.startswith('//')) or original_parsed.hostname is None:
-            host = '%s://%s' % (scheme, host)
+            host = 'https://%s' % (host)
         parsed = urlparse.urlsplit(host)
 
         host = escape_quotes(parsed.hostname)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/10114

In VM-based installs, the user provides image pull creds to us, then we put them in an authfile and give it to podman via `--authfile`.
This is not so simple with ContainerGroups because we need to use the k8s API to apply a podspec to create containers in this paradigm.  

Currently, the EE pod gets created, but errors when pulling the custom EE in from the private repo:

![image](https://user-images.githubusercontent.com/11698892/117727466-0c181080-b1b6-11eb-93bd-703a6d629394.png)

This work will modify the __init__() for the AWXReceptorJob class to create a k8s secret in the given namespace, then specify that secret name in the pod-spec as an `imagePullSecret`

Also, the imagePullPolicy was not being enforced when running JT's in EE's using container groups, this is because the `imagePullPolicy` nevery got set on the pod spec.  


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

Issues that this solves:
* Image pull secret now gets created in the cluster namespace specified by the user for that container group.  
* imagePullSecret name gets set on the pod spec
* If the pull secret already exists in the namespace, delete it, then create it.  (`kube_api.replace_namespaced_secret` did not work for this case...)
* Enforce `imagePullPolicy` for EE's in container groups
* Basic error handling