### PR TITLE
set execution node's userid to 1000

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -65,7 +65,7 @@ services:
 {% endfor %}
   execution_node_1:
     image: quay.io/awx/awx_devel:devel
-    user: root
+    user: "1000"
     container_name: tools_execution_node_1
     hostname: execution_node_1
     command: 'receptor --config /etc/receptor/awx-1-receptor-standalone.conf'


### PR DESCRIPTION
With container user is set to `root`, ansible-runner was giving this error while we were doing the capacity check on the execution node, presumably while trying to spin up a container(-in-a-container):

```
Error: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver
```

This brings the compose files for `docker-compose` and `docker-compose-build` into sync.