### PR TITLE
Fix awx collections copy_item warning keyword error

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -421,7 +421,7 @@ class ControllerAPIModule(ControllerModule):
     def copy_item(self, existing_item, copy_from_name_or_id, new_item_name, endpoint=None, item_type='unknown', copy_lookup_data=None):
 
         if existing_item is not None:
-            self.warn(msg="A {0} with the name {1} already exists.".format(item_type, new_item_name))
+            self.warn("A {0} with the name {1} already exists.".format(item_type, new_item_name))
             self.json_output['changed'] = False
             self.json_output['copied'] = False
             return existing_item

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -24,3 +24,26 @@ def test_create_project(run_module, admin_user, organization, silence_warning):
 
     result.pop('invocation')
     assert result == {'name': 'foo', 'id': proj.id}
+
+@pytest.mark.django_db
+def test_create_project_copy_from(run_module, admin_user, organization, silence_warning):
+    ''' Test the copy_from functionality'''
+    result = run_module(
+        'project',
+        dict(name='foo', organization=organization.name, scm_type='git', scm_url='https://foo.invalid', wait=False, scm_update_cache_timeout=5),
+        admin_user,
+    )
+    assert result.pop('changed', None), result
+    proj_name = 'bar'
+    result = run_module(
+        'project',
+        dict(name=proj_name, copy_from='foo', scm_type='git', wait=False),
+        admin_user,
+    )
+    assert result.pop('changed', None), result
+    result = run_module(
+        'project',
+        dict(name=proj_name, copy_from='foo', scm_type='git', wait=False),
+        admin_user,
+    )
+    silence_warning.assert_called_with(f"A project with the name {proj_name} already exists.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- warn() does not take keyword 'msg'
- add testing around the copy_from parameter for project creation
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.1
```
