### PR TITLE
Adds version context processor back in to fix api browser doc link

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -270,6 +270,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 'awx.ui.context_processors.csp',
+                'awx.ui.context_processors.version',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
             ],

--- a/awx/ui/context_processors.py
+++ b/awx/ui/context_processors.py
@@ -1,6 +1,18 @@
 import base64
 import os
 
+from awx.main.utils import get_awx_version
+
 
 def csp(request):
     return {'csp_nonce': base64.encodebytes(os.urandom(32)).decode().rstrip()}
+
+
+def version(request):
+    context = getattr(request, 'parser_context', {})
+    return {
+        'version': get_awx_version(),
+        'tower_version': get_awx_version(),
+        'short_tower_version': get_awx_version().split('-')[0],
+        'deprecated': getattr(context.get('view'), 'deprecated', False),
+    }


### PR DESCRIPTION
##### SUMMARY
Here's what it looks like on devel now (note the URL in the bottom left):

<img width="1532" alt="Screen Shot 2021-06-07 at 7 54 28 PM" src="https://user-images.githubusercontent.com/9889020/121101663-4206df80-c7ca-11eb-9a4d-1483591582ad.png">

Here's what it looks like after the change (note the URL in the bottom left):

<img width="1495" alt="Screen Shot 2021-06-07 at 7 53 00 PM" src="https://user-images.githubusercontent.com/9889020/121101675-4af7b100-c7ca-11eb-8688-e1fde8e39ebf.png">

I dropped this in as it was before the removal of the old UI.  I believe the new UI needs access to some of these variables as well to force assets to be refetched after upgrade.

Also of note: I have no idea what I'm doing with django so please help me to become educated if I've done something silly here.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API