### PR TITLE
Properly compile translated API strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ clean-schema:
 
 clean-languages:
 	rm -f $(I18N_FLAG_FILE)
-	find . -type f -regex ".*\.mo$$" -delete
+	find ./awx/locale/ -type f -regex ".*\.mo$" -delete
 
 # Remove temporary build files, compiled Python files.
 clean: clean-ui clean-api clean-awxkit clean-dist
@@ -396,6 +396,7 @@ awx/ui_next/node_modules:
 	NODE_OPTIONS=--max-old-space-size=4096 $(NPM_BIN) --prefix awx/ui_next --loglevel warn ci
 
 $(UI_BUILD_FLAG_FILE):
+	$(PYTHON) tools/scripts/compilemessages.py
 	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run compile-strings
 	$(NPM_BIN) --prefix awx/ui_next --loglevel warn run build
 	mkdir -p awx/public/static/css

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -217,7 +217,7 @@ class APIView(views.APIView):
             if hasattr(self, '__init_request_error__'):
                 response = self.handle_exception(self.__init_request_error__)
             if response.status_code == 401:
-                response.data['detail'] += ' To establish a login session, visit /api/login/.'
+                response.data['detail'] += _(' To establish a login session, visit') + ' /api/login/.'
                 logger.info(status_msg)
             else:
                 logger.warning(status_msg)

--- a/awx/locale/fr/LC_MESSAGES/django.po
+++ b/awx/locale/fr/LC_MESSAGES/django.po
@@ -6032,7 +6032,7 @@ msgstr "Les paramètres requis manquants dans {dependency}."
 msgid ""
 "Invalid group_type parameters. Expected instance of dict but got "
 "{parameters_type} instead."
-msgstr "Paramètres group_type non valides. Instance attendue de dict mais obtenue à la place."
+msgstr "Paramètres group_type non valides. Instance attendue de dict mais {parameters_type} obtenue à la place."
 
 #: awx/sso/fields.py:476
 #, python-brace-format


### PR DESCRIPTION
##### SUMMARY

Fixes: https://github.com/ansible/awx/issues/10681

Now when `make ui-devel` is run, it will compile the API translated strings and display them to the client browser.  

```
[chadams@chadams-work awx]$ make ui-devel
make[1]: Entering directory '/home/chadams/awx'
python3.8 tools/scripts/compilemessages.py
processing file django.po in /home/chadams/awx/awx/locale/fr/LC_MESSAGES
processing file django.po in /home/chadams/awx/awx/locale/zh/LC_MESSAGES
processing file django.po in /home/chadams/awx/awx/locale/en-us/LC_MESSAGES
processing file django.po in /home/chadams/awx/awx/locale/ja/LC_MESSAGES
processing file django.po in /home/chadams/awx/awx/locale/es/LC_MESSAGES
processing file django.po in /home/chadams/awx/awx/locale/nl/LC_MESSAGES
npm --prefix awx/ui_next --loglevel warn run compile-strings
...
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

