### PR TITLE
Disable cancel button on http 405

### DIFF
--- a/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
+++ b/awx/ui_next/src/components/JobCancelButton/JobCancelButton.jsx
@@ -27,11 +27,14 @@ function JobCancelButton({
     cancelError
   );
 
+  const isAlreadyCancelled = cancelError?.response?.status === 405;
+
   return (
     <>
-      <Tooltip content={title}>
+      <Tooltip content={isAlreadyCancelled ? null : title}>
         {showIconButton ? (
           <Button
+            isDisabled={isAlreadyCancelled}
             aria-label={title}
             ouiaId="cancel-job-button"
             onClick={() => setIsOpen(true)}
@@ -41,6 +44,7 @@ function JobCancelButton({
           </Button>
         ) : (
           <Button
+            isDisabled={isAlreadyCancelled}
             aria-label={title}
             variant="secondary"
             ouiaId="cancel-job-button"
@@ -83,7 +87,7 @@ function JobCancelButton({
           {t`Are you sure you want to cancel this job?`}
         </AlertModal>
       )}
-      {error && (
+      {error && !isAlreadyCancelled && (
         <AlertModal
           isOpen={error}
           variant="danger"


### PR DESCRIPTION
##### SUMMARY
for #9905 

When a 405 is received, it means the job is already cancelled. Treat the
request as a success and don't show an error modal.

We disable the button to handle a rare scenario where we receive the 405 long before
the job status is properly updated to "cancelled" over websockets. We want to prevent
more cancel requests when this happens. We're disabling instead of hiding the button
because, assuming the status hasn't changed over sockets, the buttons that usually
replace the cancel button on the toolbar won't be shown yet and we don't want to
needlessly flicker and shift button positions around by rapidly loading and unloading
a different number of buttons onto the bar.
