### PR TITLE
Avoid reload on manual logout

### DIFF
--- a/awx/ui_next/src/App.jsx
+++ b/awx/ui_next/src/App.jsx
@@ -86,7 +86,7 @@ const AuthorizedRoutes = ({ routeConfig }) => {
 };
 
 const ProtectedRoute = ({ children, ...rest }) => {
-  const { setAuthRedirectTo } = useSession();
+  const { authRedirectTo, setAuthRedirectTo } = useSession();
   const { pathname } = useLocation();
 
   if (isAuthenticated(document.cookie)) {
@@ -99,7 +99,8 @@ const ProtectedRoute = ({ children, ...rest }) => {
     );
   }
 
-  setAuthRedirectTo(pathname);
+  setAuthRedirectTo(authRedirectTo === '/logout' ? '/' : pathname);
+
   return <Redirect to="/login" />;
 };
 

--- a/awx/ui_next/src/contexts/Session.jsx
+++ b/awx/ui_next/src/contexts/Session.jsx
@@ -74,14 +74,14 @@ function SessionProvider({ children }) {
 
   const logout = useCallback(async () => {
     if (!isSessionExpired.current) {
-      history.replace('/');
+      setAuthRedirectTo('/logout');
     }
     await RootAPI.logout();
     setSessionTimeout(0);
     setSessionCountdown(0);
     clearTimeout(sessionTimeoutId.current);
     clearInterval(sessionIntervalId.current);
-  }, [setSessionTimeout, setSessionCountdown, history]);
+  }, [setSessionTimeout, setSessionCountdown]);
 
   useEffect(() => {
     if (!isAuthenticated(document.cookie)) {


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/10383

Instead of reloading, set the `authRedirectTo` context variable to "/logout" and handle it as a special case when routing

