### PR TITLE
Commits settings.DEFAULT_EXECUTION_ENVIRONMENTS updates into the database

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                     changed = True
 
                 for ee in reversed(settings.DEFAULT_EXECUTION_ENVIRONMENTS):
-                    _, created = ExecutionEnvironment.objects.get_or_create(name=ee['name'], defaults={'image': ee['image'], 'managed_by_tower': True})
+                    _, created = ExecutionEnvironment.objects.update_or_create(name=ee['name'], defaults={'image': ee['image'], 'managed_by_tower': True})
 
                 if created:
                     changed = True


### PR DESCRIPTION
##### SUMMARY

Fixes: https://github.com/ansible/awx-operator/issues/256

cc: @shanemcd 

Cannot update execution environment version in place by updating the `AWX` spec via `awx-operator`.  For example, consider the scenario below:

```yaml
spec:
  tower_ee_images:
    - image: registry.tatu.home/ansible/awx-ee:0.1.0
      name: My Custom Execution Environment
```
![image](https://user-images.githubusercontent.com/809840/117844254-85af0d80-b24d-11eb-9fab-ea39d54a1741.png)


The expectation would be once you modify the `AWX` spec to the version below, the `EE` should reflect this change once the `awx-operator` finishes its reconciliation. 


After:
```yaml
spec:
  tower_ee_images:
    - image: registry.tatu.home/ansible/awx-ee:0.2.0
      name: My Custom Execution Environment
```
![image](https://user-images.githubusercontent.com/809840/117844828-0110bf00-b24e-11eb-9b84-f0cd63cbe469.png)

```yaml
-- deployment got updated
- args:
        - receptor
        - --config
        - /etc/receptor.conf
        image: registry.tatu.home/ansible/awx-ee:0.2.0
        imagePullPolicy: IfNotPresent
        name: awx-devel-ee-ee
```

Besides the `awx-operator` updated the YAML deployment as expected, the change did not hit the database. 

```sql
awx=# select * from main_executionenvironment;
 id |    created    |   modified    | description |     image      | managed_by_tower | created_by_id | credential_id | modified_by_id | organization_id |      name      | pull 
----+---------------+---------------+-------------+----------------+------------------+---------------+---------------+----------------+-----------------+----------------+------
  1 | 2021-05-11 15.| 2021-05-11 15.|             | registry.tatu..| t                |             1 |               |              1 |                 | My Custom Exec.| 
    |.:24:02.674302.|.:24:02.674327.|             |.home/ansible/a.|                  |               |               |                |                 |.ution Environm.| 
    |.+00           |.+00           |             |.wx-ee:0.1.0    |                  |               |               |                |                 |.ent            | 
(1 row)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Quick proof of concept

```yaml
>>> settings.DEFAULT_EXECUTION_ENVIRONMENTS
[{'name': 'My Custom Execution Environment', 'image': 'registry.tatu.home/ansible/awx-ee:0.2.0'}]
>>> [a.name for a in  ExecutionEnvironment.objects.all()]
['My Custom Execution Environment']
>>> [a.image for a in  ExecutionEnvironment.objects.all()]
['registry.tatu.home/ansible/awx-ee:0.2.0']

*** updating to new but keeping name 
>>> _, created = ExecutionEnvironment.objects.update_or_create(name='My Custom Execution Environment', defaults={'image': 'registry.tatu.home/ansible/awx-ee:0.3.0', 'managed_by_tower': True})
>>> [a.name for a in  ExecutionEnvironment.objects.all()]
['My Custom Execution Environment']
>>> [a.image for a in  ExecutionEnvironment.objects.all()]
['registry.tatu.home/ansible/awx-ee:0.3.0']

*** adding a new name
>>> _, created = ExecutionEnvironment.objects.update_or_create(name='My Custom Execution Environment2', defaults={'image': 'registry.tatu.home/ansible/awx-ee:0.3.0', 'managed_by_tower': True})
>>> [a.name for a in  ExecutionEnvironment.objects.all()]
['My Custom Execution Environment2', 'My Custom Execution Environment']
>>> [a.image for a in  ExecutionEnvironment.objects.all()]
['registry.tatu.home/ansible/awx-ee:0.3.0', 'registry.tatu.home/ansible/awx-ee:0.3.0']

```
