### PR TITLE
reload settings on fork or new thread

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1086,8 +1086,11 @@ def cleanup_new_process(func):
 
     @wraps(func)
     def wrapper_cleanup_new_process(*args, **kwargs):
+        from awx.conf.settings import SettingsWrapper  # noqa
+
         django_connection.close()
         django_cache.close()
+        SettingsWrapper.initialize()
         return func(*args, **kwargs)
 
     return wrapper_cleanup_new_process


### PR DESCRIPTION
* Reloading settings will re-import cache. Django cache is thread aware,
but keeping an old reference to the cache avoids the awareness.

The performance team that was hitting this every time before. With this change they are unable to recreated.
