### PR TITLE
Enforces Proper permissions for Host Groups List

### DIFF
--- a/awx/ui_next/src/api/models/Hosts.js
+++ b/awx/ui_next/src/api/models/Hosts.js
@@ -21,7 +21,7 @@ class Hosts extends Base {
   }
 
   readGroupsOptions(id) {
-    return this.http.options(`${this.baseUrl}${id}/groups/`);
+    return this.http.options(`${this.baseUrl}${id}/all_groups/`);
   }
 
   associateGroup(id, groupId) {


### PR DESCRIPTION
##### SUMMARY
This closes #10549.  The bug was that the request to get options data was hitting the wrong end point.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![Screen Shot 2021-07-19 at 4 13 03 PM](https://user-images.githubusercontent.com/39280967/126221243-6b65f9b2-4a15-409b-acb9-8807b8a7059f.png)
