### PR TITLE
Fixes bug where checkbox list item was selecting things twice

### DIFF
--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.jsx
@@ -208,7 +208,7 @@ describe('<AdHocCommands />', () => {
       wrapper
         .find('td#check-action-item-2')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
 
     wrapper.update();
@@ -227,7 +227,7 @@ describe('<AdHocCommands />', () => {
       wrapper
         .find('td#check-action-item-4')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
 
     wrapper.update();
@@ -377,11 +377,7 @@ describe('<AdHocCommands />', () => {
       wrapper
         .find('td#check-action-item-2')
         .find('input')
-        .simulate('change', {
-          target: {
-            checked: true,
-          },
-        });
+        .simulate('click');
     });
 
     wrapper.update();
@@ -400,11 +396,7 @@ describe('<AdHocCommands />', () => {
       wrapper
         .find('td#check-action-item-4')
         .find('input')
-        .simulate('change', {
-          target: {
-            checked: true,
-          },
-        });
+        .simulate('click');
     });
 
     wrapper.update();

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.test.jsx
@@ -155,7 +155,7 @@ describe('<AdHocCommandsWizard/>', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
 
     wrapper.update();
@@ -181,7 +181,7 @@ describe('<AdHocCommandsWizard/>', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
 
     wrapper.update();

--- a/awx/ui_next/src/components/AddRole/AddResourceRole.test.jsx
+++ b/awx/ui_next/src/components/AddRole/AddResourceRole.test.jsx
@@ -95,6 +95,7 @@ describe('<_AddResourceRole />', () => {
 
     // Step 2
     await waitForElement(wrapper, 'EmptyStateBody', el => el.length === 0);
+    expect(wrapper.find('Chip').length).toBe(0);
     act(() =>
       wrapper.find('CheckboxListItem[name="foo"]').invoke('onSelect')(true)
     );
@@ -102,6 +103,7 @@ describe('<_AddResourceRole />', () => {
     expect(
       wrapper.find('CheckboxListItem[name="foo"]').prop('isSelected')
     ).toBe(true);
+    expect(wrapper.find('Chip').length).toBe(1);
     act(() => wrapper.find('Button[type="submit"]').prop('onClick')());
     wrapper.update();
 

--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.jsx
@@ -100,7 +100,9 @@ function SelectResourceStep({
         headerRow={
           <HeaderRow qsConfig={QS_Config(sortColumns)}>
             {sortColumns.map(({ name, key }) => (
-              <HeaderCell sortKey={key}>{name}</HeaderCell>
+              <HeaderCell sortKey={key} key={key}>
+                {name}
+              </HeaderCell>
             ))}
           </HeaderRow>
         }

--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.test.jsx
@@ -122,7 +122,7 @@ describe('<SelectResourceStep />', () => {
     checkboxListItemWrapper
       .first()
       .find('input[type="checkbox"]')
-      .simulate('change', { target: { checked: true } });
+      .simulate('click');
     expect(handleRowClick).toHaveBeenCalledWith(data.results[0]);
   });
 });

--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.jsx
@@ -34,7 +34,6 @@ const CheckboxListItem = ({
         select={{
           rowIndex,
           isSelected,
-          onSelect: isSelected ? onDeselect : onSelect,
           variant: isRadio ? 'radio' : 'checkbox',
         }}
         name={name}
@@ -43,7 +42,7 @@ const CheckboxListItem = ({
 
       {columns?.length > 0 ? (
         columns.map(col => (
-          <Td aria-label={col.name} dataLabel={col.key}>
+          <Td aria-label={col.name} dataLabel={col.key} key={col.key}>
             {item[col.key]}
           </Td>
         ))

--- a/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.test.jsx
+++ b/awx/ui_next/src/components/LaunchPrompt/steps/CredentialsStep.test.jsx
@@ -183,7 +183,7 @@ describe('CredentialsStep', () => {
       wrapper
         .find('td#check-action-item-2')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
     wrapper.update();
     expect(wrapper.find('Alert').length).toBe(1);
@@ -244,7 +244,7 @@ describe('CredentialsStep', () => {
       wrapper
         .find('td#check-action-item-5')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
     wrapper.update();
     expect(wrapper.find('Alert').length).toBe(0);
@@ -321,7 +321,7 @@ describe('CredentialsStep', () => {
       wrapper
         .find('td#check-action-item-33')
         .find('input')
-        .simulate('change', { target: { checked: true } });
+        .simulate('click');
     });
     wrapper.update();
     expect(wrapper.find('Alert').length).toBe(0);

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
@@ -343,11 +343,7 @@ describe('<ScheduleAdd />', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .simulate('change', {
-          target: {
-            checked: true,
-          },
-        });
+        .simulate('click');
     });
     wrapper.update();
     expect(

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
@@ -475,11 +475,7 @@ describe('<ScheduleEdit />', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .simulate('change', {
-          target: {
-            checked: true,
-          },
-        });
+        .simulate('click');
     });
     wrapper.update();
 
@@ -607,11 +603,7 @@ describe('<ScheduleEdit />', () => {
       wrapper
         .find('td#check-action-item-2')
         .find('input')
-        .simulate('change', {
-          target: {
-            checked: true,
-          },
-        });
+        .simulate('click');
     });
     wrapper.update();
 

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
@@ -345,11 +345,7 @@ describe('<ScheduleForm />', () => {
         promptWrapper
           .find('td#check-action-item-1')
           .find('input')
-          .simulate('change', {
-            target: {
-              checked: true,
-            },
-          });
+          .simulate('click');
       });
       promptWrapper.update();
       expect(

--- a/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.test.jsx
+++ b/awx/ui_next/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.test.jsx
@@ -152,7 +152,7 @@ describe('<UserAndTeamAccessAdd/>', () => {
         .find('CheckboxListItem')
         .first()
         .find('input[type="checkbox"]')
-        .simulate('change', { target: { checked: true } })
+        .simulate('click')
     );
 
     wrapper.update();
@@ -235,7 +235,7 @@ describe('<UserAndTeamAccessAdd/>', () => {
         .find('CheckboxListItem')
         .first()
         .find('input[type="checkbox"]')
-        .simulate('change', { target: { checked: true } })
+        .simulate('click')
     );
 
     wrapper.update();

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { func, shape } from 'prop-types';
 import { Formik, useField } from 'formik';
-
 import { t } from '@lingui/macro';
 import {
   Button,

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.jsx
@@ -134,7 +134,7 @@ describe('<CredentialPluginPrompt />', () => {
         wrapper
           .find('td#check-action-item-1')
           .find('input')
-          .invoke('onChange')(true);
+          .simulate('click');
       });
       wrapper.update();
       expect(

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.test.jsx
@@ -267,7 +267,7 @@ describe('NodeModal', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .prop('onChange')(true);
+        .simulate('click');
     });
     wrapper.update();
     await act(async () => {
@@ -337,7 +337,7 @@ describe('NodeModal', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .prop('onChange')(true);
+        .simulate('click');
     });
     wrapper.update();
     await act(async () => {
@@ -376,7 +376,7 @@ describe('NodeModal', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .prop('onChange')(true);
+        .simulate('click');
     });
     wrapper.update();
     await act(async () => {
@@ -415,7 +415,7 @@ describe('NodeModal', () => {
       wrapper
         .find('td#check-action-item-1')
         .find('input')
-        .prop('onChange')(true)
+        .simulate('click')
     );
     wrapper.update();
 
@@ -673,7 +673,7 @@ describe('Edit existing node', () => {
       newWrapper
         .find('td#check-action-item-1')
         .find('input')
-        .prop('onChange')();
+        .simulate('click');
       newWrapper.update();
     });
     newWrapper.update();


### PR DESCRIPTION
##### SUMMARY
Resolves #10338 

There was a click event on the row and the underlying checkbox.  I got rid of the underlying click event so now its only handled at the row level.

![checkbox_double_select](https://user-images.githubusercontent.com/9889020/120655887-1e057000-c451-11eb-9e7d-202155019c30.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
