### PR TITLE
Update login redirect to a be text input field

### DIFF
--- a/awx/ui_next/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.jsx
+++ b/awx/ui_next/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.jsx
@@ -216,7 +216,6 @@ function MiscAuthenticationEdit() {
                 <InputField
                   name="LOGIN_REDIRECT_OVERRIDE"
                   config={authentication.LOGIN_REDIRECT_OVERRIDE}
-                  type="url"
                 />
                 <InputField
                   name="ACCESS_TOKEN_EXPIRE_SECONDS"


### PR DESCRIPTION
Update login redirect to a be text input field. Allowing values like
`/sso/login/saml/?idp=SSO`

closes: https://github.com/ansible/awx/issues/10612
