### PR TITLE
Add RBAC rules to the side-nav

### DIFF
--- a/awx/ui_next/src/App.jsx
+++ b/awx/ui_next/src/App.jsx
@@ -12,8 +12,12 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';
 import { Card, PageSection } from '@patternfly/react-core';
-import { ConfigProvider, useAuthorizedPath } from './contexts/Config';
 import { SessionProvider, useSession } from './contexts/Session';
+import {
+  ConfigProvider,
+  useAuthorizedPath,
+  useUserProfile,
+} from './contexts/Config';
 import AppContainer from './components/AppContainer';
 import Background from './components/Background';
 import ContentError from './components/ContentError';
@@ -37,6 +41,17 @@ function ErrorFallback({ error }) {
     </PageSection>
   );
 }
+
+const RenderAppContainer = () => {
+  const userProfile = useUserProfile();
+  const navRouteConfig = getRouteConfig(userProfile);
+
+  return (
+    <AppContainer navRouteConfig={navRouteConfig}>
+      <AuthorizedRoutes routeConfig={navRouteConfig} />
+    </AppContainer>
+  );
+};
 
 const AuthorizedRoutes = ({ routeConfig }) => {
   const isAuthorized = useAuthorizedPath();
@@ -150,9 +165,7 @@ function App() {
             </Route>
             <ProtectedRoute>
               <ConfigProvider>
-                <AppContainer navRouteConfig={getRouteConfig()}>
-                  <AuthorizedRoutes routeConfig={getRouteConfig()} />
-                </AppContainer>
+                <RenderAppContainer />
               </ConfigProvider>
             </ProtectedRoute>
           </Switch>

--- a/awx/ui_next/src/routeConfig.jsx
+++ b/awx/ui_next/src/routeConfig.jsx
@@ -22,8 +22,8 @@ import Users from './screens/User';
 import WorkflowApprovals from './screens/WorkflowApproval';
 import { Jobs } from './screens/Job';
 
-function getRouteConfig() {
-  return [
+function getRouteConfig(userProfile = {}) {
+  let routeConfig = [
     {
       groupTitle: <Trans>Views</Trans>,
       groupId: 'views_group',
@@ -155,6 +155,29 @@ function getRouteConfig() {
       ],
     },
   ];
+
+  const deleteRoute = name => {
+    routeConfig.forEach(group => {
+      group.routes = group.routes.filter(({ path }) => !path.includes(name));
+    });
+    routeConfig = routeConfig.filter(groups => groups.routes.length);
+  };
+
+  const deleteRouteGroup = name => {
+    routeConfig = routeConfig.filter(({ groupId }) => !groupId.includes(name));
+  };
+
+  if (userProfile?.isSuperUser || userProfile?.isSystemAuditor)
+    return routeConfig;
+  deleteRouteGroup('settings');
+  deleteRoute('management_jobs');
+  deleteRoute('credential_types');
+  if (userProfile?.isOrgAdmin) return routeConfig;
+  deleteRoute('applications');
+  deleteRoute('instance_groups');
+  if (!userProfile?.isNotificationAdmin) deleteRoute('notification_templates');
+
+  return routeConfig;
 }
 
 export default getRouteConfig;

--- a/awx/ui_next/src/routeConfig.test.jsx
+++ b/awx/ui_next/src/routeConfig.test.jsx
@@ -1,0 +1,248 @@
+import getRouteConfig from './routeConfig';
+
+const userProfile = {
+  isSuperUser: false,
+  isSystemAuditor: false,
+  isOrgAdmin: false,
+  isNotificationAdmin: false,
+  isExecEnvAdmin: false,
+};
+
+const filterPaths = sidebar => {
+  const visibleRoutes = [];
+  sidebar.forEach(({ routes }) => {
+    routes.forEach(route => {
+      visibleRoutes.push(route.path);
+    });
+  });
+
+  return visibleRoutes;
+};
+describe('getRouteConfig', () => {
+  test('routes for system admin', () => {
+    const sidebar = getRouteConfig({ ...userProfile, isSuperUser: true });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/credential_types',
+      '/notification_templates',
+      '/management_jobs',
+      '/instance_groups',
+      '/applications',
+      '/execution_environments',
+      '/settings',
+    ]);
+  });
+
+  test('routes for system auditor', () => {
+    const sidebar = getRouteConfig({ ...userProfile, isSystemAuditor: true });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/credential_types',
+      '/notification_templates',
+      '/management_jobs',
+      '/instance_groups',
+      '/applications',
+      '/execution_environments',
+      '/settings',
+    ]);
+  });
+
+  test('routes for org admin', () => {
+    const sidebar = getRouteConfig({ ...userProfile, isOrgAdmin: true });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/notification_templates',
+      '/instance_groups',
+      '/applications',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for notifications admin', () => {
+    const sidebar = getRouteConfig({
+      ...userProfile,
+      isNotificationAdmin: true,
+    });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/notification_templates',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for execution environments admin', () => {
+    const sidebar = getRouteConfig({ ...userProfile, isExecEnvAdmin: true });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for regular users', () => {
+    const sidebar = getRouteConfig(userProfile);
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for execution environment admins and notification admin', () => {
+    const sidebar = getRouteConfig({
+      ...userProfile,
+      isExecEnvAdmin: true,
+      isNotificationAdmin: true,
+    });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/notification_templates',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for execution environment admins and organization admins', () => {
+    const sidebar = getRouteConfig({
+      ...userProfile,
+      isExecEnvAdmin: true,
+      isOrgAdmin: true,
+    });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/notification_templates',
+      '/instance_groups',
+      '/applications',
+      '/execution_environments',
+    ]);
+  });
+
+  test('routes for notification admins and organization admins', () => {
+    const sidebar = getRouteConfig({
+      ...userProfile,
+      isNotificationAdmin: true,
+      isOrgAdmin: true,
+    });
+    const filteredPaths = filterPaths(sidebar);
+    expect(filteredPaths).toEqual([
+      '/home',
+      '/jobs',
+      '/schedules',
+      '/activity_stream',
+      '/workflow_approvals',
+      '/templates',
+      '/credentials',
+      '/projects',
+      '/inventories',
+      '/hosts',
+      '/organizations',
+      '/users',
+      '/teams',
+      '/notification_templates',
+      '/instance_groups',
+      '/applications',
+      '/execution_environments',
+    ]);
+  });
+});


### PR DESCRIPTION
Add RBAC rules to the side-nav

System Admin
System Auditor
Org Admin
Notification Admin
Execution Environment Admin
Normal User

Those are the user profiles taken in consideration when displaying the
side-nav.

On the previous UI implementation we do show the workflow approvals as part of the page toolbar, now on the the new UI we do have a dedicated path  on the side bar for this screen. I kept this last one visible for all users, since we also show the workflow approvals as part of the page toolbar for all users. We can revisit this if necessary.


See: https://github.com/ansible/awx/issues/4426



