### PR TITLE
Allow requirements.yml/yaml files to be anywhere in project_path related #5000

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -192,7 +192,7 @@
           environment:
             ANSIBLE_FORCE_COLOR: false
             GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
-          loop: "{{ requirements_files.files | selectattr('path','match','.*/roles/requirements.yml$') | list }}"
+          loop: "{{ requirements_files.files | selectattr('path','match','.*/roles/requirements.ya?ml$') | list }}"
           loop_control:
             label: "{{ item.path }}"
       when: roles_enabled|bool
@@ -216,7 +216,7 @@
             # Put the local tmp directory in same volume as collection destination
             # otherwise, files cannot be moved accross volumes and will cause error
             ANSIBLE_LOCAL_TEMP: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/tmp"
-          loop: "{{ requirements_files.files | selectattr('path','match','.*/collections/requirements.yml$') | list }}"
+          loop: "{{ requirements_files.files | selectattr('path','match','.*/collections/requirements.ya?ml$') | list }}"
           loop_control:
             label: "{{ item.path }}"
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -156,6 +156,14 @@
   name: Install content with ansible-galaxy command if necessary
   tasks:
 
+    - name: Find All requirements.yml Files
+      find:
+        paths: "{{ project_path | quote }}"
+        recurse: yes
+        patterns: "requirements.ya?ml"
+        use_regex: yes
+      register: requirements_files
+
     - name: Check content sync settings
       debug:
         msg: "Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization."
@@ -174,20 +182,19 @@
     - block:
         - name: fetch galaxy roles from requirements.(yml/yaml)
           command: >
-            ansible-galaxy role install -r {{ item }}
+            ansible-galaxy role install -r "{{ item.path | quote }}"
             --roles-path {{projects_root}}/.__awx_cache/{{local_path}}/stage/requirements_roles
             {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
           args:
             chdir: "{{project_path|quote}}"
           register: galaxy_result
-          with_fileglob:
-            - "{{project_path|quote}}/roles/requirements.yaml"
-            - "{{project_path|quote}}/roles/requirements.yml"
           changed_when: "'was installed successfully' in galaxy_result.stdout"
           environment:
             ANSIBLE_FORCE_COLOR: false
             GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
-
+          loop: "{{ requirements_files.files | selectattr('path','match','.*/roles/requirements.yml$') | list }}"
+          loop_control:
+            label: "{{ item.path }}"
       when: roles_enabled|bool
       tags:
         - install_roles
@@ -195,17 +202,12 @@
     - block:
         - name: fetch galaxy collections from collections/requirements.(yml/yaml)
           command: >
-            ansible-galaxy collection install -r {{ item }}
+            ansible-galaxy collection install -r "{{ item.path | quote }}"
             --collections-path {{projects_root}}/.__awx_cache/{{local_path}}/stage/requirements_collections
             {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
           args:
             chdir: "{{project_path|quote}}"
           register: galaxy_collection_result
-          with_fileglob:
-            - "{{project_path|quote}}/collections/requirements.yaml"
-            - "{{project_path|quote}}/collections/requirements.yml"
-            - "{{project_path|quote}}/requirements.yaml"
-            - "{{project_path|quote}}/requirements.yml"
           changed_when: "'Installing ' in galaxy_collection_result.stdout"
           environment:
             ANSIBLE_FORCE_COLOR: false
@@ -214,6 +216,9 @@
             # Put the local tmp directory in same volume as collection destination
             # otherwise, files cannot be moved accross volumes and will cause error
             ANSIBLE_LOCAL_TEMP: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/tmp"
+          loop: "{{ requirements_files.files | selectattr('path','match','.*/collections/requirements.yml$') | list }}"
+          loop_control:
+            label: "{{ item.path }}"
 
       when:
         - "ansible_version.full is version_compare('2.9', '>=')"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change searches the project_path for all instances of requirements.yml/yaml and adds them to a list. This list is then used to select which roles/requirements.yml/yaml or collections/requirements.yml/yaml are added. This removes the hardcoding of the requirements.yml/yaml in project_update.yml and allows users to have them in multiple locations.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI - project.update.yml

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
