### PR TITLE
Expand sos report plugin compatibility

### DIFF
--- a/tools/sosreport/tower.py
+++ b/tools/sosreport/tower.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2016 Ansible, Inc.
 # All Rights Reserved.
 
-from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+try:
+    from sos.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+except ImportError:
+    from sos.report.plugins import Plugin, RedHatPlugin, UbuntuPlugin
+
 
 SOSREPORT_TOWER_COMMANDS = [
     "awx-manage --version", # tower version


### PR DESCRIPTION
sos 4 now uses sos.report.plugin when sos 3 was using sos.plugins. This
change allows compatibility with both.