### PR TITLE
Fix ansible-test pep8 bug and add notable release

### DIFF
--- a/awx_collection/README.md
+++ b/awx_collection/README.md
@@ -67,11 +67,12 @@ Notable releases of the `awx.awx` collection:
 
  - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
  - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
+ - 19.2.1 large renaming purged "tower" names (like options and module names), adding redirects for old names
  - 0.0.1-devel is the version you should see if installing from source, which is intended for development and expected to be unstable.
 
 The following notes are changes that may require changes to playbooks:
 
- - The module tower_notification was renamed tower_notification_template. In ansible >= 2.10 there is a seemless redirect. Ansible 2.9 does not respect the redirect.
+ - The module tower_notification was renamed tower_notification_template. In ansible >= 2.10 there is a seamless redirect. Ansible 2.9 does not respect the redirect.
  - When a project is created, it will wait for the update/sync to finish by default; this can be turned off with the `wait` parameter, if desired.
  - Creating a "scan" type job template is no longer supported.
  - Specifying a custom certificate via the `TOWER_CERTIFICATE` environment variable no longer works.

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -25,6 +25,7 @@ def test_create_project(run_module, admin_user, organization, silence_warning):
     result.pop('invocation')
     assert result == {'name': 'foo', 'id': proj.id}
 
+
 @pytest.mark.django_db
 def test_create_project_copy_from(run_module, admin_user, organization, silence_warning):
     ''' Test the copy_from functionality'''

--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -73,6 +73,7 @@ Notable releases of the `{{ collection_namespace }}.{{ collection_package }}` co
 {% if collection_package | lower() == "awx" %}
  - 7.0.0 is intended to be identical to the content prior to the migration, aside from changes necessary to function as a collection.
  - 11.0.0 has no non-deprecated modules that depend on the deprecated `tower-cli` [PyPI](https://pypi.org/project/ansible-tower-cli/).
+ - 19.2.1 large renaming purged "tower" names (like options and module names), adding redirects for old names
  - 0.0.1-devel is the version you should see if installing from source, which is intended for development and expected to be unstable.
 {% else %}
  - 3.7.0 initial release


### PR DESCRIPTION
Fixes

```
Error Message
The test `ansible-test sanity --test pep8` failed with 1 error:
Stacktrace
test/awx/test_project.py:28:1: E302: expected 2 blank lines, found 1
```

And add a notable release to the https://galaxy.ansible.com/awx/awx page