### PR TITLE
Default source_project to organization for inventory source

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -256,7 +256,10 @@ def main():
     if ee is not None:
         inventory_source_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
     if source_project is not None:
-        inventory_source_fields['source_project'] = module.resolve_name_to_id('projects', source_project)
+        source_project_object = module.get_one('projects', name_or_id=source_project, data=lookup_data)
+        if not source_project_object:
+            module.fail_json(msg='The specified source project, {0}, was not found.'.format(lookup_data))
+        inventory_source_fields['source_project'] = source_project_object['id']
 
     OPTIONAL_VARS = (
         'description',

--- a/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
@@ -28,6 +28,14 @@
         scm_url: https://github.com/ansible/test-playbooks
         wait: true
 
+    - name: Create a git project with same name, different org
+      project:
+        name: "{{ project_name }}"
+        organization: Default
+        scm_type: git
+        scm_url: https://github.com/ansible/test-playbooks
+        wait: true
+
     - name: Create an Inventory
       inventory:
         name: "{{ inv_name }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related #10571 

Adds the defaulting of the source_project (when given) to be looked up under the `organization` selected in the same way the inventory is looked up.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- awx_collection

##### AWX VERSION
awx_collection v19.2.2
