### PR TITLE
Install boto to ci ansible python env

### DIFF
--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -36,7 +36,7 @@ jobs:
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
           AWS_REGION: 'us-east-1'
         run: |
-          pip install boto3
+          ansible localhost -c local, -m command -a "{{ ansible_python_interpreter + ' -m pip install boto3'}}"
           ansible localhost -c local -m aws_s3 \
             -a 'src=${{ github.workspace }}/schema.json bucket=awx-public-ci-files object=schema.json mode=put permission=public-read'
 


### PR DESCRIPTION
##### SUMMARY
Addresses a post-merge [schema upload failure](https://github.com/ansible/awx/runs/3118168665) on devel.

I verified [the approach](https://github.com/ansible/awx/blob/pip-boto/.github/workflows/upload_schema.yml#L39) by [reproducing the failure](https://github.com/ansible/awx/actions/runs/1054176726/workflow#L21-L23) with a temporary workflow that ran on this PR and then confirming that the error was [resolved](https://github.com/ansible/awx/actions/runs/1054150052/workflow#L20-L22) with another temporary workflow that ran on this pr.
