### PR TITLE
Run capacity checks with container isolation

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -207,7 +207,7 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
     @property
     def execution_capacity(self):
         # TODO: update query to exclude based on node_type field
-        return sum([inst.capacity for inst in self.instances.exclude(version__startswith='ansible-runner-')])
+        return sum([inst.capacity for inst in self.instances.filter(version__startswith='ansible-runner-')])
 
     @property
     def jobs_running(self):

--- a/tools/docker-receptor.yml
+++ b/tools/docker-receptor.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - "./docker-compose-cluster:/etc/receptor"
   receptor-hop:
-    image: quay.io/ansible/awx-ee:devel
+    image: quay.io/project-receptor/receptor:latest
     user: root
     container_name: tools_receptor_hop
     hostname: receptor-hop
@@ -29,8 +29,8 @@ services:
     volumes:
       - "../../docker-compose-cluster:/etc/receptor"
   receptor-1:
-    image: quay.io/ansible/awx-ee:devel
-    user: root
+    image: quay.io/awx/awx_devel:devel
+    user: "1000"
     container_name: tools_receptor_1
     hostname: receptor-1
     command: 'receptor --config /etc/receptor/awx-1-receptor.conf'
@@ -38,9 +38,11 @@ services:
       - receptor-hop
     volumes:
       - "../../docker-compose-cluster:/etc/receptor"
+      - "/sys/fs/cgroup:/sys/fs/cgroup"
+    privileged: true
   receptor-2:
-    image: quay.io/ansible/awx-ee:devel
-    user: root
+    image: quay.io/awx/awx_devel:devel
+    user: "1000"
     container_name: tools_receptor_2
     hostname: receptor-2
     command: 'receptor --config /etc/receptor/awx-2-receptor.conf'
@@ -48,9 +50,11 @@ services:
       - receptor-hop
     volumes:
       - "../../docker-compose-cluster:/etc/receptor"
+      - "/sys/fs/cgroup:/sys/fs/cgroup"
+    privileged: true
   receptor-3:
-    image: quay.io/ansible/awx-ee:devel
-    user: root
+    image: quay.io/awx/awx_devel:devel
+    user: "1000"
     container_name: tools_receptor_3
     hostname: receptor-3
     command: 'receptor --config /etc/receptor/awx-3-receptor.conf'
@@ -58,3 +62,5 @@ services:
       - receptor-hop
     volumes:
       - "../../docker-compose-cluster:/etc/receptor"
+      - "/sys/fs/cgroup:/sys/fs/cgroup"
+    privileged: true


### PR DESCRIPTION
This requires swapping out the container images
  for the execution nodes from awx-ee to the awx image

For completeness, the hop node image is switched to the raw
  receptor image

A few outright bugs are fixed here
  memory calculation just was not right at all
  the execution_capacity calculation was reverse of intention

Drop in a few TODOs about error handling from debugging

----

I have this running a real job in the development environment, so that's as complete as I'm going for at the moment.