### PR TITLE
Fixes bug where activity stream changes were displaying as [object object]

### DIFF
--- a/awx/ui_next/src/screens/ActivityStream/ActivityStreamDetailButton.jsx
+++ b/awx/ui_next/src/screens/ActivityStream/ActivityStreamDetailButton.jsx
@@ -52,7 +52,9 @@ function ActivityStreamDetailButton({ streamItem, user, description }) {
             <VariablesDetail
               label={t`Changes`}
               rows={changeRows}
-              value={streamItem?.changes}
+              value={
+                streamItem?.changes ? JSON.stringify(streamItem.changes) : ''
+              }
             />
           )}
         </DetailList>

--- a/awx/ui_next/src/screens/ActivityStream/ActivityStreamDetailButton.test.jsx
+++ b/awx/ui_next/src/screens/ActivityStream/ActivityStreamDetailButton.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import ActivityStreamDetailButton from './ActivityStreamDetailButton';
 
@@ -17,5 +16,65 @@ describe('<ActivityStreamDetailButton />', () => {
         description={<span>foo</span>}
       />
     );
+  });
+  test('details are properly rendered', () => {
+    function assertDetail(label, value) {
+      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
+      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
+    }
+
+    const wrapper = mountWithContexts(
+      <ActivityStreamDetailButton
+        streamItem={{
+          summary_fields: {
+            actor: {
+              id: 1,
+              username: 'Bob',
+              first_name: '',
+              last_name: '',
+            },
+            setting: [
+              {
+                category: 'system',
+                name: 'INSIGHTS_TRACKING_STATE',
+              },
+            ],
+          },
+          timestamp: '2021-05-25T18:17:59.835788Z',
+          operation: 'create',
+          changes: {
+            value: false,
+            id: 6,
+          },
+          object1: 'setting',
+          object2: '',
+          object_association: '',
+          action_node: 'awx_1',
+          object_type: '',
+        }}
+        user={<Link to="/users/1/details">Bob</Link>}
+        description={<span>foo</span>}
+      />
+    );
+
+    expect(wrapper.find('Modal[title="Event detail"]').prop('isOpen')).toBe(
+      false
+    );
+
+    wrapper.find('Button').simulate('click');
+
+    expect(wrapper.find('Modal[title="Event detail"]').prop('isOpen')).toBe(
+      true
+    );
+
+    assertDetail('Time', '5/25/2021, 6:17:59 PM');
+    assertDetail('Initiated by', 'Bob');
+    assertDetail('Setting category', 'system');
+    assertDetail('Setting name', 'INSIGHTS_TRACKING_STATE');
+    assertDetail('Action', 'foo');
+
+    const input = wrapper.find('VariablesDetail___StyledCodeEditor');
+    expect(input).toHaveLength(1);
+    expect(input.prop('value')).toEqual('{\n  "value": false,\n  "id": 6\n}');
   });
 });


### PR DESCRIPTION
##### SUMMARY
Resolves #10138 

Here it is working:

<img width="1363" alt="Screen Shot 2021-05-25 at 3 23 32 PM" src="https://user-images.githubusercontent.com/9889020/119556626-41535f80-bd6d-11eb-9568-9b5d452a9b0e.png">

In this case the `value` passed to the VariablesDetail component is a straight up JSON object (not a stringified JSON object) which that component does not seem to like in its current state.

Rather than looking at changing the VariablesDetail implementation I decided to just stringify the object before it gets passed in.  Since this object is generated by the backend I think it's safe to assume it will always be an object.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
