### PR TITLE
Fix conditional to check that minikube should start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,7 @@ CLUSTER_NODE_COUNT ?= 1
 MINIKUBE_CONTAINER_GROUP ?= false
 
 docker-compose-sources: .git/hooks/pre-commit
-	@if [ $(MINIKUBE_CONTAINER_GROUP) ]; then\
+	@if [ $(MINIKUBE_CONTAINER_GROUP) = true ]; then\
 	    ansible-playbook -i tools/docker-compose/inventory tools/docker-compose-minikube/deploy.yml; \
 	fi;
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`make docker-compose` tries to start container group without this fix
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```
