### PR TITLE
Fix NoneType being passed to library function in tower_receive.

### DIFF
--- a/awx_collection/plugins/modules/tower_receive.py
+++ b/awx_collection/plugins/modules/tower_receive.py
@@ -169,7 +169,7 @@ def main():
     export_all = module.params.get('all')
     assets_to_export = {}
     for asset_type in SEND_ORDER:
-        assets_to_export[asset_type] = module.params.get(asset_type)
+        assets_to_export[asset_type] = module.params.get(asset_type, [])
 
     result = dict(
         assets=None,


### PR DESCRIPTION
##### SUMMARY

Commit 38352063e8caadcc0b641d87bd95f350529d51bf removed the inventory_script module parameter. Since `tower_cli.cli.transfer.common.SEND_ORDER` still includes it, this resulted in a None being parsed from the module parameters instead of the default empty array, breaking execution downstream at [ansible/tower-cli:tower_cli/cli/transfer/common.py#413](https://github.com/ansible/tower-cli/blob/master/tower_cli/cli/transfer/common.py#L413) where a non-null list is expected.

This changes asset type export list parsing to defensively fall back to an empty list explicitly, instead of relying on module parameter defaults.

Discovered through ansible/workshops#1184.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - `awx.awx.tower_receive`

##### AWX VERSION

 - Issue introduced in `19.1.0`.
