### PR TITLE
Workaround Minikube issue on MacOS and enable preflights

### DIFF
--- a/tools/docker-compose-minikube/minikube/defaults/main.yml
+++ b/tools/docker-compose-minikube/minikube/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 sources_dest: '_sources'
 driver: 'docker'
+addons:
+  - default-storageclass
+  - storage-provisioner
+  - dashboard
 
 minikube_url_linux: 'https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64'
 minikube_url_macos: 'https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64'

--- a/tools/docker-compose-minikube/minikube/tasks/main.yml
+++ b/tools/docker-compose-minikube/minikube/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Include pre-flight checks
+  include_tasks: preflight.yml
+
 - name: Create _sources directory
   file:
     path: "{{ sources_dest }}"
@@ -40,7 +43,23 @@
     - ansible_system == "Darwin"
 
 - name: Starting Minikube
-  shell: "{{ sources_dest }}/minikube start --driver={{ driver }} --install-addons=true --addons=ingress"
+  shell: "{{ sources_dest }}/minikube start --driver={{ driver }} --install-addons=true --addons={{ addons | join(',') }}"
+  register: minikube_stdout
+
+- name: Enable Ingress Controller on Minikube
+  shell: "{{ sources_dest }}/minikube addons enable ingress"
+  when:
+    - minikube_stdout.rc == 0
+  register: _minikube_ingress
+  ignore_errors: true
+
+- name: Show Minikube Ingress known-issue 7332 warning
+  pause:
+    seconds: 5
+    prompt: "The Minikube Ingress addon has been disabled since it looks like you are hitting https://github.com/kubernetes/minikube/issues/7332"
+  when:
+    - '"minikube/issues/7332" in _minikube_ingress.stderr'
+    - ansible_system == "Darwin"
 
 - name: Create ServiceAccount and clusterRoleBinding
   k8s:

--- a/tools/docker-compose-minikube/minikube/tasks/preflight.yml
+++ b/tools/docker-compose-minikube/minikube/tasks/preflight.yml
@@ -1,0 +1,12 @@
+---
+- name: Check if Kubernetes python module is installed
+  shell: pip freeze | grep openshift
+  register: _pip_openshift
+  ignore_errors: true
+
+- name: Preflight check - require openshift python module
+  assert:
+    fail_msg: "The openshift python module was not found. You can either install it via 'pip install openshift' or using your distro package manager."
+    that:
+      - _pip_openshift.rc == 0
+      - "'openshift==' in _pip_openshift.stdout"


### PR DESCRIPTION
##### SUMMARY
 Workaround Minikube issue on MacOS and enable preflights

Currently there is an issue https://github.com/kubernetes/minikube/issues/7332 whenever enabling the `Ingress` controller for Minikube on MacOS. 

This PR addresses this problem and also enable a precheck to verify if the `openshift` Python module is present. 

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [minikube : Starting Minikube] *************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "_sources/minikube start --driver=docker --install-addons=true --addons=ingress",
 "delta": "0:01:01.264186", "end": "2021-07-19 09:06:00.022524", "msg": "non-zero return code", 
"rc": 14, "start": "2021-07-19 09:04:58.758338",
 "stderr": "X Exiting due to MK_USAGE: Due to networking limitations of driver docker on darwin, ingress addon is not supported.\n
Alternatively to use this addon you can use a vm-based driver:\n\n\t'minikube start --vm=true'\n\n
To track the update on this work in progress feature please check:\nhttps://github.com/kubernetes/minikube/issues/7332", "stderr_lines": ["X Exiting due to MK_USAGE: Due to networking limitations of driver docker on darwin, ingress addon is not supported.", "Alternatively to use this addon you can use a vm-based driver:", "", "\t'minikube start --vm=true'", "", "To track the update on this work in progress feature please check:", "https://github.com/kubernetes/minikube/issues/7332"],
 "stdout": "* minikube v1.22.0 on Darwin 11.2.3\n* Using the docker driver based on user configuration\n* Starting control plane node minikube in cluster minikube\n* Pulling base image ...\n* Creating docker container (CPUs=2, Memory=4000MB) ...\n* Preparing Kubernetes v1.21.2 on Docker 20.10.7 ...\n  - Generating certificates and keys ...\n  - Booting up control plane ...\n  - Configuring RBAC rules ...\n* Verifying Kubernetes components...", "stdout_lines": ["* minikube v1.22.0 on Darwin 11.2.3", "* Using the docker driver based on user configuration", "* Starting control plane node minikube in cluster minikube", "* Pulling base image ...", "* Creating docker container (CPUs=2, Memory=4000MB) ...", "* Preparing Kubernetes v1.21.2 on Docker 20.10.7 ...", "  - Generating certificates and keys ...", "  - Booting up control plane ...", "  - Configuring RBAC rules ...", "* Verifying Kubernetes components..."]}
 
PLAY RECAP **************************************************************************************************************
localhost                  : ok=4    changed=3    unreachable=0    failed=1    skipped=2    rescued=0    ignored=0
```
