### PR TITLE
Fixes bug where users were unable to click on text next to checkboxes/radios in modals

### DIFF
--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { withRouter, useLocation } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import useRequest from '../../util/useRequest';
-
 import { SearchColumns, SortColumns } from '../../types';
 import DataListToolbar from '../DataListToolbar';
 import CheckboxListItem from '../CheckboxListItem';

--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
@@ -15,8 +15,20 @@ const CheckboxListItem = ({
   columns,
   item,
 }) => {
+  const handleRowClick = () => {
+    if (isSelected && !isRadio) {
+      onDeselect(itemId);
+    } else {
+      onSelect(itemId);
+    }
+  };
+
   return (
-    <Tr ouiaId={`list-item-${itemId}`} id={`list-item-${itemId}`}>
+    <Tr
+      ouiaId={`list-item-${itemId}`}
+      id={`list-item-${itemId}`}
+      onClick={handleRowClick}
+    >
       <Td
         id={`check-action-item-${itemId}`}
         select={{

--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
@@ -23,7 +23,6 @@ const CheckboxListItem = ({
           rowIndex,
           isSelected,
           onSelect: isSelected ? onDeselect : onSelect,
-          disable: isDisabled,
           variant: isRadio ? 'radio' : 'checkbox',
         }}
         name={name}

--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
@@ -4,7 +4,6 @@ import { t } from '@lingui/macro';
 import { Td, Tr } from '@patternfly/react-table';
 
 const CheckboxListItem = ({
-  isDisabled = false,
   isRadio = false,
   isSelected = false,
   itemId,

--- a/awx/ui_next/src/components/OptionsList/OptionsList.jsx
+++ b/awx/ui_next/src/components/OptionsList/OptionsList.jsx
@@ -9,7 +9,6 @@ import {
   oneOfType,
 } from 'prop-types';
 import styled from 'styled-components';
-
 import { t } from '@lingui/macro';
 import SelectedList from '../SelectedList';
 import CheckboxListItem from '../CheckboxListItem';
@@ -41,7 +40,6 @@ function OptionsList({
   deselectItem,
   renderItemChip,
   isLoading,
-
   displayKey,
 }) {
   return (


### PR DESCRIPTION
##### SUMMARY
link #8852 

This should impact lists in modals where the user can select one or more of the rows.  They should now be able to click on the text/row in order to select.  Examples:

![row_select](https://user-images.githubusercontent.com/9889020/119680573-4e288f80-be0f-11eb-8157-e69dd0143d58.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
