### PR TITLE
tweak message about image pull option

### DIFF
--- a/awx/main/migrations/0126_executionenvironment_container_options.py
+++ b/awx/main/migrations/0126_executionenvironment_container_options.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ('always', 'Always pull container before running.'),
-                    ('missing', 'No pull option has been selected.'),
+                    ('missing', 'Only pull the image if not present before running.'),
                     ('never', 'Never pull container before running.'),
                 ],
                 blank=True,

--- a/awx/main/models/execution_environments.py
+++ b/awx/main/models/execution_environments.py
@@ -14,7 +14,7 @@ class ExecutionEnvironment(CommonModel):
 
     PULL_CHOICES = [
         ('always', _("Always pull container before running.")),
-        ('missing', _("No pull option has been selected.")),
+        ('missing', _("Only pull the image if not present before running.")),
         ('never', _("Never pull container before running.")),
     ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I'm not sure if it is OK to change the migration in this way.

This message in the UI didn't make sense to me. If you all prefer the existing message, that is fine...I just think it is weird and doesn't tell you what it does.

If I don't care, I can leave it on `---------` in the UI which is "do whatever the default is"
If I do care, its weird to choose an option saying I don't choose and option.

![Screenshot from 2021-05-24 17-16-28](https://user-images.githubusercontent.com/29239279/119409151-dc3c3300-bcb4-11eb-9576-4c44d25a8d0c.png)
