### PR TITLE
Set timeout limit for e2e workflow

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -7,6 +7,7 @@ jobs:
   e2e-test:
     if: contains(github.event.pull_request.labels.*.name, 'qe:e2e')
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Usually, this workflow takes ~20 to 30 minutes to complete, by default, Github sets to 360 minutes.