### PR TITLE
run dev cluster haproxy container as root

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -60,8 +60,9 @@ services:
 {% if cluster_node_count|int > 1 %}
   haproxy:
     image: haproxy
+    user: "{{ ansible_user_uid }}"
     volumes:
-      - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
+      - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:Z"
     ports:
       - "8013:8013"
       - "8043:8043"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
otherwise you'll get permission errors
`sources_haproxy_1 | [ALERT]    (1) : Could not open configuration file /usr/local/etc/haproxy/haproxy.cfg : Permission denied`
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.1
```
