### PR TITLE
Skip sliced jobs from the workflow EE logic

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -474,7 +474,8 @@ class ExecutionEnvironmentMixin(models.Model):
         wf_node = getattr(self, 'unified_job_node', None)
         while wf_node is not None:
             wf_template = wf_node.workflow_job.workflow_job_template
-            if wf_template.execution_environment is not None:
+            # NOTE: sliced workflow_jobs have a null workflow_job_template
+            if wf_template and wf_template.execution_environment is not None:
                 return wf_template.execution_environment
             wf_node = getattr(wf_node.workflow_job, 'unified_job_node', None)
         if getattr(self, 'project', None) and self.project.default_environment is not None:


### PR DESCRIPTION
Addressing some unanticipated fallout from https://github.com/ansible/awx/pull/10305

Sliced jobs rely on creating a workflow job, but they do not have a `workflow_job_template`, so in those cases, that was causing a traceback.

```
2021-06-03 20:10:52,319 ERROR    [a17ebd7f] awx.main.dispatch Worker failed to run task awx.main.tasks.RunJob(*[341], **{}
Traceback (most recent call last):
  File "/awx_devel/awx/main/dispatch/worker/task.py", line 90, in perform_work
    result = self.run_callable(body)
  File "/awx_devel/awx/main/dispatch/worker/task.py", line 65, in run_callable
    return _call(*args, **kwargs)
  File "/awx_devel/awx/main/tasks.py", line 759, in _wrapped
    return f(self, *args, **kwargs)
  File "/awx_devel/awx/main/tasks.py", line 1264, in run
    self.instance = self.update_model(self.instance.pk, execution_environment=self.instance.resolve_execution_environment())
  File "/awx_devel/awx/main/models/mixins.py", line 477, in resolve_execution_environment
    if wf_template.execution_environment is not None:
AttributeError: 'NoneType' object has no attribute 'execution_environment'
```

that is fixed with this, at least for my one simple test case

This left jobs hanging out in "waiting" status, which is really not good.