### PR TITLE
Redirect documentation to awx-operator docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,12 +3,6 @@ Table of Contents
 
    * [Installing AWX](#installing-awx)
       * [The AWX Operator](#the-awx-operator)
-         * [Quickstart with minikube](#quickstart-with-minikube)
-            * [Starting minikube](#starting-minikube)
-            * [Deploying the AWX Operator](#deploying-the-awx-operator)
-               * [Verifying the Operator Deployment](#verifying-the-operator-deployment)
-            * [Deploy AWX](#deploy-awx)
-               * [Accessing AWX](#accessing-awx)
    * [Installing the AWX CLI](#installing-the-awx-cli)
       * [Building the CLI Documentation](#building-the-cli-documentation)
 
@@ -22,109 +16,9 @@ If you're attempting to migrate an older Docker-based AWX installation, see: [Mi
 
 ## The AWX Operator
 
-Starting in version 18.0, the [AWX Operator](https://github.com/ansible/awx-operator) is the preferred way to install AWX.
+Starting in version 18.0, the [AWX Operator](https://github.com/ansible/awx-operator) is the preferred way to install AWX. Please refer to the [AWX Operator](https://github.com/ansible/awx-operator) documentation.
 
 AWX can also alternatively be installed and [run in Docker](./tools/docker-compose/README.md), but this install path is only recommended for development/test-oriented deployments, and has no official published release.
-
-### Quickstart with minikube
-
-If you don't have an existing OpenShift or Kubernetes cluster, minikube is a fast and easy way to get up and running.
-
-To install minikube, follow the steps in their [documentation](https://minikube.sigs.k8s.io/docs/start/).
-
-:warning: NOTE |
---- |
-If you're about to install minikube or have already installed it, please be sure you're using [Minikube v1.18.1](https://github.com/kubernetes/minikube/releases/tag/v1.18.1). There's a [bug](https://github.com/ansible/awx-operator/issues/205) right now that will not allow you to run it using Minikube v1.19.x.
-#### Starting minikube
-
-Once you have installed minikube, run the following command to start it. You may wish to customize these options.
-
-```
-$ minikube start --cpus=4 --memory=8g --addons=ingress
-```
-
-#### Deploying the AWX Operator
-
-For a comprehensive overview of features, see [README.md](https://github.com/ansible/awx-operator/blob/devel/README.md) in the awx-operator repo. The following steps are the bare minimum to get AWX up and running.
-
-Start by going to https://github.com/ansible/awx-operator/releases and making note of the latest release. Replace `<tag>` in the URL below with the version you are deploying:
-
-```
-$ minikube kubectl -- apply -f https://raw.githubusercontent.com/ansible/awx-operator/<tag>/deploy/awx-operator.yaml
-```
-
-##### Verifying the Operator Deployment
-
-After a few seconds, the operator should be up and running. Verify it by running the following command:
-
-```
-$ minikube kubectl get pods
-NAME                           READY   STATUS    RESTARTS   AGE
-awx-operator-7c78bfbfd-xb6th   1/1     Running   0          11s
-```
-
-#### Deploy AWX
-
-Once the Operator is running, you can now deploy AWX by creating a simple YAML file:
-
-```
-$ cat myawx.yml
----
-apiVersion: awx.ansible.com/v1beta1
-kind: AWX
-metadata:
-  name: awx
-spec:
-  tower_ingress_type: Ingress
-```
-
-> If a custom AWX image is needed, see [these docs](./docs/build_awx_image.md) on how to build and use it.
-
-And then creating the AWX object in the Kubernetes API:
-
-```
-$ minikube kubectl apply -- -f myawx.yml
-awx.awx.ansible.com/awx created
-```
-
-After creating the AWX object in the Kubernetes API, the operator will begin running its reconciliation loop. 
-
-To see what's going on, you can tail the logs of the operator pod (note that your pod name will be different):
-
-```
-$ minikube kubectl logs -- -f awx-operator-7c78bfbfd-xb6th
-```
-
-After a few seconds, you will see the database and application pods show up. On a fresh system, it may take a few minutes for the container images to download.
-
-```
-$ minikube kubectl get pods
-NAME                           READY   STATUS    RESTARTS   AGE
-awx-5ffbfd489c-bvtvf           3/3     Running   0          2m54s
-awx-operator-7c78bfbfd-xb6th   1/1     Running   0          6m42s
-awx-postgres-0                 1/1     Running   0          2m58s
-```
-
-##### Accessing AWX
-
-To access the AWX UI, you'll need to grab the service url from minikube:
-
-```
-$ minikube service awx-service --url
-http://192.168.59.2:31868
-```
-
-On fresh installs, you will see the "AWX is currently upgrading." page until database migrations finish.
-
-Once you are redirected to the login screen, you can now log in by obtaining the generated admin password (note: do not copy the trailing `%`):
-
-```
-$ minikube kubectl -- get secret awx-admin-password -o jsonpath='{.data.password}' | base64 --decode
-b6ChwVmqEiAsil2KSpH4xGaZPeZvWnWj%
-```
-
-Now you can log in at the URL above with the username "admin" and the password above. Happy Automating!
-
 
 # Installing the AWX CLI
 


### PR DESCRIPTION
##### SUMMARY

CC: @shanemcd 

Related: https://github.com/ansible/awx-operator/pull/330

The PR https://github.com/ansible/awx-operator/pull/330 enhances the AWX installation process via the `awx-operator`. 

This PR redirects the installation notes to the `awx-operator` page so we can simplify and easy maintain the docs in one place. 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

