### PR TITLE
Adding AWX_CONTAINER_GROUP_POD_LAUNCH_TIMEOUT in defaults.py

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3017,6 +3017,7 @@ class AWXReceptorJob:
 
             receptor_params = {
                 "secret_kube_pod": spec_yaml,
+                "pod_pending_timeout": getattr(settings, 'AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT', "5m"),
             }
 
             if self.credential:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -70,9 +70,9 @@ IS_K8S = False
 
 RECEPTOR_RELEASE_WORK = True
 AWX_CONTAINER_GROUP_K8S_API_TIMEOUT = 10
-AWX_CONTAINER_GROUP_POD_LAUNCH_RETRIES = 100
-AWX_CONTAINER_GROUP_POD_LAUNCH_RETRY_DELAY = 5
 AWX_CONTAINER_GROUP_DEFAULT_NAMESPACE = os.getenv('MY_POD_NAMESPACE', 'default')
+# Timeout when waiting for pod to enter running state. If the pod is still in pending state , it will be terminated. Valid time units are "s", "m", "h". Example : "5m" , "10s".
+AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT = "5m"
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/


### PR DESCRIPTION
--- Adding a new global variable AWX_CONTAINER_GROUP_POD_LAUNCH_TIMEOUT in defaults.py
--- Passing this parameter in receptor_params in AWXReceptorJob class

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related issue : https://github.com/ansible/receptor/issues/315
Corresponding PR on receptor side : https://github.com/ansible/receptor/pull/316

I have added a global variable AWX_CONTAINER_GROUP_POD_LAUNCH_TIMEOUT  ( and set default value as 5 minutes ).
This will be passed onto Receptor in case a job is container group task.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

File Name : ```awx/main/tasks.py```
Class Name : ```AWXReceptorJob```
Function name: ```receptor_params(self)```

Before the change the value of ```receptor_params``` before returning was :

```>>> receptor_params
{'secret_kube_config': '---\n'
                       'apiVersion: v1\n'
                       'clusters:\n'
                       '- cluster:\n'
                       '    insecure-skip-tls-verify: true\n'
                       '    server: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'contexts:\n'
                       '- context:\n'
                       '    cluster: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '    namespace: default\n'
                       '    user: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'current-context: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'kind: Config\n'
                       'preferences: {}\n'
                       'users:\n'
                       '- name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  user:\n'
                       '    token: '
                       'sha256~otM0Z2vC8qfzm3eV0tfz-0V4DXKPqLC_Pp1gxXKuC-c\n',
 'secret_kube_pod': '---\n'
                    'apiVersion: v1\n'
                    'kind: Pod\n'
                    'metadata:\n'
                    '  labels:\n'
                    '    ansible-awx: 04366fdb-65ec-4efc-bb01-685e9ca7e05b\n'
                    "    ansible-awx-job-id: '21'\n"
                    '  name: automation-job-21\n'
                    '  namespace: default\n'
                    'spec:\n'
                    '  containers:\n'
                    '  - args:\n'
                    '    - ansible-runner\n'
                    '    - worker\n'
                    '    - --private-data-dir=/runner\n'
                    '    image: quay.io/ansible/awx-ee:0.2.0\n'
                    '    name: worker\n'}
>>>
``` 


After the change the value of ```receptor_params``` before returning is :
```>>> receptor_params
{'pod_pending_timeout': '5m',
 'secret_kube_config': '---\n'
                       'apiVersion: v1\n'
                       'clusters:\n'
                       '- cluster:\n'
                       '    insecure-skip-tls-verify: true\n'
                       '    server: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'contexts:\n'
                       '- context:\n'
                       '    cluster: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '    namespace: default\n'
                       '    user: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'current-context: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       'kind: Config\n'
                       'preferences: {}\n'
                       'users:\n'
                       '- name: '
                       'https://api.tower.ocp4.testing.ansible.com:6443\n'
                       '  user:\n'
                       '    token: '
                       'sha256~otM0Z2vC8qfzm3eV0tfz-0V4DXKPqLC_Pp1gxXKuC-c\n',
 'secret_kube_pod': '---\n'
                    'apiVersion: v1\n'
                    'kind: Pod\n'
                    'metadata:\n'
                    '  labels:\n'
                    '    ansible-awx: 04366fdb-65ec-4efc-bb01-685e9ca7e05b\n'
                    "    ansible-awx-job-id: '21'\n"
                    '  name: automation-job-21\n'
                    '  namespace: default\n'
                    'spec:\n'
                    '  containers:\n'
                    '  - args:\n'
                    '    - ansible-runner\n'
                    '    - worker\n'
                    '    - --private-data-dir=/runner\n'
                    '    image: quay.io/ansible/awx-ee:0.2.0\n'
                    '    name: worker\n'}
>>>
```

We can see that an extra parameter has been added : ```'pod_pending_timeout': '5m',```

####Additional changes : 
--- Removed ```AWX_CONTAINER_GROUP_POD_LAUNCH_RETRIES``` from ```defaults.py``` as it was not being used anywhere
--- Removed ```AWX_CONTAINER_GROUP_POD_LAUNCH_RETRY_DELAY``` from ```defaults.py``` as it was not being used anywhere