### PR TITLE
Test cleanup

### DIFF
--- a/awx/ui_next/src/App.test.jsx
+++ b/awx/ui_next/src/App.test.jsx
@@ -31,6 +31,5 @@ describe('<App />', () => {
     });
     expect(wrapper.length).toBe(1);
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/components/About/About.jsx
+++ b/awx/ui_next/src/components/About/About.jsx
@@ -31,7 +31,7 @@ function About({ version, isOpen, onClose }) {
     <AboutModal
       isOpen={isOpen}
       onClose={onClose}
-      productName={`Ansible ${brandName.current}`}
+      productName={brandName.current}
       trademark={`${copyright} ${new Date().getFullYear()} ${redHatInc}`}
       brandImageSrc="/static/media/logo-header.svg"
       brandImageAlt={t`Brand Image`}

--- a/awx/ui_next/src/components/About/About.test.jsx
+++ b/awx/ui_next/src/components/About/About.test.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { shallow } from 'enzyme';
 import About from './About';
 
-describe('<About />', () => {
-  let aboutWrapper;
-  let closeButton;
-  const onClose = jest.fn();
-  test('initially renders without crashing', () => {
-    aboutWrapper = mountWithContexts(<About isOpen onClose={onClose} />);
-    expect(aboutWrapper.length).toBe(1);
-    aboutWrapper.unmount();
-  });
+jest.mock('../../util/useBrandName', () => ({
+  __esModule: true,
+  default: () => ({
+    current: 'AWX',
+  }),
+}));
 
-  test('close button calls onClose handler', () => {
-    aboutWrapper = mountWithContexts(<About isOpen onClose={onClose} />);
-    closeButton = aboutWrapper.find('AboutModalBoxCloseButton Button');
-    closeButton.simulate('click');
-    expect(onClose).toBeCalled();
-    aboutWrapper.unmount();
+describe('<About />', () => {
+  test('should render AboutModal', () => {
+    const onClose = jest.fn();
+    const wrapper = shallow(<About isOpen onClose={onClose} />);
+
+    const modal = wrapper.find('AboutModal');
+    expect(modal).toHaveLength(1);
+    expect(modal.prop('onClose')).toEqual(onClose);
+    expect(modal.prop('productName')).toEqual('Ansible AWX');
+    expect(modal.prop('isOpen')).toEqual(true);
   });
 });

--- a/awx/ui_next/src/components/About/About.test.jsx
+++ b/awx/ui_next/src/components/About/About.test.jsx
@@ -17,7 +17,7 @@ describe('<About />', () => {
     const modal = wrapper.find('AboutModal');
     expect(modal).toHaveLength(1);
     expect(modal.prop('onClose')).toEqual(onClose);
-    expect(modal.prop('productName')).toEqual('Ansible AWX');
+    expect(modal.prop('productName')).toEqual('AWX');
     expect(modal.prop('isOpen')).toEqual(true);
   });
 });

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommands.test.jsx
@@ -76,8 +76,8 @@ describe('<AdHocCommands />', () => {
     });
   });
   let wrapper;
+
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCommandsWizard.test.jsx
@@ -54,7 +54,6 @@ describe('<AdHocCommandsWizard/>', () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should mount properly', async () => {

--- a/awx/ui_next/src/components/AdHocCommands/AdHocCredentialStep.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocCredentialStep.test.jsx
@@ -36,7 +36,6 @@ describe('<AdHocCredentialStep />', () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should mount properly', async () => {

--- a/awx/ui_next/src/components/AdHocCommands/AdHocExecutionEnironmentStep.test.jsx
+++ b/awx/ui_next/src/components/AdHocCommands/AdHocExecutionEnironmentStep.test.jsx
@@ -33,9 +33,9 @@ describe('<AdHocExecutionEnvironmentStep />', () => {
       );
     });
   });
+
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should mount properly', async () => {

--- a/awx/ui_next/src/components/AddRole/AddResourceRole.test.jsx
+++ b/awx/ui_next/src/components/AddRole/AddResourceRole.test.jsx
@@ -16,7 +16,6 @@ jest.mock('../../api/models/Users');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-
   useHistory: () => ({ push: jest.fn(), location: { pathname: {} } }),
 }));
 // TODO: Once error handling is functional in

--- a/awx/ui_next/src/components/AddRole/SelectRoleStep.test.jsx
+++ b/awx/ui_next/src/components/AddRole/SelectRoleStep.test.jsx
@@ -34,6 +34,7 @@ describe('<SelectRoleStep />', () => {
       name: 'foo',
     },
   ];
