### PR TITLE
Fix docker-clean-volumes target when not using minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,9 @@ docker-compose-clean: awx/projects
 	docker-compose -f tools/docker-compose/_sources/docker-compose.yml rm -sf
 
 docker-compose-container-group-clean:
-	tools/docker-compose-minikube/_sources/minikube delete
+	@if [ -f "tools/docker-compose-minikube/_sources/minikube" ]; then \
+	    tools/docker-compose-minikube/_sources/minikube delete; \
+	fi
 	rm -rf tools/docker-compose-minikube/_sources/
 
 # Base development image build


### PR DESCRIPTION
Without this patch, you get:

```
tools/docker-compose-minikube/_sources/minikube delete
make: tools/docker-compose-minikube/_sources/minikube: No such file or directory
```
