### PR TITLE
Remove default text from bug title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: Create a report to help us improve
-title: "[Bug]: "
+title: ""
 labels:
   - bug
 body:


### PR DESCRIPTION
##### SUMMARY
We use labels for these, so the extra text isn't needed.

##### ADDITIONAL INFORMATION
![Screenshot from 2021-07-01 09-02-07](https://user-images.githubusercontent.com/9753817/124128787-1b476c00-da4b-11eb-8585-4247995e09d8.png)

