### PR TITLE
Close file before returning

### DIFF
--- a/awxkit/awxkit/yaml_file.py
+++ b/awxkit/awxkit/yaml_file.py
@@ -89,9 +89,9 @@ def load_file(filename):
         path = local(filename)
 
     if path.check():
-        fp = path.open()
-        # FIXME - support load_all()
-        return yaml.load(fp, Loader=Loader)
+        with open(path, 'r') as fp:
+            # FIXME - support load_all()
+            return yaml.load(fp, Loader=Loader)
     else:
         msg = 'Unable to load data file at %s' % path
         raise Exception(msg)


### PR DESCRIPTION
Resolves

```
/home/alancoding/repos/tower-qa/tests/lib/plugins/pytest_restqa/plugin.py:122: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/alancoding/repos/tower-qa/scripts/resource_loading/data_latest_loading.yml' mode='r' encoding='UTF-8'>
  qe_config.resources = PseudoNamespace(yaml_file.load_file(config.option.resource_file))
```

We have this same pattern earlier in the file.