### PR TITLE
Return 404 for ad_hoc_command_events list api. Remove api endtpoint

### DIFF
--- a/awx/api/urls/ad_hoc_command_event.py
+++ b/awx/api/urls/ad_hoc_command_event.py
@@ -3,11 +3,10 @@
 
 from django.conf.urls import url
 
-from awx.api.views import AdHocCommandEventList, AdHocCommandEventDetail
+from awx.api.views import AdHocCommandEventDetail
 
 
 urls = [
-    url(r'^$', AdHocCommandEventList.as_view(), name='ad_hoc_command_event_list'),
     url(r'^(?P<pk>[0-9]+)/$', AdHocCommandEventDetail.as_view(), name='ad_hoc_command_event_detail'),
 ]
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3906,18 +3906,6 @@ class AdHocCommandRelaunch(GenericAPIView):
             return Response(data, status=status.HTTP_201_CREATED, headers=headers)
 
 
-class AdHocCommandEventList(NoTruncateMixin, ListAPIView):
-
-    model = models.AdHocCommandEvent
-    serializer_class = serializers.AdHocCommandEventSerializer
-    search_fields = ('stdout',)
-
-    def get_queryset(self):
-        adhoc = self.get_parent_object()
-        self.check_parent_access(adhoc)
-        return adhoc.get_event_queryset()
-
-
 class AdHocCommandEventDetail(RetrieveAPIView):
 
     model = models.AdHocCommandEvent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Returned 404 at https://localhost:8043/api/v2/ad_hoc_command_events/ and removed api endpoint for this

#10392 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.2
```


