### PR TITLE
Add receptor_node field to instance_group

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4885,6 +4885,7 @@ class InstanceGroupSerializer(BaseSerializer):
             "policy_instance_minimum",
             "policy_instance_list",
             "pod_spec_override",
+            "receptor_node",
             "summary_fields",
         )
 

--- a/awx/main/migrations/0145_instance_group_receptor_node.py
+++ b/awx/main/migrations/0145_instance_group_receptor_node.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0144_event_partitions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='instancegroup',
+            name='receptor_node',
+            field=models.CharField(
+                blank=True,
+                default=None,
+                help_text='Receptor node to send all jobs to from this instance group',
+                max_length=40,
+                null=True,
+            ),
+        ),
+    ]

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -187,6 +187,10 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
             default='',
         )
     )
+    receptor_node = models.TextField(
+        blank=True,
+        default=None,
+    )
     policy_instance_percentage = models.IntegerField(default=0, help_text=_("Percentage of Instances to automatically assign to this group"))
     policy_instance_minimum = models.IntegerField(default=0, help_text=_("Static minimum number of Instances to automatically assign to this group"))
     policy_instance_list = JSONField(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR adds a field to the instance_group model called receptor_node.  When set, the value of this field will be passed to `receptor_ctl.submit_work`, which will cause the local Receptor node to send the job to the named remote Receptor node instead of running it locally.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.0
```


##### ADDITIONAL INFORMATION

To try this in a single node Docker development environment, update your `tools/docker-compose/receptor.conf` and replace the `local-only` line with:

```
- tcp-peer:
    address: 172.18.0.1:2222
    redial: true
```
(This assumes you have the standard Docker setup where your host-only network is 172.18.0.0/24.)

Then, outside the container, run a Receptor instance with the following config:

```
---
- node:
    id: node1

- log-level: debug

- control-service:
    service: control
    filename: /tmp/receptor.sock

- tcp-listener:
    port: 2222

- work-command:
    worktype: local
    command: ansible-runner
    params: worker
    allowruntimeparams: true

- work-kubernetes:
    worktype: kubernetes-runtime-auth
    authmethod: runtime
    allowruntimeauth: true
    allowruntimepod: true
    allowruntimeparams: true

- work-kubernetes:
    worktype: kubernetes-incluster-auth
    authmethod: incluster
    allowruntimeauth: true
    allowruntimepod: true
    allowruntimeparams: true
```

Start the AWX development environment and you should see the the internal Receptor node `awx-1` connect and establish routing.  Create an instance group through the UI, let's say named `test`, and add the awx-1 instance to it.  Then inside the awx container, run `awx-manage dbshell` and set the Receptor node for the instance group as follows:

```
update main_instancegroup set receptor_node='node1' where name='test';
```

Now set a job template to run on this instance group and launch it.  It should run on your host, outside the container, via the node1 Receptor instance.
