### PR TITLE
Fix ignoring --no-color for awx-manage list_instances command

### DIFF
--- a/awx/main/management/commands/list_instances.py
+++ b/awx/main/management/commands/list_instances.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         super(Command, self).__init__()
+        no_color = options.get("no_color", False)
 
         groups = list(InstanceGroup.objects.all())
         ungrouped = Ungrouped()
@@ -44,6 +45,8 @@ class Command(BaseCommand):
                     color = '\033[91m'
                 if x.enabled is False:
                     color = '\033[90m[DISABLED] '
+                if no_color:
+                    color = ''
                 fmt = '\t' + color + '{0.hostname} capacity={0.capacity} version={1}'
                 if x.capacity:
                     fmt += ' heartbeat="{0.modified:%Y-%m-%d %H:%M:%S}"'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
-->
Fix ignoring --no-color for awx-manage list_instances command

#10387 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.2
```
