### PR TITLE
Make sure that the resolved EE gets attached to new workflow jobs

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -525,7 +525,12 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
         )
 
     def create_unified_job(self, **kwargs):
+        from awx.main.signals import disable_activity_stream
+
         workflow_job = super(WorkflowJobTemplate, self).create_unified_job(**kwargs)
+        with disable_activity_stream():
+            workflow_job.execution_environment = workflow_job.resolve_execution_environment()
+            workflow_job.save()
         workflow_job.copy_nodes_from_original(original=self)
         return workflow_job
 


### PR DESCRIPTION
##### SUMMARY
Make sure that the resolved EE gets attached to new workflow jobs.  This is solely for future reference and UI consistency, since workflows are not actually executed in EE images.

related #10399 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
