### PR TITLE
Added examples for custom webhook notification body

### DIFF
--- a/awx_collection/plugins/modules/notification_template.py
+++ b/awx_collection/plugins/modules/notification_template.py
@@ -236,6 +236,13 @@ EXAMPLES = '''
       url: http://www.example.com/hook
       headers:
         X-Custom-Header: value123
+    messages:
+      started:
+        body: !unsafe '{"msg": "{{ job_friendly_name }}{{ job.id }} started"}'
+      success:
+        body: !unsafe '{"msg": "{{ job_friendly_name }} completed in {{ job.elapsed }} seconds"}'
+      error:
+        body: !unsafe '{"msg": "{{ job_friendly_name }} FAILED! Please look at {{ job.url }}"}'
     state: present
     controller_config_file: "~/tower_cli.cfg"
 


### PR DESCRIPTION
##### SUMMARY
Added examples for custom webhook notification bodies, as they are not the same as the existing example for custom slack notification messages, and I had to look through the AWX code to figure out what it wants there.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - awx_collection
 - awx.awx.notification_template

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```


##### ADDITIONAL INFORMATION
The slack example above will not throw any error if applied to a webhook notification, however it will also have not effect.
