### PR TITLE
Do not show `not` as choice for Advanced Search on Smart Inventory

### DIFF
--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -39,6 +39,7 @@ function DataListToolbar({
   additionalControls,
   qsConfig,
   pagination,
+  enableNegativeFiltering,
 }) {
   const showExpandCollapse = onCompact && onExpand;
   const [isKebabOpen, setIsKebabOpen] = useState(false);
@@ -90,6 +91,7 @@ function DataListToolbar({
               onReplaceSearch={onReplaceSearch}
               onShowAdvancedSearch={onShowAdvancedSearch}
               onRemove={onRemove}
+              enableNegativeFiltering={enableNegativeFiltering}
             />
           </ToolbarItem>
           {sortColumns && (
@@ -170,6 +172,7 @@ DataListToolbar.propTypes = {
   onSelectAll: PropTypes.func,
   onSort: PropTypes.func,
   additionalControls: PropTypes.arrayOf(PropTypes.node),
+  enableNegativeFiltering: PropTypes.bool,
 };
 
 DataListToolbar.defaultProps = {
@@ -188,6 +191,7 @@ DataListToolbar.defaultProps = {
   onSelectAll: null,
   onSort: null,
   additionalControls: [],
+  enableNegativeFiltering: true,
 };
 
 export default DataListToolbar;

--- a/awx/ui_next/src/components/Lookup/HostFilterLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/HostFilterLookup.jsx
@@ -111,13 +111,13 @@ const buildSearchColumns = () => [
 
 function HostFilterLookup({
   helperTextInvalid,
-
   isValid,
   isDisabled,
   onBlur,
   onChange,
   organizationId,
   value,
+  enableNegativeFiltering,
 }) {
   const history = useHistory();
   const location = useLocation();
@@ -342,7 +342,13 @@ function HostFilterLookup({
                 item={{ ...item, url: `/hosts/${item.id}/details` }}
               />
             )}
-            renderToolbar={props => <DataListToolbar {...props} fillWidth />}
+            renderToolbar={props => (
+              <DataListToolbar
+                {...props}
+                fillWidth
+                enableNegativeFiltering={enableNegativeFiltering}
+              />
+            )}
             toolbarSearchColumns={searchColumns}
             toolbarSortColumns={[
               {
@@ -374,6 +380,7 @@ HostFilterLookup.propTypes = {
   onChange: func,
   organizationId: number,
   value: string,
+  enableNegativeFiltering: bool,
 };
 HostFilterLookup.defaultProps = {
   isValid: true,
@@ -381,6 +388,7 @@ HostFilterLookup.defaultProps = {
   onChange: () => {},
   organizationId: null,
   value: '',
+  enableNegativeFiltering: true,
 };
 
 export default withRouter(HostFilterLookup);

--- a/awx/ui_next/src/components/Search/AdvancedSearch.jsx
+++ b/awx/ui_next/src/components/Search/AdvancedSearch.jsx
@@ -32,6 +32,7 @@ function AdvancedSearch({
   searchableKeys,
   relatedSearchableKeys,
   maxSelectHeight,
+  enableNegativeFiltering,
 }) {
   // TODO: blocked by pf bug, eventually separate these into two groups in the select
   // for now, I'm spreading set to get rid of duplicate keys...when they are grouped
@@ -111,12 +112,14 @@ function AdvancedSearch({
           value="or"
           description={t`Returns results that satisfy this one or any other filters.`}
         />
-        <SelectOption
-          id="not-option-select"
-          key="not"
-          value="not"
-          description={t`Returns results that have values other than this one as well as other filters.`}
-        />
+        {enableNegativeFiltering && (
+          <SelectOption
+            id="not-option-select"
+            key="not"
+            value="not"
+            description={t`Returns results that have values other than this one as well as other filters.`}
+          />
+        )}
       </Select>
       <Select
         ouiaId="set-key-typeahead"
@@ -299,12 +302,14 @@ AdvancedSearch.propTypes = {
   searchableKeys: PropTypes.arrayOf(PropTypes.string),
   relatedSearchableKeys: PropTypes.arrayOf(PropTypes.string),
   maxSelectHeight: PropTypes.string,
+  enableNegativeFiltering: PropTypes.bool,
 };
 
 AdvancedSearch.defaultProps = {
   searchableKeys: [],
   relatedSearchableKeys: [],
   maxSelectHeight: '300px',
+  enableNegativeFiltering: true,
 };
 
 export default AdvancedSearch;

--- a/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
+++ b/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
@@ -339,4 +339,28 @@ describe('<AdvancedSearch />', () => {
     wrapper.update();
     expect(advancedSearchMock).toBeCalledWith('', 'baz');
   });
+
+  test('Remove not operator from set type', () => {
+    wrapper = mountWithContexts(
+      <AdvancedSearch
+        onSearch={jest.fn}
+        searchableKeys={['foo', 'bar']}
+        relatedSearchableKeys={['bar', 'baz']}
+        enableNegativeFiltering={false}
+      />
+    );
+    wrapper
+      .find('Select[aria-label="Set type select"] SelectToggle')
+      .simulate('click');
+    const selectOptions = wrapper.find(
+      'Select[aria-label="Set type select"] SelectOption'
+    );
+    expect(selectOptions).toHaveLength(2);
+    expect(
+      selectOptions.find('SelectOption[id="or-option-select"]').prop('value')
+    ).toBe('or');
+    expect(
+      selectOptions.find('SelectOption[id="and-option-select"]').prop('value')
+    ).toBe('and');
+  });
 });

--- a/awx/ui_next/src/components/Search/Search.jsx
+++ b/awx/ui_next/src/components/Search/Search.jsx
@@ -32,7 +32,6 @@ const NoOptionDropdown = styled.div`
 
 function Search({
   columns,
-
   onSearch,
   onReplaceSearch,
   onRemove,
@@ -43,6 +42,7 @@ function Search({
   onShowAdvancedSearch,
   isDisabled,
   maxSelectHeight,
+  enableNegativeFiltering,
 }) {
   const [isSearchDropdownOpen, setIsSearchDropdownOpen] = useState(false);
   const [searchKey, setSearchKey] = useState(
@@ -206,6 +206,7 @@ function Search({
               searchableKeys={searchableKeys}
               relatedSearchableKeys={relatedSearchableKeys}
               maxSelectHeight={maxSelectHeight}
+              enableNegativeFiltering={enableNegativeFiltering}
             />
           )) ||
             (options && (
@@ -325,6 +326,7 @@ Search.propTypes = {
   onShowAdvancedSearch: PropTypes.func.isRequired,
   isDisabled: PropTypes.bool,
   maxSelectHeight: PropTypes.string,
+  enableNegativeFiltering: PropTypes.bool,
 };
 
 Search.defaultProps = {
@@ -332,6 +334,7 @@ Search.defaultProps = {
   onRemove: null,
   isDisabled: false,
   maxSelectHeight: '300px',
+  enableNegativeFiltering: true,
 };
 
 export default withRouter(Search);

--- a/awx/ui_next/src/screens/Inventory/shared/SmartInventoryForm.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/SmartInventoryForm.jsx
@@ -81,6 +81,7 @@ const SmartInventoryFormFields = ({ inventory }) => {
         onBlur={() => hostFilterHelpers.setTouched()}
         isValid={!hostFilterMeta.touched || !hostFilterMeta.error}
         isDisabled={!organizationField.value}
+        enableNegativeFiltering={false}
       />
       <InstanceGroupsLookup
         value={instanceGroupsField.value}


### PR DESCRIPTION
Do not show `not` set type as a  choice for Advanced Search on Smart Inventory since
this feature is not implemented on the API side yet.

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/9053044/121083632-ad8e8400-c7ad-11eb-8ed2-357dcca0e3d5.png">


See: https://github.com/ansible/awx/issues/2817
