### PR TITLE
Update translation make target for ui_next

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,10 +551,13 @@ awx-kube-dev-build: Dockerfile.kube-dev
 # Translation TASKS
 # --------------------------------------
 
-# generate UI .pot
+# generate UI .pot file, an empty template of strings yet to be translated
 pot: $(UI_BUILD_FLAG_FILE)
-	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run extract-strings
-	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run extract-template
+	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run extract-template --clean
+
+# generate UI .po files for each locale (will update translated strings for `en`)
+po: $(UI_BUILD_FLAG_FILE)
+	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run extract-strings -- --clean
 
 # generate API django .pot .po
 LANG = "en-us"

--- a/awx/ui_next/package.json
+++ b/awx/ui_next/package.json
@@ -74,6 +74,7 @@
     "lint": "eslint --ext .js --ext .jsx .",
     "add-locale": "lingui add-locale",
     "extract-strings": "lingui extract",
+    "extract-template": "lingui extract-template",
     "compile-strings": "lingui compile",
     "prettier": "prettier --write \"src/**/*.{js,jsx,scss}\"",
     "prettier-check": "prettier --check \"src/**/*.{js,jsx,scss}\""


### PR DESCRIPTION
##### SUMMARY

This adds the [`--clean` flag](https://lingui.js.org/tutorials/cli.html#cleaning-up-obsolete-messages) to the extract-strings command (cleans up obsolete strings) and separates out the `extract-template` command.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Translation Automation

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.0
```
