### PR TITLE
Display error message if schedule does not exist

### DIFF
--- a/awx/ui_next/src/components/Schedule/Schedule.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.jsx
@@ -69,6 +69,19 @@ function Schedule({
     },
   ];
 
+  if (!isLoading && error) {
+    return (
+      <ContentError isNotFound error={error}>
+        {error.response && error.response.status === 404 && (
+          <span>
+            {t`Schedule not found.`}{' '}
+            <Link to={`${pathRoot}schedules`}>{t`View Schedules`}</Link>
+          </span>
+        )}
+      </ContentError>
+    );
+  }
+
   if (isLoading || !schedule?.summary_fields?.unified_job_template?.id) {
     return <ContentLoading />;
   }

--- a/awx/ui_next/src/components/Schedule/Schedules.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedules.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
+
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
 import ScheduleList from './ScheduleList';
@@ -19,6 +19,7 @@ function Schedules({
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
+
   const hasDaysToKeepField = [
     'cleanup_activitystream',
     'cleanup_jobs',


### PR DESCRIPTION
Display error message if schedule does not exist when redirecting to
details page.

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/9053044/124177943-ea812a00-da7e-11eb-8c28-116f1c77d917.png">


closes: https://github.com/ansible/awx/issues/9550


