### PR TITLE
Add an nginx location directive for the favicon

### DIFF
--- a/tools/docker-compose/nginx.vh.default.conf
+++ b/tools/docker-compose/nginx.vh.default.conf
@@ -30,6 +30,8 @@ server {
         sendfile off;
     }
 
+    location /favicon.ico { alias /awx_devel/awx/public/static/favicon.ico; }
+
     location ~ ^/websocket {
         # Pass request to the upstream alias
         proxy_pass http://daphne;
@@ -89,6 +91,8 @@ server {
         access_log off;
         sendfile off;
     }
+
+    location /favicon.ico { alias /awx_devel/awx/public/static/favicon.ico; }
 
     location ~ ^/websocket {
         # Pass request to the upstream alias


### PR DESCRIPTION
##### SUMMARY

Add an nginx location directive for the favicon so that the rewrite rule that adds slashes to the ends of requested
urls doesn't get to it.

related #8618 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```
