### PR TITLE
Remove explicit eula acceptance

### DIFF
--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -24,7 +24,7 @@ from awx.api.generics import APIView
 from awx.conf.registry import settings_registry
 from awx.main.analytics import all_collectors
 from awx.main.ha import is_ha_environment
-from awx.main.utils import get_awx_version, get_custom_venv_choices, to_python_boolean
+from awx.main.utils import get_awx_version, get_custom_venv_choices
 from awx.main.utils.licensing import validate_entitlement_manifest
 from awx.api.versioning import reverse, drf_reverse
 from awx.main.constants import PRIVILEGE_ESCALATION_METHODS
@@ -313,16 +313,6 @@ class ApiV2ConfigView(APIView):
     def post(self, request):
         if not isinstance(request.data, dict):
             return Response({"error": _("Invalid subscription data")}, status=status.HTTP_400_BAD_REQUEST)
-        if "eula_accepted" not in request.data:
-            return Response({"error": _("Missing 'eula_accepted' property")}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            eula_accepted = to_python_boolean(request.data["eula_accepted"])
-        except ValueError:
-            return Response({"error": _("'eula_accepted' value is invalid")}, status=status.HTTP_400_BAD_REQUEST)
-
-        if not eula_accepted:
-            return Response({"error": _("'eula_accepted' must be True")}, status=status.HTTP_400_BAD_REQUEST)
-        request.data.pop("eula_accepted")
         try:
             data_actual = json.dumps(request.data)
         except Exception:

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/EulaStep.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/EulaStep.jsx
@@ -1,31 +1,17 @@
 import React from 'react';
 
-import { Trans, t } from '@lingui/macro';
-import { useField } from 'formik';
+import { t } from '@lingui/macro';
 import { Flex, FormGroup, TextArea } from '@patternfly/react-core';
-import { required } from '../../../../util/validators';
 import { useConfig } from '../../../../contexts/Config';
-import { CheckboxField } from '../../../../components/FormField';
 
 function EulaStep() {
-  const { eula, me } = useConfig();
-  const [, meta] = useField('eula');
-  const isValid = !(meta.touched && meta.error);
+  const { eula } = useConfig();
   return (
     <Flex
       spaceItems={{ default: 'spaceItemsMd' }}
       direction={{ default: 'column' }}
     >
-      <b>
-        <Trans>Agree to the end user license agreement and click submit.</Trans>
-      </b>
-      <FormGroup
-        fieldId="eula"
-        label={t`End User License Agreement`}
-        validated={isValid ? 'default' : 'error'}
-        helperTextInvalid={meta.error}
-        isRequired
-      >
+      <FormGroup fieldId="eula" label={t`End User License Agreement`}>
         <TextArea
           id="eula-container"
           style={{ minHeight: '200px' }}
@@ -34,16 +20,6 @@ function EulaStep() {
         >
           {eula}
         </TextArea>
-        <CheckboxField
-          name="eula"
-          aria-label={t`Agree to end user license agreement`}
-          label={t`I agree to the End User License Agreement`}
-          id="eula"
-          isDisabled={!me.is_superuser}
-          validate={required(
-            t`Please agree to End User License Agreement before proceeding.`
-          )}
-        />
       </FormGroup>
     </Flex>
   );

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
 import { useHistory, Link, useRouteMatch } from 'react-router-dom';
-
 import { t, Trans } from '@lingui/macro';
 import { Formik, useFormikContext } from 'formik';
 import {
@@ -41,7 +40,6 @@ const CustomFooter = ({ isSubmitLoading }) => {
                 isDisabled={
                   (!values.manifest_file && !values.subscription) ||
                   !me?.is_superuser ||
-                  !values.eula ||
                   Object.keys(errors).length !== 0
                 }
                 type="button"
@@ -133,13 +131,9 @@ function SubscriptionEdit() {
       if (form.manifest_file) {
         await ConfigAPI.create({
           manifest: form.manifest_file,
-          eula_accepted: form.eula,
         });
       } else if (form.subscription) {
         await ConfigAPI.attach({ pool_id: form.subscription.pool_id });
-        await ConfigAPI.create({
-          eula_accepted: form.eula,
-        });
       }
 
       if (!hasValidKey) {
@@ -223,7 +217,6 @@ function SubscriptionEdit() {
     <>
       <Formik
         initialValues={{
-          eula: false,
           insights: true,
           manifest_file: null,
           manifest_filename: '',

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.test.jsx
@@ -186,20 +186,7 @@ describe('<SubscriptionEdit />', () => {
       });
       wrapper.update();
       expect(wrapper.find('EulaStep').length).toBe(1);
-      expect(wrapper.find('CheckboxField').length).toBe(1);
       expect(wrapper.find('button#subscription-wizard-submit').length).toBe(1);
-    });
-
-    test('checking EULA agreement should enable Submit button', async () => {
-      expect(
-        wrapper.find('button#subscription-wizard-submit').prop('disabled')
-      ).toBe(true);
-      await act(async () => {
-        wrapper.find('Checkbox[name="eula"] input').simulate('change', {
-          target: { value: true, name: 'eula' },
-        });
-      });
-      wrapper.update();
       expect(
         wrapper.find('button#subscription-wizard-submit').prop('disabled')
       ).toBe(false);
@@ -369,18 +356,6 @@ describe('<SubscriptionEdit />', () => {
       expect(wrapper.find('SubscriptionStep').length).toBe(0);
       expect(wrapper.find('AnalyticsStep').length).toBe(0);
       expect(wrapper.find('EulaStep').length).toBe(1);
-    });
-
-    test('submit should be disabled until EULA agreement checked', async () => {
-      expect(
-        wrapper.find('button#subscription-wizard-submit').prop('disabled')
-      ).toBe(true);
-      await act(async () => {
-        wrapper.find('Checkbox[name="eula"] input').simulate('change', {
-          target: { value: true, name: 'eula' },
-        });
-      });
-      wrapper.update();
       expect(
         wrapper.find('button#subscription-wizard-submit').prop('disabled')
       ).toBe(false);

--- a/awx_collection/plugins/modules/tower_license.py
+++ b/awx_collection/plugins/modules/tower_license.py
@@ -25,11 +25,6 @@ options:
         - file path to a Red Hat subscription manifest (a .zip file)
       required: True
       type: str
-    eula_accepted:
-      description:
-        - Whether or not the EULA is accepted.
-      required: True
-      type: bool
     force:
       description:
         - By default, the license manifest will only be applied if Tower is currently
@@ -46,7 +41,6 @@ EXAMPLES = '''
 - name: Set the license using a file
   tower_license:
     manifest: "/tmp/my_manifest.zip"
-    eula_accepted: True
 '''
 
 import base64
@@ -58,15 +52,11 @@ def main():
     module = TowerAPIModule(
         argument_spec=dict(
             manifest=dict(type='str', required=True),
-            eula_accepted=dict(type='bool', required=True),
             force=dict(type='bool', required=False),
         ),
     )
 
     json_output = {'changed': False}
-
-    if not module.params.get('eula_accepted'):
-        module.fail_json(msg='You must accept the EULA by passing in the param eula_accepted as True')
 
     try:
         manifest = base64.b64encode(open(module.params.get('manifest'), 'rb').read())
@@ -94,7 +84,7 @@ def main():
     # Do the actual install, if we need to
     if perform_install:
         json_output['changed'] = True
-        module.post_endpoint('config', data={'eula_accepted': True, 'manifest': manifest.decode()})
+        module.post_endpoint('config', data={'manifest': manifest.decode()})
 
     module.exit_json(**json_output)
 


### PR DESCRIPTION
##### SUMMARY
Issue: https://github.com/ansible/tower/issues/4948

This PR changes the entitlement process to no require explicit acceptance of the Eula, but still display it for the user to read.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.1.0
```

##### ADDITIONAL INFO

If the `eula_accepted` field is passed, it will just be ignored.  
