### PR TITLE
Treat the awx_1 node as a hybrid node for now, use local work type

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -207,7 +207,7 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
     @property
     def execution_capacity(self):
         # TODO: update query to exclude based on node_type field
-        return sum([inst.capacity for inst in self.instances.filter(version__startswith='ansible-runner-')])
+        return sum([inst.capacity for inst in self.instances.all()])
 
     @property
     def jobs_running(self):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3231,7 +3231,10 @@ class AWXReceptorJob:
             else:
                 work_type = 'kubernetes-incluster-auth'
         elif isinstance(self.task.instance, (Job, AdHocCommand)):
-            work_type = 'ansible-runner'
+            if self.task.instance.execution_node == self.task.instance.controller_node:
+                work_type = 'local'
+            else:
+                work_type = 'ansible-runner'
         else:
             work_type = 'local'
 


### PR DESCRIPTION
With this, jobs are successfully running on both nodes, the `awx_1` node and the `execution_node_1` node.

![Screenshot from 2021-07-22 13-57-18](https://user-images.githubusercontent.com/1385596/126686651-4a163638-b0dd-46f4-a8b1-7645b630fe7b.png)

The intent is that this should work for traditional installs too.