### PR TITLE
bumped django version to 2.2.20 in devel

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -16,6 +16,12 @@ then run the script:
 NOTE: `./updater.sh` uses /usr/bin/python3.6, to match the current python version
 (3.6) used to build releases.
 
+##### Note - watch out for the updater script, using paths local to your machine instead of generalized paths; ie
+```bash
+    # via -r /awx_devel/requirements/requirements.in <-RIGHT
+    # via -r /home/foo/bar/awx/requirements/requirements.in <-WRONG
+```
+
 #### Upgrading Unpinned Dependency
 
 If you require a new version of a dependency that does not have a pinned version

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,7 @@ cryptography<3.0.0
 Cython<3 # Since the bump to PyYAML 5.4.1 this is now a mandatory dep
 daphne
 distro
-django==2.2.16  # see UPGRADE BLOCKERs
+django==2.2.20  # see UPGRADE BLOCKERs
 django-auth-ldap
 django-cors-headers>=3.5.0
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,7 +85,7 @@ dictdiffer==0.8.1
     # via openshift
 distro==1.5.0
     # via -r /awx_devel/requirements/requirements.in
-django==2.2.16
+django==2.2.20
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Bumped Django version from `2.2.16` -> `2.2.20` for the `devel` environment. All builds, tests and tests consuming the `AWX_USE_FIPS` flag passed in Jenkins. 

AWX Issue - https://github.com/ansible/tower/issues/4930

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```
