### PR TITLE
Enter flake8 rules in tox config as actual config entries

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,8 @@ setenv =
   BLACK_ARGS = --check
 commands =
   make black
-  flake8 awx --select=F401,F402,F821,F823,F841
+  flake8 awx
   yamllint -s .
+
+[flake8]
+select = F401,F402,F821,F823,F841


### PR DESCRIPTION
I _really_ like to do things like

```
flake8 awx/main/models
```

but this is made impractical where running `flake8` for the project carries with it an assumption that you will pass a specific set of options.

https://flake8.pycqa.org/en/latest/user/configuration.html

Blessedly, flake8 is flexible in their config options so that it may weather the storm of python project config wars.