### PR TITLE
Allow the ExecutionEnvironment.managed_by_tower field to be editable …

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1396,7 +1396,6 @@ class ProjectOptionsSerializer(BaseSerializer):
 
 class ExecutionEnvironmentSerializer(BaseSerializer):
     show_capabilities = ['edit', 'delete', 'copy']
-    managed_by_tower = serializers.ReadOnlyField()
 
     class Meta:
         model = ExecutionEnvironment


### PR DESCRIPTION
##### SUMMARY

…again

This reverses the last of the restrictions put in place by #9346

related #10287 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```