### PR TITLE
Remove mix usage of hooks and HOC for router

### DIFF
--- a/awx/ui_next/src/components/AddRole/SelectResourceStep.js
+++ b/awx/ui_next/src/components/AddRole/SelectResourceStep.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import useRequest from 'hooks/useRequest';
 import { SearchColumns, SortColumns } from 'types';
@@ -147,4 +147,4 @@ SelectResourceStep.defaultProps = {
 };
 
 export { SelectResourceStep as _SelectResourceStep };
-export default withRouter(SelectResourceStep);
+export default SelectResourceStep;

--- a/awx/ui_next/src/components/Lookup/ApplicationLookup.js
+++ b/awx/ui_next/src/components/Lookup/ApplicationLookup.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { func, node, string } from 'prop-types';
-import { withRouter, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import { FormGroup } from '@patternfly/react-core';
 import { ApplicationsAPI } from 'api';
@@ -151,4 +151,4 @@ ApplicationLookup.defaultProps = {
   fieldName: 'application',
 };
 
-export default withRouter(ApplicationLookup);
+export default ApplicationLookup;

--- a/awx/ui_next/src/components/Lookup/HostFilterLookup.js
+++ b/awx/ui_next/src/components/Lookup/HostFilterLookup.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { withRouter, useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { number, func, bool, string } from 'prop-types';
 
 import styled from 'styled-components';
@@ -411,4 +411,4 @@ HostFilterLookup.defaultProps = {
   enableRelatedFuzzyFiltering: true,
 };
 
-export default withRouter(HostFilterLookup);
+export default HostFilterLookup;

--- a/awx/ui_next/src/screens/Job/Job.js
+++ b/awx/ui_next/src/screens/Job/Job.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import {
   Route,
-  withRouter,
   Switch,
   Redirect,
   Link,
@@ -173,5 +172,5 @@ function Job({ setBreadcrumb }) {
   );
 }
 
-export default withRouter(Job);
+export default Job;
 export { Job as _Job };

--- a/awx/ui_next/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui_next/src/screens/Job/JobOutput/JobOutput.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useHistory, useLocation, withRouter } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import styled from 'styled-components';
 import {
@@ -952,4 +952,4 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
 }
 
 export { JobOutput as _JobOutput };
-export default withRouter(JobOutput);
+export default JobOutput;

--- a/awx/ui_next/src/screens/Organization/Organization.js
+++ b/awx/ui_next/src/screens/Organization/Organization.js
@@ -4,7 +4,6 @@ import { t } from '@lingui/macro';
 import {
   Switch,
   Route,
-  withRouter,
   Redirect,
   Link,
   useLocation,
@@ -235,5 +234,5 @@ function Organization({ setBreadcrumb, me }) {
   );
 }
 
-export default withRouter(Organization);
+export default Organization;
 export { Organization as _Organization };

--- a/awx/ui_next/src/screens/Project/Project.js
+++ b/awx/ui_next/src/screens/Project/Project.js
@@ -4,7 +4,6 @@ import { t } from '@lingui/macro';
 import {
   Switch,
   Route,
-  withRouter,
   Redirect,
   Link,
   useParams,
@@ -207,5 +206,5 @@ function Project({ setBreadcrumb }) {
   );
 }
 
-export default withRouter(Project);
+export default Project;
 export { Project as _Project };


### PR DESCRIPTION
There were a few cases that hooks and HOC were being used at the same on
a certain component. Remove HOC from those ones.

