### PR TITLE
when sharing paths use little z

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -855,7 +855,9 @@ class BaseTask(object):
         if settings.AWX_ISOLATION_SHOW_PATHS:
             params['container_volume_mounts'] = []
             for this_path in settings.AWX_ISOLATION_SHOW_PATHS:
-                params['container_volume_mounts'].append(f'{this_path}:{this_path}:Z')
+                # Using z allows the dir to mounted by multiple containers
+                # Uppercase Z restricts access (in weird ways) to 1 container at a time
+                params['container_volume_mounts'].append(f'{this_path}:{this_path}:z')
         return params
 
     def build_private_data(self, instance, private_data_dir):


### PR DESCRIPTION
* AWX_ISOLATION_SHOW_PATHS will be shared between containers. Strange
file not found error can crop up when concurrently accessing shared
directories between multiple containers that are bind mounted with big
Z. So make sure we use little z.

Fixes errors like below:

```
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/git ls-remote file:///opt/tmpawx/at_DrunkMail525450112299457413919634186288881628802211907645041298254_test/ -h refs/heads/HEAD", "msg": "fatal: '/opt/tmpawx/at_DrunkMail525450112299457413919634186288881628802211907645041298254_test/' does not appear to be a git repository\\nfatal: Could not read from remote repository.\\n\\nPlease make sure you have the correct access rights\\nand the repository exists.", "rc": 128, "stderr": "fatal: '/opt/tmpawx/at_DrunkMail525450112299457413919634186288881628802211907645041298254_test/' does not appear to be a git repository\\nfatal: Could not read from remote repository.\\n\\nPlease make sure you have the correct access rights\\nand the repository exists.\\n", "stderr_lines": ["fatal: '/opt/tmpawx/at_DrunkMail525450112299457413919634186288881628802211907645041298254_test/' does not appear to be a git repository", "fatal: Could not read from remote repository.", "", "Please make sure you have the correct access rights", "and the repository exists."], "stdout": "", "stdout_lines": []}```