+
   test('initially renders without crashing', () => {
     wrapper = shallowWithContexts(
       <SelectRoleStep
@@ -43,8 +44,8 @@ describe('<SelectRoleStep />', () => {
       />
     );
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
+
   test('clicking role fires onRolesClick callback', () => {
     const onRolesClick = jest.fn();
     wrapper = mountWithContexts(
@@ -63,6 +64,5 @@ describe('<SelectRoleStep />', () => {
       name: 'Project Admin',
       description: 'Can manage all projects of the organization',
     });
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
+++ b/awx/ui_next/src/components/AppContainer/NavExpandableGroup.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, { oneOfType, string, arrayOf } from 'prop-types';
 import { matchPath, Link, withRouter } from 'react-router-dom';
 import { NavExpandable, NavItem } from '@patternfly/react-core';
 
@@ -58,9 +58,9 @@ class NavExpandableGroup extends Component {
 }
 
 NavExpandableGroup.propTypes = {
-  groupId: PropTypes.string.isRequired,
-  groupTitle: PropTypes.element.isRequired,
-  routes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  groupId: string.isRequired,
+  groupTitle: oneOfType([PropTypes.element, string]).isRequired,
+  routes: arrayOf(PropTypes.object).isRequired,
 };
 
 export default withRouter(NavExpandableGroup);

--- a/awx/ui_next/src/components/AppContainer/PageHeaderToolbar.test.jsx
+++ b/awx/ui_next/src/components/AppContainer/PageHeaderToolbar.test.jsx
@@ -14,10 +14,6 @@ describe('PageHeaderToolbar', () => {
   const onAboutClick = jest.fn();
   const onLogoutClick = jest.fn();
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('expected content is rendered on initialization', async () => {
     await act(async () => {
       wrapper = mountWithContexts(

--- a/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.test.jsx
+++ b/awx/ui_next/src/components/CheckboxListItem/CheckboxListItem.test.jsx
@@ -6,14 +6,18 @@ import CheckboxListItem from './CheckboxListItem';
 describe('CheckboxListItem', () => {
   test('renders the expected content', () => {
     const wrapper = mount(
-      <CheckboxListItem
-        itemId={1}
-        name="Buzz"
-        label="Buzz"
-        isSelected={false}
-        onSelect={() => {}}
-        onDeselect={() => {}}
-      />
+      <table>
+        <tbody>
+          <CheckboxListItem
+            itemId={1}
+            name="Buzz"
+            label="Buzz"
+            isSelected={false}
+            onSelect={() => {}}
+            onDeselect={() => {}}
+          />
+        </tbody>
+      </table>
     );
     expect(wrapper).toHaveLength(1);
   });

--- a/awx/ui_next/src/components/CodeEditor/VariablesDetail.test.jsx
+++ b/awx/ui_next/src/components/CodeEditor/VariablesDetail.test.jsx
@@ -8,7 +8,7 @@ jest.mock('../../api');
 describe('<VariablesDetail>', () => {
   test('should render readonly CodeEditor', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="---foo: bar" label="Variables" />
+      <VariablesDetail value="---foo: bar" label="Variables" name="test" />
     );
     const input = wrapper.find('VariablesDetail___StyledCodeEditor');
     expect(input).toHaveLength(1);
@@ -19,7 +19,7 @@ describe('<VariablesDetail>', () => {
 
   test('should detect JSON', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value='{"foo": "bar"}' label="Variables" />
+      <VariablesDetail value='{"foo": "bar"}' label="Variables" name="test" />
     );
     const input = wrapper.find('VariablesDetail___StyledCodeEditor');
     expect(input).toHaveLength(1);
@@ -28,7 +28,7 @@ describe('<VariablesDetail>', () => {
 
   test('should format JSON', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value='{"foo": "bar"}' label="Variables" />
+      <VariablesDetail value='{"foo": "bar"}' label="Variables" name="test" />
     );
     const input = wrapper.find('VariablesDetail___StyledCodeEditor');
     expect(input).toHaveLength(1);
@@ -37,7 +37,7 @@ describe('<VariablesDetail>', () => {
 
   test('should convert between modes', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="---foo: bar" label="Variables" />
+      <VariablesDetail value="---foo: bar" label="Variables" name="test" />
     );
     wrapper.find('MultiButtonToggle').invoke('onChange')('javascript');
     const input = wrapper.find('VariablesDetail___StyledCodeEditor');
@@ -52,7 +52,7 @@ describe('<VariablesDetail>', () => {
 
   test('should render label and value --- when there are no values', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="" label="Variables" />
+      <VariablesDetail value="" label="Variables" name="test" />
     );
     expect(wrapper.find('VariablesDetail___StyledCodeEditor').length).toBe(1);
     expect(wrapper.find('.pf-c-form__label').text()).toBe('Variables');
@@ -60,7 +60,7 @@ describe('<VariablesDetail>', () => {
 
   test('should update value if prop changes', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="---foo: bar" label="Variables" />
+      <VariablesDetail value="---foo: bar" label="Variables" name="test" />
     );
     act(() => {
       wrapper.find('MultiButtonToggle').invoke('onChange')('javascript');
@@ -76,7 +76,7 @@ describe('<VariablesDetail>', () => {
 
   test('should default yaml value to "---"', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="" label="Variables" />
+      <VariablesDetail value="" label="Variables" name="test" />
     );
     const input = wrapper.find('VariablesDetail___StyledCodeEditor');
     expect(input.prop('value')).toEqual('---');
@@ -84,7 +84,7 @@ describe('<VariablesDetail>', () => {
 
   test('should default empty json to "{}"', () => {
     const wrapper = mountWithContexts(
-      <VariablesDetail value="" label="Variables" />
+      <VariablesDetail value="" label="Variables" name="test" />
     );
     act(() => {
       wrapper.find('MultiButtonToggle').invoke('onChange')('javascript');

--- a/awx/ui_next/src/components/CopyButton/CopyButton.test.jsx
+++ b/awx/ui_next/src/components/CopyButton/CopyButton.test.jsx
@@ -8,9 +8,6 @@ jest.mock('../../api');
 let wrapper;
 
 describe('<CopyButton/>', () => {
-  afterEach(() => {
-    wrapper.unmount();
-  });
   test('should mount properly', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
@@ -24,6 +21,7 @@ describe('<CopyButton/>', () => {
     });
     expect(wrapper.find('CopyButton').length).toBe(1);
   });
+
   test('should call the correct function on button click', async () => {
     const copyItem = jest.fn();
     await act(async () => {

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import DataListToolbar from './DataListToolbar';
 import AddDropDownButton from '../AddDropDownButton/AddDropDownButton';
@@ -100,6 +101,7 @@ describe('<DataListToolbar />', () => {
         searchColumns={searchColumns}
         sortColumns={sortColumns}
         onSort={onSort}
+        onSearch={() => {}}
       />
     );
     const sortDropdownToggle = toolbar.find(sortDropdownToggleSelector);
@@ -122,6 +124,7 @@ describe('<DataListToolbar />', () => {
         searchColumns={searchColumns}
         sortColumns={sortColumns}
         onSort={onSort}
+        onSearch={() => {}}
       />
     );
     toolbar.update();
@@ -155,92 +158,28 @@ describe('<DataListToolbar />', () => {
     searchDropdownItems.at(0).simulate('click', mockedSearchEvent);
   });
 
-  test('it displays correct sort icon', () => {
-    const NUM_QS_CONFIG = {
+  test('should render sort icon', () => {
+    const qsConfig = {
       namespace: 'organization',
       dateFields: ['modified', 'created'],
       defaultParams: { page: 1, page_size: 5, order_by: 'id' },
       integerFields: ['page', 'page_size', 'id'],
     };
+    const sortColumns = [{ name: 'Name', key: 'name' }];
 
-    const NUM_DESC_QS_CONFIG = {
-      namespace: 'organization',
-      dateFields: ['modified', 'created'],
-      defaultParams: { page: 1, page_size: 5, order_by: '-id' },
-      integerFields: ['page', 'page_size', 'id'],
-    };
-
-    const ALPH_QS_CONFIG = {
-      namespace: 'organization',
-      dateFields: ['modified', 'created'],
-      defaultParams: { page: 1, page_size: 5, order_by: 'name' },
-      integerFields: ['page', 'page_size', 'id'],
-    };
-
-    const ALPH_DESC_QS_CONFIG = {
-      namespace: 'organization',
-      dateFields: ['modified', 'created'],
-      defaultParams: { page: 1, page_size: 5, order_by: '-name' },
-      integerFields: ['page', 'page_size', 'id'],
-    };
-
-    const forwardNumericIconSelector = 'SortNumericDownIcon';
-    const reverseNumericIconSelector = 'SortNumericDownAltIcon';
-    const forwardAlphaIconSelector = 'SortAlphaDownIcon';
-    const reverseAlphaIconSelector = 'SortAlphaDownAltIcon';
-
-    const numericColumns = [{ name: 'ID', key: 'id' }];
-
-    const alphaColumns = [{ name: 'Name', key: 'name' }];
-
-    const searchColumns = [
-      { name: 'Name', key: 'name', isDefault: true },
-      { name: 'ID', key: 'id' },
-    ];
-
-    toolbar = mountWithContexts(
+    const wrapper = shallow(
       <DataListToolbar
-        qsConfig={NUM_DESC_QS_CONFIG}
-        searchColumns={searchColumns}
-        sortColumns={numericColumns}
+        qsConfig={qsConfig}
+        searchColumns={[{ name: 'ID', key: 'id' }]}
+        sortColumns={sortColumns}
+        onSort={onSort}
       />
     );
 
-    const reverseNumericIcon = toolbar.find(reverseNumericIconSelector);
-    expect(reverseNumericIcon.length).toBe(1);
-
-    toolbar = mountWithContexts(
-      <DataListToolbar
-        qsConfig={NUM_QS_CONFIG}
-        searchColumns={searchColumns}
-        sortColumns={numericColumns}
-      />
-    );
-
-    const forwardNumericIcon = toolbar.find(forwardNumericIconSelector);
-    expect(forwardNumericIcon.length).toBe(1);
-
-    toolbar = mountWithContexts(
-      <DataListToolbar
-        qsConfig={ALPH_DESC_QS_CONFIG}
-        searchColumns={searchColumns}
-        sortColumns={alphaColumns}
-      />
-    );
-
-    const reverseAlphaIcon = toolbar.find(reverseAlphaIconSelector);
-    expect(reverseAlphaIcon.length).toBe(1);
-
-    toolbar = mountWithContexts(
-      <DataListToolbar
-        qsConfig={ALPH_QS_CONFIG}
-        searchColumns={searchColumns}
-        sortColumns={alphaColumns}
-      />
-    );
-
-    const forwardAlphaIcon = toolbar.find(forwardAlphaIconSelector);
-    expect(forwardAlphaIcon.length).toBe(1);
+    const sort = wrapper.find('Sort');
+    expect(sort.prop('qsConfig')).toEqual(qsConfig);
+    expect(sort.prop('columns')).toEqual(sortColumns);
+    expect(sort.prop('onSort')).toEqual(onSort);
   });
 
   test('should render additionalControls', () => {

--- a/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
+++ b/awx/ui_next/src/components/DataListToolbar/DataListToolbar.test.jsx
@@ -15,13 +15,6 @@ describe('<DataListToolbar />', () => {
     integerFields: ['page', 'page_size'],
   };
 
-  afterEach(() => {
-    if (toolbar) {
-      toolbar.unmount();
-      toolbar = null;
-    }
-  });
-
   const onSearch = jest.fn();
   const onReplaceSearch = jest.fn();
   const onSort = jest.fn();

--- a/awx/ui_next/src/components/DisassociateButton/DisassociateButton.test.jsx
+++ b/awx/ui_next/src/components/DisassociateButton/DisassociateButton.test.jsx
@@ -40,7 +40,6 @@ describe('<DisassociateButton />', () => {
 
     afterAll(() => {
       jest.clearAllMocks();
-      wrapper.unmount();
     });
 
     test('should render button', () => {

--- a/awx/ui_next/src/components/ErrorDetail/ErrorDetail.jsx
+++ b/awx/ui_next/src/components/ErrorDetail/ErrorDetail.jsx
@@ -36,6 +36,10 @@ function ErrorDetail({ error }) {
   const { response } = error;
   const [isExpanded, setIsExpanded] = useState(false);
 
+  if (!error) {
+    return null;
+  }
+
   const handleToggle = () => {
     setIsExpanded(!isExpanded);
   };
@@ -84,7 +88,10 @@ function ErrorDetail({ error }) {
 }
 
 ErrorDetail.propTypes = {
-  error: PropTypes.instanceOf(Error).isRequired,
+  error: PropTypes.instanceOf(Error),
+};
+ErrorDetail.defaultProps = {
+  error: null,
 };
 
 export default ErrorDetail;

--- a/awx/ui_next/src/components/ExpandCollapse/ExpandCollapse.test.jsx
+++ b/awx/ui_next/src/components/ExpandCollapse/ExpandCollapse.test.jsx
@@ -15,6 +15,5 @@ describe('<ExpandCollapse />', () => {
       />
     );
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/components/FieldWithPrompt/FieldWithPrompt.test.jsx
+++ b/awx/ui_next/src/components/FieldWithPrompt/FieldWithPrompt.test.jsx
@@ -6,10 +6,6 @@ import FieldWithPrompt from './FieldWithPrompt';
 describe('FieldWithPrompt', () => {
   let wrapper;
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('Required asterisk and Popover hidden when not required and tooltip not provided', () => {
     wrapper = mountWithContexts(
       <Formik

--- a/awx/ui_next/src/components/JobList/JobListCancelButton.test.jsx
+++ b/awx/ui_next/src/components/JobList/JobListCancelButton.test.jsx
@@ -5,9 +5,6 @@ import JobListCancelButton from './JobListCancelButton';
 describe('<JobListCancelButton />', () => {
   let wrapper;
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
   test('should be disabled when no rows are selected', () => {
     wrapper = mountWithContexts(<JobListCancelButton jobsToCancel={[]} />);
     expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(

--- a/awx/ui_next/src/components/JobList/JobListItem.test.jsx
+++ b/awx/ui_next/src/components/JobList/JobListItem.test.jsx
@@ -41,10 +41,6 @@ describe('<JobListItem />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('initially renders successfully', () => {
     expect(wrapper.find('JobListItem').length).toBe(1);
   });
@@ -116,10 +112,6 @@ describe('<JobListItem with failed job />', () => {
       </table>,
       { context: { router: { history } } }
     );
-  });
-
-  afterEach(() => {
-    wrapper.unmount();
   });
 
   test('launch button shown to users with launch capabilities', () => {

--- a/awx/ui_next/src/components/ListHeader/ListHeader.test.jsx
+++ b/awx/ui_next/src/components/ListHeader/ListHeader.test.jsx
@@ -24,7 +24,6 @@ describe('ListHeader', () => {
       />
     );
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
 
   test('should navigate when DataListToolbar calls onSort prop', async () => {

--- a/awx/ui_next/src/components/Lookup/ApplicationLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/ApplicationLookup.test.jsx
@@ -36,7 +36,6 @@ describe('ApplicationLookup', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should render successfully', async () => {

--- a/awx/ui_next/src/components/Lookup/ExecutionEnvironmentLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/ExecutionEnvironmentLookup.test.jsx
@@ -38,7 +38,6 @@ describe('ExecutionEnvironmentLookup', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should render successfully', async () => {

--- a/awx/ui_next/src/components/Lookup/InventoryLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/InventoryLookup.test.jsx
@@ -26,7 +26,6 @@ describe('InventoryLookup', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should render successfully and fetch data', async () => {

--- a/awx/ui_next/src/components/Lookup/Lookup.jsx
+++ b/awx/ui_next/src/components/Lookup/Lookup.jsx
@@ -7,6 +7,7 @@ import {
   number,
   oneOfType,
   shape,
+  node,
 } from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { useField } from 'formik';
@@ -206,7 +207,7 @@ const Item = shape({
 Lookup.propTypes = {
   id: string,
   header: string,
-  modalDescription: string,
+  modalDescription: oneOfType([string, node]),
   onChange: func.isRequired,
   value: oneOfType([Item, arrayOf(Item)]),
   multiple: bool,

--- a/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/MultiCredentialsLookup.test.jsx
@@ -122,7 +122,6 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should load credential types', async () => {

--- a/awx/ui_next/src/components/Lookup/OrganizationLookup.test.jsx
+++ b/awx/ui_next/src/components/Lookup/OrganizationLookup.test.jsx
@@ -12,7 +12,6 @@ describe('OrganizationLookup', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should render successfully', async () => {

--- a/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.jsx
+++ b/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.jsx
@@ -10,6 +10,7 @@ const SmallButton = styled(Button)`
     font-size: var(--pf-global--FontSize--xs);
   }
 `;
+SmallButton.displayName = 'SmallButton';
 
 function MultiButtonToggle({ buttons, value, onChange, name }) {
   const setValue = newValue => {

--- a/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.test.jsx
+++ b/awx/ui_next/src/components/MultiButtonToggle/MultiButtonToggle.test.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import MultiButtonToggle from './MultiButtonToggle';
 
 describe('<MultiButtonToggle />', () => {
   let wrapper;
   const onChange = jest.fn();
+
   beforeAll(() => {
-    wrapper = mount(
+    wrapper = shallow(
       <MultiButtonToggle
         buttons={[
           ['yaml', 'YAML'],
@@ -14,20 +15,20 @@ describe('<MultiButtonToggle />', () => {
         ]}
         value="yaml"
         onChange={onChange}
+        name="the-button"
       />
     );
   });
-  afterAll(() => {
-    wrapper.unmount();
-  });
+
   it('should render buttons successfully', () => {
-    const buttons = wrapper.find('Button');
+    const buttons = wrapper.find('SmallButton');
     expect(buttons.length).toBe(2);
     expect(buttons.at(0).props().variant).toBe('primary');
     expect(buttons.at(1).props().variant).toBe('secondary');
   });
+
   it('should call onChange function when button clicked', () => {
-    const buttons = wrapper.find('Button');
+    const buttons = wrapper.find('SmallButton');
     buttons.at(1).simulate('click');
     expect(onChange).toHaveBeenCalledWith('json');
   });

--- a/awx/ui_next/src/components/NotificationList/NotificationListItem.test.jsx
+++ b/awx/ui_next/src/components/NotificationList/NotificationListItem.test.jsx
@@ -21,10 +21,6 @@ describe('<NotificationListItem canToggleNotifications />', () => {
   });
 
   afterEach(() => {
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = null;
-    }
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/components/PaginatedTable/ToolbarDeleteButton.test.jsx
+++ b/awx/ui_next/src/components/PaginatedTable/ToolbarDeleteButton.test.jsx
@@ -40,8 +40,8 @@ describe('<ToolbarDeleteButton />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
+
   test('should render button', () => {
     wrapper = mountWithContexts(
       <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[]} />

--- a/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.test.jsx
+++ b/awx/ui_next/src/components/PromptDetail/PromptProjectDetail.test.jsx
@@ -25,10 +25,6 @@ describe('PromptProjectDetail', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('should render successfully', () => {
     expect(wrapper.find('PromptProjectDetail')).toHaveLength(1);
   });

--- a/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.test.jsx
+++ b/awx/ui_next/src/components/ResourceAccessList/ResourceAccessList.test.jsx
@@ -133,7 +133,6 @@ describe('<ResourceAccessList />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/components/Schedule/Schedule.test.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedule.test.jsx
@@ -113,12 +113,11 @@ describe('<Schedule />', () => {
     });
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
   });
-  afterAll(() => {
-    wrapper.unmount();
-  });
+
   test('renders successfully', async () => {
     expect(wrapper.length).toBe(1);
   });
+
   test('expect all tabs to exist, including Back to Schedules', async () => {
     expect(
       wrapper.find('button[link="/templates/job_template/1/schedules"]').length

--- a/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleAdd/ScheduleAdd.test.jsx
@@ -73,7 +73,9 @@ describe('<ScheduleAdd />', () => {
         />
       );
     });
+    wrapper.update();
   });
+
   test('Successfully creates a schedule with repeat frequency: None (run once)', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -95,6 +97,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200325T100000 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
+
   test('Successfully creates a schedule with 10 minute repeat frequency after 10 occurrences', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -117,6 +120,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200325T103000 RRULE:INTERVAL=10;FREQ=MINUTELY;COUNT=10',
     });
   });
+
   test('Successfully creates a schedule with hourly repeat frequency ending on a specific date/time', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -140,6 +144,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=HOURLY;UNTIL=20200326T104500',
     });
   });
+
   test('Successfully creates a schedule with daily repeat frequency', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -161,6 +166,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=DAILY',
     });
   });
+
   test('Successfully creates a schedule with weekly repeat frequency on mon/wed/fri', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -183,6 +189,7 @@ describe('<ScheduleAdd />', () => {
       rrule: `DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=${RRule.MO},${RRule.WE},${RRule.FR}`,
     });
   });
+
   test('Successfully creates a schedule with monthly repeat frequency on the first day of the month', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -207,6 +214,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200401T104500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYMONTHDAY=1',
     });
   });
+
   test('Successfully creates a schedule with monthly repeat frequency on the last tuesday of the month', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -259,6 +267,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200301T000000 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1',
     });
   });
+
   test('Successfully creates a schedule with yearly repeat frequency on the second Friday in April', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -285,6 +294,7 @@ describe('<ScheduleAdd />', () => {
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=2;BYDAY=FR;BYMONTH=4',
     });
   });
+
   test('Successfully creates a schedule with yearly repeat frequency on the first weekday in October', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -464,6 +474,7 @@ describe('<ScheduleAdd />', () => {
         />
       );
     });
+    scheduleSurveyWrapper.update();
     await act(async () => {
       scheduleSurveyWrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',

--- a/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleEdit/ScheduleEdit.test.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { RRule } from 'rrule';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import {
   SchedulesAPI,
   InventoriesAPI,
@@ -191,12 +188,13 @@ describe('<ScheduleEdit />', () => {
         />
       );
     });
-    await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
+    wrapper.update();
   });
+
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
+
   test('Successfully creates a schedule with repeat frequency: None (run once)', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -210,6 +208,7 @@ describe('<ScheduleEdit />', () => {
         timezone: 'America/New_York',
       });
     });
+
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run once schedule',
@@ -218,6 +217,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200325T100000 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
+
   test('Successfully creates a schedule with 10 minute repeat frequency after 10 occurrences', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -241,6 +241,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200325T103000 RRULE:INTERVAL=10;FREQ=MINUTELY;COUNT=10',
     });
   });
+
   test('Successfully creates a schedule with hourly repeat frequency ending on a specific date/time', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -256,6 +257,7 @@ describe('<ScheduleEdit />', () => {
         timezone: 'America/New_York',
       });
     });
+
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run every hour until date',
@@ -264,6 +266,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=HOURLY;UNTIL=20200326T104500',
     });
   });
+
   test('Successfully creates a schedule with daily repeat frequency', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -308,6 +311,7 @@ describe('<ScheduleEdit />', () => {
       rrule: `DTSTART;TZID=America/New_York:20200325T104500 RRULE:INTERVAL=1;FREQ=WEEKLY;BYDAY=${RRule.MO},${RRule.WE},${RRule.FR}`,
     });
   });
+
   test('Successfully creates a schedule with monthly repeat frequency on the first day of the month', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -333,6 +337,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200401T104500 RRULE:INTERVAL=1;FREQ=MONTHLY;BYMONTHDAY=1',
     });
   });
+
   test('Successfully creates a schedule with monthly repeat frequency on the last tuesday of the month', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -362,6 +367,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200331T110000 RRULE:INTERVAL=1;FREQ=MONTHLY;BYSETPOS=-1;BYDAY=TU',
     });
   });
+
   test('Successfully creates a schedule with yearly repeat frequency on the first day of March', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -388,6 +394,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200301T000000 RRULE:INTERVAL=1;FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=1',
     });
   });
+
   test('Successfully creates a schedule with yearly repeat frequency on the second Friday in April', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -416,6 +423,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200410T111500 RRULE:INTERVAL=1;FREQ=YEARLY;BYSETPOS=2;BYDAY=FR;BYMONTH=4',
     });
   });
+
   test('Successfully creates a schedule with yearly repeat frequency on the first weekday in October', async () => {
     await act(async () => {
       wrapper.find('Formik').invoke('onSubmit')({
@@ -653,6 +661,7 @@ describe('<ScheduleEdit />', () => {
         'DTSTART;TZID=America/New_York:20200402T184500 RRULE:INTERVAL=1;COUNT=1;FREQ=MINUTELY',
     });
   });
+
   test('should submit survey with default values properly, without opening prompt wizard', async () => {
     let scheduleSurveyWrapper;
     await act(async () => {
@@ -741,6 +750,8 @@ describe('<ScheduleEdit />', () => {
         />
       );
     });
+    scheduleSurveyWrapper.update();
+
     await act(async () => {
       scheduleSurveyWrapper.find('Formik').invoke('onSubmit')({
         description: 'test description',
@@ -753,6 +764,7 @@ describe('<ScheduleEdit />', () => {
         timezone: 'America/New_York',
       });
     });
+
     expect(SchedulesAPI.update).toHaveBeenCalledWith(27, {
       description: 'test description',
       name: 'Run once schedule',

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleList.test.jsx
@@ -52,10 +52,6 @@ describe('ScheduleList', () => {
       wrapper.update();
     });
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
-
     test('should fetch schedules from api and render the list', () => {
       expect(loadSchedules).toHaveBeenCalled();
       expect(wrapper.find('ScheduleListItem').length).toBe(5);

--- a/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleList/ScheduleListItem.test.jsx
@@ -64,10 +64,6 @@ describe('ScheduleListItem', () => {
       );
     });
 
-    afterAll(() => {
-      wrapper.unmount();
-    });
-
     test('Name correctly shown with correct link', () => {
       expect(
         wrapper
@@ -149,10 +145,6 @@ describe('ScheduleListItem', () => {
       );
     });
 
-    afterAll(() => {
-      wrapper.unmount();
-    });
-
     test('Name correctly shown with correct link', () => {
       expect(
         wrapper
@@ -215,10 +207,6 @@ describe('ScheduleListItem', () => {
           </tbody>
         </table>
       );
-    });
-
-    afterAll(() => {
-      wrapper.unmount();
     });
 
     test('should show missing resource icon', () => {

--- a/awx/ui_next/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.test.jsx
+++ b/awx/ui_next/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.test.jsx
@@ -15,15 +15,15 @@ describe('<ScheduleOccurrences>', () => {
         />
       );
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('Local option initially set', async () => {
       expect(wrapper.find('MultiButtonToggle').props().value).toBe('local');
     });
+
     test('It renders the correct number of dates', async () => {
       expect(wrapper.find('dd').children().length).toBe(2);
     });
+
     test('Clicking UTC button toggles the dates to utc', async () => {
       wrapper.find('button[aria-label="UTC"]').simulate('click');
       expect(wrapper.find('MultiButtonToggle').props().value).toBe('utc');
@@ -44,6 +44,7 @@ describe('<ScheduleOccurrences>', () => {
       ).toBe('3/30/2020, 4:00:00 AM');
     });
   });
+
   describe('Only one date passed in', () => {
     test('Component should not render chldren', async () => {
       wrapper = mountWithContexts(
@@ -55,7 +56,6 @@ describe('<ScheduleOccurrences>', () => {
         />
       );
       expect(wrapper.find('ScheduleOccurrences').children().length).toBe(0);
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/components/Schedule/Schedules.test.jsx
+++ b/awx/ui_next/src/components/Schedule/Schedules.test.jsx
@@ -19,6 +19,7 @@ describe('<Schedules />', () => {
           jobTemplate={jobTemplate}
           loadSchedules={() => {}}
           loadScheduleOptions={() => {}}
+          apiModel={{ createSchedule: () => {} }}
         />,
 
         {

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.jsx
@@ -178,7 +178,6 @@ function ScheduleForm({
   hasDaysToKeepField,
   handleCancel,
   handleSubmit,
-
   schedule,
   submitError,
   resource,
@@ -234,8 +233,14 @@ function ScheduleForm({
     {
       zonesOptions: [],
       credentials: [],
+      isLoading: true,
     }
   );
+
+  useEffect(() => {
+    loadScheduleData();
+  }, [loadScheduleData]);
+
   const missingRequiredInventory = useCallback(() => {
     let missingInventory = false;
     if (
@@ -356,10 +361,6 @@ function ScheduleForm({
     missingRequiredInventory,
     hasCredentialsThatPrompt,
   ]);
-
-  useEffect(() => {
-    loadScheduleData();
-  }, [loadScheduleData]);
 
   let showPromptButton = false;
 

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
@@ -730,10 +730,6 @@ describe('<ScheduleForm />', () => {
         );
       });
 
-      await act(async () => {
-        wrapper.find('DatePicker[aria-label="End date"]').simulate('blur');
-      });
-
       wrapper.update();
       expect(wrapper.find('#schedule-End-datetime-helper').text()).toBe(
         'Please select an end date/time that comes after the start date/time.'

--- a/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
+++ b/awx/ui_next/src/components/Schedule/shared/ScheduleForm.test.jsx
@@ -168,6 +168,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('ContentError').length).toBe(1);
     });
   });
+
   describe('Cancel', () => {
     test('should make the appropriate callback', async () => {
       const handleCancel = jest.fn();
@@ -226,8 +227,10 @@ describe('<ScheduleForm />', () => {
       expect(handleCancel).toHaveBeenCalledTimes(1);
     });
   });
+
   describe('Prompted Schedule', () => {
     let promptWrapper;
+
     beforeEach(async () => {
       SchedulesAPI.readZoneInfo.mockResolvedValue({
         data: [
@@ -284,8 +287,8 @@ describe('<ScheduleForm />', () => {
         el => el.length > 0
       );
     });
+
     afterEach(() => {
-      promptWrapper.unmount();
       jest.clearAllMocks();
     });
 
@@ -375,6 +378,7 @@ describe('<ScheduleForm />', () => {
       promptWrapper.update();
       expect(promptWrapper.find('Wizard').length).toBe(0);
     });
+
     test('should render prompt button with disabled save button', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -423,6 +427,7 @@ describe('<ScheduleForm />', () => {
       );
     });
   });
+
   describe('Add', () => {
     beforeAll(async () => {
       SchedulesAPI.readZoneInfo.mockResolvedValue({
@@ -473,9 +478,7 @@ describe('<ScheduleForm />', () => {
       });
       await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('initially renders expected fields and values', () => {
       const now = new Date();
       const closestQuarterHour = new Date(
@@ -503,6 +506,7 @@ describe('<ScheduleForm />', () => {
         'none'
       );
     });
+
     test('correct frequency details fields and values shown when frequency changed to minute', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -526,6 +530,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
     });
+
     test('correct frequency details fields and values shown when frequency changed to hour', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -549,6 +554,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
     });
+
     test('correct frequency details fields and values shown when frequency changed to day', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -572,6 +578,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
     });
+
     test('correct frequency details fields and values shown when frequency changed to week', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -595,6 +602,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
     });
+
     test('correct frequency details fields and values shown when frequency changed to month', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -629,6 +637,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('select#schedule-run-on-day-month').length).toBe(0);
       expect(wrapper.find('select#schedule-run-on-the-month').length).toBe(0);
     });
+
     test('correct frequency details fields and values shown when frequency changed to year', async () => {
       const runFrequencySelect = wrapper.find(
         'FormGroup[label="Run frequency"] FormSelect'
@@ -663,6 +672,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('select#schedule-run-on-day-month').length).toBe(1);
       expect(wrapper.find('select#schedule-run-on-the-month').length).toBe(1);
     });
+
     test('occurrences field properly shown when end after selection is made', async () => {
       await act(async () => {
         wrapper
@@ -690,6 +700,7 @@ describe('<ScheduleForm />', () => {
       });
       wrapper.update();
     });
+
     test('error shown when end date/time comes before start date/time', async () => {
       await act(async () => {
         wrapper
@@ -728,6 +739,7 @@ describe('<ScheduleForm />', () => {
         'Please select an end date/time that comes after the start date/time.'
       );
     });
+
     test('error shown when on day number is not between 1 and 31', async () => {
       act(() => {
         wrapper.find('select[id="schedule-frequency"]').invoke('onChange')(
@@ -761,6 +773,7 @@ describe('<ScheduleForm />', () => {
       );
     });
   });
+
   describe('Edit', () => {
     beforeEach(async () => {
       SchedulesAPI.readZoneInfo.mockResolvedValue({
@@ -773,12 +786,12 @@ describe('<ScheduleForm />', () => {
 
       SchedulesAPI.readCredentials.mockResolvedValue(credentials);
     });
+
     afterEach(() => {
-      wrapper.unmount();
       jest.clearAllMocks();
     });
 
-    test('should  make API calls to fetch credentials, launch configuration, and survey configuration', async () => {
+    test('should make API calls to fetch credentials, launch configuration, and survey configuration', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
           <ScheduleForm
@@ -906,6 +919,7 @@ describe('<ScheduleForm />', () => {
           />
         );
       });
+      wrapper.update();
       expect(wrapper.find('ScheduleForm').length).toBe(1);
       defaultFieldsVisible();
       expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(0);
@@ -920,6 +934,7 @@ describe('<ScheduleForm />', () => {
         'none'
       );
     });
+
     test('initially renders expected fields and values with existing schedule that runs every 10 minutes', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -941,6 +956,8 @@ describe('<ScheduleForm />', () => {
           />
         );
       });
+      wrapper.update();
+
       expect(wrapper.find('ScheduleForm').length).toBe(1);
       defaultFieldsVisible();
       expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
@@ -959,6 +976,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
     });
+
     test('initially renders expected fields and values with existing schedule that runs every hour 10 times', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -981,6 +999,8 @@ describe('<ScheduleForm />', () => {
           />
         );
       });
+      wrapper.update();
+
       expect(wrapper.find('ScheduleForm').length).toBe(1);
       defaultFieldsVisible();
       expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
@@ -1000,6 +1020,7 @@ describe('<ScheduleForm />', () => {
       expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
       expect(wrapper.find('input#schedule-occurrences').prop('value')).toBe(10);
     });
+
     test('initially renders expected fields and values with existing schedule that runs every day', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -1021,25 +1042,28 @@ describe('<ScheduleForm />', () => {
             }}
           />
         );
-        expect(wrapper.find('ScheduleForm').length).toBe(1);
-        defaultFieldsVisible();
-        expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
-
-        nonRRuleValuesMatch();
-        expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
-          'day'
-        );
-        expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
-        expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
-        expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
-        expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
       });
+      wrapper.update();
+
+      expect(wrapper.find('ScheduleForm').length).toBe(1);
+      defaultFieldsVisible();
+      expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
+
+      nonRRuleValuesMatch();
+      expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
+        'day'
+      );
+      expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
+      expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
+      expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
+      expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
     });
+
     test('initially renders expected fields and values with existing schedule that runs every week on m/w/f until Jan 1, 2020', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -1062,6 +1086,8 @@ describe('<ScheduleForm />', () => {
           />
         );
       });
+      wrapper.update();
+
       expect(wrapper.find('ScheduleForm').length).toBe(1);
       defaultFieldsVisible();
       expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
@@ -1107,6 +1133,7 @@ describe('<ScheduleForm />', () => {
         wrapper.find('TimePicker[aria-label="End time"]').prop('value')
       ).toBe('1:00 AM');
     });
+
     test('initially renders expected fields and values with existing schedule that runs every month on the last weekday', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -1128,37 +1155,43 @@ describe('<ScheduleForm />', () => {
             }}
           />
         );
-        expect(wrapper.find('ScheduleForm').length).toBe(1);
-        defaultFieldsVisible();
-        expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
-
-        nonRRuleValuesMatch();
-        expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
-          'month'
-        );
-        expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
-        expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
-        expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
-        expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
-        expect(wrapper.find('input#schedule-run-on-day').prop('checked')).toBe(
-          false
-        );
-        expect(wrapper.find('input#schedule-run-on-the').prop('checked')).toBe(
-          true
-        );
-        expect(
-          wrapper.find('select#schedule-run-on-the-occurrence').prop('value')
-        ).toBe(-1);
-        expect(
-          wrapper.find('select#schedule-run-on-the-day').prop('value')
-        ).toBe('weekday');
       });
+      wrapper.update();
+
+      expect(wrapper.find('ScheduleForm').length).toBe(1);
+      defaultFieldsVisible();
+
+      expect(wrapper.find('ScheduleForm').length).toBe(1);
+      defaultFieldsVisible();
+      expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
+
+      nonRRuleValuesMatch();
+      expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
+        'month'
+      );
+      expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
+      expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
+      expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
+      expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
+      expect(wrapper.find('input#schedule-run-on-day').prop('checked')).toBe(
+        false
+      );
+      expect(wrapper.find('input#schedule-run-on-the').prop('checked')).toBe(
+        true
+      );
+      expect(
+        wrapper.find('select#schedule-run-on-the-occurrence').prop('value')
+      ).toBe(-1);
+      expect(wrapper.find('select#schedule-run-on-the-day').prop('value')).toBe(
+        'weekday'
+      );
     });
+
     test('initially renders expected fields and values with existing schedule that runs every year on the May 6', async () => {
       await act(async () => {
         wrapper = mountWithContexts(
@@ -1180,36 +1213,38 @@ describe('<ScheduleForm />', () => {
             }}
           />
         );
-        expect(wrapper.find('ScheduleForm').length).toBe(1);
-        defaultFieldsVisible();
-        expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(1);
-        expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
-        expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
-
-        nonRRuleValuesMatch();
-        expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
-          'year'
-        );
-        expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
-        expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
-        expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
-        expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
-        expect(wrapper.find('input#schedule-run-on-day').prop('checked')).toBe(
-          true
-        );
-        expect(wrapper.find('input#schedule-run-on-the').prop('checked')).toBe(
-          false
-        );
-        expect(
-          wrapper.find('select#schedule-run-on-day-month').prop('value')
-        ).toBe(5);
-        expect(
-          wrapper.find('input#schedule-run-on-day-number').prop('value')
-        ).toBe(6);
       });
+      wrapper.update();
+
+      expect(wrapper.find('ScheduleForm').length).toBe(1);
+      defaultFieldsVisible();
+      expect(wrapper.find('FormGroup[label="End"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Run every"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="Run on"]').length).toBe(1);
+      expect(wrapper.find('FormGroup[label="End date/time"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="On days"]').length).toBe(0);
+      expect(wrapper.find('FormGroup[label="Occurrences"]').length).toBe(0);
+
+      nonRRuleValuesMatch();
+      expect(wrapper.find('select#schedule-frequency').prop('value')).toBe(
+        'year'
+      );
+      expect(wrapper.find('input#end-never').prop('checked')).toBe(true);
+      expect(wrapper.find('input#end-after').prop('checked')).toBe(false);
+      expect(wrapper.find('input#end-on-date').prop('checked')).toBe(false);
+      expect(wrapper.find('input#schedule-run-every').prop('value')).toBe(1);
+      expect(wrapper.find('input#schedule-run-on-day').prop('checked')).toBe(
+        true
+      );
+      expect(wrapper.find('input#schedule-run-on-the').prop('checked')).toBe(
+        false
+      );
+      expect(
+        wrapper.find('select#schedule-run-on-day-month').prop('value')
+      ).toBe(5);
+      expect(
+        wrapper.find('input#schedule-run-on-day-number').prop('value')
+      ).toBe(6);
     });
   });
 });

--- a/awx/ui_next/src/components/ScreenHeader/ScreenHeader.test.jsx
+++ b/awx/ui_next/src/components/ScreenHeader/ScreenHeader.test.jsx
@@ -43,7 +43,6 @@ describe('<ScreenHeader />', () => {
     expect(breadcrumbItem.first().text()).toBe('Foo');
     expect(breadcrumbItem.last().text()).toBe('One');
     expect(breadcrumbHeading.text()).toBe('Bar');
-    breadcrumbWrapper.unmount();
   });
 
   test('renders breadcrumb items defined in breadcrumbConfig', () => {
@@ -66,7 +65,6 @@ describe('<ScreenHeader />', () => {
       expect(breadcrumbWrapper.find('BreadcrumbItem')).toHaveLength(
         crumbLength
       );
-      breadcrumbWrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/components/ScreenHeader/ScreenHeader.test.jsx
+++ b/awx/ui_next/src/components/ScreenHeader/ScreenHeader.test.jsx
@@ -5,10 +5,6 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import ScreenHeader from './ScreenHeader';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<ScreenHeader />', () => {
   let breadcrumbWrapper;
   let breadcrumb;

--- a/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
+++ b/awx/ui_next/src/components/Search/AdvancedSearch.test.jsx
@@ -7,7 +7,6 @@ describe('<AdvancedSearch />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/components/SelectableCard/SelectableCard.test.jsx
+++ b/awx/ui_next/src/components/SelectableCard/SelectableCard.test.jsx
@@ -8,11 +8,10 @@ describe('<SelectableCard />', () => {
   test('initially renders without crashing when not selected', () => {
     wrapper = shallow(<SelectableCard onClick={onClick} />);
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
+
   test('initially renders without crashing when selected', () => {
     wrapper = shallow(<SelectableCard isSelected onClick={onClick} />);
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/components/SelectedList/DraggableSelectedList.test.jsx
+++ b/awx/ui_next/src/components/SelectedList/DraggableSelectedList.test.jsx
@@ -6,8 +6,8 @@ describe('<DraggableSelectedList />', () => {
   let wrapper;
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
+
   test('should render expected rows', () => {
     const mockSelected = [
       {

--- a/awx/ui_next/src/components/Sort/Sort.jsx
+++ b/awx/ui_next/src/components/Sort/Sort.jsx
@@ -147,4 +147,7 @@ Sort.defaultProps = {
   onSort: null,
 };
 
-export default withRouter(Sort);
+export { Sort as _Sort };
+const Wrapped = withRouter(Sort);
+Wrapped.displayName = 'Sort';
+export default Wrapped;

--- a/awx/ui_next/src/components/Sort/Sort.test.jsx
+++ b/awx/ui_next/src/components/Sort/Sort.test.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
 import {
   mountWithContexts,
   waitForElement,
 } from '../../../testUtils/enzymeHelpers';
 
-import Sort from './Sort';
+import Sort, { _Sort as SortUnwrapped } from './Sort';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/organizations',
+  }),
+}));
 
 describe('<Sort />', () => {
   let sort;
@@ -16,7 +24,7 @@ describe('<Sort />', () => {
     }
   });
 
-  test('it triggers the expected callbacks', () => {
+  test('should trigger onSort callback', () => {
     const qsConfig = {
       namespace: 'item',
       defaultParams: { page: 1, page_size: 5, order_by: 'name' },
@@ -150,71 +158,79 @@ describe('<Sort />', () => {
     expect(onSort).toBeCalledWith('bar', 'ascending');
   });
 
-  test('It displays correct sort icon', () => {
-    const forwardNumericIconSelector = 'SortNumericDownIcon';
-    const reverseNumericIconSelector = 'SortNumericDownAltIcon';
-    const forwardAlphaIconSelector = 'SortAlphaDownIcon';
-    const reverseAlphaIconSelector = 'SortAlphaDownAltIcon';
-
+  test('should display numeric descending icon', () => {
     const qsConfigNumDown = {
       namespace: 'item',
       defaultParams: { page: 1, page_size: 5, order_by: '-id' },
       integerFields: ['page', 'page_size', 'id'],
     };
+    const numericColumns = [{ name: 'ID', key: 'id' }];
+
+    const wrapper = shallow(
+      <SortUnwrapped
+        qsConfig={qsConfigNumDown}
+        columns={numericColumns}
+        onSort={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find('SortNumericDownAltIcon')).toHaveLength(1);
+  });
+
+  test('should display numeric ascending icon', () => {
     const qsConfigNumUp = {
       namespace: 'item',
       defaultParams: { page: 1, page_size: 5, order_by: 'id' },
       integerFields: ['page', 'page_size', 'id'],
     };
+    const numericColumns = [{ name: 'ID', key: 'id' }];
+
+    const wrapper = shallow(
+      <SortUnwrapped
+        qsConfig={qsConfigNumUp}
+        columns={numericColumns}
+        onSort={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find('SortNumericDownIcon')).toHaveLength(1);
+  });
+
+  test('should display alphanumeric descending icon', () => {
     const qsConfigAlphaDown = {
       namespace: 'item',
       defaultParams: { page: 1, page_size: 5, order_by: '-name' },
       integerFields: ['page', 'page_size'],
     };
-    const qsConfigAlphaUp = {
+    const alphaColumns = [{ name: 'Name', key: 'name' }];
+
+    const wrapper = shallow(
+      <SortUnwrapped
+        qsConfig={qsConfigAlphaDown}
+        columns={alphaColumns}
+        onSort={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find('SortAlphaDownAltIcon')).toHaveLength(1);
+  });
+
+  test('should display alphanumeric ascending icon', () => {
+    const qsConfigAlphaDown = {
       namespace: 'item',
       defaultParams: { page: 1, page_size: 5, order_by: 'name' },
       integerFields: ['page', 'page_size'],
     };
-
-    const numericColumns = [{ name: 'ID', key: 'id' }];
     const alphaColumns = [{ name: 'Name', key: 'name' }];
-    const onSort = jest.fn();
 
-    sort = mountWithContexts(
-      <Sort
-        qsConfig={qsConfigNumDown}
-        columns={numericColumns}
-        onSort={onSort}
-      />
-    );
-
-    const reverseNumericIcon = sort.find(reverseNumericIconSelector);
-    expect(reverseNumericIcon.length).toBe(1);
-
-    sort = mountWithContexts(
-      <Sort qsConfig={qsConfigNumUp} columns={numericColumns} onSort={onSort} />
-    );
-
-    const forwardNumericIcon = sort.find(forwardNumericIconSelector);
-    expect(forwardNumericIcon.length).toBe(1);
-
-    sort = mountWithContexts(
-      <Sort
+    const wrapper = shallow(
+      <SortUnwrapped
         qsConfig={qsConfigAlphaDown}
         columns={alphaColumns}
-        onSort={onSort}
+        onSort={jest.fn()}
       />
     );
 
-    const reverseAlphaIcon = sort.find(reverseAlphaIconSelector);
-    expect(reverseAlphaIcon.length).toBe(1);
-
-    sort = mountWithContexts(
-      <Sort qsConfig={qsConfigAlphaUp} columns={alphaColumns} onSort={onSort} />
-    );
-
-    const forwardAlphaIcon = sort.find(forwardAlphaIconSelector);
-    expect(forwardAlphaIcon.length).toBe(1);
+    expect(wrapper.find('SortAlphaDownIcon')).toHaveLength(1);
   });
 });

--- a/awx/ui_next/src/screens/ActivityStream/ActivityStream.test.jsx
+++ b/awx/ui_next/src/screens/ActivityStream/ActivityStream.test.jsx
@@ -1,25 +1,17 @@
 import React from 'react';
-
+import { act } from 'react-dom/test-utils';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import ActivityStream from './ActivityStream';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
+jest.mock('../../api');
 
 describe('<ActivityStream />', () => {
-  let pageWrapper;
-
-  beforeEach(() => {
-    pageWrapper = mountWithContexts(<ActivityStream />);
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
-  });
-
-  test('initially renders without crashing', () => {
+  test('initially renders without crashing', async () => {
+    let pageWrapper;
+    await act(async () => {
+      pageWrapper = await mountWithContexts(<ActivityStream />);
+    });
     expect(pageWrapper.length).toBe(1);
   });
 });

--- a/awx/ui_next/src/screens/Application/Application/Application.test.jsx
+++ b/awx/ui_next/src/screens/Application/Application/Application.test.jsx
@@ -15,6 +15,7 @@ jest.mock('react-router-dom', () => ({
   }),
   useParams: () => ({ id: 1 }),
 }));
+
 const options = {
   data: {
     actions: {

--- a/awx/ui_next/src/screens/Application/Applications.test.jsx
+++ b/awx/ui_next/src/screens/Application/Applications.test.jsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { shallow } from 'enzyme';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Applications from './Applications';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<Applications />', () => {
   let wrapper;
-
-  afterEach(() => {
-    wrapper.unmount();
-  });
 
   test('renders successfully', () => {
     wrapper = mountWithContexts(<Applications />);
@@ -28,22 +20,20 @@ describe('<Applications />', () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/add'],
     });
-    wrapper = mountWithContexts(<Applications />, {
+    wrapper = shallow(<Applications />, {
       context: { router: { history } },
     });
     expect(wrapper.find('Modal[title="Application information"]').length).toBe(
       0
     );
-    await act(async () => {
-      wrapper
-        .find('ApplicationAdd')
-        .props()
-        .onSuccessfulAdd({
-          name: 'test',
-          client_id: 'foobar',
-          client_secret: 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
-        });
-    });
+    wrapper
+      .find('ApplicationAdd')
+      .props()
+      .onSuccessfulAdd({
+        name: 'test',
+        client_id: 'foobar',
+        client_secret: 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
+      });
     wrapper.update();
     expect(wrapper.find('Modal[title="Application information"]').length).toBe(
       1

--- a/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialAdd/CredentialAdd.test.jsx
@@ -196,7 +196,6 @@ describe('<CredentialAdd />', () => {
       });
       wrapper.update();
       expect(wrapper.find('ContentError').length).toBe(1);
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
@@ -485,7 +485,6 @@ describe('<CredentialEdit />', () => {
       });
       wrapper.update();
       expect(wrapper.find('ContentError').length).toBe(1);
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialEdit/CredentialEdit.test.jsx
@@ -350,10 +350,6 @@ describe('<CredentialEdit />', () => {
       });
     });
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
-
     test('initially renders successfully', async () => {
       expect(wrapper.find('CredentialEdit').length).toBe(1);
     });

--- a/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialList/CredentialList.test.jsx
@@ -33,7 +33,6 @@ describe('<CredentialList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Credential/CredentialList/CredentialListItem.test.jsx
+++ b/awx/ui_next/src/screens/Credential/CredentialList/CredentialListItem.test.jsx
@@ -10,10 +10,6 @@ jest.mock('../../../api');
 describe('<CredentialListItem />', () => {
   let wrapper;
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('edit button shown to users with edit capabilities', () => {
     wrapper = mountWithContexts(
       <table>

--- a/awx/ui_next/src/screens/Credential/Credentials.test.jsx
+++ b/awx/ui_next/src/screens/Credential/Credentials.test.jsx
@@ -1,60 +1,16 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { shallow } from 'enzyme';
 import Credentials from './Credentials';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<Credentials />', () => {
-  let wrapper;
+  test('should set breadcrumb config', () => {
+    const wrapper = shallow(<Credentials />);
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
-  test('initially renders successfully', () => {
-    wrapper = mountWithContexts(<Credentials />);
-  });
-
-  test('should display credential list breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/credentials'],
+    const header = wrapper.find('ScreenHeader');
+    expect(header.prop('streamType')).toEqual('credential');
+    expect(header.prop('breadcrumbConfig')).toEqual({
+      '/credentials': 'Credentials',
+      '/credentials/add': 'Create New Credential',
     });
-
-    wrapper = mountWithContexts(<Credentials />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-          },
-        },
-      },
-    });
-
-    expect(wrapper.find('Crumb').length).toBe(0);
-    expect(wrapper.find('Title').text()).toBe('Credentials');
-  });
-
-  test('should display create new credential breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/credentials/add'],
-    });
-
-    wrapper = mountWithContexts(<Credentials />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-          },
-        },
-      },
-    });
-
-    expect(wrapper.find('Crumb').length).toBe(2);
-    expect(wrapper.find('Title').text()).toBe('Create New Credential');
   });
 });

--- a/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialForm.test.jsx
@@ -95,15 +95,15 @@ describe('<CredentialForm />', () => {
         );
       });
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('should display form fields on add properly', async () => {
       addFieldExpects();
     });
+
     test('should hide Test button initially', () => {
       expect(wrapper.find('Button[children="Test"]').length).toBe(0);
     });
+
     test('should update form values', async () => {
       // name and description change
       await act(async () => {
@@ -135,6 +135,7 @@ describe('<CredentialForm />', () => {
         name: 'organization',
       });
     });
+
     test('should display cred type subform when scm type select has a value', async () => {
       await act(async () => {
         await wrapper
@@ -218,6 +219,7 @@ describe('<CredentialForm />', () => {
         wrapper.find('textarea#credential-ssh_key_data').prop('value')
       ).toBe('');
     });
+
     test('should update field when RSA Private Key file uploaded', async () => {
       await act(async () => {
         wrapper.find('FileUpload#credential-ssh_key_data').invoke('onChange')(
@@ -232,6 +234,7 @@ describe('<CredentialForm />', () => {
         '-----BEGIN PRIVATE KEY-----\\nBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\\n-----END PRIVATE KEY-----\\n'
       );
     });
+
     test('should show error when error thrown parsing JSON', async () => {
       await act(async () => {
         await wrapper
@@ -295,9 +298,6 @@ describe('<CredentialForm />', () => {
   });
 
   describe('Edit', () => {
-    afterEach(() => {
-      wrapper.unmount();
-    });
     test('Initially renders successfully', async () => {
       await act(async () => {
         wrapper = mountWithContexts(

--- a/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.jsx
@@ -15,9 +15,6 @@ const fieldOptions = {
 
 describe('<CredentialField />', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
   test('renders correctly without initial value', () => {
     wrapper = mountWithContexts(
       <Formik
@@ -42,6 +39,7 @@ describe('<CredentialField />', () => {
     expect(wrapper.find('KeyIcon').length).toBe(1);
     expect(wrapper.find('PficonHistoryIcon').length).toBe(0);
   });
+
   test('renders correctly with initial value', () => {
     wrapper = mountWithContexts(
       <Formik
@@ -68,6 +66,7 @@ describe('<CredentialField />', () => {
     expect(wrapper.find('KeyIcon').length).toBe(1);
     expect(wrapper.find('PficonHistoryIcon').length).toBe(1);
   });
+
   test('replace/revert button behaves as expected', async () => {
     wrapper = mountWithContexts(
       <Formik

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.jsx
@@ -128,6 +128,7 @@ function CredentialPluginField(props) {
       {fieldOptions.ask_at_runtime ? (
         <FieldWithPrompt
           isRequired={isRequired}
+          fieldId={`credential-${fieldOptions.id}`}
           label={fieldOptions.label}
           promptId={`credential-prompt-${fieldOptions.id}`}
           promptName={`passwordPrompts.${fieldOptions.id}`}

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 import { TextInput } from '@patternfly/react-core';
+import { act } from 'react-dom/test-utils';
 import { mountWithContexts } from '../../../../../testUtils/enzymeHelpers';
 import CredentialPluginField from './CredentialPluginField';
 
@@ -9,6 +10,8 @@ const fieldOptions = {
   label: 'Username',
   type: 'string',
 };
+
+jest.mock('../../../../api');
 
 describe('<CredentialPluginField />', () => {
   let wrapper;
@@ -34,20 +37,23 @@ describe('<CredentialPluginField />', () => {
         </Formik>
       );
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('renders the expected content', () => {
       expect(wrapper.find('input').length).toBe(1);
       expect(wrapper.find('KeyIcon').length).toBe(1);
       expect(wrapper.find('CredentialPluginSelected').length).toBe(0);
     });
-    test('clicking plugin button shows plugin prompt', () => {
+
+    test('clicking plugin button shows plugin prompt', async () => {
       expect(wrapper.find('CredentialPluginPrompt').length).toBe(0);
-      wrapper.find('KeyIcon').simulate('click');
+      await act(async () => {
+        wrapper.find('KeyIcon').simulate('click');
+      });
+      wrapper.update();
       expect(wrapper.find('CredentialPluginPrompt').length).toBe(1);
     });
   });
+
   describe('Plugin already configured', () => {
     beforeAll(() => {
       wrapper = mountWithContexts(
@@ -78,9 +84,7 @@ describe('<CredentialPluginField />', () => {
         </Formik>
       );
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('renders the expected content', () => {
       expect(wrapper.find('CredentialPluginPrompt').length).toBe(0);
       expect(wrapper.find('input').length).toBe(0);

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.jsx
@@ -99,10 +99,6 @@ describe('<CredentialPluginPrompt />', () => {
       });
     });
 
-    afterAll(() => {
-      wrapper.unmount();
-    });
-
     test('should render Wizard with all steps', async () => {
       const wizard = await waitForElement(wrapper, 'Wizard');
       const steps = wizard.prop('steps');
@@ -119,15 +115,18 @@ describe('<CredentialPluginPrompt />', () => {
         wrapper.find('Radio').filterWhere(radio => radio.isChecked).length
       ).toBe(0);
     });
+
     test('next button disabled until credential selected', () => {
       expect(wrapper.find('Button[children="Next"]').prop('isDisabled')).toBe(
         true
       );
     });
+
     test('clicking cancel button calls correct function', () => {
       wrapper.find('Button[children="Cancel"]').simulate('click');
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+
     test('clicking credential row enables next button', async () => {
       await waitForElement(wrapper, 'CheckboxListItem', el => el.length > 0);
       await act(async () => {
@@ -207,9 +206,7 @@ describe('<CredentialPluginPrompt />', () => {
         );
       });
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('should render Wizard with all steps', async () => {
       const wizard = await waitForElement(wrapper, 'Wizard');
       const steps = wizard.prop('steps');
@@ -218,6 +215,7 @@ describe('<CredentialPluginPrompt />', () => {
       expect(steps[0].name).toEqual('Credential');
       expect(steps[1].name).toEqual('Metadata');
     });
+
     test('credentials step renders correctly', async () => {
       await waitForElement(wrapper, 'CheckboxListItem', el => el.length > 0);
 
@@ -233,6 +231,7 @@ describe('<CredentialPluginPrompt />', () => {
         false
       );
     });
+
     test('metadata step renders correctly', async () => {
       await act(async () => {
         wrapper.find('Button[children="Next"]').simulate('click');
@@ -247,6 +246,7 @@ describe('<CredentialPluginPrompt />', () => {
         wrapper.find('input#credential-secret_version').prop('value')
       ).toBe('9000');
     });
+
     test('clicking Test button makes correct call', async () => {
       await act(async () => {
         wrapper.find('Button[children="Test"]').simulate('click');

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginSelected.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginSelected.test.jsx
@@ -16,17 +16,17 @@ describe('<CredentialPluginSelected />', () => {
       />
     );
   });
-  afterAll(() => {
-    wrapper.unmount();
-  });
+
   test('renders the expected content', () => {
     expect(wrapper.find('CredentialChip').length).toBe(1);
     expect(wrapper.find('KeyIcon').length).toBe(1);
   });
+
   test('clearing plugin calls expected function', () => {
     wrapper.find('CredentialChip button').simulate('click');
     expect(onClearPlugin).toBeCalledTimes(1);
   });
+
   test('editing plugin calls expected function', () => {
     wrapper.find('KeyIcon').simulate('click');
     expect(onEditPlugin).toBeCalledTimes(1);

--- a/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginTestAlert.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/CredentialPlugins/CredentialPluginTestAlert.test.jsx
@@ -4,9 +4,7 @@ import CredentialPluginTestAlert from './CredentialPluginTestAlert';
 
 describe('<CredentialPluginTestAlert />', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
+
   test('renders expected content when test is successful', () => {
     wrapper = mountWithContexts(
       <CredentialPluginTestAlert
@@ -20,6 +18,7 @@ describe('<CredentialPluginTestAlert />', () => {
       'Test passed'
     );
   });
+
   test('renders expected content when test fails with the expected return string formatting', () => {
     wrapper = mountWithContexts(
       <CredentialPluginTestAlert
@@ -41,6 +40,7 @@ describe('<CredentialPluginTestAlert />', () => {
       'HTTP 404: not found'
     );
   });
+
   test('renders expected content when test fails without the expected return string formatting', () => {
     wrapper = mountWithContexts(
       <CredentialPluginTestAlert

--- a/awx/ui_next/src/screens/Credential/shared/ExternalTestModal.test.jsx
+++ b/awx/ui_next/src/screens/Credential/shared/ExternalTestModal.test.jsx
@@ -30,7 +30,7 @@ const credential = {
 
 describe('<ExternalTestModal />', () => {
   let wrapper;
-  afterEach(() => wrapper.unmount());
+
   test('should display metadata fields correctly', async () => {
     wrapper = mountWithContexts(
       <ExternalTestModal
@@ -46,6 +46,7 @@ describe('<ExternalTestModal />', () => {
     expect(wrapper.find('input#credential-secret_key').length).toBe(1);
     expect(wrapper.find('input#credential-secret_version').length).toBe(1);
   });
+
   test('should make the test request correctly when testing an existing credential', async () => {
     wrapper = mountWithContexts(
       <ExternalTestModal
@@ -85,6 +86,7 @@ describe('<ExternalTestModal />', () => {
       },
     });
   });
+
   test('should make the test request correctly when testing a new credential', async () => {
     wrapper = mountWithContexts(
       <ExternalTestModal
@@ -123,6 +125,7 @@ describe('<ExternalTestModal />', () => {
       },
     });
   });
+
   test('should display the alert after a successful test', async () => {
     CredentialTypesAPI.test.mockResolvedValue({});
     wrapper = mountWithContexts(
@@ -148,6 +151,7 @@ describe('<ExternalTestModal />', () => {
     expect(wrapper.find('Alert').length).toBe(1);
     expect(wrapper.find('Alert').props().variant).toBe('success');
   });
+
   test('should display the alert after a failed test', async () => {
     CredentialTypesAPI.test.mockRejectedValue({
       inputs: `HTTP 404

--- a/awx/ui_next/src/screens/CredentialType/CredentialTypes.test.jsx
+++ b/awx/ui_next/src/screens/CredentialType/CredentialTypes.test.jsx
@@ -4,10 +4,6 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import CredentialTypes from './CredentialTypes';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<CredentialTypes/>', () => {
   let pageWrapper;
   let pageSections;
@@ -15,10 +11,6 @@ describe('<CredentialTypes/>', () => {
   beforeEach(() => {
     pageWrapper = mountWithContexts(<CredentialTypes />);
     pageSections = pageWrapper.find('PageSection');
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui_next/src/screens/Dashboard/Dashboard.test.jsx
+++ b/awx/ui_next/src/screens/Dashboard/Dashboard.test.jsx
@@ -7,9 +7,6 @@ import { DashboardAPI } from '../../api';
 import Dashboard from './Dashboard';
 
 jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
 
 describe('<Dashboard />', () => {
   let pageWrapper;
@@ -22,10 +19,6 @@ describe('<Dashboard />', () => {
       graphRequest.mockResolvedValue({});
       pageWrapper = mountWithContexts(<Dashboard />);
     });
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui_next/src/screens/Dashboard/DashboardGraph.test.jsx
+++ b/awx/ui_next/src/screens/Dashboard/DashboardGraph.test.jsx
@@ -7,9 +7,6 @@ import { DashboardAPI } from '../../api';
 import DashboardGraph from './DashboardGraph';
 
 jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
 
 describe('<DashboardGraph/>', () => {
   let pageWrapper;
@@ -24,9 +21,6 @@ describe('<DashboardGraph/>', () => {
     });
   });
 
-  afterEach(() => {
-    pageWrapper.unmount();
-  });
   test('renders month-based/all job type chart by default', () => {
     expect(graphRequest).toHaveBeenCalledWith({
       job_type: 'all',

--- a/awx/ui_next/src/screens/Dashboard/shared/Count.test.jsx
+++ b/awx/ui_next/src/screens/Dashboard/shared/Count.test.jsx
@@ -7,10 +7,6 @@ import Count from './Count';
 describe('<Count />', () => {
   let pageWrapper;
 
-  afterEach(() => {
-    pageWrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
     pageWrapper = mountWithContexts(<Count link="foo" />);
     expect(pageWrapper.length).toBe(1);

--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.jsx
@@ -90,7 +90,6 @@ describe('<ExecutionEnvironmentAdd/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.jsx
@@ -82,7 +82,6 @@ describe('<ExecutionEnvironmentEdit/>', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironments.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/ExecutionEnvironments.test.jsx
@@ -13,10 +13,6 @@ describe('<ExecutionEnvironments/>', () => {
     pageSections = pageWrapper.find('PageSection');
   });
 
-  afterEach(() => {
-    pageWrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
     expect(pageWrapper.length).toBe(1);
     expect(pageSections.length).toBe(1);

--- a/awx/ui_next/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.jsx
+++ b/awx/ui_next/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.jsx
@@ -145,7 +145,6 @@ describe('<ExecutionEnvironmentForm/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('Initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Host/Host.test.jsx
+++ b/awx/ui_next/src/screens/Host/Host.test.jsx
@@ -37,10 +37,6 @@ describe('<Host />', () => {
     });
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('should render expected tabs', async () => {
     const expectedTabs = ['Details', 'Facts', 'Groups', 'Completed Jobs'];
     wrapper.find('RoutedTabs li').forEach((tab, index) => {

--- a/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostGroups/HostGroupsList.test.jsx
@@ -108,7 +108,6 @@ describe('<HostGroupsList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Host/HostList/HostListItem.test.jsx
+++ b/awx/ui_next/src/screens/Host/HostList/HostListItem.test.jsx
@@ -38,10 +38,6 @@ describe('<HostsListItem />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('edit button shown to users with edit capabilities', () => {
     expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
   });

--- a/awx/ui_next/src/screens/Host/Hosts.test.jsx
+++ b/awx/ui_next/src/screens/Host/Hosts.test.jsx
@@ -1,41 +1,28 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { shallow } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Hosts from './Hosts';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
+jest.mock('../../api');
 
 describe('<Hosts />', () => {
-  test('initially renders successfully', () => {
-    mountWithContexts(<Hosts />);
-  });
-
   test('should display a breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/hosts'],
-    });
-    const match = { path: '/hosts', url: '/hosts', isExact: true };
+    const wrapper = shallow(<Hosts />);
 
-    const wrapper = mountWithContexts(<Hosts />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-            match,
-          },
-        },
-      },
+    const header = wrapper.find('ScreenHeader');
+    expect(header.prop('streamType')).toEqual('host');
+    expect(header.prop('breadcrumbConfig')).toEqual({
+      '/hosts': 'Hosts',
+      '/hosts/add': 'Create New Host',
     });
-    expect(wrapper.find('Title').length).toBe(1);
-    wrapper.unmount();
   });
 
-  test('should render Host component', () => {
+  test('should render Host component', async () => {
+    let wrapper;
     const history = createMemoryHistory({
       initialEntries: ['/hosts/1'],
     });
@@ -46,11 +33,12 @@ describe('<Hosts />', () => {
       isExact: true,
     };
 
-    const wrapper = mountWithContexts(<Hosts />, {
-      context: { router: { history, route: { match } } },
+    await act(async () => {
+      wrapper = await mountWithContexts(<Hosts />, {
+        context: { router: { history, route: { match } } },
+      });
     });
 
     expect(wrapper.find('Host').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.test.jsx
@@ -67,7 +67,6 @@ describe('<ContainerGroupAdd/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui_next/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.test.jsx
@@ -113,7 +113,6 @@ describe('<ContainerGroupEdit/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully', async () => {

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.test.jsx
@@ -63,7 +63,6 @@ describe('<InstanceGroupAdd/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.jsx
@@ -68,7 +68,6 @@ describe('<InstanceGroupEdit>', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('controlplane instance group name can not be updated', async () => {

--- a/awx/ui_next/src/screens/InstanceGroup/InstanceGroups.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/InstanceGroups.test.jsx
@@ -4,10 +4,6 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import InstanceGroups from './InstanceGroups';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<InstanceGroups/>', () => {
   let pageWrapper;
   let pageSections;
@@ -15,10 +11,6 @@ describe('<InstanceGroups/>', () => {
   beforeEach(() => {
     pageWrapper = mountWithContexts(<InstanceGroups />);
     pageSections = pageWrapper.find('PageSection');
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui_next/src/screens/InstanceGroup/Instances/InstanceList.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/Instances/InstanceList.test.jsx
@@ -134,7 +134,6 @@ describe('<InstanceList/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should have data fetched', () => {

--- a/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/shared/ContainerGroupForm.test.jsx
@@ -91,7 +91,6 @@ describe('<ContainerGroupForm/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('Initially renders successfully', () => {

--- a/awx/ui_next/src/screens/InstanceGroup/shared/InstanceGroupForm.test.jsx
+++ b/awx/ui_next/src/screens/InstanceGroup/shared/InstanceGroupForm.test.jsx
@@ -60,7 +60,6 @@ describe('<InstanceGroupForm/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('Initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Inventory/Inventories.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/Inventories.test.jsx
@@ -4,19 +4,11 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Inventories from './Inventories';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<Inventories />', () => {
   let pageWrapper;
 
   beforeEach(() => {
     pageWrapper = mountWithContexts(<Inventories />);
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.jsx
@@ -43,7 +43,6 @@ describe('<InventoryGroupHostList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully ', () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.test.jsx
@@ -26,10 +26,6 @@ describe('<InventoryGroupHostListItem />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('should display expected row item content', () => {
     expect(wrapper.find('b').text()).toContain(
       '.host-000001.group-00000.dummy'

--- a/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.jsx
@@ -96,7 +96,6 @@ describe('<InventoryGroupsList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should fetch groups from api and render them in the list', async () => {
@@ -201,7 +200,6 @@ describe('<InventoryGroupsList/> error handling', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should show content error when api throws error on initial render', async () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryHost/InventoryHost.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHost/InventoryHost.test.jsx
@@ -41,10 +41,6 @@ describe('<InventoryHost />', () => {
     });
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('should render expected tabs', async () => {
     const expectedTabs = [
       'Back to Hosts',

--- a/awx/ui_next/src/screens/Inventory/InventoryHost/InventoryHost.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHost/InventoryHost.test.jsx
@@ -32,9 +32,7 @@ describe('<InventoryHost />', () => {
   let history;
 
   beforeEach(async () => {
-    InventoriesAPI.readHostDetail.mockResolvedValue({
-      data: { ...mockHost },
-    });
+    InventoriesAPI.readHostDetail.mockResolvedValue(mockHost);
 
     await act(async () => {
       wrapper = mountWithContexts(

--- a/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.test.jsx
@@ -100,7 +100,6 @@ describe('<InventoryHostGroupsList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHostItem.test.jsx
@@ -44,10 +44,6 @@ describe('<InventoryHostItem />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('edit button shown to users with edit capabilities', () => {
     expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
   });

--- a/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHosts.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryHosts/InventoryHosts.test.jsx
@@ -3,6 +3,14 @@ import { createMemoryHistory } from 'history';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryHosts from './InventoryHosts';
 
+jest.mock('./InventoryHostList', () => {
+  const InventoryHostList = () => <div />;
+  return {
+    __esModule: true,
+    default: InventoryHostList,
+  };
+});
+
 describe('<InventoryHosts />', () => {
   test('should render inventory host list', () => {
     const history = createMemoryHistory({
@@ -20,6 +28,5 @@ describe('<InventoryHosts />', () => {
     });
 
     expect(wrapper.find('InventoryHostList').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.jsx
@@ -95,7 +95,6 @@ describe('<InventoryRelatedGroupList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully ', () => {

--- a/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.jsx
@@ -11,19 +11,19 @@ describe('<InventoryRelatedGroupListItem />', () => {
 
   beforeEach(() => {
     wrapper = mountWithContexts(
-      <InventoryRelatedGroupListItem
-        detailUrl="/group/1"
-        editUrl="/group/1"
-        group={mockGroup}
-        isSelected={false}
-        onSelect={() => {}}
-        rowIndex={0}
-      />
+      <table>
+        <tbody>
+          <InventoryRelatedGroupListItem
+            detailUrl="/group/1"
+            editUrl="/group/1"
+            group={mockGroup}
+            isSelected={false}
+            onSelect={() => {}}
+            rowIndex={0}
+          />
+        </tbody>
+      </table>
     );
-  });
-
-  afterEach(() => {
-    wrapper.unmount();
   });
 
   test('should display expected row item content', () => {
@@ -36,14 +36,18 @@ describe('<InventoryRelatedGroupListItem />', () => {
 
   test('edit button hidden from users without edit capabilities', () => {
     wrapper = mountWithContexts(
-      <InventoryRelatedGroupListItem
-        detailUrl="/group/1"
-        editUrl="/group/1"
-        group={mockRelatedGroups.results[2]}
-        isSelected={false}
-        onSelect={() => {}}
-        rowIndex={0}
-      />
+      <table>
+        <tbody>
+          <InventoryRelatedGroupListItem
+            detailUrl="/group/1"
+            editUrl="/group/1"
+            group={mockRelatedGroups.results[2]}
+            isSelected={false}
+            onSelect={() => {}}
+            rowIndex={0}
+          />
+        </tbody>
+      </table>
     );
     expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
   });

--- a/awx/ui_next/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.test.jsx
@@ -72,7 +72,6 @@ describe('<InventorySourceAdd />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('new form displays primary form fields', async () => {

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySourceListItem.test.jsx
@@ -23,7 +23,6 @@ const source = {
 describe('<InventorySourceListItem />', () => {
   let wrapper;
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Inventory/InventorySources/InventorySources.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/InventorySources/InventorySources.test.jsx
@@ -6,6 +6,5 @@ describe('<InventorySources />', () => {
   test('initially renders without crashing', () => {
     const wrapper = shallow(<InventorySources />);
     expect(wrapper.length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Inventory/SmartInventory.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventory.test.jsx
@@ -22,7 +22,6 @@ describe('<SmartInventory />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHost/SmartInventoryHost.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHost/SmartInventoryHost.test.jsx
@@ -34,9 +34,7 @@ describe('<SmartInventoryHost />', () => {
   });
 
   test('should render expected tabs', async () => {
-    InventoriesAPI.readHostDetail.mockResolvedValue({
-      data: { ...mockHost },
-    });
+    InventoriesAPI.readHostDetail.mockResolvedValue(mockHost);
     await act(async () => {
       wrapper = mountWithContexts(
         <SmartInventoryHost
@@ -73,9 +71,7 @@ describe('<SmartInventoryHost />', () => {
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    InventoriesAPI.readHostDetail.mockResolvedValue({
-      data: { ...mockHost },
-    });
+    InventoriesAPI.readHostDetail.mockResolvedValue(mockHost);
     history = createMemoryHistory({
       initialEntries: ['/inventories/smart_inventory/1/hosts/1/foobar'],
     });

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHost/SmartInventoryHost.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHost/SmartInventoryHost.test.jsx
@@ -29,7 +29,6 @@ describe('<SmartInventoryHost />', () => {
   let history;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.jsx
@@ -37,7 +37,6 @@ describe('<SmartInventoryHostList />', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders successfully', () => {

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.test.jsx
@@ -37,10 +37,6 @@ describe('<SmartInventoryHostListItem />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('should render expected row cells', () => {
     const cells = wrapper.find('Td');
     expect(cells).toHaveLength(4);

--- a/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHosts.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHosts.test.jsx
@@ -8,6 +8,13 @@ import {
 import SmartInventoryHosts from './SmartInventoryHosts';
 
 jest.mock('../../../api');
+jest.mock('./SmartInventoryHostList', () => {
+  const SmartInventoryHostList = () => <div />;
+  return {
+    __esModule: true,
+    default: SmartInventoryHostList,
+  };
+});
 
 describe('<SmartInventoryHosts />', () => {
   test('should render smart inventory host list', () => {
@@ -26,8 +33,10 @@ describe('<SmartInventoryHosts />', () => {
       }
     );
     expect(wrapper.find('SmartInventoryHostList').length).toBe(1);
+    expect(wrapper.find('SmartInventoryHostList').prop('inventory')).toEqual({
+      id: 1,
+    });
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should render smart inventory host details', async () => {
@@ -51,6 +60,5 @@ describe('<SmartInventoryHosts />', () => {
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('SmartInventoryHost').length).toBe(1);
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.test.jsx
+++ b/awx/ui_next/src/screens/Inventory/shared/InventorySourceSyncButton.test.jsx
@@ -21,7 +21,6 @@ describe('<InventorySourceSyncButton />', () => {
     );
   });
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Job/Job.test.jsx
+++ b/awx/ui_next/src/screens/Job/Job.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
-import Job from './Jobs';
+import Job from './Job';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobDetail/JobDetail.test.jsx
@@ -15,8 +15,8 @@ describe('<JobDetail />', () => {
     expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
     expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
   }
+
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/HostStatusBar.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/HostStatusBar.test.jsx
@@ -13,10 +13,6 @@ describe('<HostStatusBar />', () => {
     wrapper = mountWithContexts(<HostStatusBar counts={mockCounts} />);
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
     expect(wrapper.length).toBe(1);
   });

--- a/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Job/JobOutput/shared/OutputToolbar.test.jsx
@@ -22,10 +22,6 @@ describe('<OutputToolbar />', () => {
     );
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
     expect(wrapper.length).toBe(1);
   });

--- a/awx/ui_next/src/screens/Job/Jobs.test.jsx
+++ b/awx/ui_next/src/screens/Job/Jobs.test.jsx
@@ -1,37 +1,26 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
-
+import { shallow } from 'enzyme';
 import Jobs from './Jobs';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
+  useRouteMatch: () => ({
+    path: '/',
+  }),
 }));
 
 describe('<Jobs />', () => {
-  test('initially renders successfully', () => {
-    mountWithContexts(<Jobs />);
+  test('initially renders successfully', async () => {
+    const wrapper = shallow(<Jobs />);
+    expect(wrapper.find('JobList')).toHaveLength(1);
   });
 
   test('should display a breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/jobs'],
+    const wrapper = shallow(<Jobs />);
+    const screenHeader = wrapper.find('ScreenHeader');
+    expect(screenHeader).toHaveLength(1);
+    expect(screenHeader.prop('breadcrumbConfig')).toEqual({
+      '/jobs': 'Jobs',
     });
-    const match = { path: '/jobs', url: '/jobs', isExact: true };
-
-    const wrapper = mountWithContexts(<Jobs />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-            match,
-          },
-        },
-      },
-    });
-    expect(wrapper.find('Title').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Job/WorkflowOutput/WorkflowOutput.test.jsx
+++ b/awx/ui_next/src/screens/Job/WorkflowOutput/WorkflowOutput.test.jsx
@@ -115,7 +115,6 @@ describe('WorkflowOutput', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
     delete window.SVGElement.prototype.getBBox;
     delete window.SVGElement.prototype.getBoundingClientRect;
     delete window.SVGElement.prototype.height;

--- a/awx/ui_next/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.jsx
@@ -44,10 +44,6 @@ describe('WorkflowOutputToolbar', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('should render correct toolbar item', () => {
     shouldFind(`Button[ouiaId="edit-workflow"]`);
     shouldFind('Button#workflow-output-toggle-legend');

--- a/awx/ui_next/src/screens/ManagementJob/ManagementJobs.test.jsx
+++ b/awx/ui_next/src/screens/ManagementJob/ManagementJobs.test.jsx
@@ -4,10 +4,6 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import ManagementJobs from './ManagementJobs';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<ManagementJobs />', () => {
   let pageWrapper;
   let pageSections;
@@ -15,10 +11,6 @@ describe('<ManagementJobs />', () => {
   beforeEach(() => {
     pageWrapper = mountWithContexts(<ManagementJobs />);
     pageSections = pageWrapper.find('PageSection');
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('renders ok', () => {

--- a/awx/ui_next/src/screens/Metrics/Metrics.test.jsx
+++ b/awx/ui_next/src/screens/Metrics/Metrics.test.jsx
@@ -33,7 +33,6 @@ describe('<Metrics/>', () => {
     });
   });
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
   test('should mound properly', () => {

--- a/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplates.test.jsx
+++ b/awx/ui_next/src/screens/NotificationTemplate/NotificationTemplates.test.jsx
@@ -2,26 +2,21 @@ import React from 'react';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import NotificationTemplates from './NotificationTemplates';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
+jest.mock('./NotificationTemplateList', () => {
+  const NotificationTemplateList = () => <div />;
+  return {
+    __esModule: true,
+    default: NotificationTemplateList,
+  };
+});
 
 describe('<NotificationTemplates />', () => {
-  let pageWrapper;
-  let pageSections;
-
-  beforeEach(() => {
-    pageWrapper = mountWithContexts(<NotificationTemplates />);
-    pageSections = pageWrapper.find('PageSection');
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
-    expect(pageWrapper.length).toBe(1);
-    expect(pageSections.length).toBe(2);
+    const wrapper = mountWithContexts(<NotificationTemplates />);
+
+    const pageSections = wrapper.find('PageSection');
+    expect(pageSections).toHaveLength(1);
     expect(pageSections.first().props().variant).toBe('light');
+    expect(wrapper.find('NotificationTemplateList')).toHaveLength(1);
   });
 });

--- a/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationDetail/OrganizationDetail.jsx
@@ -124,7 +124,7 @@ function OrganizationDetail({ organization }) {
             value={
               <ChipGroup numChips={5} totalChips={instanceGroups.length}>
                 {instanceGroups.map(ig => (
-                  <Link to={`${buildLinkURL(ig)}${ig.id}/details`}>
+                  <Link to={`${buildLinkURL(ig)}${ig.id}/details`} key={ig.id}>
                     <Chip key={ig.id} isReadOnly>
                       {ig.name}
                     </Chip>

--- a/awx/ui_next/src/screens/Organization/OrganizationEdit/OrganizationEdit.test.jsx
+++ b/awx/ui_next/src/screens/Organization/OrganizationEdit/OrganizationEdit.test.jsx
@@ -39,7 +39,9 @@ describe('<OrganizationEdit />', () => {
       description: 'new description',
       default_environment: null,
     };
-    wrapper.find('OrganizationForm').prop('onSubmit')(updatedOrgData, [], []);
+    await act(async () => {
+      wrapper.find('OrganizationForm').prop('onSubmit')(updatedOrgData, [], []);
+    });
 
     expect(OrganizationsAPI.update).toHaveBeenCalledWith(1, updatedOrgData);
   });

--- a/awx/ui_next/src/screens/Project/Projects.test.jsx
+++ b/awx/ui_next/src/screens/Project/Projects.test.jsx
@@ -1,37 +1,16 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
-
-import Projects from './Projects';
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
+import { shallow } from 'enzyme';
+import { _Projects as Projects } from './Projects';
 
 describe('<Projects />', () => {
-  test('initially renders successfully', () => {
-    mountWithContexts(<Projects />);
-  });
-
   test('should display a breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/projects'],
-    });
-    const match = { path: '/projects', url: '/projects', isExact: true };
+    const wrapper = shallow(<Projects />);
 
-    const wrapper = mountWithContexts(<Projects />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-            match,
-          },
-        },
-      },
+    const header = wrapper.find('ScreenHeader');
+    expect(header.prop('streamType')).toBe('project');
+    expect(header.prop('breadcrumbConfig')).toEqual({
+      '/projects': 'Projects',
+      '/projects/add': 'Create New Project',
     });
-    expect(wrapper.find('Title').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
+++ b/awx/ui_next/src/screens/Project/shared/ProjectForm.test.jsx
@@ -98,7 +98,6 @@ describe('<ProjectForm />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Schedule/AllSchedules.test.jsx
+++ b/awx/ui_next/src/screens/Schedule/AllSchedules.test.jsx
@@ -1,39 +1,15 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { shallow } from 'enzyme';
 import AllSchedules from './AllSchedules';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<AllSchedules />', () => {
-  let wrapper;
+  test('should set breadcrumb config', () => {
+    const wrapper = shallow(<AllSchedules />);
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
-  test('initially renders successfully', () => {
-    wrapper = mountWithContexts(<AllSchedules />);
-  });
-
-  test('should display schedule list breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/schedules'],
+    const header = wrapper.find('ScreenHeader');
+    expect(header.prop('streamType')).toEqual('schedule');
+    expect(header.prop('breadcrumbConfig')).toEqual({
+      '/schedules': 'Schedules',
     });
-
-    wrapper = mountWithContexts(<AllSchedules />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-          },
-        },
-      },
-    });
-
-    expect(wrapper.find('Title').text()).toBe('Schedules');
   });
 });

--- a/awx/ui_next/src/screens/Setting/Jobs/Jobs.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Jobs/Jobs.test.jsx
@@ -18,7 +18,6 @@ describe('<Jobs />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/Jobs/JobsDetail/JobsDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Jobs/JobsDetail/JobsDetail.test.jsx
@@ -37,7 +37,6 @@ describe('<JobsDetail />', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/LDAP/LDAP.test.jsx
+++ b/awx/ui_next/src/screens/Setting/LDAP/LDAP.test.jsx
@@ -18,7 +18,6 @@ describe('<LDAP />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.test.jsx
@@ -46,7 +46,6 @@ describe('<LDAPDetail />', () => {
     });
 
     afterAll(() => {
-      wrapper.unmount();
       jest.clearAllMocks();
     });
 

--- a/awx/ui_next/src/screens/Setting/Logging/Logging.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Logging/Logging.test.jsx
@@ -39,7 +39,6 @@ describe('<Logging />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.test.jsx
@@ -34,7 +34,6 @@ describe('<LoggingDetail />', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/MiscAuthentication/MiscAuthentication.test.jsx
+++ b/awx/ui_next/src/screens/Setting/MiscAuthentication/MiscAuthentication.test.jsx
@@ -20,7 +20,6 @@ describe('<MiscAuthentication />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/MiscSystem/MiscSystem.test.jsx
+++ b/awx/ui_next/src/screens/Setting/MiscSystem/MiscSystem.test.jsx
@@ -20,7 +20,6 @@ describe('<MiscSystem />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/RADIUS/RADIUS.test.jsx
+++ b/awx/ui_next/src/screens/Setting/RADIUS/RADIUS.test.jsx
@@ -23,7 +23,6 @@ describe('<RADIUS />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/RADIUS/RADIUSEdit/RADIUSEdit.test.jsx
+++ b/awx/ui_next/src/screens/Setting/RADIUS/RADIUSEdit/RADIUSEdit.test.jsx
@@ -29,7 +29,6 @@ describe('<RADIUSEdit />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.test.jsx
@@ -54,7 +54,6 @@ describe('<SAMLDetail />', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/SettingList.test.jsx
+++ b/awx/ui_next/src/screens/Setting/SettingList.test.jsx
@@ -7,9 +7,7 @@ describe('<SettingList />', () => {
   beforeEach(() => {
     wrapper = mountWithContexts(<SettingList />);
   });
-  afterEach(() => {
-    wrapper.unmount();
-  });
+
   test('initially renders without crashing', () => {
     expect(wrapper.length).toBe(1);
   });

--- a/awx/ui_next/src/screens/Setting/Settings.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Settings.test.jsx
@@ -30,7 +30,6 @@ describe('<Settings />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/Settings.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Settings.test.jsx
@@ -11,10 +11,6 @@ import Settings from './Settings';
 
 jest.mock('../../api');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<Settings />', () => {
   let wrapper;
 

--- a/awx/ui_next/src/screens/Setting/Subscription/Subscription.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/Subscription.test.jsx
@@ -41,6 +41,8 @@ describe('<Subscription />', () => {
           config: {
             license_info: {
               license_type: 'enterprise',
+              automated_instances: '1',
+              automated_since: '1614714228',
             },
           },
         },

--- a/awx/ui_next/src/screens/Setting/Subscription/Subscription.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/Subscription.test.jsx
@@ -24,7 +24,6 @@ describe('<Subscription />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.jsx
@@ -76,7 +76,12 @@ describe('<SubscriptionDetail />', () => {
 
   test('should render edit button for system admin', () => {
     wrapper = mountWithContexts(<SubscriptionDetail />, {
-      context: { ...config, me: { is_superuser: true } },
+      context: {
+        config: {
+          ...config,
+          me: { is_superuser: true },
+        },
+      },
     });
 
     expect(wrapper.find('Button[aria-label="edit"]').length).toBe(1);

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.jsx
@@ -44,10 +44,6 @@ describe('<SubscriptionDetail />', () => {
     });
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('initially renders without crashing', () => {
     expect(wrapper.find('SubscriptionDetail').length).toBe(1);
   });

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.test.jsx
@@ -29,7 +29,6 @@ describe('<AnalyticsStep />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders without crashing', async () => {

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/EulaStep.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/EulaStep.test.jsx
@@ -29,7 +29,6 @@ describe('<EulaStep />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders without crashing', async () => {

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.test.jsx
@@ -54,7 +54,6 @@ describe('<SubscriptionModal />', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders without crashing', async () => {

--- a/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.test.jsx
+++ b/awx/ui_next/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.test.jsx
@@ -29,7 +29,6 @@ describe('<SubscriptionStep />', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('initially renders without crashing', async () => {

--- a/awx/ui_next/src/screens/Setting/TACACS/TACACS.test.jsx
+++ b/awx/ui_next/src/screens/Setting/TACACS/TACACS.test.jsx
@@ -22,7 +22,6 @@ describe('<TACACS />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.test.jsx
@@ -39,7 +39,6 @@ describe('<TACACSDetail />', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/TACACS/TACACSEdit/TACACSEdit.test.jsx
+++ b/awx/ui_next/src/screens/Setting/TACACS/TACACSEdit/TACACSEdit.test.jsx
@@ -31,7 +31,6 @@ describe('<TACACSEdit />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/UI/UI.test.jsx
+++ b/awx/ui_next/src/screens/Setting/UI/UI.test.jsx
@@ -23,7 +23,6 @@ describe('<UI />', () => {
   let wrapper;
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/UI/UIDetail/UIDetail.test.jsx
+++ b/awx/ui_next/src/screens/Setting/UI/UIDetail/UIDetail.test.jsx
@@ -37,7 +37,6 @@ describe('<UIDetail />', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/UI/UIEdit/UIEdit.test.jsx
+++ b/awx/ui_next/src/screens/Setting/UI/UIEdit/UIEdit.test.jsx
@@ -29,7 +29,6 @@ describe('<UIEdit />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Setting/shared/RevertAllAlert.test.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/RevertAllAlert.test.jsx
@@ -8,6 +8,5 @@ describe('RevertAllAlert', () => {
       <RevertAllAlert onClose={() => {}} onRevertAll={() => {}} />
     );
     expect(wrapper).toHaveLength(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Setting/shared/RevertButton.test.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/RevertButton.test.jsx
@@ -7,10 +7,6 @@ import RevertButton from './RevertButton';
 describe('RevertButton', () => {
   let wrapper;
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('button text should display "Revert"', async () => {
     wrapper = mountWithContexts(
       <Formik

--- a/awx/ui_next/src/screens/Setting/shared/RevertFormActionGroup.test.jsx
+++ b/awx/ui_next/src/screens/Setting/shared/RevertFormActionGroup.test.jsx
@@ -12,6 +12,5 @@ describe('RevertFormActionGroup', () => {
       />
     );
     expect(wrapper).toHaveLength(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.test.jsx
+++ b/awx/ui_next/src/screens/Team/TeamDetail/TeamDetail.test.jsx
@@ -33,10 +33,6 @@ describe('<TeamDetail />', () => {
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
   });
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('initially renders successfully', async () => {
     await waitForElement(wrapper, 'TeamDetail');
   });

--- a/awx/ui_next/src/screens/Team/TeamRoles/TeamRoleListItem.test.jsx
+++ b/awx/ui_next/src/screens/Team/TeamRoles/TeamRoleListItem.test.jsx
@@ -20,10 +20,14 @@ describe('<TeamRoleListItem/>', () => {
 
   test('should mount properly', () => {
     wrapper = mountWithContexts(
-      <TeamRoleListItem
-        role={role}
-        detailUrl="/templates/job_template/15/details"
-      />
+      <table>
+        <tbody>
+          <TeamRoleListItem
+            role={role}
+            detailUrl="/templates/job_template/15/details"
+          />
+        </tbody>
+      </table>
     );
 
     expect(wrapper.length).toBe(1);
@@ -31,10 +35,14 @@ describe('<TeamRoleListItem/>', () => {
 
   test('should render proper list item data', () => {
     wrapper = mountWithContexts(
-      <TeamRoleListItem
-        role={role}
-        detailUrl="/templates/job_template/15/details"
-      />
+      <table>
+        <tbody>
+          <TeamRoleListItem
+            role={role}
+            detailUrl="/templates/job_template/15/details"
+          />
+        </tbody>
+      </table>
     );
     expect(wrapper.find('Td[dataLabel="Resource Name"]').text()).toBe(
       'template delete project'
@@ -47,20 +55,28 @@ describe('<TeamRoleListItem/>', () => {
 
   test('should render deletable chip', () => {
     wrapper = mountWithContexts(
-      <TeamRoleListItem
-        role={role}
-        detailUrl="/templates/job_template/15/details"
-      />
+      <table>
+        <tbody>
+          <TeamRoleListItem
+            role={role}
+            detailUrl="/templates/job_template/15/details"
+          />
+        </tbody>
+      </table>
     );
     expect(wrapper.find('Chip').prop('isReadOnly')).toBe(false);
   });
   test('should render read only chip', () => {
     role.summary_fields.user_capabilities.unattach = false;
     wrapper = mountWithContexts(
-      <TeamRoleListItem
-        role={role}
-        detailUrl="/templates/job_template/15/details"
-      />
+      <table>
+        <tbody>
+          <TeamRoleListItem
+            role={role}
+            detailUrl="/templates/job_template/15/details"
+          />
+        </tbody>
+      </table>
     );
     expect(wrapper.find('Chip').prop('isReadOnly')).toBe(true);
   });

--- a/awx/ui_next/src/screens/Team/TeamRoles/TeamRolesList.test.jsx
+++ b/awx/ui_next/src/screens/Team/TeamRoles/TeamRolesList.test.jsx
@@ -175,7 +175,6 @@ describe('<TeamRolesList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
   test('should render properly', async () => {
     TeamsAPI.readRoles.mockResolvedValue(roles);

--- a/awx/ui_next/src/screens/Team/shared/TeamForm.test.jsx
+++ b/awx/ui_next/src/screens/Team/shared/TeamForm.test.jsx
@@ -30,7 +30,6 @@ describe('<TeamForm />', () => {
   };
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.jsx
@@ -222,7 +222,7 @@ function JobTemplateDetail({ template }) {
           virtualEnvironment={custom_virtualenv}
           executionEnvironment={summary_fields?.resolved_environment}
           helpText={t`The execution environment that will be used when launching
-          this job template. The resolved execution environment can be overridden by 
+          this job template. The resolved execution environment can be overridden by
           explicitly assigning a different one to this job template.`}
         />
         <Detail label={t`Source Control Branch`} value={template.scm_branch} />
@@ -290,7 +290,7 @@ function JobTemplateDetail({ template }) {
                 totalChips={summary_fields.credentials.length}
               >
                 {summary_fields.credentials.map(c => (
-                  <Link to={`/credentials/${c.id}/details`}>
+                  <Link to={`/credentials/${c.id}/details`} key={c.id}>
                     <CredentialChip key={c.id} credential={c} isReadOnly />
                   </Link>
                 ))}

--- a/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateDetail/JobTemplateDetail.test.jsx
@@ -37,6 +37,7 @@ describe('<JobTemplateDetail />', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   test('should render successfully with missing summary fields', async () => {
     await act(async () => {
       wrapper = mountWithContexts(

--- a/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.test.jsx
+++ b/awx/ui_next/src/screens/Template/JobTemplateEdit/JobTemplateEdit.test.jsx
@@ -299,7 +299,10 @@ describe('<JobTemplateEdit />', () => {
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
-        <JobTemplateEdit template={mockJobTemplate} />
+        <JobTemplateEdit
+          template={mockJobTemplate}
+          reloadTemplate={jest.fn()}
+        />
       );
     });
     wrapper.update();

--- a/awx/ui_next/src/screens/Template/Survey/MultipleChoiceField.test.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/MultipleChoiceField.test.jsx
@@ -13,9 +13,9 @@ describe('<MultipleChoiceField/>', () => {
         <Formik
           initialValues={{
             formattedChoices: [
-              { choice: 'apollo', isDefault: true },
-              { choice: 'alex', isDefault: true },
-              { choice: 'athena', isDefault: false },
+              { id: 1, choice: 'apollo', isDefault: true },
+              { id: 2, choice: 'alex', isDefault: true },
+              { id: 3, choice: 'athena', isDefault: false },
             ],
             type: 'multiselect',
           }}

--- a/awx/ui_next/src/screens/Template/Survey/SurveyPreviewModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyPreviewModal.test.jsx
@@ -75,12 +75,6 @@ describe('<SurveyPreviewModal />', () => {
     });
     waitForElement(wrapper, 'Form');
   });
-  afterAll(() => {
-    wrapper.unmount();
-  });
-  test('renders successfully', async () => {
-    expect(wrapper.find('SurveyPreviewModal').length).toBe(1);
-  });
 
   test('Renders proper fields', async () => {
     const question1 = wrapper.find('FormGroup[label="Text Question"]');

--- a/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.test.jsx
+++ b/awx/ui_next/src/screens/Template/Survey/SurveyQuestionEdit.test.jsx
@@ -55,10 +55,6 @@ describe('<SurveyQuestionEdit />', () => {
       });
     });
 
-    afterEach(() => {
-      wrapper.unmount();
-    });
-
     test('should render form', () => {
       expect(wrapper.find('SurveyQuestionForm')).toHaveLength(1);
     });
@@ -149,8 +145,6 @@ describe('<SurveyQuestionEdit />', () => {
       expect(history.location.pathname).toEqual(
         '/templates/job_templates/1/survey'
       );
-
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/screens/Template/Templates.test.jsx
+++ b/awx/ui_next/src/screens/Template/Templates.test.jsx
@@ -3,19 +3,11 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Templates from './Templates';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<Templates />', () => {
   let pageWrapper;
 
   beforeEach(() => {
     pageWrapper = mountWithContexts(<Templates />);
-  });
-
-  afterEach(() => {
-    pageWrapper.unmount();
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplate.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplate.test.jsx
@@ -50,10 +50,11 @@ describe('<WorkflowJobTemplate />', () => {
       },
     });
   });
+
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
+
   test('initially renders successfully', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
@@ -61,6 +62,7 @@ describe('<WorkflowJobTemplate />', () => {
       );
     });
   });
+
   test('When component mounts API is called and the response is put in state', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
@@ -70,6 +72,7 @@ describe('<WorkflowJobTemplate />', () => {
     expect(WorkflowJobTemplatesAPI.readDetail).toBeCalled();
     expect(OrganizationsAPI.read).toBeCalled();
   });
+
   test('notifications tab shown for admins', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
@@ -84,6 +87,7 @@ describe('<WorkflowJobTemplate />', () => {
     );
     expect(tabs.at(3).text()).toEqual('Notifications');
   });
+
   test('notifications tab hidden with reduced permissions', async () => {
     OrganizationsAPI.read.mockResolvedValue({
       data: {
@@ -135,6 +139,7 @@ describe('<WorkflowJobTemplate />', () => {
 
     await waitForElement(wrapper, 'ContentError', el => el.length === 1);
   });
+
   test('should call to get webhook key', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/templates/workflow_job_template/1/foobar'],
@@ -161,6 +166,7 @@ describe('<WorkflowJobTemplate />', () => {
     });
     expect(WorkflowJobTemplatesAPI.readWebhookKey).toHaveBeenCalled();
   });
+
   test('should not call to get webhook key', async () => {
     WorkflowJobTemplatesAPI.readWorkflowJobTemplateOptions.mockResolvedValueOnce(
       {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.jsx
@@ -116,7 +116,7 @@ describe('<WorkflowJobTemplateAdd/>', () => {
       description: '',
       extra_vars: '---',
       inventory: undefined,
-      limit: null,
+      limit: '',
       organization: undefined,
       scm_branch: '',
       webhook_credential: undefined,

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.test.jsx
@@ -15,10 +15,6 @@ describe('DeleteAllNodesModal', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Delete All button dispatches as expected', () => {
     wrapper.find('button#confirm-delete-all-nodes').simulate('click');
     expect(dispatch).toHaveBeenCalledWith({

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.test.jsx
@@ -32,10 +32,6 @@ describe('LinkDeleteModal', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Confirm button dispatches as expected', () => {
     wrapper.find('button#confirm-link-removal').simulate('click');
     expect(dispatch).toHaveBeenCalledWith({

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.test.jsx
@@ -27,10 +27,6 @@ describe('LinkModal', () => {
       );
     });
 
-    afterAll(() => {
-      wrapper.unmount();
-    });
-
     test('Dropdown defaults to success when adding new link', () => {
       expect(wrapper.find('AnsibleSelect').prop('value')).toBe('success');
     });
@@ -57,6 +53,7 @@ describe('LinkModal', () => {
       expect(onConfirm).toHaveBeenCalledWith('always');
     });
   });
+
   describe('Editing existing link', () => {
     test('Dropdown defaults to existing link type when editing link', () => {
       wrapper = mountWithContexts(
@@ -79,7 +76,6 @@ describe('LinkModal', () => {
         </WorkflowDispatchContext.Provider>
       );
       expect(wrapper.find('AnsibleSelect').prop('value')).toBe('failure');
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.test.jsx
@@ -32,10 +32,6 @@ describe('NodeDeleteModal', () => {
       );
     });
 
-    afterAll(() => {
-      wrapper.unmount();
-    });
-
     test('Mounts successfully', () => {
       expect(wrapper.length).toBe(1);
     });
@@ -63,6 +59,7 @@ describe('NodeDeleteModal', () => {
       });
     });
   });
+
   describe('Node without unified job template', () => {
     test('Mounts successfully', () => {
       wrapper = mountWithContexts(
@@ -79,7 +76,6 @@ describe('NodeDeleteModal', () => {
         </WorkflowDispatchContext.Provider>
       );
       expect(wrapper.length).toBe(1);
-      wrapper.unmount();
     });
   });
 });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeNextButton.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeNextButton.test.jsx
@@ -28,10 +28,6 @@ describe('NodeNextButton', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Button text matches', () => {
     expect(wrapper.find('button').text()).toBe(buttonText);
   });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.test.jsx
@@ -15,9 +15,6 @@ const onUpdateNodeResource = jest.fn();
 
 describe('InventorySourcesList', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
   test('Row selected when nodeResource id matches row id and clicking new row makes expected callback', async () => {
     InventorySourcesAPI.read.mockResolvedValueOnce({
       data: {
@@ -74,6 +71,7 @@ describe('InventorySourcesList', () => {
       url: '/api/v2/inventory_sources/2',
     });
   });
+
   test('Error shown when read() request errors', async () => {
     InventorySourcesAPI.read.mockRejectedValue(new Error());
     await act(async () => {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.jsx
@@ -17,8 +17,8 @@ describe('JobTemplatesList', () => {
   let wrapper;
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
+
   test('Row selected when nodeResource id matches row id and clicking new row makes expected callback', async () => {
     JobTemplatesAPI.read.mockResolvedValueOnce({
       data: {
@@ -81,6 +81,7 @@ describe('JobTemplatesList', () => {
       project: 2,
     });
   });
+
   test('Error shown when read() request errors', async () => {
     JobTemplatesAPI.read.mockRejectedValue(new Error());
     JobTemplatesAPI.readOptions.mockResolvedValue({

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.test.jsx
@@ -15,9 +15,7 @@ const onUpdateNodeResource = jest.fn();
 
 describe('ProjectsList', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
+
   test('Row selected when nodeResource id matches row id and clicking new row makes expected callback', async () => {
     ProjectsAPI.read.mockResolvedValueOnce({
       data: {
@@ -70,6 +68,7 @@ describe('ProjectsList', () => {
       url: '/api/v2/projects/2',
     });
   });
+
   test('Error shown when read() request errors', async () => {
     ProjectsAPI.read.mockRejectedValue(new Error());
     await act(async () => {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.test.jsx
@@ -15,9 +15,7 @@ const onUpdateNodeResource = jest.fn();
 
 describe('WorkflowJobTemplatesList', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
+
   test('Row selected when nodeResource id matches row id and clicking new row makes expected callback', async () => {
     WorkflowJobTemplatesAPI.read.mockResolvedValueOnce({
       data: {
@@ -76,6 +74,7 @@ describe('WorkflowJobTemplatesList', () => {
       url: '/api/v2/workflow_job_templates/2',
     });
   });
+
   test('Error shown when read() request errors', async () => {
     WorkflowJobTemplatesAPI.read.mockRejectedValue(new Error());
     await act(async () => {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.test.jsx
@@ -85,7 +85,6 @@ describe('NodeViewModal', () => {
 
     afterAll(() => {
       jest.resetAllMocks();
-      wrapper.unmount();
     });
 
     test('should render prompt detail', () => {
@@ -151,7 +150,6 @@ describe('NodeViewModal', () => {
       expect(JobTemplatesAPI.readWebhookKey).not.toHaveBeenCalledWith();
       expect(JobTemplatesAPI.readLaunch).toHaveBeenCalledWith(1);
       expect(JobTemplatesAPI.readInstanceGroups).toHaveBeenCalledTimes(1);
-      wrapper.unmount();
       jest.clearAllMocks();
     });
 
@@ -169,7 +167,6 @@ describe('NodeViewModal', () => {
       });
       waitForLoaded(wrapper);
       expect(wrapper.find('ContentError').length).toBe(1);
-      wrapper.unmount();
       jest.clearAllMocks();
     });
 
@@ -186,7 +183,6 @@ describe('NodeViewModal', () => {
       });
       waitForLoaded(wrapper);
       expect(wrapper.find('Button#node-view-edit-button').length).toBe(1);
-      wrapper.unmount();
       jest.clearAllMocks();
     });
 
@@ -203,7 +199,6 @@ describe('NodeViewModal', () => {
       });
       waitForLoaded(wrapper);
       expect(wrapper.find('Button#node-view-edit-button').length).toBe(0);
-      wrapper.unmount();
       jest.clearAllMocks();
     });
   });
@@ -237,7 +232,6 @@ describe('NodeViewModal', () => {
       expect(WorkflowJobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readInstanceGroups).not.toHaveBeenCalled();
-      wrapper.unmount();
       jest.clearAllMocks();
     });
   });
@@ -271,7 +265,6 @@ describe('NodeViewModal', () => {
       expect(WorkflowJobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readInstanceGroups).not.toHaveBeenCalled();
-      wrapper.unmount();
       jest.clearAllMocks();
     });
   });
@@ -305,7 +298,6 @@ describe('NodeViewModal', () => {
       expect(WorkflowJobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readLaunch).not.toHaveBeenCalled();
       expect(JobTemplatesAPI.readInstanceGroups).not.toHaveBeenCalled();
-      wrapper.unmount();
       jest.clearAllMocks();
     });
   });

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.test.jsx
@@ -16,10 +16,6 @@ describe('RunStep', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Default selected card matches default link type when present', () => {
     expect(wrapper.find('#link-type-success').props().isSelected).toBe(true);
     expect(wrapper.find('#link-type-failure').props().isSelected).toBe(false);

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/UnsavedChangesModal.test.jsx
@@ -17,10 +17,6 @@ describe('UnsavedChangesModal', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Exit Without Saving button dispatches as expected', () => {
     wrapper.find('button#confirm-exit-without-saving').simulate('click');
     expect(onExit).toHaveBeenCalled();

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.test.jsx
@@ -141,7 +141,6 @@ describe('Visualizer', () => {
   });
 
   afterAll(() => {
-    wrapper.unmount();
     delete window.SVGElement.prototype.getBBox;
     delete window.SVGElement.prototype.getBoundingClientRect;
     delete window.SVGElement.prototype.height;

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.test.jsx
@@ -62,9 +62,6 @@ describe('VisualizerLink', () => {
       </WorkflowDispatchContext.Provider>
     );
   });
-  afterAll(() => {
-    wrapper.unmount();
-  });
 
   test('Displays action tooltip on hover and updates help text on hover', () => {
     expect(wrapper.find('WorkflowActionTooltip').length).toBe(0);

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.test.jsx
@@ -73,12 +73,11 @@ describe('VisualizerNode', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('Displays unified job template name inside node', () => {
       expect(wrapper.find('NodeResourceName').text()).toBe('Automation JT');
     });
+
     test('Displays action tooltip on hover and updates help text on hover', () => {
       expect(wrapper.find('WorkflowActionTooltip').length).toBe(0);
       wrapper.find('g').simulate('mouseenter');
@@ -234,9 +233,7 @@ describe('VisualizerNode', () => {
         </WorkflowDispatchContext.Provider>
       );
     });
-    afterAll(() => {
-      wrapper.unmount();
-    });
+
     test('Displays correct help text when hovering over node while adding link', () => {
       expect(wrapper.find('WorkflowActionTooltip').length).toBe(0);
       wrapper.find('g').simulate('mouseenter');
@@ -248,6 +245,7 @@ describe('VisualizerNode', () => {
       expect(wrapper.find('WorkflowActionTooltip').length).toBe(0);
       expect(updateHelpText).toHaveBeenCalledWith(null);
     });
+
     test('Dispatches properly when node is clicked', () => {
       wrapper
         .find('foreignObject')
@@ -259,6 +257,7 @@ describe('VisualizerNode', () => {
       });
     });
   });
+
   describe('Node without unified job template', () => {
     test('Displays DELETED text inside node when unified job template is missing', () => {
       const wrapper = mountWithContexts(
@@ -279,6 +278,7 @@ describe('VisualizerNode', () => {
       expect(wrapper.find('NodeResourceName').text()).toBe('DELETED');
     });
   });
+
   describe('Node without full unified job template', () => {
     let wrapper;
     beforeEach(() => {
@@ -336,9 +336,7 @@ describe('VisualizerNode', () => {
         </WorkflowDispatchContext.Provider>
       );
     });
-    afterEach(() => {
-      wrapper.unmount();
-    });
+
     test('Attempts to fetch full unified job template on view', async () => {
       wrapper.find('g').simulate('mouseenter');
       await act(async () => {
@@ -348,6 +346,7 @@ describe('VisualizerNode', () => {
       });
       expect(JobTemplatesAPI.readDetail).toHaveBeenCalledWith(7);
     });
+
     test('Displays error fetching full unified job template', async () => {
       JobTemplatesAPI.readDetail.mockRejectedValueOnce(
         new Error({
@@ -371,6 +370,7 @@ describe('VisualizerNode', () => {
       wrapper.update();
       expect(wrapper.find('AlertModal').length).toBe(1);
     });
+
     test('Attempts to fetch credentials on view', async () => {
       JobTemplatesAPI.readDetail.mockResolvedValueOnce({
         data: {

--- a/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.test.jsx
+++ b/awx/ui_next/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.test.jsx
@@ -54,10 +54,6 @@ describe('VisualizerToolbar', () => {
     );
   });
 
-  afterAll(() => {
-    wrapper.unmount();
-  });
-
   test('Shows correct number of nodes', () => {
     // The start node (id=1) and deleted nodes (isDeleted=true) should be ignored
     expect(wrapper.find('Badge').text()).toBe('1');

--- a/awx/ui_next/src/screens/Template/shared/WebhookSubForm.test.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WebhookSubForm.test.jsx
@@ -23,6 +23,7 @@ describe('<WebhookSubForm />', () => {
     webhook_service: 'github',
     webhook_key: 'webhook key',
   };
+
   beforeEach(async () => {
     history = createMemoryHistory({
       initialEntries: ['templates/job_template/51/edit'],
@@ -51,13 +52,11 @@ describe('<WebhookSubForm />', () => {
       );
     });
   });
+
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
-  test('mounts properly', () => {
-    expect(wrapper.length).toBe(1);
-  });
+
   test('should render initial values properly', () => {
     waitForElement(wrapper, 'Lookup__ChipHolder', el => el.lenth > 0);
     expect(wrapper.find('AnsibleSelect').prop('value')).toBe('github');
@@ -73,6 +72,7 @@ describe('<WebhookSubForm />', () => {
       'Github credential'
     );
   });
+
   test('should make other credential type available', async () => {
     CredentialsAPI.read.mockResolvedValue({
       data: { results: [{ id: 13, name: 'GitLab credential' }] },
@@ -93,6 +93,7 @@ describe('<WebhookSubForm />', () => {
         .prop('value')
     ).toBe('A NEW WEBHOOK KEY WILL BE GENERATED ON SAVE.');
   });
+
   test('should have disabled button to update webhook key', async () => {
     let newWrapper;
     await act(async () => {

--- a/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
+++ b/awx/ui_next/src/screens/Template/shared/WorkflowJobTemplateForm.jsx
@@ -290,7 +290,7 @@ const FormikApp = withFormik({
       organization: template?.summary_fields?.organization || null,
       labels: template.summary_fields?.labels?.results || [],
       extra_vars: template.extra_vars || '---',
-      limit: template.limit || null,
+      limit: template.limit || '',
       scm_branch: template.scm_branch || '',
       allow_simultaneous: template.allow_simultaneous || false,
       webhook_credential: template?.summary_fields?.webhook_credential || null,

--- a/awx/ui_next/src/screens/User/UserList/UserListItem.test.jsx
+++ b/awx/ui_next/src/screens/User/UserList/UserListItem.test.jsx
@@ -16,10 +16,6 @@ i18n.activate('en');
 
 let wrapper;
 
-afterEach(() => {
-  wrapper.unmount();
-});
-
 describe('UserListItem with full permissions', () => {
   beforeEach(() => {
     wrapper = mountWithContexts(
@@ -39,9 +35,11 @@ describe('UserListItem with full permissions', () => {
       </I18nProvider>
     );
   });
+
   test('initially renders successfully', () => {
     expect(wrapper.length).toBe(1);
   });
+
   test('edit button shown to users with edit capabilities', () => {
     expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
   });

--- a/awx/ui_next/src/screens/User/UserRoles/UserRolesList.test.jsx
+++ b/awx/ui_next/src/screens/User/UserRoles/UserRolesList.test.jsx
@@ -94,6 +94,7 @@ const roles = {
 };
 
 describe('<UserRolesList />', () => {
+  let wrapper;
   beforeEach(() => {
     UsersAPI.readOptions.mockResolvedValue({
       data: {
@@ -102,11 +103,11 @@ describe('<UserRolesList />', () => {
       },
     });
   });
-  let wrapper;
+
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
+
   test('should render properly', async () => {
     UsersAPI.readRoles.mockResolvedValue(roles);
 

--- a/awx/ui_next/src/screens/User/UserTeams/UserTeamList.test.jsx
+++ b/awx/ui_next/src/screens/User/UserTeams/UserTeamList.test.jsx
@@ -118,7 +118,6 @@ describe('<UserTeamList />', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
   test('should load and render teams', async () => {

--- a/awx/ui_next/src/screens/User/UserTokenAdd/UserTokenAdd.test.jsx
+++ b/awx/ui_next/src/screens/User/UserTokenAdd/UserTokenAdd.test.jsx
@@ -22,9 +22,9 @@ const onSuccessfulAdd = jest.fn();
 
 describe('<UserTokenAdd />', () => {
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
+
   test('handleSubmit should post to api', async () => {
     await act(async () => {
       wrapper = mountWithContexts(

--- a/awx/ui_next/src/screens/User/UserTokens/UserTokens.test.jsx
+++ b/awx/ui_next/src/screens/User/UserTokens/UserTokens.test.jsx
@@ -8,10 +8,6 @@ import UserTokens from './UserTokens';
 describe('<UserTokens />', () => {
   let wrapper;
 
-  afterEach(() => {
-    wrapper.unmount();
-  });
-
   test('renders successfully', () => {
     wrapper = mountWithContexts(<UserTokens />);
     expect(wrapper.length).toBe(1);

--- a/awx/ui_next/src/screens/User/Users.test.jsx
+++ b/awx/ui_next/src/screens/User/Users.test.jsx
@@ -1,38 +1,23 @@
 import React from 'react';
-import { createMemoryHistory } from 'history';
-
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
-
+import { shallow } from 'enzyme';
 import Users from './Users';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
+  useRouteMatch: () => ({
+    path: 'users',
+  }),
 }));
 
 describe('<Users />', () => {
-  test('initially renders successfully', () => {
-    const wrapper = mountWithContexts(<Users />);
-    wrapper.unmount();
-  });
+  test('should set breadcrumbs', () => {
+    const wrapper = shallow(<Users />);
 
-  test('should display a breadcrumb heading', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/users'],
+    const header = wrapper.find('ScreenHeader');
+    expect(header.prop('streamType')).toBe('user');
+    expect(header.prop('breadcrumbConfig')).toEqual({
+      '/users': 'Users',
+      '/users/add': 'Create New User',
     });
-    const match = { path: '/users', url: '/users', isExact: true };
-
-    const wrapper = mountWithContexts(<Users />, {
-      context: {
-        router: {
-          history,
-          route: {
-            location: history.location,
-            match,
-          },
-        },
-      },
-    });
-    expect(wrapper.find('Title').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/User/shared/UserForm.test.jsx
+++ b/awx/ui_next/src/screens/User/shared/UserForm.test.jsx
@@ -27,7 +27,6 @@ describe('<UserForm />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/User/shared/UserTokenForm.test.jsx
+++ b/awx/ui_next/src/screens/User/shared/UserTokenForm.test.jsx
@@ -28,9 +28,7 @@ const applications = {
 };
 describe('<UserTokenForm />', () => {
   let wrapper;
-  beforeEach(() => {});
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.jsx
+++ b/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.jsx
@@ -29,7 +29,6 @@ describe('<WorkflowApprovalList />', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 

--- a/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.test.jsx
+++ b/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.test.jsx
@@ -9,9 +9,6 @@ jest.mock('../../../api/models/WorkflowApprovals');
 
 describe('<WorkflowApprovalListItem />', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
 
   test('should display never expires status', () => {
     wrapper = mountWithContexts(
@@ -28,6 +25,7 @@ describe('<WorkflowApprovalListItem />', () => {
     );
     expect(wrapper.find('Label[children="Never expires"]').length).toBe(1);
   });
+
   test('should display timed out status', () => {
     wrapper = mountWithContexts(
       <table>
@@ -47,6 +45,7 @@ describe('<WorkflowApprovalListItem />', () => {
     );
     expect(wrapper.find('Label[children="Timed out"]').length).toBe(1);
   });
+
   test('should display canceled status', () => {
     wrapper = mountWithContexts(
       <table>
@@ -66,6 +65,7 @@ describe('<WorkflowApprovalListItem />', () => {
     );
     expect(wrapper.find('Label[children="Canceled"]').length).toBe(1);
   });
+
   test('should display approved status', () => {
     wrapper = mountWithContexts(
       <table>
@@ -93,6 +93,7 @@ describe('<WorkflowApprovalListItem />', () => {
     );
     expect(wrapper.find('Label[children="Approved"]').length).toBe(1);
   });
+
   test('should display denied status', () => {
     wrapper = mountWithContexts(
       <table>

--- a/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovals.test.jsx
+++ b/awx/ui_next/src/screens/WorkflowApproval/WorkflowApprovals.test.jsx
@@ -11,10 +11,6 @@ import mockWorkflowApprovals from './data.workflowApprovals.json';
 
 jest.mock('../../api');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
-
 describe('<WorkflowApprovals />', () => {
   beforeEach(() => {
     WorkflowApprovalsAPI.read.mockResolvedValue({
@@ -70,6 +66,5 @@ describe('<WorkflowApprovals />', () => {
 
     await waitForElement(wrapper, 'ContentLoading', el => el.length === 0);
     expect(wrapper.find('Title').length).toBe(1);
-    wrapper.unmount();
   });
 });

--- a/awx/ui_next/src/screens/WorkflowApproval/shared/WorkflowApprovalStatus.test.jsx
+++ b/awx/ui_next/src/screens/WorkflowApproval/shared/WorkflowApprovalStatus.test.jsx
@@ -8,15 +8,14 @@ const workflowApproval = mockWorkflowApprovals.results[0];
 
 describe('<WorkflowApprovalStatus />', () => {
   let wrapper;
-  afterEach(() => {
-    wrapper.unmount();
-  });
+
   test('shows no expiration when approval status is pending and no approval_expiration', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus workflowApproval={workflowApproval} />
     );
     expect(wrapper.text()).toBe('Never expires');
   });
+
   test('shows expiration date/time when approval status is pending and approval_expiration present', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus
@@ -30,6 +29,7 @@ describe('<WorkflowApprovalStatus />', () => {
       `Expires on ${formatDateString('2020-10-10T17:13:12.067947Z')}`
     );
   });
+
   test('shows when an approval has timed out', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus
@@ -42,6 +42,7 @@ describe('<WorkflowApprovalStatus />', () => {
     );
     expect(wrapper.find('Label').text()).toBe('Timed out');
   });
+
   test('shows when an approval has canceled', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus
@@ -54,6 +55,7 @@ describe('<WorkflowApprovalStatus />', () => {
     );
     expect(wrapper.find('Label').text()).toBe('Canceled');
   });
+
   test('shows when an approval has approved', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus
@@ -73,6 +75,7 @@ describe('<WorkflowApprovalStatus />', () => {
     );
     expect(wrapper.find('Label').text()).toBe('Approved');
   });
+
   test('shows when an approval has denied', () => {
     wrapper = mountWithContexts(
       <WorkflowApprovalStatus

--- a/awx/ui_next/src/setupTests.js
+++ b/awx/ui_next/src/setupTests.js
@@ -14,8 +14,9 @@ require('@nteract/mockument');
 // eslint-disable-next-line import/prefer-default-export
 export const asyncFlush = () => new Promise(resolve => setImmediate(resolve));
 
-let consoleHasError = false;
-const { error } = global.console;
+let hasConsoleError = false;
+let hasConsoleWarn = false;
+const { error, warn } = global.console;
 
 global.console = {
   ...console,
@@ -25,15 +26,23 @@ global.console = {
   // fail tests that log errors.
   // adapted from https://github.com/facebook/jest/issues/6121#issuecomment-708330601
   error: (...args) => {
-    consoleHasError = true;
+    hasConsoleError = true;
     error(...args);
+  },
+  warn: (...args) => {
+    hasConsoleWarn = true;
+    warn(...args);
   },
 };
 
 afterEach(() => {
-  if (consoleHasError) {
-    consoleHasError = false;
+  if (hasConsoleError) {
+    hasConsoleError = false;
     throw new Error('Error logged to console');
+  }
+  if (hasConsoleWarn) {
+    hasConsoleWarn = false;
+    throw new Error('Warning logged to console');
   }
 });
 

--- a/awx/ui_next/src/util/validators.jsx
+++ b/awx/ui_next/src/util/validators.jsx
@@ -16,6 +16,7 @@ export function required(message) {
     return undefined;
   };
 }
+
 export function validateTime() {
   return value => {
     const timeRegex = new RegExp(

--- a/awx/ui_next/src/util/validators.test.js
+++ b/awx/ui_next/src/util/validators.test.js
@@ -1,3 +1,5 @@
+import { i18n } from '@lingui/core';
+import en from '../locales/en/messages';
 import {
   required,
   minLength,
@@ -13,6 +15,12 @@ import {
 } from './validators';
 
 describe('validators', () => {
+  beforeAll(() => {
+    i18n.loadLocaleData({ en: { plurals: en } });
+    i18n.load({ en });
+    i18n.activate('en');
+  });
+
   test('required returns undefined if value given', () => {
     expect(required(null)('some value')).toBeUndefined();
     expect(required('oops')('some value')).toBeUndefined();
@@ -169,6 +177,7 @@ describe('validators', () => {
   test('bob has email', () => {
     expect(requiredEmail()('bob@localhost')).toBeUndefined();
   });
+
   test('validate time validates properly', () => {
     expect(validateTime()('12:15 PM')).toBeUndefined();
     expect(validateTime()('1:15 PM')).toBeUndefined();

--- a/awx/ui_next/testUtils/enzymeHelpers.jsx
+++ b/awx/ui_next/testUtils/enzymeHelpers.jsx
@@ -61,6 +61,7 @@ const defaultContexts = {
   session: {
     isSessionExpired: false,
     logout: () => {},
+    setAuthRedirectTo: () => {},
   },
 };
 


### PR DESCRIPTION
##### SUMMARY
* Makes a unit test fail if any errors or warnings are logged (see setupTest.js)
* Updates/fixes all tests that were logging errors
* Fixes a key cause of test flake caused by Jobs.test.jsx (I have still seen a rogue "Network error" cause a flaky failure once; which I will hopefully take care of in a subsequent PR)
* Removes all unnecessary calls to `wrapper.unmount()` (this also surfaced several instances of tests leaving asynchronous code running after test completion, which are now fixed)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
