### PR TITLE
Prevents delete of instance groups list item controlplane and default

### DIFF
--- a/awx/ui_next/src/api/models/Settings.js
+++ b/awx/ui_next/src/api/models/Settings.js
@@ -14,6 +14,10 @@ class Settings extends Base {
     return this.http.patch(`${this.baseUrl}all/`, data);
   }
 
+  readAll() {
+    return this.http.get(`${this.baseUrl}all/`);
+  }
+
   updateCategory(category, data) {
     return this.http.patch(`${this.baseUrl}${category}/`, data);
   }

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroup.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroup.jsx
@@ -13,7 +13,7 @@ import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 
 import useRequest from '../../util/useRequest';
-import { InstanceGroupsAPI } from '../../api';
+import { InstanceGroupsAPI, SettingsAPI } from '../../api';
 import RoutedTabs from '../../components/RoutedTabs';
 import ContentError from '../../components/ContentError';
 import ContentLoading from '../../components/ContentLoading';
@@ -31,12 +31,28 @@ function InstanceGroup({ setBreadcrumb }) {
     isLoading,
     error: contentError,
     request: fetchInstanceGroups,
-    result: instanceGroup,
+    result: { instanceGroup, defaultControlPlane, defaultExecution },
   } = useRequest(
     useCallback(async () => {
-      const { data } = await InstanceGroupsAPI.readDetail(id);
-      return data;
-    }, [id])
+      const [
+        { data },
+        {
+          data: {
+            DEFAULT_CONTROL_PLANE_QUEUE_NAME,
+            DEFAULT_EXECUTION_QUEUE_NAME,
+          },
+        },
+      ] = await Promise.all([
+        InstanceGroupsAPI.readDetail(id),
+        SettingsAPI.readAll(),
+      ]);
+      return {
+        instanceGroup: data,
+        defaultControlPlane: DEFAULT_CONTROL_PLANE_QUEUE_NAME,
+        defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
+      };
+    }, [id]),
+    { instanceGroup: {}, defaultControlPlane: '', defaultExecution: '' }
   );
 
   useEffect(() => {
@@ -115,7 +131,11 @@ function InstanceGroup({ setBreadcrumb }) {
             {instanceGroup && (
               <>
                 <Route path="/instance_groups/:id/edit">
-                  <InstanceGroupEdit instanceGroup={instanceGroup} />
+                  <InstanceGroupEdit
+                    instanceGroup={instanceGroup}
+                    defaultExecution={defaultExecution}
+                    defaultControlPlane={defaultControlPlane}
+                  />
                 </Route>
                 <Route path="/instance_groups/:id/details">
                   <InstanceGroupDetails instanceGroup={instanceGroup} />

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroup.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroup.jsx
@@ -52,7 +52,7 @@ function InstanceGroup({ setBreadcrumb }) {
         defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
       };
     }, [id]),
-    { instanceGroup: {}, defaultControlPlane: '', defaultExecution: '' }
+    { instanceGroup: null, defaultControlPlane: '', defaultExecution: '' }
   );
 
   useEffect(() => {

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.jsx
@@ -5,7 +5,11 @@ import { CardBody } from '../../../components/Card';
 import { InstanceGroupsAPI } from '../../../api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
-function InstanceGroupEdit({ instanceGroup }) {
+function InstanceGroupEdit({
+  instanceGroup,
+  defaultExecution,
+  defaultControlPlane,
+}) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/instance_groups/${instanceGroup.id}/details`;
@@ -27,6 +31,8 @@ function InstanceGroupEdit({ instanceGroup }) {
     <CardBody>
       <InstanceGroupForm
         instanceGroup={instanceGroup}
+        defaultExecution={defaultExecution}
+        defaultControlPlane={defaultControlPlane}
         onSubmit={handleSubmit}
         submitError={submitError}
         onCancel={handleCancel}

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.jsx
@@ -55,7 +55,11 @@ describe('<InstanceGroupEdit>', () => {
     history = createMemoryHistory();
     await act(async () => {
       wrapper = mountWithContexts(
-        <InstanceGroupEdit instanceGroup={instanceGroupData} />,
+        <InstanceGroupEdit
+          defaultExecution="default"
+          defaultControlPlane="controlplane"
+          instanceGroup={instanceGroupData}
+        />,
         {
           context: { router: { history } },
         }
@@ -68,12 +72,14 @@ describe('<InstanceGroupEdit>', () => {
     wrapper.unmount();
   });
 
-  test('tower instance group name can not be updated', async () => {
+  test('controlplane instance group name can not be updated', async () => {
     let towerWrapper;
     await act(async () => {
       towerWrapper = mountWithContexts(
         <InstanceGroupEdit
-          instanceGroup={{ ...instanceGroupData, name: 'tower' }}
+          defaultExecution="default"
+          defaultControlPlane="controlplane"
+          instanceGroup={{ ...instanceGroupData, name: 'controlplane' }}
         />,
         {
           context: { router: { history } },
@@ -85,7 +91,29 @@ describe('<InstanceGroupEdit>', () => {
     ).toBeTruthy();
     expect(
       towerWrapper.find('input#instance-group-name').prop('value')
-    ).toEqual('tower');
+    ).toEqual('controlplane');
+  });
+
+  test('default instance group name can not be updated', async () => {
+    let towerWrapper;
+    await act(async () => {
+      towerWrapper = mountWithContexts(
+        <InstanceGroupEdit
+          defaultExecution="default"
+          defaultControlPlane="controlplane"
+          instanceGroup={{ ...instanceGroupData, name: 'default' }}
+        />,
+        {
+          context: { router: { history } },
+        }
+      );
+    });
+    expect(
+      towerWrapper.find('input#instance-group-name').prop('disabled')
+    ).toBeTruthy();
+    expect(
+      towerWrapper.find('input#instance-group-name').prop('value')
+    ).toEqual('default');
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui_next/src/screens/InstanceGroup/shared/InstanceGroupForm.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/shared/InstanceGroupForm.jsx
@@ -10,8 +10,9 @@ import FormActionGroup from '../../../components/FormActionGroup';
 import { required, minMaxValue } from '../../../util/validators';
 import { FormColumnLayout } from '../../../components/FormLayout';
 
-function InstanceGroupFormFields() {
+function InstanceGroupFormFields({ defaultExecution, defaultControlPlane }) {
   const [instanceGroupNameField, ,] = useField('name');
+
   return (
     <>
       <FormField
@@ -21,7 +22,10 @@ function InstanceGroupFormFields() {
         type="text"
         validate={required(null)}
         isRequired
-        isDisabled={instanceGroupNameField.value === 'tower'}
+        isDisabled={
+          instanceGroupNameField.value === defaultExecution ||
+          instanceGroupNameField.value === defaultControlPlane
+        }
       />
       <FormField
         id="instance-group-policy-instance-minimum"
@@ -50,6 +54,7 @@ function InstanceGroupFormFields() {
 
 function InstanceGroupForm({
   instanceGroup = {},
+
   onSubmit,
   onCancel,
   submitError,


### PR DESCRIPTION
##### SUMMARY
This addresses #10396. `controlplane` instance group is part of every build where as the `default` instance group is part of Openshit/Kubernetes install.
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![Screen Shot 2021-06-10 at 10 06 42 AM](https://user-images.githubusercontent.com/39280967/121539458-b3fe4500-c9d3-11eb-862a-6dd8edc35220.png)
