### PR TITLE
Renders Command Module in job detail view and improves Ad Hoc Commands execution permissions

### DIFF
--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.js
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.js
@@ -47,21 +47,6 @@ describe('<AdHocCommands />', () => {
         BRAND_NAME: 'AWX',
       },
     });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {
-            module_name: {
-              choices: [
-                ['command', 'command'],
-                ['shell', 'shell'],
-              ],
-            },
-          },
-          POST: {},
-        },
-      },
-    });
     CredentialTypesAPI.read.mockResolvedValue({
       data: { count: 1, results: [{ id: 1, name: 'cred' }] },
     });
@@ -95,21 +80,6 @@ describe('<AdHocCommands />', () => {
   });
 
   test('should open the wizard', async () => {
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {
-            module_name: {
-              choices: [
-                ['command', 'command'],
-                ['foo', 'foo'],
-              ],
-            },
-            verbosity: { choices: [[1], [2]] },
-          },
-        },
-      },
-    });
     InventoriesAPI.readDetail.mockResolvedValue({ data: { organization: 1 } });
     CredentialTypesAPI.read.mockResolvedValue({
       data: { results: [{ id: 1 }] },
@@ -126,12 +96,21 @@ describe('<AdHocCommands />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <AdHocCommands
+          moduleOptions={[
+            ['command', 'command'],
+            ['foo', 'foo'],
+          ]}
           adHocItems={adHocItems}
           hasListItems
           onLaunchLoading={() => jest.fn()}
         />
       );
     });
+    await waitForElement(
+      wrapper,
+      'button[aria-label="Run Command"]',
+      el => el.length === 1
+    );
     await act(async () =>
       wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
     );
@@ -167,18 +146,26 @@ describe('<AdHocCommands />', () => {
       },
     });
     ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
-      data: { actions: { GET: {} } },
+      data: { actions: { GET: {}, POST: {} } },
     });
     await act(async () => {
       wrapper = mountWithContexts(
         <AdHocCommands
           adHocItems={adHocItems}
           hasListItems
+          moduleOptions={[
+            ['command', 'command'],
+            ['foo', 'foo'],
+          ]}
           onLaunchLoading={() => jest.fn()}
         />
       );
     });
-
+    await waitForElement(
+      wrapper,
+      'button[aria-label="Run Command"]',
+      el => el.length === 1
+    );
     await act(async () =>
       wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
     );
@@ -279,23 +266,6 @@ describe('<AdHocCommands />', () => {
         },
       })
     );
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {
-            module_name: {
-              choices: [
-                ['command', 'command'],
-                ['foo', 'foo'],
-              ],
-            },
-            verbosity: {
-              choices: [[1], [2]],
-            },
-          },
-        },
-      },
-    });
     InventoriesAPI.readDetail.mockResolvedValue({
       data: { organization: 1 },
     });
@@ -336,18 +306,26 @@ describe('<AdHocCommands />', () => {
       },
     });
     ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
-      data: { actions: { GET: {} } },
+      data: { actions: { GET: {}, POST: {} } },
     });
     await act(async () => {
       wrapper = mountWithContexts(
         <AdHocCommands
           adHocItems={adHocItems}
+          moduleOptions={[
+            ['command', 'command'],
+            ['foo', 'foo'],
+          ]}
           hasListItems
           onLaunchLoading={() => jest.fn()}
         />
       );
     });
-
+    await waitForElement(
+      wrapper,
+      'button[aria-label="Run Command"]',
+      el => el.length === 1
+    );
     await act(async () =>
       wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
     );
@@ -427,45 +405,18 @@ describe('<AdHocCommands />', () => {
     await waitForElement(wrapper, 'ErrorDetail', el => el.length > 0);
   });
 
