### PR TITLE
allow singular execution_environment for cli

### DIFF
--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -27,6 +27,7 @@ DEPRECATED_RESOURCES = {
     'inventory_updates': 'inventory_update',
     'jobs': 'job',
     'job_templates': 'job_template',
+    'execution_environments': 'execution_environment',
     'labels': 'label',
     'workflow_job_template_nodes': 'node',
     'notification_templates': 'notification_template',


### PR DESCRIPTION
this makes "execution_environments" or "execution_environment" work
which is helpful

Now these both work:
```
awx execution_environments create --name foobar --image quay.io/ansible/awx-ee:latest
```
```
awx execution_environment create --name foobar1 --image quay.io/ansible/awx-ee:latest
```