### PR TITLE
Execution environments are meaningless for workflows

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -471,13 +471,6 @@ class ExecutionEnvironmentMixin(models.Model):
         template = getattr(self, 'unified_job_template', None)
         if template is not None and template.execution_environment is not None:
             return template.execution_environment
-        wf_node = getattr(self, 'unified_job_node', None)
-        while wf_node is not None:
-            wf_template = wf_node.workflow_job.workflow_job_template
-            # NOTE: sliced workflow_jobs have a null workflow_job_template
-            if wf_template and wf_template.execution_environment is not None:
-                return wf_template.execution_environment
-            wf_node = getattr(wf_node.workflow_job, 'unified_job_node', None)
         if getattr(self, 'project_id', None) and self.project.default_environment is not None:
             return self.project.default_environment
         if getattr(self, 'organization_id', None) and self.organization.default_environment is not None:

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -595,6 +595,9 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
     def _get_related_jobs(self):
         return WorkflowJob.objects.filter(workflow_job_template=self)
 
+    def resolve_execution_environment(self):
+        return None  # EEs are not meaningful for workflows
+
 
 class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificationMixin, WebhookMixin):
     class Meta:

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -47,10 +47,6 @@ options:
       description:
         - Variables which will be made available to jobs ran inside the workflow.
       type: dict
-    execution_environment:
-      description:
-        - Execution Environment to use for the WFJT.
-      type: str
     organization:
       description:
         - Organization the workflow job template exists in.
@@ -666,7 +662,6 @@ def main():
         description=dict(),
         extra_vars=dict(type='dict'),
         organization=dict(),
-        execution_environment=dict(),
         survey_spec=dict(type='dict', aliases=['survey']),
         survey_enabled=dict(type='bool'),
         allow_simultaneous=dict(type='bool'),
@@ -712,10 +707,6 @@ def main():
     if organization:
         organization_id = module.resolve_name_to_id('organizations', organization)
         search_fields['organization'] = new_fields['organization'] = organization_id
-
-    ee = module.params.get('execution_environment')
-    if ee:
-        new_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
 
     # Attempt to look up an existing item based on the provided data
     existing_item = module.get_one('workflow_job_templates', name_or_id=name, **{'data': search_fields})


### PR DESCRIPTION
##### SUMMARY

Execution environments are meaningless for workflows, so, remove them from the API endpoints for workflows.  Also, tear out
the WFJT.execution_environment step in the resolver.  If we want that to be a thing, it ought to be a .default_environment instead.

related #10399

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
