### PR TITLE
Expose the EE resolver to the API

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -724,6 +724,19 @@ class UnifiedJobTemplateSerializer(BaseSerializer):
         else:
             return super(UnifiedJobTemplateSerializer, self).to_representation(obj)
 
+    def get_summary_fields(self, obj):
+        summary_fields = super().get_summary_fields(obj)
+
+        if self.is_detail_view:
+            resolved_ee = obj.resolve_execution_environment()
+            summary_fields['resolved_environment'] = {
+                field: getattr(resolved_ee, field, None)
+                for field in SUMMARIZABLE_FK_FIELDS['execution_environment']
+                if getattr(resolved_ee, field, None) is not None
+            }
+
+        return summary_fields
+
 
 class UnifiedJobSerializer(BaseSerializer):
     show_capabilities = ['start', 'delete']

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -477,11 +477,11 @@ class ExecutionEnvironmentMixin(models.Model):
             if wf_template.execution_environment is not None:
                 return wf_template.execution_environment
             wf_node = getattr(wf_node.workflow_job, 'unified_job_node', None)
-        if getattr(self, 'project', None) and self.project.default_environment is not None:
+        if getattr(self, 'project_id', None) and self.project.default_environment is not None:
             return self.project.default_environment
-        if getattr(self, 'organization', None) and self.organization.default_environment is not None:
+        if getattr(self, 'organization_id', None) and self.organization.default_environment is not None:
             return self.organization.default_environment
-        if getattr(self, 'inventory', None) and self.inventory.organization is not None:
+        if getattr(self, 'inventory_id', None) and self.inventory.organization is not None:
             if self.inventory.organization.default_environment is not None:
                 return self.inventory.organization.default_environment
 


### PR DESCRIPTION
##### SUMMARY

This change exposes the output of `.resolve_execution_environment()` for job templates as a new summary field in the API.  Note that this is only exposed for the detail views, not the list views.  Also, there is the caveat for job templates that may be run under workflows that the workflow EE might override the results of this value.

related #10210

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```