### PR TITLE
Make quay.io the registry URL default

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1118,6 +1118,7 @@ ManagedCredentialType(
                 'label': ugettext_noop('Authentication URL'),
                 'type': 'string',
                 'help_text': ugettext_noop('Authentication endpoint for the container registry.'),
+                'default': 'quay.io',
             },
             {
                 'id': 'username',


### PR DESCRIPTION
##### SUMMARY
It's unclear what format the registry "Authentication URL" should be.

![Screenshot from 2021-06-11 09-55-45](https://user-images.githubusercontent.com/1385596/121697785-63eab580-ca9b-11eb-8e59-9d006dcb898b.png)

It's too late to change the strings because of translations, ping @rooftopcellist, but this change would clarify the format without adding wording.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Seems to behave pretty good in the UI.