-  test('should disable run command button due to permissions', async () => {
-    InventoriesAPI.readHosts.mockResolvedValue({
-      data: { results: [], count: 0 },
-    });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-        },
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          adHocItems={adHocItems}
-          hasListItems
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
-    const runCommandsButton = wrapper.find('button[aria-label="Run Command"]');
-    expect(runCommandsButton.prop('disabled')).toBe(true);
-  });
-
   test('should disable run command button due to lack of list items', async () => {
     InventoriesAPI.readHosts.mockResolvedValue({
       data: { results: [], count: 0 },
     });
-    InventoriesAPI.readAdHocOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: { module_name: { choices: [['module']] } },
-        },
-      },
-    });
+
     await act(async () => {
       wrapper = mountWithContexts(
         <AdHocCommands
+          moduleOptions={[
+            ['command', 'command'],
+            ['foo', 'foo'],
+          ]}
           adHocItems={adHocItems}
           hasListItems={false}
           onLaunchLoading={() => jest.fn()}
@@ -478,7 +429,7 @@ describe('<AdHocCommands />', () => {
   });
 
   test('should open alert modal when error on fetching data', async () => {
-    InventoriesAPI.readAdHocOptions.mockRejectedValue(
+    InventoriesAPI.readDetail.mockRejectedValue(
       new Error({
         response: {
           config: {
@@ -493,6 +444,10 @@ describe('<AdHocCommands />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <AdHocCommands
+          moduleOptions={[
+            ['command', 'command'],
+            ['foo', 'foo'],
+          ]}
           adHocItems={adHocItems}
           hasListItems
           onLaunchLoading={() => jest.fn()}

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.js
@@ -35,6 +35,21 @@ describe('<InventoryGroupHostList />', () => {
         },
       },
     });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(<InventoryGroupHostList />);
     });
@@ -52,6 +67,7 @@ describe('<InventoryGroupHostList />', () => {
   test('should fetch inventory group hosts from api and render them in the list', () => {
     expect(GroupsAPI.readAllHosts).toHaveBeenCalled();
     expect(InventoriesAPI.readHostsOptions).toHaveBeenCalled();
+    expect(InventoriesAPI.readAdHocOptions).toHaveBeenCalled();
     expect(wrapper.find('InventoryGroupHostListItem').length).toBe(3);
   });
 
@@ -95,7 +111,7 @@ describe('<InventoryGroupHostList />', () => {
     });
   });
 
-  test('should show add dropdown button according to permissions', async () => {
+  test('should show add dropdown button and Run Commands according to permissions', async () => {
     expect(wrapper.find('AddDropDownButton').length).toBe(1);
     InventoriesAPI.readHostsOptions.mockResolvedValueOnce({
       data: {
@@ -109,6 +125,7 @@ describe('<InventoryGroupHostList />', () => {
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('AddDropDownButton').length).toBe(0);
+    expect(wrapper.find('AdHocCommands').length).toBe(1);
   });
 
   test('expected api calls are made for multi-delete', async () => {
@@ -270,5 +287,25 @@ describe('<InventoryGroupHostList />', () => {
       wrapper = mountWithContexts(<InventoryGroupHostList />);
     });
     await waitForElement(wrapper, 'ContentError', el => el.length === 1);
+  });
+  test('should not render ad hoc commands button', async () => {
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+        },
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryGroupHostList />);
+    });
+    expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.js
@@ -76,6 +76,21 @@ describe('<InventoryGroupsList />', () => {
         },
       },
     });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
     const history = createMemoryHistory({
       initialEntries: ['/inventories/inventory/3/groups'],
     });
@@ -86,7 +101,12 @@ describe('<InventoryGroupsList />', () => {
         </Route>,
         {
           context: {
-            router: { history, route: { location: history.location } },
+            router: {
+              history,
+              route: {
+                location: history.location,
+              },
+            },
           },
         }
       );
@@ -101,6 +121,10 @@ describe('<InventoryGroupsList />', () => {
   test('should fetch groups from api and render them in the list', async () => {
     expect(InventoriesAPI.readGroups).toHaveBeenCalled();
     expect(wrapper.find('InventoryGroupItem').length).toBe(3);
+  });
+
+  test('should render Run Commands button', async () => {
+    expect(wrapper.find('AdHocCommands')).toHaveLength(1);
   });
 
   test('should check and uncheck the row item', async () => {
@@ -165,6 +189,27 @@ describe('<InventoryGroupsList />', () => {
       expect(el.find('input').props().checked).toBe(false);
     });
   });
+
+  test('should not render ad hoc commands button', async () => {
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+        },
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryGroupsList />);
+    });
+    expect(wrapper.find('AdHocCommands')).toHaveLength(0);
+  });
 });
 
 describe('<InventoryGroupsList/> error handling', () => {
@@ -181,6 +226,21 @@ describe('<InventoryGroupsList/> error handling', () => {
       data: {
         actions: {
           GET: {},
+          POST: {},
+        },
+      },
+    });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
           POST: {},
         },
       },

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
@@ -41,6 +41,8 @@ function InventoryHostGroupsList() {
       actions,
       relatedSearchableKeys,
       searchableKeys,
+      moduleOptions,
+      isAdHocDisabled,
     },
     error: contentError,
     isLoading,
@@ -54,12 +56,16 @@ function InventoryHostGroupsList() {
           data: { count, results },
         },
         hostGroupOptions,
+        adHocOptions,
       ] = await Promise.all([
         HostsAPI.readAllGroups(hostId, params),
         HostsAPI.readGroupsOptions(hostId),
+        InventoriesAPI.readAdHocOptions(invId),
       ]);
 
       return {
+        moduleOptions: adHocOptions.data.actions.GET.module_name.choices,
+        isAdHocDisabled: !adHocOptions.data.actions.POST,
         groups: results,
         itemCount: count,
         actions: hostGroupOptions.data.actions,
@@ -77,6 +83,8 @@ function InventoryHostGroupsList() {
       actions: {},
       relatedSearchableKeys: [],
       searchableKeys: [],
+      moduleOptions: [],
+      isAdHocDisabled: true,
     }
   );
 
@@ -209,11 +217,16 @@ function InventoryHostGroupsList() {
                     />,
                   ]
                 : []),
-              <AdHocCommands
-                adHocItems={selected}
-                hasListItems={itemCount > 0}
-                onLaunchLoading={setIsAdHocLaunchLoading}
-              />,
+              ...(!isAdHocDisabled
+                ? [
+                    <AdHocCommands
+                      adHocItems={selected}
+                      hasListItems={itemCount > 0}
+                      moduleOptions={moduleOptions}
+                      onLaunchLoading={setIsAdHocLaunchLoading}
+                    />,
+                  ]
+                : []),
               <DisassociateButton
                 key="disassociate"
                 onDisassociate={handleDisassociate}

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.js
@@ -80,6 +80,21 @@ describe('<InventoryHostGroupsList />', () => {
         },
       },
     });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
     const history = createMemoryHistory({
       initialEntries: ['/inventories/inventory/1/hosts/3/groups'],
     });
@@ -109,6 +124,10 @@ describe('<InventoryHostGroupsList />', () => {
   test('should fetch groups from api and render them in the list', async () => {
     expect(HostsAPI.readAllGroups).toHaveBeenCalled();
     expect(wrapper.find('InventoryHostGroupItem').length).toBe(3);
+  });
+
+  test('should render Run Commands button', async () => {
+    expect(wrapper.find('AdHocCommands')).toHaveLength(1);
   });
 
   test('should check and uncheck the row item', async () => {
@@ -172,6 +191,27 @@ describe('<InventoryHostGroupsList />', () => {
     wrapper.find('.pf-c-table__check input').forEach(el => {
       expect(el.props().checked).toBe(false);
     });
+  });
+
+  test('should not render Run Commands button', async () => {
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+        },
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryHostGroupsList />);
+    });
+    expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 
   test('should show content error when api throws error on initial render', async () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.js
@@ -35,6 +35,8 @@ function InventoryHostList() {
       actions,
       relatedSearchableKeys,
       searchableKeys,
+      moduleOptions,
+      isAdHocDisabled,
     },
     error: contentError,
     isLoading,
@@ -42,12 +44,15 @@ function InventoryHostList() {
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, search);
-      const [response, hostOptions] = await Promise.all([
+      const [response, hostOptions, adHocOptions] = await Promise.all([
         InventoriesAPI.readHosts(id, params),
         InventoriesAPI.readHostsOptions(id),
+        InventoriesAPI.readAdHocOptions(id),
       ]);
 
       return {
+        moduleOptions: adHocOptions.data.actions.GET.module_name.choices,
+        isAdHocDisabled: !adHocOptions.data.actions.POST,
         hosts: response.data.results,
         hostCount: response.data.count,
         actions: hostOptions.data.actions,
@@ -65,6 +70,8 @@ function InventoryHostList() {
       actions: {},
       relatedSearchableKeys: [],
       searchableKeys: [],
+      moduleOptions: [],
+      isAdHocDisabled: true,
     }
   );
 
@@ -152,11 +159,16 @@ function InventoryHostList() {
                     />,
                   ]
                 : []),
-              <AdHocCommands
-                adHocItems={selected}
-                hasListItems={hostCount > 0}
-                onLaunchLoading={setIsAdHocLaunchLoading}
-              />,
+              ...(!isAdHocDisabled
+                ? [
+                    <AdHocCommands
+                      moduleOptions={moduleOptions}
+                      adHocItems={selected}
+                      hasListItems={hostCount > 0}
+                      onLaunchLoading={setIsAdHocLaunchLoading}
+                    />,
+                  ]
+                : []),
               <ToolbarDeleteButton
                 key="delete"
                 onDelete={handleDeleteHosts}

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.test.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostList.test.js
@@ -93,6 +93,23 @@ describe('<InventoryHostList />', () => {
         },
       },
     });
+
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
+
     await act(async () => {
       wrapper = mountWithContexts(<InventoryHostList />);
     });
@@ -106,6 +123,10 @@ describe('<InventoryHostList />', () => {
   test('should fetch hosts from api and render them in the list', async () => {
     expect(InventoriesAPI.readHosts).toHaveBeenCalled();
     expect(wrapper.find('InventoryHostItem').length).toBe(3);
+  });
+
+  test('should render Run Commands button', async () => {
+    expect(wrapper.find('AdHocCommands')).toHaveLength(1);
   });
 
   test('should check and uncheck the row item', async () => {
@@ -321,5 +342,28 @@ describe('<InventoryHostList />', () => {
       );
     });
     await waitForElement(wrapper, 'ContentError', el => el.length === 1);
+  });
+
+  test('should not render Run Commands button', async () => {
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+        },
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <InventoryHostList inventory={mockInventory} />
+      );
+    });
+    expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.js
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.js
@@ -87,6 +87,21 @@ describe('<InventoryRelatedGroupList />', () => {
         ],
       },
     });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(<InventoryRelatedGroupList />);
     });
