### PR TITLE
Wait until inventory is fully deleted in silent_delete

### DIFF
--- a/awxkit/awxkit/api/pages/inventory.py
+++ b/awxkit/awxkit/api/pages/inventory.py
@@ -5,6 +5,7 @@ import json
 from awxkit.api.pages import Credential, Organization, Project, UnifiedJob, UnifiedJobTemplate
 from awxkit.utils import filter_by_class, random_title, update_payload, not_provided, PseudoNamespace, poll_until
 from awxkit.api.mixins import DSAdapter, HasCreate, HasInstanceGroups, HasNotifications, HasVariables, HasCopy
+from awxkit.config import config
 from awxkit.api.resources import resources
 import awxkit.exceptions as exc
 from . import base
@@ -97,9 +98,18 @@ class Inventory(HasCopy, HasCreate, HasInstanceGroups, HasVariables, base.Base):
         poll_until(_wait, interval=1, timeout=60)
 
     def silent_delete(self):
-        r = super(Inventory, self).silent_delete()
-        self.wait_until_deleted()
-        return r
+        try:
+            if not config.prevent_teardown:
+                r = self.delete()
+                self.wait_until_deleted()
+                return r
+        except (exc.NoContent, exc.NotFound, exc.Forbidden):
+            pass
+        except (exc.BadRequest, exc.Conflict) as e:
+            if 'Resource is being used' in e.msg:
+                pass
+            else:
+                raise e
 
     def update_inventory_sources(self, wait=False):
         response = self.related.update_inventory_sources.post()

--- a/awxkit/awxkit/api/pages/inventory.py
+++ b/awxkit/awxkit/api/pages/inventory.py
@@ -96,6 +96,11 @@ class Inventory(HasCopy, HasCreate, HasInstanceGroups, HasVariables, base.Base):
 
         poll_until(_wait, interval=1, timeout=60)
 
+    def silent_delete(self):
+        r = super(Inventory, self).silent_delete()
+        self.wait_until_deleted()
+        return r
+
     def update_inventory_sources(self, wait=False):
         response = self.related.update_inventory_sources.post()
         source_ids = [entry['inventory_source'] for entry in response if entry['status'] == 'started']


### PR DESCRIPTION
The `silent_delete` method does not appear to be used by the AWX CLI. I believe the only use is from:

https://github.com/ansible/awx/blob/eec4f8dcc27428cd1aeb1c251d43052a3ea780e8/awxkit/awxkit/api/pages/base.py#L185-L187

This is used in integration tests to cleanup at the end of a test. Whenever inventory gets deleted, this leads to various conflict scenarios and deadlocks. This tends to play out by:

 - DELETE request for the inventory object
 - DELETE request for the organization
   - within the request-response cycle, this cascade deletes other objects, or takes SET_NULL action

Because the actual inventory deletion happens in a separate task, this means that inventory and organization deletion cascades are happening simultaneously (dependent on timing and resources).

This is low-priority on our list of practical concerns, because the inventory object accurately reports that its deletion is in progress. Clients can workaround if needed - and that's what I'm trying to do here. In an effort to reduce the flakiness and erroneous errors in integration tests, I propose that this will basically serialize the teardown process (for a given test agent), and that will eliminate a large cluster of flaky errors.