### PR TITLE
Include the EE set on a workflow template in the resolver hierarchy

### DIFF
--- a/awx/main/models/ad_hoc_commands.py
+++ b/awx/main/models/ad_hoc_commands.py
@@ -215,9 +215,6 @@ class AdHocCommand(UnifiedJob, JobNotificationMixin):
             self.name = Truncator(u': '.join(filter(None, (self.module_name, self.module_args)))).chars(512)
             if 'name' not in update_fields:
                 update_fields.append('name')
-        if not self.execution_environment_id:
-            self.execution_environment = self.resolve_execution_environment()
-            update_fields.append('execution_environment')
         super(AdHocCommand, self).save(*args, **kwargs)
 
     @property

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -366,8 +366,6 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
             for fd, val in eager_fields.items():
                 setattr(unified_job, fd, val)
 
-        unified_job.execution_environment = self.resolve_execution_environment()
-
         # NOTE: slice workflow jobs _get_parent_field_name method
         # is not correct until this is set
         if not parent_field_name:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3059,8 +3059,8 @@ class AWXReceptorJob:
 
     @property
     def pod_definition(self):
-        if self.task:
-            ee = self.task.instance.resolve_execution_environment()
+        if self.task and self.task.instance.execution_environment:
+            ee = self.task.instance.execution_environment
         else:
             ee = get_default_execution_environment()
 


### PR DESCRIPTION
##### SUMMARY

This step comes immediately after checking the actual job/template for
an explicitly set EE.

Note that now, because of how jobs are spawned off of workflow nodes,
the call to .resolve_execution_environment() no longer happens in
.create_unified_job().  The job instance within .create_unified_job()
doesn't yet have access to the node that it will be attached to,
making it impossible to use this information in the resolver if called
there.

related #9560

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```

```
