### PR TITLE
Addresses bug where advanced search by groups wasn't working on host list

### DIFF
--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.jsx
@@ -40,6 +40,7 @@ function DataListToolbar({
   qsConfig,
   pagination,
   enableNegativeFiltering,
+  enableRelatedFuzzyFiltering,
 }) {
   const showExpandCollapse = onCompact && onExpand;
   const [isKebabOpen, setIsKebabOpen] = useState(false);
@@ -92,6 +93,7 @@ function DataListToolbar({
               onShowAdvancedSearch={onShowAdvancedSearch}
               onRemove={onRemove}
               enableNegativeFiltering={enableNegativeFiltering}
+              enableRelatedFuzzyFiltering={enableRelatedFuzzyFiltering}
             />
           </ToolbarItem>
           {sortColumns && (
@@ -173,6 +175,7 @@ DataListToolbar.propTypes = {
   onSort: PropTypes.func,
   additionalControls: PropTypes.arrayOf(PropTypes.node),
   enableNegativeFiltering: PropTypes.bool,
+  enableRelatedFuzzyFiltering: PropTypes.bool,
 };
 
 DataListToolbar.defaultProps = {
@@ -192,6 +195,7 @@ DataListToolbar.defaultProps = {
   onSort: null,
   additionalControls: [],
   enableNegativeFiltering: true,
+  enableRelatedFuzzyFiltering: true,
 };
 
 export default DataListToolbar;

--- a/awx/ui_next/src/components/Lookup/HostFilterLookup.jsx
+++ b/awx/ui_next/src/components/Lookup/HostFilterLookup.jsx
@@ -118,6 +118,7 @@ function HostFilterLookup({
   organizationId,
   value,
   enableNegativeFiltering,
+  enableRelatedFuzzyFiltering,
 }) {
   const history = useHistory();
   const location = useLocation();
@@ -347,6 +348,7 @@ function HostFilterLookup({
                 {...props}
                 fillWidth
                 enableNegativeFiltering={enableNegativeFiltering}
+                enableRelatedFuzzyFiltering={enableRelatedFuzzyFiltering}
               />
             )}
             toolbarSearchColumns={searchColumns}
@@ -381,6 +383,7 @@ HostFilterLookup.propTypes = {
   organizationId: number,
   value: string,
   enableNegativeFiltering: bool,
+  enableRelatedFuzzyFiltering: bool,
 };
 HostFilterLookup.defaultProps = {
   isValid: true,
@@ -389,6 +392,7 @@ HostFilterLookup.defaultProps = {
   organizationId: null,
   value: '',
   enableNegativeFiltering: true,
+  enableRelatedFuzzyFiltering: true,
 };
 
 export default withRouter(HostFilterLookup);

--- a/awx/ui_next/src/components/Lookup/shared/HostFilterUtils.jsx
+++ b/awx/ui_next/src/components/Lookup/shared/HostFilterUtils.jsx
@@ -7,9 +7,18 @@ export function toSearchParams(string = '') {
   if (string === '') {
     return {};
   }
-  return string
-    .replace(/^\?/, '')
-    .replace(/&/g, ' and ')
+
+  const readableParamsStr = string.replace(/^\?/, '').replace(/&/g, ' and ');
+  const orArr = readableParamsStr.split(/ or /);
+
+  if (orArr.length > 1) {
+    orArr.forEach((str, index) => {
+      orArr[index] = `or__${str}`;
+    });
+  }
+
+  return orArr
+    .join(' and ')
     .split(/ and | or /)
     .map(s => s.split('='))
     .reduce((searchParams, [k, v]) => {

--- a/awx/ui_next/src/components/Lookup/shared/HostFilterUtils.test.jsx
+++ b/awx/ui_next/src/components/Lookup/shared/HostFilterUtils.test.jsx
@@ -33,6 +33,20 @@ describe('toSearchParams', () => {
     };
     expect(toSearchParams(string)).toEqual(paramsObject);
   });
+  test('should take a host filter string separated by or and return search params object with or', () => {
+    string = 'foo=bar or foo=baz';
+    paramsObject = {
+      or__foo: ['bar', 'baz'],
+    };
+    expect(toSearchParams(string)).toEqual(paramsObject);
+  });
+  test('should take a host filter string with or and return search params object with or', () => {
+    string = 'or__foo=1&or__foo=2';
+    paramsObject = {
+      or__foo: ['1', '2'],
+    };
+    expect(toSearchParams(string)).toEqual(paramsObject);
+  });
 });
 
 describe('toQueryString', () => {
@@ -107,6 +121,13 @@ describe('toHostFilter', () => {
     expect(toHostFilter(object)).toEqual(
       'name=foo or name__contains=bar or name__iexact=foo'
     );
+  });
+
+  test('should return a host filter with or conditional when value is array', () => {
+    const object = {
+      or__groups__id: ['1', '2'],
+    };
+    expect(toHostFilter(object)).toEqual('groups__id=1 or groups__id=2');
   });
 });
 

--- a/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
+++ b/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
@@ -209,6 +209,29 @@ describe('<AdvancedSearch />', () => {
         .prop('onKeyDown')({ key: 'Enter', preventDefault: jest.fn });
     });
     wrapper.update();
+    expect(advancedSearchMock).toBeCalledWith('baz__name__icontains', 'bar');
+    jest.clearAllMocks();
+    act(() => {
+      wrapper.find('Select[aria-label="Key select"]').invoke('onCreateOption')(
+        'baz'
+      );
+    });
+    wrapper.update();
+    act(() => {
+      wrapper
+        .find('Select[aria-label="Related search type"]')
+        .invoke('onSelect')({}, 'search');
+      wrapper
+        .find('TextInputBase[aria-label="Advanced search value input"]')
+        .invoke('onChange')('bar');
+    });
+    wrapper.update();
+    act(() => {
+      wrapper
+        .find('TextInputBase[aria-label="Advanced search value input"]')
+        .prop('onKeyDown')({ key: 'Enter', preventDefault: jest.fn });
+    });
+    wrapper.update();
     expect(advancedSearchMock).toBeCalledWith('baz__search', 'bar');
   });
 
@@ -217,7 +240,7 @@ describe('<AdvancedSearch />', () => {
     wrapper = mountWithContexts(
       <AdvancedSearch
         onSearch={advancedSearchMock}
-        searchableKeys={[]}
+        searchableKeys={['foo']}
         relatedSearchableKeys={[]}
       />
     );
@@ -230,6 +253,9 @@ describe('<AdvancedSearch />', () => {
         {},
         'foo'
       );
+    });
+    wrapper.update();
+    act(() => {
       wrapper.find('Select[aria-label="Lookup select"]').invoke('onSelect')(
         {},
         'exact'
@@ -253,7 +279,7 @@ describe('<AdvancedSearch />', () => {
     wrapper = mountWithContexts(
       <AdvancedSearch
         onSearch={advancedSearchMock}
-        searchableKeys={[]}
+        searchableKeys={['foo']}
         relatedSearchableKeys={[]}
       />
     );
@@ -265,6 +291,9 @@ describe('<AdvancedSearch />', () => {
       wrapper.find('Select[aria-label="Key select"]').invoke('onCreateOption')(
         'foo'
       );
+    });
+    wrapper.update();
+    act(() => {
       wrapper.find('Select[aria-label="Lookup select"]').invoke('onSelect')(
         {},
         'exact'
@@ -305,6 +334,9 @@ describe('<AdvancedSearch />', () => {
       wrapper.find('Select[aria-label="Key select"]').invoke('onCreateOption')(
         'foo'
       );
+    });
+    wrapper.update();
+    act(() => {
       wrapper.find('Select[aria-label="Lookup select"]').invoke('onSelect')(
         {},
         'exact'
@@ -362,5 +394,35 @@ describe('<AdvancedSearch />', () => {
     expect(
       selectOptions.find('SelectOption[id="and-option-select"]').prop('value')
     ).toBe('and');
+  });
+
+  test('Remove search option from related search type', () => {
+    wrapper = mountWithContexts(
+      <AdvancedSearch
+        onSearch={jest.fn}
+        searchableKeys={['foo', 'bar']}
+        relatedSearchableKeys={['bar', 'baz']}
+        enableRelatedFuzzyFiltering={false}
+      />
+    );
+    act(() => {
+      wrapper.find('Select[aria-label="Key select"]').invoke('onCreateOption')(
+        'baz'
+      );
+    });
+    wrapper.update();
+    wrapper
+      .find('Select[aria-label="Related search type"] SelectToggle')
+      .simulate('click');
+    const selectOptions = wrapper.find(
+      'Select[aria-label="Related search type"] SelectOption'
+    );
+    expect(selectOptions).toHaveLength(2);
+    expect(
+      selectOptions.find('SelectOption[id="name-option-select"]').prop('value')
+    ).toBe('name__icontains');
+    expect(
+      selectOptions.find('SelectOption[id="id-option-select"]').prop('value')
+    ).toBe('id');
   });
 });

--- a/awx/ui_next/src/components/Search/Search.jsx
+++ b/awx/ui_next/src/components/Search/Search.jsx
@@ -43,6 +43,7 @@ function Search({
   isDisabled,
   maxSelectHeight,
   enableNegativeFiltering,
+  enableRelatedFuzzyFiltering,
 }) {
   const [isSearchDropdownOpen, setIsSearchDropdownOpen] = useState(false);
   const [searchKey, setSearchKey] = useState(
@@ -207,6 +208,7 @@ function Search({
               relatedSearchableKeys={relatedSearchableKeys}
               maxSelectHeight={maxSelectHeight}
               enableNegativeFiltering={enableNegativeFiltering}
+              enableRelatedFuzzyFiltering={enableRelatedFuzzyFiltering}
             />
           )) ||
             (options && (
@@ -327,6 +329,7 @@ Search.propTypes = {
   isDisabled: PropTypes.bool,
   maxSelectHeight: PropTypes.string,
   enableNegativeFiltering: PropTypes.bool,
+  enableRelatedFuzzyFiltering: PropTypes.bool,
 };
 
 Search.defaultProps = {
@@ -335,6 +338,7 @@ Search.defaultProps = {
   isDisabled: false,
   maxSelectHeight: '300px',
   enableNegativeFiltering: true,
+  enableRelatedFuzzyFiltering: true,
 };
 
 export default withRouter(Search);

--- a/awx/ui_next/src/screens/Host/HostList/HostList.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostList.jsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
-
 import { t } from '@lingui/macro';
 import { Card, PageSection } from '@patternfly/react-core';
-
 import { HostsAPI } from '../../../api';
 import AlertModal from '../../../components/AlertModal';
 import DataListToolbar from '../../../components/DataListToolbar';
@@ -46,8 +44,15 @@ function HostList() {
     }
   });
 
-  const hasNonDefaultSearchParams =
-    Object.keys(nonDefaultSearchParams).length > 0;
+  const hasInvalidHostFilterKeys = () => {
+    const nonDefaultSearchKeys = Object.keys(nonDefaultSearchParams);
+    return (
+      nonDefaultSearchKeys.filter(searchKey => searchKey.startsWith('not__'))
+        .length > 0 ||
+      nonDefaultSearchKeys.filter(searchKey => searchKey.endsWith('__search'))
+        .length > 0
+    );
+  };
 
   const {
     result: { hosts, count, actions, relatedSearchableKeys, searchableKeys },
@@ -185,7 +190,11 @@ function HostList() {
                 ...(canAdd
                   ? [
                       <SmartInventoryButton
-                        isDisabled={!hasNonDefaultSearchParams}
+                        hasInvalidKeys={hasInvalidHostFilterKeys()}
+                        isDisabled={
+                          Object.keys(nonDefaultSearchParams).length === 0 ||
+                          hasInvalidHostFilterKeys()
+                        }
                         onClick={() => handleSmartInventoryClick()}
                       />,
                     ]

--- a/awx/ui_next/src/screens/Host/HostList/SmartInventoryButton.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/SmartInventoryButton.jsx
@@ -1,52 +1,69 @@
 import React from 'react';
-import { func } from 'prop-types';
+import { bool, func } from 'prop-types';
 import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
-
 import { t } from '@lingui/macro';
 import { useKebabifiedMenu } from '../../../contexts/Kebabified';
 
-function SmartInventoryButton({ onClick, isDisabled }) {
+function SmartInventoryButton({ onClick, isDisabled, hasInvalidKeys }) {
   const { isKebabified } = useKebabifiedMenu();
 
-  if (isKebabified) {
+  const renderTooltipContent = () => {
+    if (hasInvalidKeys) {
+      return t`Some search modifiers like not__ and __search are not supported in Smart Inventory host filters.  Remove these to create a new Smart Inventory with this filter.`;
+    }
+    if (isDisabled) {
+      return t`Enter at least one search filter to create a new Smart Inventory`;
+    }
+
+    return t`Create a new Smart Inventory with the applied filter`;
+  };
+
+  const renderContent = () => {
+    if (isKebabified) {
+      return (
+        <DropdownItem
+          key="add"
+          isDisabled={isDisabled}
+          component="button"
+          onClick={onClick}
+        >
+          {t`Smart Inventory`}
+        </DropdownItem>
+      );
+    }
+
     return (
-      <DropdownItem
-        key="add"
-        isDisabled={isDisabled}
-        component="button"
+      <Button
+        ouiaId="smart-inventory-button"
         onClick={onClick}
+        aria-label={t`Smart Inventory`}
+        variant="secondary"
+        isDisabled={isDisabled}
       >
         {t`Smart Inventory`}
-      </DropdownItem>
+      </Button>
     );
-  }
+  };
 
   return (
     <Tooltip
       key="smartInventory"
-      content={
-        !isDisabled
-          ? t`Create a new Smart Inventory with the applied filter`
-          : t`Enter at least one search filter to create a new Smart Inventory`
-      }
+      content={renderTooltipContent()}
       position="top"
     >
-      <div>
-        <Button
-          ouiaId="smart-inventory-button"
-          onClick={onClick}
-          aria-label={t`Smart Inventory`}
-          variant="secondary"
-          isDisabled={isDisabled}
-        >
-          {t`Smart Inventory`}
-        </Button>
-      </div>
+      <div>{renderContent()}</div>
     </Tooltip>
   );
 }
 SmartInventoryButton.propTypes = {
+  hasInvalidKeys: bool,
+  isDisabled: bool,
   onClick: func.isRequired,
+};
+
+SmartInventoryButton.defaultProps = {
+  hasInvalidKeys: false,
+  isDisabled: false,
 };
 
 export default SmartInventoryButton;

--- a/awx/ui_next/src/screens/Inventory/shared/SmartInventoryForm.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/SmartInventoryForm.jsx
@@ -82,6 +82,7 @@ const SmartInventoryFormFields = ({ inventory }) => {
         isValid={!hostFilterMeta.touched || !hostFilterMeta.error}
         isDisabled={!organizationField.value}
         enableNegativeFiltering={false}
+        enableRelatedFuzzyFiltering={false}
       />
       <InstanceGroupsLookup
         value={instanceGroupsField.value}


### PR DESCRIPTION
##### SUMMARY
link #10400 

OK so this got a bit more complicated than I wanted it to but I think on the whole this is a nice improvement.  In the initial bug report it was noted that we were ignoring the `or`/`not` operators when searching on a related key (in this case it was groups).  We were also ignoring the modifier at the end (icontains, exact, startswith, etc).  Since we were always defaulting to `__search` for these types of keys this was actually valid.  The API doesn't like us attempting to do something like `?or__groups__search=foo` or `?groups__search__icontains` because they aren't valid.  So, I changed the UX a little bit.  A user can still do a fuzzy search on a related key but the prefix is disabled in this case:

<img width="1377" alt="Screen Shot 2021-06-10 at 2 10 02 PM" src="https://user-images.githubusercontent.com/9889020/121575598-917d2380-c9f5-11eb-8d21-33b2cdaaeff8.png">

I changed the third dropdown (specifically for related keys) to contain the following options: `search`, `id`, `name__icontains` which I think would be the three most general cases.  `id` and `name__icontains` do allow for prefixing (`or`, `not`, `and`).

This should make searching on related keys a little bit easier and a little bit more flexible since name and id weren't possible in the UI before.

Once place where this is a little different is the host filter in the smart inventory form.  Using `__search` currently throws an error when the user attempts to save.  I believe this is an API bug and will file it as such but for now I prevent users from attempting to use `__search` by removing it as an option for this particular list.  When this bug gets fixed in the API we can remove this logic.

I also noticed that there was a bug where `or__` search terms were being converted to `and` when using the Smart Inventory button on the host list so I fixed that.

Here's the fix in action:

![host_search](https://user-images.githubusercontent.com/9889020/121576509-7363f300-c9f6-11eb-90ad-e0facf77d235.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
