### PR TITLE
Remove reload on manual logout

### DIFF
--- a/awx/ui_next/src/contexts/Session.jsx
+++ b/awx/ui_next/src/contexts/Session.jsx
@@ -73,15 +73,12 @@ function SessionProvider({ children }) {
   const [authRedirectTo, setAuthRedirectTo] = useState('/');
 
   const logout = useCallback(async () => {
-    if (!isSessionExpired.current) {
-      history.replace('/');
-    }
     await RootAPI.logout();
     setSessionTimeout(0);
     setSessionCountdown(0);
     clearTimeout(sessionTimeoutId.current);
     clearInterval(sessionIntervalId.current);
-  }, [setSessionTimeout, setSessionCountdown, history]);
+  }, [setSessionTimeout, setSessionCountdown]);
 
   useEffect(() => {
     if (!isAuthenticated(document.cookie)) {


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/10383

We initiate a reload on manual logout, resulting in requests to `/config` that always return a 400 error due to being unauthenticated. 

From what I can tell, we might not actually need to do the reload since the `login` redirect will still happen once the logout request resolves. 