### PR TITLE
MAX_PAGE_SIZE should be cast to int

### DIFF
--- a/awx/api/pagination.py
+++ b/awx/api/pagination.py
@@ -26,7 +26,7 @@ class DisabledPaginator(DjangoPaginator):
 class Pagination(pagination.PageNumberPagination):
 
     page_size_query_param = 'page_size'
-    max_page_size = settings.MAX_PAGE_SIZE
+    max_page_size = int(settings.MAX_PAGE_SIZE)
     count_disabled = False
 
     def get_next_link(self):
@@ -75,7 +75,7 @@ class LimitPagination(pagination.BasePagination):
     default_limit = api_settings.PAGE_SIZE
     limit_query_param = 'limit'
     limit_query_description = _('Number of results to return per page.')
-    max_page_size = settings.MAX_PAGE_SIZE
+    max_page_size = int(settings.MAX_PAGE_SIZE)
 
     def paginate_queryset(self, queryset, request, view=None):
         self.limit = self.get_limit(request)


### PR DESCRIPTION
##### SUMMARY

@tchellomello noticed this 500 error when setting the `MAX_PAGE_SIZE` variable.  It just needs to be cast to an int.  

```[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web] 2021-06-15 19:40:19,879 ERROR    [ec0cb56586aa4cb7903e1fa0eaf2d28c] django.request Internal Server Error: /api/v2/credentials/ 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web] Traceback (most recent call last): 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     response = get_response(request) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     response = self.process_exception_by_middleware(e, request) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     response = wrapped_callback(request, *callback_args, **callback_kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/usr/lib64/python3.8/contextlib.py", line 75, in inner 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return func(*args, **kwds) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return view_func(*args, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/views/generic/base.py", line 71, in view 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return self.dispatch(request, *args, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/api/generics.py", line 324, in dispatch 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return super(APIView, self).dispatch(request, *args, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     response = self.handle_exception(exc) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     self.raise_uncaught_exception(exc) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     raise exc 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     response = handler(request, *args, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/generics.py", line 199, in get 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return self.list(request, *args, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/mixins.py", line 40, in list 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     page = self.paginate_queryset(queryset) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/generics.py", line 171, in paginate_queryset 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return self.paginator.paginate_queryset(queryset, self.request, view=self) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/api/pagination.py", line 60, in paginate_queryset 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return super(Pagination, self).paginate_queryset(queryset, request, **kwargs) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/pagination.py", line 196, in paginate_queryset 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     page_size = self.get_page_size(request) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/pagination.py", line 257, in get_page_size 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return _positive_int( 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]   File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/rest_framework/pagination.py", line 30, in _positive_int 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web]     return min(ret, cutoff) 
[awx-ssl-ca-78c4878d75-js8mq awx-ssl-ca-web] TypeError: '<' not supported between instances of 'str' and 'int' 
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.0
```
