### PR TITLE
Update Dockerfile.j2

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -153,7 +153,7 @@ RUN dnf --enablerepo=debuginfo -y install python3-debuginfo || :
 
 {% if build_dev|bool %}
 RUN dnf install -y podman
-RUN echo -e 'cgroup_manager = "cgroupfs"\nevents_logger = "file"' > /etc/containers/libpod.conf
+RUN echo -e '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"' > /etc/containers/containers.conf
 {% endif %}
 
 # Ensure we must use fully qualified image names


### PR DESCRIPTION
##### SUMMARY

Jobs unable to start because podman trying to use systemd cgroup manager. See error below :

```
WARN[0000] Failed to add conmon to systemd sandbox cgroup: dial unix /run/systemd/private: connect: no such file or directory
Error: OCI runtime error: systemd cgroup flag passed, but systemd support for managing cgroups is not available
```

related #10099 

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION

```
awx: 19.0.0
```


##### ADDITIONAL INFORMATION

* According to this PR https://github.com/containers/podman/pull/7009, podman switch references from libpod.conf to containers.conf.
* According to containers.conf man (https://github.com/containers/common/blob/main/docs/containers.conf.5.md), configuration file is a TOML file but engine section declaration is missing.

thanks to @Siorde too :+1: 