@@ -105,6 +120,10 @@ describe('<InventoryRelatedGroupList />', () => {
     expect(GroupsAPI.readChildren).toHaveBeenCalled();
     expect(InventoriesAPI.readGroupsOptions).toHaveBeenCalled();
     expect(wrapper.find('InventoryRelatedGroupListItem').length).toBe(3);
+  });
+
+  test('should render Run Commands Button', async () => {
+    expect(wrapper.find('AdHocCommands')).toHaveLength(1);
   });
 
   test('should check and uncheck the row item', async () => {
@@ -219,5 +238,26 @@ describe('<InventoryRelatedGroupList />', () => {
       wrapper.find('button[aria-label="Save"]').prop('onClick')()
     );
     expect(GroupsAPI.associateChildGroup).toBeCalledTimes(1);
+  });
+
+  test('should not render Run Commands button', async () => {
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+        },
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+    });
+    expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 });

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.js
@@ -76,7 +76,7 @@ function JobDetail({ job }) {
     project_update: t`Source Control Update`,
     inventory_update: t`Inventory Sync`,
     job: job.job_type === 'check' ? t`Playbook Check` : t`Playbook Run`,
-    ad_hoc_command: t`Command`,
+    ad_hoc_command: t`Run Command`,
     system_job: t`Management Job`,
     workflow_job: t`Workflow Job`,
   };
