### PR TITLE
Fixes bug where source list page would crash if first sync was running

### DIFF
--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
@@ -25,7 +25,7 @@ import InventorySourceListItem from './InventorySourceListItem';
 import useWsInventorySources from './useWsInventorySources';
 import { relatedResourceDeleteRequests } from '../../../util/getRelatedResourceDeleteDetails';
 
-const QS_CONFIG = getQSConfig('inventory_sources', {
+const QS_CONFIG = getQSConfig('inventory-sources', {
   page: 1,
   page_size: 20,
   order_by: 'name',

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.jsx
@@ -25,8 +25,7 @@ import InventorySourceListItem from './InventorySourceListItem';
 import useWsInventorySources from './useWsInventorySources';
 import { relatedResourceDeleteRequests } from '../../../util/getRelatedResourceDeleteDetails';
 
-const QS_CONFIG = getQSConfig('inventory', {
-  not__source: '',
+const QS_CONFIG = getQSConfig('inventory_sources', {
   page: 1,
   page_size: 20,
   order_by: 'name',

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceList.test.jsx
@@ -115,7 +115,6 @@ describe('<InventorySourceList />', () => {
 
   test('api calls should be made on mount', async () => {
     expect(InventoriesAPI.readSources).toHaveBeenCalledWith('1', {
-      not__source: '',
       order_by: 'name',
       page: 1,
       page_size: 20,

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.jsx
@@ -94,16 +94,18 @@ function InventorySourceListItem({
         <ActionsTd dataLabel={t`Actions`}>
           {['running', 'pending', 'waiting'].includes(source?.status) ? (
             <ActionItem visible={source.summary_fields.user_capabilities.start}>
-              <JobCancelButton
-                job={{
-                  type: 'inventory_update',
-                  id: source.summary_fields.last_job.id,
-                }}
-                errorTitle={t`Inventory Source Sync Error`}
-                errorMessage={t`Failed to cancel Inventory Source Sync`}
-                title={t`Cancel Inventory Source Sync`}
-                showIconButton
-              />
+              {source.summary_fields?.current_job?.id && (
+                <JobCancelButton
+                  job={{
+                    type: 'inventory_update',
+                    id: source.summary_fields.current_job.id,
+                  }}
+                  errorTitle={t`Inventory Source Sync Error`}
+                  errorMessage={t`Failed to cancel Inventory Source Sync`}
+                  title={t`Cancel Inventory Source Sync`}
+                  showIconButton
+                />
+              )}
             </ActionItem>
           ) : (
             <ActionItem

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.test.jsx
@@ -198,4 +198,33 @@ describe('<InventorySourceListItem />', () => {
       'Custom virtual environment /var/lib/awx/env must be replaced by an execution environment.'
     );
   });
+
+  test('should render cancel button while job is running', () => {
+    const onSelect = jest.fn();
+    wrapper = mountWithContexts(
+      <table>
+        <tbody>
+          <InventorySourceListItem
+            source={{
+              ...source,
+              status: 'running',
+              summary_fields: {
+                ...source.summary_fields,
+                current_job: {
+                  id: 1000,
+                  status: 'running',
+                },
+              },
+              custom_virtualenv: '/var/lib/awx/env',
+              execution_environment: null,
+            }}
+            isSelected={false}
+            onSelect={onSelect}
+            label="Source Bar"
+          />
+        </tbody>
+      </table>
+    );
+    expect(wrapper.find('JobCancelButton').length).toBe(1);
+  });
 });


### PR DESCRIPTION
##### SUMMARY
link #10411 

The ID being passed to the cancel button was incorrect as well.  We want to reference `current_job` not `last_job`.

![inv_src_sync](https://user-images.githubusercontent.com/9889020/121583099-d73dea00-c9fd-11eb-9f94-e0c292aa53f7.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
