### PR TITLE
Run flake8 on the AWX collection in CI

### DIFF
--- a/awx_collection/plugins/lookup/schedule_rrule.py
+++ b/awx_collection/plugins/lookup/schedule_rrule.py
@@ -91,7 +91,6 @@ from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError
 from datetime import datetime
 from dateutil import rrule
-from distutils.version import LooseVersion
 
 try:
     import pytz

--- a/awx_collection/plugins/modules/application.py
+++ b/awx_collection/plugins/modules/application.py
@@ -89,8 +89,6 @@ EXAMPLES = '''
       - http://tower.com/api/v2/
 '''
 
-import time
-
 from ..module_utils.controller_api import ControllerAPIModule
 
 
@@ -128,9 +126,6 @@ def main():
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(application)
-
-    # Attempt to look up associated field items the user specified.
-    association_fields = {}
 
     # Create the data that gets sent for create and update
     application_fields = {

--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -68,7 +68,6 @@ EXAMPLES = '''
 
 
 from ..module_utils.controller_api import ControllerAPIModule
-import json
 
 
 def main():

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -96,7 +96,6 @@ EXAMPLES = '''
     credential: 'all'
 '''
 
-from os import environ
 import logging
 from ansible.module_utils.six.moves import StringIO
 from ..module_utils.awxkit import ControllerAWXKitModule

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -56,7 +56,7 @@ import logging
 
 # In this module we don't use EXPORTABLE_RESOURCES, we just want to validate that our installed awxkit has import/export
 try:
-    from awxkit.api.pages.api import EXPORTABLE_RESOURCES # noqa
+    from awxkit.api.pages.api import EXPORTABLE_RESOURCES  # noqa
 
     HAS_EXPORTABLE_RESOURCES = True
 except ImportError:

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -56,7 +56,7 @@ import logging
 
 # In this module we don't use EXPORTABLE_RESOURCES, we just want to validate that our installed awxkit has import/export
 try:
-    from awxkit.api.pages.api import EXPORTABLE_RESOURCES
+    from awxkit.api.pages.api import EXPORTABLE_RESOURCES # noqa
 
     HAS_EXPORTABLE_RESOURCES = True
 except ImportError:

--- a/awx_collection/plugins/modules/job_wait.py
+++ b/awx_collection/plugins/modules/job_wait.py
@@ -151,7 +151,7 @@ def main():
         module.fail_json(msg='Unable to wait on ' + job_type.rstrip("s") + ' {0}; that ID does not exist.'.format(job_id))
 
     # Invoke wait function
-    result = module.wait_on_url(url=job['url'], object_name=job_id, object_type='legacy_job_wait', timeout=timeout, interval=interval)
+    module.wait_on_url(url=job['url'], object_name=job_id, object_type='legacy_job_wait', timeout=timeout, interval=interval)
 
     module.exit_json(**module.json_output)
 

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -232,9 +232,6 @@ def wait_for_project_update(module, last_request):
         if not wait:
             module.exit_json(**module.json_output)
 
-        # Grab our start time to compare against for the timeout
-        start = time.time()
-
         # Invoke wait function
         result_final = module.wait_on_url(
             url=result['json']['url'], object_name=module.get_item_name(last_request), object_type='Project Update', timeout=timeout, interval=interval
@@ -293,12 +290,10 @@ def main():
     scm_update_on_launch = module.params.get('scm_update_on_launch')
     scm_update_cache_timeout = module.params.get('scm_update_cache_timeout')
     default_ee = module.params.get('default_environment')
-    custom_virtualenv = module.params.get('custom_virtualenv')
     organization = module.params.get('organization')
     state = module.params.get('state')
     wait = module.params.get('wait')
     update_project = module.params.get('update_project')
-    interval = module.params.get('interval')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
     lookup_data = {}

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -78,8 +78,6 @@ EXAMPLES = '''
 '''
 
 from ..module_utils.controller_api import ControllerAPIModule
-import json
-import time
 
 
 def main():
@@ -125,9 +123,6 @@ def main():
 
     if not wait:
         module.exit_json(**module.json_output)
-
-    # Grab our start time to compare against for the timeout
-    start = time.time()
 
     # Invoke wait function
     result = module.wait_on_url(

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -555,8 +555,6 @@ def create_schema_nodes(module, response, schema, workflow_id):
 
         # Start Approval Node creation process
         if workflow_node['unified_job_template']['type'] == 'workflow_approval':
-            new_fields = {}
-
             for field_name in (
                 'name',
                 'description',
@@ -627,7 +625,6 @@ def create_schema_nodes_association(module, response, schema, workflow_id):
                         if sub_obj is None:
                             module.fail_json(msg='Could not find {0} entry with name {1}'.format(association, sub_name))
                         id_list.append(sub_obj['id'])
-                        temp = sub_obj['id']
                     if id_list:
                         association_fields[association] = id_list
 

--- a/awx_collection/plugins/modules/workflow_node_wait.py
+++ b/awx_collection/plugins/modules/workflow_node_wait.py
@@ -70,7 +70,6 @@ RETURN = """
 
 
 from ..module_utils.controller_api import ControllerAPIModule
-import time
 
 
 def main():
@@ -91,10 +90,7 @@ def main():
     timeout = module.params.get("timeout")
     interval = module.params.get("interval")
 
-    node_url = "workflow_jobs/{0}/workflow_nodes/?job__name={1}".format(workflow_job_id, name)
-    # Attempt to look up workflow job node based on the provided id
-
-    result = module.wait_on_workflow_node_url(
+    module.wait_on_workflow_node_url(
         url="workflow_jobs/{0}/workflow_nodes/".format(workflow_job_id),
         object_name=name,
         object_type="Workflow Node",

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -31,7 +31,7 @@ try:
     # Because awxkit will be a directory at the root of this makefile and we are using python3, import awxkit will work even if its not installed.
     # However, awxkit will not contain api whih causes a stack failure down on line 170 when we try to mock it.
     # So here we are importing awxkit.api to prevent that. Then you only get an error on tests for awxkit functionality.
-    import awxkit.api
+    import awxkit.api  # noqa
 
     HAS_AWX_KIT = True
 except ImportError:

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -248,6 +248,15 @@ def vault_credential(organization):
 
 
 @pytest.fixture
+def kube_credential():
+    ct = CredentialType.defaults['kubernetes_bearer_token']()
+    ct.save()
+    return Credential.objects.create(
+        credential_type=ct, name='kube-cred', inputs={'host': 'my.cluster', 'bearer_token': 'my-token', 'verify_ssl': False}
+    )
+
+
+@pytest.fixture
 def silence_deprecation():
     """The deprecation warnings are stored in a global variable
     they will create cross-test interference. Use this to turn them off.

--- a/awx_collection/test/awx/test_application.py
+++ b/awx_collection/test/awx/test_application.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import pytest
 
 from awx.main.models import Organization
-from awx.main.models.oauth import OAuth2AccessToken, OAuth2Application
+from awx.main.models.oauth import OAuth2Application
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_credential_input_source.py
+++ b/awx_collection/test/awx/test_credential_input_source.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 import pytest
 
-from awx.main.models import CredentialInputSource, Credential, CredentialType, Organization
+from awx.main.models import CredentialInputSource, Credential, CredentialType
 
 
 @pytest.fixture

--- a/awx_collection/test/awx/test_instance_group.py
+++ b/awx_collection/test/awx/test_instance_group.py
@@ -5,7 +5,6 @@ __metaclass__ = type
 import pytest
 
 from awx.main.models import InstanceGroup, Instance
-from awx.main.tests.functional.conftest import kube_credential, credentialtype_kube
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_inventory.py
+++ b/awx_collection/test/awx/test_inventory.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 import pytest
 
-from awx.main.models import Inventory, Credential
+from awx.main.models import Inventory
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -194,6 +194,9 @@ def test_job_template_with_wrong_survey_spec(run_module, admin_user, project, in
     assert result.get('failed', True)
     assert result.get('msg') == "Failed to update survey: Field 'description' is missing from survey spec."
 
+    assert jt.survey_spec == survey_spec
+    assert ActivityStream.objects.count() == prior_ct
+
 
 @pytest.mark.django_db
 def test_job_template_with_survey_encrypted_default(run_module, admin_user, project, inventory, silence_warning):

--- a/awx_collection/test/awx/test_job_template.py
+++ b/awx_collection/test/awx/test_job_template.py
@@ -194,7 +194,6 @@ def test_job_template_with_wrong_survey_spec(run_module, admin_user, project, in
     assert result.get('failed', True)
     assert result.get('msg') == "Failed to update survey: Field 'description' is missing from survey spec."
 
-    assert jt.survey_spec == survey_spec
     assert ActivityStream.objects.count() == prior_ct
 
 

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -171,7 +171,7 @@ def test_conflicting_name_and_id(run_module, admin_user):
     """
     org_by_id = Organization.objects.create(name='foo')
     slug = str(org_by_id.id)
-    org_by_name = Organization.objects.create(name=slug)
+    Organization.objects.create(name=slug)
     result = run_module('team', {'name': 'foo_team', 'description': 'fooin around', 'organization': slug}, admin_user)
     assert not result.get('failed', False), result.get('msg', result)
     team = Team.objects.filter(name='foo_team').first()
@@ -189,7 +189,7 @@ def test_multiple_lookup(run_module, admin_user):
         scm_type='git',
         scm_url="https://github.com/ansible/ansible-tower-samples",
     )
-    proj2 = Project.objects.create(
+    Project.objects.create(
         name='foo',
         organization=org2,
         scm_type='git',

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,9 @@ setenv =
   BLACK_ARGS = --check
 commands =
   make black
-  flake8 awx awxkit
+  flake8 awx awxkit awx_collection
   yamllint -s .
 
 [flake8]
 select = F401,F402,F821,F823,F841
+exclude = awx/ui_next/node_modules,awx/ui/node_modules,env,awx_collection_build


### PR DESCRIPTION
We kind of assumed that linter issues like this would be picked up by `ansible-test sanity`, but they're not.

This seems to provide meaningful value. Unused variables are reflecting a lot of history of changes, and it's good to move on to leave those in the past.