### PR TITLE
Only attempt to reconnect socket if connection wasn't closed cleanly

### DIFF
--- a/awx/ui_next/src/util/useWebsocket.js
+++ b/awx/ui_next/src/util/useWebsocket.js
@@ -33,9 +33,11 @@ export default function useWebsocket(subscribeGroups) {
     ws.current.onclose = e => {
       // eslint-disable-next-line no-console
       console.debug('Socket closed. Reconnecting...', e);
-      setTimeout(() => {
-        connect();
-      }, 1000);
+      if (e.code !== 1000) {
+        setTimeout(() => {
+          connect();
+        }, 1000);
+      }
     };
 
     ws.current.onerror = err => {

--- a/awx/ui_next/src/util/useWebsocket.js
+++ b/awx/ui_next/src/util/useWebsocket.js
@@ -31,9 +31,9 @@ export default function useWebsocket(subscribeGroups) {
     };
 
     ws.current.onclose = e => {
-      // eslint-disable-next-line no-console
-      console.debug('Socket closed. Reconnecting...', e);
       if (e.code !== 1000) {
+        // eslint-disable-next-line no-console
+        console.debug('Socket closed. Reconnecting...', e);
         setTimeout(() => {
           connect();
         }, 1000);


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/8596

After some investigation, I believe that this error is caused by the reconnect logic that we have.  When the component that references the ws hook unmounts, we disconnect the socket.  There's some logic in the `onclose` method that attempts to reconnect the socket but if we've disconnected cleanly we shouldn't try to reconnect (because we probably meant to disconnect in the first place).

This _should_ clean up the console errors that we've been seeing about the socket already being in a connected state since we won't have timers running past the lifecycle of the component.

cc @keithjgrant does this sound good to you?

Here's the spec for the disconnect event https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#properties

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
