### PR TITLE
No result_traceback is blank, not null

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3004,7 +3004,7 @@ class AWXReceptorJob:
                 if state_name == 'Succeeded':
                     return res
 
-                if self.task.instance.result_traceback is None:
+                if not self.task.instance.result_traceback:
                     raise RuntimeError(detail)
 
         return res


### PR DESCRIPTION
I kept staring at a failure where:

> cannot create resource

was expected in `result_traceback`, but it was blank. The job had "error" status, sure enough.

Then I re-created, sure enough, the job was right there - error status, no explanation, no traceback, no indication of what happened. We did have logs though (which I still can't fully disambiguate).

After that initial confusion, I realized this is a server-side bug. The test is happy with what happens after this change.

~I can re-organize this diff if needed.~