@@ -337,6 +337,8 @@ function JobDetail({ job }) {
             }
           />
         )}
+        <Detail label={t`Module Name`} value={job.module_name} />
+        <Detail label={t`Module Arguments`} value={job.module_args} />
         <UserDateDetail
           label={t`Created`}
           date={job.created}

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.js
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.js
@@ -110,6 +110,38 @@ describe('<JobDetail />', () => {
     ).toHaveLength(1);
   });
 
+  test('should display module name and module arguments', () => {
+    wrapper = mountWithContexts(
+      <JobDetail
+        job={{
+          ...mockJobData,
+          type: 'ad_hoc_command',
+          module_name: 'command',
+          module_args: 'echo hello_world',
+          summary_fields: {
+            ...mockJobData.summary_fields,
+            credential: {
+              id: 2,
+              name: 'Machine cred',
+              description: '',
+              kind: 'ssh',
+              cloud: false,
+              kubernetes: false,
+              credential_type_id: 1,
+            },
+            source_workflow_job: {
+              id: 1234,
+              name: 'Test Source Workflow',
+            },
+          },
+        }}
+      />
+    );
+    assertDetail('Module Name', 'command');
+    assertDetail('Module Arguments', 'echo hello_world');
+    assertDetail('Job Type', 'Run Command');
+  });
+
   test('should show schedule that launched workflow job', async () => {
     wrapper = mountWithContexts(
       <JobDetail


### PR DESCRIPTION
##### SUMMARY
This closes #10440 and #8660.

On the job details view we now render the command module name, and the arguments.  We also remove the run command button for user that do not have permission to launch a ad hoc command. 

##### ISSUE TYPE
-enhancement

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
