### PR TITLE
Add Job data to return on wait failures

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -735,6 +735,7 @@ class ControllerAPIModule(ControllerModule):
                 self.json_output['msg'] = 'Job with id {0} failed'.format(object_name)
             else:
                 self.json_output['msg'] = 'The {0} - {1}, failed'.format(object_type, object_name)
+                self.json_output["job_data"] = result["json"]
             self.wait_output(result)
             self.fail_json(**self.json_output)
 

--- a/awx_collection/test/awx/test_ad_hoc_wait.py
+++ b/awx_collection/test/awx/test_ad_hoc_wait.py
@@ -16,7 +16,8 @@ def test_ad_hoc_command_wait_successful(run_module, admin_user):
     result['elapsed'] = float(result['elapsed'])
     assert result.pop('finished', '')[:10] == str(command.finished)[:10]
     assert result.pop('started', '')[:10] == str(command.started)[:10]
-    assert result == {"status": "successful", "changed": False, "elapsed": command.elapsed, "id": command.id}
+    assert result.pop('status', "successful"), result
+    assert result.get('changed') is False
 
 
 @pytest.mark.django_db
@@ -27,14 +28,8 @@ def test_ad_hoc_command_wait_failed(run_module, admin_user):
     result['elapsed'] = float(result['elapsed'])
     assert result.pop('finished', '')[:10] == str(command.finished)[:10]
     assert result.pop('started', '')[:10] == str(command.started)[:10]
-    assert result == {
-        "status": "failed",
-        "failed": True,
-        "changed": False,
-        "elapsed": command.elapsed,
-        "id": command.id,
-        "msg": "The ad hoc command - 1, failed",
-    }
+    assert result.get('changed') is False
+    assert result.pop('status', "failed"), result
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
This adds the returned results to the returned data when jobs fail when waited on. This brings it inline with information returned on success.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
- awx collection

##### AWX VERSION
```
19.2.0
```


##### ADDITIONAL INFORMATION
before:
```json
{
  "changed": false,
  "elapsed": 3.806,
  "finished": "2021-06-10T15:24:52.861344Z",
  "id": 153,
  "msg": "The Workflow Node - fail, failed",
  "started": "2021-06-10T15:24:49.055652Z",
  "status": "failed"
}
```

