### PR TITLE
Update tower_notification module routing

### DIFF
--- a/awx_collection/meta/runtime.yml
+++ b/awx_collection/meta/runtime.yml
@@ -43,4 +43,4 @@ plugin_routing:
         removal_date: TBD
         warning_text: see plugin documentation for details
     tower_notification:
-      redirect: tower_notification_template
+      redirect: awx.awx.tower_notification_template

--- a/awx_collection/tests/integration/targets/tower_notification_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/tower_notification_template/tasks/main.yml
@@ -250,3 +250,14 @@
 - assert:
     that:
       - result is changed
+
+- name: Delete IRC notification using redirected module name
+  tower_notification:
+    name: "{{ irc_not }}"
+    organization: Default
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - result is not changed


### PR DESCRIPTION
##### SUMMARY

When the name of the module was updated, a redirect that was added did not use a fully-qualified collection name as the redirection target.

When we try to use the old name, Ansible reports the following error:

    $ ansible -m awx.awx.tower_notification localhost
    localhost | FAILED! => {
      "msg": "The module awx.awx.tower_notification was redirected to
        tower_notification_template, which could not be loaded."
    }

Changes in this commit add the namespace and collection name to the redirect.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx.awx.tower_notification_template