### PR TITLE
The list secrets role rule is no longer not needed for container groups

### DIFF
--- a/awx/main/scheduler/kubernetes.py
+++ b/awx/main/scheduler/kubernetes.py
@@ -96,7 +96,7 @@ class PodManager(object):
                 error_msg = _('Invalid openshift or k8s cluster credential')
                 if e.status == 403:
                     error_msg = _(
-                        'Failed to create secret for container group {} because the needed service account roles are needed.  Add get, list, create and delete roles for secret resources for your cluster credential.'.format(
+                        'Failed to create secret for container group {} because the needed service account roles are needed.  Add get, create and delete roles for secret resources for your cluster credential.'.format(
                             job.instance_group.name
                         )
                     )


### PR DESCRIPTION
##### SUMMARY

The list secrets role rule is no longer not needed for container groups.  This was simplified to just get the single matching secret using the `read_namespaced_secret()` method.  