after:
```json
{
  "changed": false,
  "elapsed": 3.806,
  "finished": "2021-06-10T15:24:52.861344Z",
  "id": 153,
  "job_data": {
    "allow_simultaneous": false,
    "artifacts": {
      "test": "fail"
    },
    "canceled_on": null,
    "controller_node": "",
    "created": "2021-06-10T15:24:48.504122Z",
    "custom_virtualenv": "/var/lib/awx/venv/ansible",
    "description": "",
    "diff_mode": false,
    "elapsed": 3.806,
    "event_processing_finished": true,
    "execution_node": "localhost",
    "extra_vars": "{\"fail\": \"workflow\"}",
    "failed": true,
    "finished": "2021-06-10T15:24:52.861344Z",
    "force_handlers": false,
    "forks": 0,
    "host_status_counts": {
      "failures": 1
    },
    "id": 153,
    "instance_group": 1,
    "inventory": 1,
    "job_args": "[\"bwrap\", \"--die-with-parent\", \"--unshare-pid\", \"--dev-bind\", \"/\", \"/\", \"--proc\", \"/proc\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmp5wid0rwm\", \"/etc/ssh\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmp5wmz8ule\", \"/etc/tower\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmp4akvmhfo\", \"/home\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmplpgjkbaw\", \"/tmp\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmpgrdxeea3\", \"/var/lib/awx\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmp2hidif23\", \"/var/lib/awx/job_status\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmps2sv03e3\", \"/var/lib/awx/projects\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmpoqb_xxh7\", \"/var/log\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/ansible_runner_pi_uai8yldi/tmpyjok4bi3\", \"/var/tmp\", \"--ro-bind\", \"/var/lib/awx/venv/ansible\", \"/var/lib/awx/venv/ansible\", \"--ro-bind\", \"/var/lib/awx/venv/awx\", \"/var/lib/awx/venv/awx\", \"--bind\", \"/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm\", \"/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm\", \"--chdir\", \"/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/project\", \"ssh-agent\", \"sh\", \"-c\", \"ssh-add /tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/artifacts/153/ssh_key_data && rm -f /tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/artifacts/153/ssh_key_data && ansible-playbook -u excalibrax --ask-pass -i /tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/tmp93bq8ck1 -e @/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/env/extravars fail.yml\"]",
    "job_cwd": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/project",
    "job_env": {
      "ANSIBLE_CALLBACK_PLUGINS": "/var/lib/awx/venv/awx/lib64/python3.6/site-packages/ansible_runner/callbacks",
      "ANSIBLE_COLLECTIONS_PATHS": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
      "ANSIBLE_FORCE_COLOR": "True",
      "ANSIBLE_HOST_KEY_CHECKING": "False",
      "ANSIBLE_INVENTORY_UNPARSED_FAILED": "True",
      "ANSIBLE_PARAMIKO_RECORD_HOST_KEYS": "False",
      "ANSIBLE_RETRY_FILES_ENABLED": "False",
      "ANSIBLE_ROLES_PATH": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/requirements_roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles",
      "ANSIBLE_SSH_CONTROL_PATH_DIR": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/cp",
      "ANSIBLE_STDOUT_CALLBACK": "awx_display",
      "ANSIBLE_VENV_PATH": "/var/lib/awx/venv/ansible",
      "AWX_HOST": "https://10.42.42.212",
      "AWX_ISOLATED_DATA_DIR": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm/artifacts/153",
      "AWX_PRIVATE_DATA_DIR": "/tmp/bwrap_153_uqo3h55g/awx_153_rvlvv4nm",
      "DJANGO_LIVE_TEST_SERVER_ADDRESS": "localhost:9013-9199",
      "DJANGO_SETTINGS_MODULE": "awx.settings.production",
      "HOME": "/var/lib/awx",
      "INVENTORY_ID": "1",
      "INVOCATION_ID": "6dfbb88bc6484622a4f44ffbc1196b44",
      "JOB_ID": "153",
      "JOURNAL_STREAM": "9:24634",
      "LANG": "en_US.UTF-8",
      "MAX_EVENT_RES": "700000",
      "PATH": "/var/lib/awx/venv/ansible/bin:/var/lib/awx/venv/awx/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
      "PROJECT_REVISION": "debeb7bd98d23a5d69103f024280ac5f8927d58a",
      "PROOT_TMP_DIR": "/tmp",
      "PS1": "(awx) ",
      "PWD": "/var/lib/awx",
      "PYTHONPATH": "/var/lib/awx/venv/ansible/lib/python3.6/site-packages:",
      "RUNNER_OMIT_EVENTS": "False",
      "RUNNER_ONLY_FAILED_EVENTS": "False",
      "SHLVL": "0",
      "SUPERVISOR_ENABLED": "1",
      "SUPERVISOR_GROUP_NAME": "tower-processes",
      "SUPERVISOR_PROCESS_NAME": "awx-dispatcher",
      "SUPERVISOR_SERVER_URL": "unix:///var/run/supervisor/supervisor.sock",
      "TZ": "UTC",
      "USER": "awx",
      "VIRTUAL_ENV": "/var/lib/awx/venv/ansible"
    },
    "job_explanation": "",
    "job_slice_count": 1,
    "job_slice_number": 0,
    "job_tags": "",
    "job_template": 14,
    "job_type": "run",
    "launch_type": "workflow",
    "limit": "",
    "modified": "2021-06-10T15:24:48.953892Z",
    "name": "fail",
    "organization": 1,
    "passwords_needed_to_start": [
      
    ],
    "playbook": "fail.yml",
    "playbook_counts": {
      "play_count": 1,
      "task_count": 3
    },
    "project": 13,
    "related": {
      "activity_stream": "/api/v2/jobs/153/activity_stream/",
      "cancel": "/api/v2/jobs/153/cancel/",
      "create_schedule": "/api/v2/jobs/153/create_schedule/",
      "created_by": "/api/v2/users/1/",
      "credentials": "/api/v2/jobs/153/credentials/",
      "inventory": "/api/v2/inventories/1/",
      "job_events": "/api/v2/jobs/153/job_events/",
      "job_host_summaries": "/api/v2/jobs/153/job_host_summaries/",
      "job_template": "/api/v2/job_templates/14/",
      "labels": "/api/v2/jobs/153/labels/",
      "notifications": "/api/v2/jobs/153/notifications/",
      "organization": "/api/v2/organizations/1/",
      "project": "/api/v2/projects/13/",
      "relaunch": "/api/v2/jobs/153/relaunch/",
      "source_workflow_job": "/api/v2/workflow_jobs/152/",
      "stdout": "/api/v2/jobs/153/stdout/",
      "unified_job_template": "/api/v2/job_templates/14/"
    },
    "result_traceback": "",
    "scm_branch": "",
    "scm_revision": "debeb7bd98d23a5d69103f024280ac5f8927d58a",
    "skip_tags": "",
    "start_at_task": "",
    "started": "2021-06-10T15:24:49.055652Z",
    "status": "failed",
    "summary_fields": {
      "created_by": {
        "first_name": "",
        "id": 1,
        "last_name": "",
        "username": "admin"
      },
      "credentials": [
        {
          "cloud": false,
          "description": "",
          "id": 1,
          "kind": "ssh",
          "name": "Demo Credential"
        }
      ],
      "instance_group": {
        "id": 1,
        "is_containerized": false,
        "name": "tower"
      },
      "inventory": {
        "description": "",
        "has_active_failures": true,
        "has_inventory_sources": false,
        "hosts_with_active_failures": 1,
        "id": 1,
        "inventory_sources_with_failures": 0,
        "kind": "",
        "name": "Demo Inventory",
        "organization_id": 1,
        "total_groups": 0,
        "total_hosts": 1,
        "total_inventory_sources": 0
      },
      "job_template": {
        "description": "",
        "id": 14,
        "name": "fail"
      },
      "labels": {
        "count": 0,
        "results": [
          
        ]
      },
      "organization": {
        "description": "",
        "id": 1,
        "name": "Default"
      },
      "project": {
        "description": "",
        "id": 13,
        "name": "fail",
        "scm_type": "git",
        "status": "successful"
      },
      "source_workflow_job": {
        "description": "",
        "elapsed": 4.89,
        "failed": true,
        "id": 152,
        "name": "fail_workflow",
        "status": "failed"
      },
      "unified_job_template": {
        "description": "",
        "id": 14,
        "name": "fail",
        "unified_job_type": "job"
      },
      "user_capabilities": {
        "delete": true,
        "start": true
      }
    },
    "timeout": 0,
    "type": "job",
    "unified_job_template": 14,
    "url": "/api/v2/jobs/153/",
    "use_fact_cache": false,
    "verbosity": 0,
    "webhook_credential": null,
    "webhook_guid": "",
    "webhook_service": ""
  },
  "msg": "The Workflow Node - fail, failed",
  "started": "2021-06-10T15:24:49.055652Z",
  "status": "failed"
}
```
