### PR TITLE
Fix Job Settings Page Break on Firefox

### DIFF
--- a/awx/ui_next/src/screens/Setting/SettingList.jsx
+++ b/awx/ui_next/src/screens/Setting/SettingList.jsx
@@ -25,10 +25,11 @@ const SplitLayout = styled(PageSection)`
   }
 `;
 const Card = styled(_Card)`
-  display: inline-block;
-  break-inside: avoid;
-  margin-bottom: 24px;
-  width: 100%;
+  && {
+    display: inline-block;
+    margin-bottom: 24px;
+    width: 100%;
+  }
 `;
 const CardHeader = styled(_CardHeader)`
   && {


### PR DESCRIPTION
Fix Job Settings Page Break on Firefox

Closes: https://github.com/ansible/awx/issues/10332


Firefox:

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/9053044/123475065-e2ca0d00-d5c8-11eb-8842-a3cbb4f6c868.png">

Chrome: 

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/9053044/123475019-d5148780-d5c8-11eb-92d7-813ffa10f897.png">



