### PR TITLE
wait for database connection

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import time
 import sys
 import warnings
 
@@ -35,6 +36,7 @@ else:
     from django.db.models import indexes
     from django.db.backends.utils import names_digest
     from django.db import connection
+    from django.db.utils import OperationalError
 
 
 if HAS_DJANGO is True:
@@ -152,6 +154,19 @@ def manage():
 
     # enforce the postgres version is equal to 12. if not, then terminate program with exit code of 1
     if not MODE == 'development':
+        # wait for connection to the database
+        sys.stdout.write("Wainting for connection to database\n")
+        connected = False
+        while not connected:
+            try:
+                connection.ensure_connection()
+                connected = True
+            except OperationalError:
+                sys.stdout.write("No connection available\n")
+                time.sleep(1)
+
+        sys.stdout.write("Connection established\n")
+
         if (connection.pg_version // 10000) < 12:
             sys.stderr.write("Postgres version 12 is required\n")
             sys.exit(1)

--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import time
 import sys
 import warnings
 
@@ -36,7 +35,6 @@ else:
     from django.db.models import indexes
     from django.db.backends.utils import names_digest
     from django.db import connection
-    from django.db.utils import OperationalError
 
 
 if HAS_DJANGO is True:
@@ -154,19 +152,6 @@ def manage():
 
     # enforce the postgres version is equal to 12. if not, then terminate program with exit code of 1
     if not MODE == 'development':
-        # wait for connection to the database
-        sys.stdout.write("Wainting for connection to database\n")
-        connected = False
-        while not connected:
-            try:
-                connection.ensure_connection()
-                connected = True
-            except OperationalError:
-                sys.stdout.write("No connection available\n")
-                time.sleep(1)
-
-        sys.stdout.write("Connection established\n")
-
         if (connection.pg_version // 10000) < 12:
             sys.stderr.write("Postgres version 12 is required\n")
             sys.exit(1)

--- a/tools/ansible/roles/dockerfile/files/launch_awx.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx.sh
@@ -13,6 +13,8 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
+wait-for-migrations || exit 1
+
 awx-manage collectstatic --noinput --clear
 
 supervisord -c /etc/supervisord.conf

--- a/tools/ansible/roles/dockerfile/files/launch_awx.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx.sh
@@ -13,7 +13,9 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
-wait-for-migrations || exit 1
+set -e
+
+wait-for-migrations
 
 awx-manage collectstatic --noinput --clear
 

--- a/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
@@ -13,6 +13,6 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
-wait-for-migrations
+wait-for-migrations || exit 1
 
 supervisord -c /etc/supervisord_task.conf

--- a/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx_task.sh
@@ -13,6 +13,8 @@ if [ -n "${AWX_KUBE_DEVEL}" ]; then
     export SDB_NOTIFY_HOST=$MY_POD_IP
 fi
 
-wait-for-migrations || exit 1
+set -e
+
+wait-for-migrations
 
 supervisord -c /etc/supervisord_task.conf

--- a/tools/ansible/roles/dockerfile/files/wait-for-migrations
+++ b/tools/ansible/roles/dockerfile/files/wait-for-migrations
@@ -22,13 +22,20 @@ wait_for() {
     local rc=1
     local attempt=1
     local next_sleep="${MIN_SLEEP}"
+    local check=1
 
     while true; do
         log_message "Attempt ${attempt} of ${ATTEMPTS}"
 
         timeout "${TIMEOUT}" \
-                /bin/bash -c "! awx-manage showmigrations | grep '\[ \]'" &>/dev/null \
-            && return || rc=$?
+                /bin/bash -c "awx-manage check" &>/dev/null
+        check=$?
+
+        if [ $check -eq 0 ]; then
+            timeout "${TIMEOUT}" \
+                    /bin/bash -c "! awx-manage showmigrations | grep '\[ \]'" &>/dev/null \
+                && return || rc=$?
+        fi
 
         (( ++attempt > ATTEMPTS )) && break
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Wait for the database connection because in some environments the connection cannot be made right away. 

#10527 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

We could also stop after so many tries. Not sure what the point in continuing is if you can't use the database though.

I also tried just skipping past this check if the database was not available but it would fail later on just running collectstatic so the database is needed even for collectstatic.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 195, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/psycopg2/__init__.py", line 126, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: could not connect to server: Connection refused
	Is the server running on host "awx-postgres" (10.140.177.141) and accepting
	TCP/IP connections on port 5432?


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/awx-manage", line 8, in <module>
    sys.exit(manage())
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/__init__.py", line 155, in manage
    if (connection.pg_version // 10000) < 12:
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/__init__.py", line 28, in __getattr__
    return getattr(connections[DEFAULT_DB_ALIAS], item)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/utils/functional.py", line 80, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/postgresql/base.py", line 282, in pg_version
    with self.temporary_connection():
  File "/usr/lib64/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 593, in temporary_connection
    with self.cursor() as cursor:
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 256, in cursor
    return self._cursor()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 233, in _cursor
    self.ensure_connection()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/base/base.py", line 195, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/psycopg2/__init__.py", line 126, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
django.db.utils.OperationalError: could not connect to server: Connection refused
	Is the server running on host "awx-postgres" (10.140.177.141) and accepting
	TCP/IP connections on port 5432?
```

After
```
Wainting for connection to database
No connection available
No connection available
No connection available
No connection available
No connection available
No connection available
Connection established

183 static files copied to '/var/lib/awx/public/static'.
```
