### PR TITLE
Pin awxkit version for compatibility with Tower collection

### DIFF
--- a/awx_collection/requirements.txt
+++ b/awx_collection/requirements.txt
@@ -1,3 +1,3 @@
 pytz  # for tower_schedule_rrule lookup plugin
 python-dateutil>=2.7.0  # tower_schedule_rrule
-awxkit  # For import and export modules
+awxkit awxkit >=9.3.0,<=17.1.0  # For import and export modules


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Addresses problem with Tower Collection not having a pinned awxkit version

Seems execution environments was added in awxkit version 18.0
https://github.com/ansible/awx/blob/18.0.0/awxkit/awxkit/api/pages/api.py#L26

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
Solves #4941 on tower repo (not this one) (potentially)
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Tower Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Tower 3.8.x
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This will _break_ upstream, please only target this for the Tower collection, not the awx collection.  I was requested to open up this here instead of the other repository.
<!--- Paste verbatim command output below, e.g. before and after your change -->

