### PR TITLE
Keep tower option for credential module (for now)

### DIFF
--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -292,6 +292,7 @@ from ..module_utils.controller_api import ControllerAPIModule
 
 KIND_CHOICES = {
     'aws': 'Amazon Web Services',
+    'tower': 'Ansible Tower',  # replaced by controller, temporarily kept for compat with old Tower instances
     'controller': 'Red Hat Ansible Automation Platform',
     'gce': 'Google Compute Engine',
     'azure_rm': 'Microsoft Azure Resource Manager',

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -81,7 +81,7 @@ options:
         - Deprecated, please use credential_type
       required: False
       type: str
-      choices: ["aws", "controller", "gce", "azure_rm", "openstack", "satellite6", "rhv", "vmware", "aim", "conjur", "hashivault_kv", "hashivault_ssh",
+      choices: ["aws", "tower", "controller", "gce", "azure_rm", "openstack", "satellite6", "rhv", "vmware", "aim", "conjur", "hashivault_kv", "hashivault_ssh",
                 "azure_kv", "insights", "kubernetes_bearer_token", "net", "scm", "ssh", "github_token", "gitlab_token", "vault"]
     host:
       description:

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -407,6 +407,11 @@ def main():
             collection_name="awx.awx",
             msg='The kind parameter has been deprecated, please use credential_type instead',
             version="4.0.0")
+        if kind == 'tower':
+            module.deprecate(
+                collection_name="awx.awx",
+                msg='The server replaces the tower type with controller type in version 4.0, and playbooks must be updated',
+                version="4.0.0")
 
     cred_type_id = module.resolve_name_to_id('credential_types', credential_type if credential_type else KIND_CHOICES[kind])
     if organization:


### PR DESCRIPTION
##### SUMMARY
Allows using the credential module with Ansible Tower 3.8

We don't formally support this use case (collection version tied to server version), but we make best-effort exceptions on request.

Connect https://github.com/ansible/awx/issues/10582

##### ISSUE TYPE
 - Feature Pull Request

##### AWX VERSION
```
19.2.2
```


##### ADDITIONAL INFORMATION
My test playbook:

```yaml
---
- hosts: localhost
  gather_facts: false
  connection: local
  collections:
    - awx.awx
  tasks:
    - name: add the default organization
      awx.awx.organization:
        name: Default

    - name: add tower credential into ansible tower
      awx.awx.credential:
        name: "Sean Tower Credential"
        kind: tower
        organization: Default
        inputs:
          host: "https://localhost:8043/"
          username: admin
          password: "p4ssword"
```
