### PR TITLE
[WIP] [Automated-Installer] first iteration of ansible plugin for generating and validating user-defined mesh topology

### DIFF
--- a/awx_collection/plugins/action/calculate_mesh.py
+++ b/awx_collection/plugins/action/calculate_mesh.py
@@ -33,6 +33,15 @@ class ActionModule(ActionBase):
         },
     }
 
+    _REQUIRED_ATTRIBUTES = {
+        'receptor_log_level': 'info',
+        'receptor_control_service_name': 'control',
+        'receptor_control_filename': 'receptor.sock',
+        'receptor_listener_port': 2222,
+        'receptor_listener_protocol': 'tcp'
+    }
+
+
     def generate_control_plane_topology(self, data):
         res = defaultdict(set)
         for index, control_node in enumerate(data["groups"][self._CONTROL_PLANE]):
@@ -107,6 +116,15 @@ class ActionModule(ActionBase):
             )
         return vars["node_type"]
 
+    def assert_attributes(self, vars=None, attr=None):
+        """
+        Assert if a required attribute is present
+        otherwise return with a default value.
+        """
+        if attr not in vars.keys():
+            return self._REQUIRED_ATTRIBUTES[attr]
+        return vars[attr]
+
     def assert_unique_group(self, task_vars=None):
         """
         A given host cannot be part of the automationcontroller and execution_nodes group.
@@ -159,6 +177,12 @@ class ActionModule(ActionBase):
                     group_name=group,
                     valid_types=self._NODE_VALID_TYPES,
                 )
+
+                # ensure all receptor attributes are set
+                for attr in self._REQUIRED_ATTRIBUTES.keys():
+                    myhost_data[attr] = self.assert_attributes(
+                        vars=_host_vars,
+                        attr=attr)
                 data[host] = myhost_data
 
         return dict(mesh=data)

--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -90,7 +90,7 @@ class ActionModule(ActionBase):
 
         return None
 
-    def preflight_verify_node_type(self, task_vars=None, group_name=None, valid_types=None,):
+    def assert_verify_node_type(self, task_vars=None, group_name=None, valid_types=None,):
         """
         Members of given group_name must have a valid node_type.
         """
@@ -104,7 +104,7 @@ class ActionModule(ActionBase):
         return
 
 
-    def preflight_unique_group(self, task_vars=None):
+    def assert_unique_group(self, task_vars=None):
         """
         A given host cannot be part of the automationcontroller and execution_nodes group.
         """
@@ -125,10 +125,9 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = dict()
 
-        # Series of preflight that must pass
-        self.preflight_unique_group(task_vars)
-        self.preflight_verify_node_type(task_vars, group_name='automationcontroller', valid_types=CONTROLLER_NODE_TYPES)
-        self.preflight_verify_node_type(task_vars, group_name='execution_nodes', valid_types=EXECUTION_NODE_TYPES)
+        self.assert_unique_group(task_vars)
+        self.assert_verify_node_type(task_vars, group_name='automationcontroller', valid_types=CONTROLLER_NODE_TYPES)
+        self.assert_verify_node_type(task_vars, group_name='execution_nodes', valid_types=EXECUTION_NODE_TYPES)
 
         result = super(ActionModule, self).run(tmp, task_vars)
         # module_args = self._task.args.copy()

--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# Make coding more python3-ish, this is required for contributions to Ansible
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from datetime import datetime
+
+
+class ActionModule(ActionBase):
+    __res = """
+    strict digraph "" {
+    rankdir = LR
+    subgraph cluster_0 {
+        graph [label="Control Nodes", type=solid];
+    """
+
+    def ge(data=None):
+        res = {}
+        for index, control_node in enumerate(data["control_nodes"]["hosts"]):
+            res[control_node] = data["control_nodes"]["hosts"][(index + 1) :]
+        return res
+
+    def g(type=None, data=None):
+        res = {}
+        if type is None:
+            return None
+        if type not in data.keys():
+            return None
+        for node in data[type]["hosts"]:
+            # check to see if vertex exists
+            if not node in res:
+                res[node] = []
+            if "peers" in (data["_meta"]["hostvars"][node].keys()):
+                for peer in (data["_meta"]["hostvars"][node]["peers"]).split(","):
+                    # handle groups
+                    if peer in data.keys():
+                        ## list comprehension to produce peers list. excludes circular reference to node
+                        res[node] = res[node] + [
+                            x for x in data[peer]["hosts"] if x != node
+                        ]
+                    else:
+                        res[node].append(peer)
+        return res
+
+    def deep_merge_dicts(lhs=None, rhs=None):
+
+        local_lhs = lhs
+        local_rhs = rhs
+
+        if local_lhs is None or local_rhs is None:
+            return
+        for key, value in local_rhs.items():
+            if key in local_lhs:
+                local_lhs[key] = local_lhs[key] + value
+            else:
+                local_lhs[key] = value
+
+        return local_lhs
+
+    def generate_dot_syntax_from_dict(dict=None):
+
+        if dict is None:
+            return
+
+        res = ""
+
+        for label, nodes in dict.items():
+            for node in nodes:
+                res += '"{0}" -> "{1}";\n'.format(label, node)
+
+        return res
+
+    def detect_cycles(dict=None, data=None):
+
+        if dict is None:
+            return
+
+        for key, nodes in dict.items():
+            for node in nodes:
+                if "peers" in (data["_meta"]["hostvars"][node].keys()):
+                    if key in (data["_meta"]["hostvars"][node]["peers"]).split(","): # comma seperated string
+                        raise Exception(
+                            "Cycle Detected Between [{0}] <-> [{1}]".format(key, node)
+                        )
+
+        return None
+
+    def run(self, tmp=None, task_vars=None):
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        # module_args = self._task.args.copy()
+        # module_return = self._execute_module(
+        #     module_name="ansible.builtin.ini",
+        #     module_args=module_args,
+        #     task_vars=task_vars,
+        #     tmp=tmp,
+        # )
+
+        ret = dict()
+        # remote_date = None
+        # if not module_return.get("failed"):
+        #     for key, value in module_return["ansible_facts"].items():
+        #         if key == "ansible_date_time":
+        #             remote_date = value["iso8601"]
+
+        # if remote_date:
+        #     remote_date_obj = datetime.strptime(remote_date, "%Y-%m-%dT%H:%M:%SZ")
+        #     time_delta = datetime.utcnow() - remote_date_obj
+        #     ret["delta_seconds"] = time_delta.seconds
+        #     ret["delta_days"] = time_delta.days
+        #     ret["delta_microseconds"] = time_delta.microseconds
+
+        ret["hello"] = task_vars["hostvars"]
+
+        return dict(stdout=dict(ret))
+

--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 
 class ActionModule(ActionBase):
+
     __res = """
     strict digraph "" {
     rankdir = LR
@@ -16,13 +17,13 @@ class ActionModule(ActionBase):
         graph [label="Control Nodes", type=solid];
     """
 
-    def ge(data=None):
+    def generate_control_plane_topology(type=None, data=None):
         res = {}
-        for index, control_node in enumerate(data["control_nodes"]["hosts"]):
-            res[control_node] = data["control_nodes"]["hosts"][(index + 1) :]
+        for index, control_node in enumerate(data[type]["hosts"]):
+            res[control_node] = data[type]["hosts"][(index + 1) :]
         return res
 
-    def g(type=None, data=None):
+    def generate_topology_from_input(type=None, data=None):
         res = {}
         if type is None:
             return None
@@ -37,9 +38,7 @@ class ActionModule(ActionBase):
                     # handle groups
                     if peer in data.keys():
                         ## list comprehension to produce peers list. excludes circular reference to node
-                        res[node] = res[node] + [
-                            x for x in data[peer]["hosts"] if x != node
-                        ]
+                        res[node] = res[node] + [x for x in data[peer]["hosts"] if x != node]
                     else:
                         res[node].append(peer)
         return res
@@ -80,11 +79,8 @@ class ActionModule(ActionBase):
         for key, nodes in dict.items():
             for node in nodes:
                 if "peers" in (data["_meta"]["hostvars"][node].keys()):
-                    if key in (data["_meta"]["hostvars"][node]["peers"]).split(","): # comma seperated string
-                        raise Exception(
-                            "Cycle Detected Between [{0}] <-> [{1}]".format(key, node)
-                        )
-
+                    if key in (data["_meta"]["hostvars"][node]["peers"]).split(","):
+                        raise Exception("Cycle Detected Between [{0}] <-> [{1}]".format(key, node))
         return None
 
     def run(self, tmp=None, task_vars=None):
@@ -92,30 +88,14 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = dict()
 
+        import sdb
+
+        sdb.set_trace()
+
         result = super(ActionModule, self).run(tmp, task_vars)
-        # module_args = self._task.args.copy()
-        # module_return = self._execute_module(
-        #     module_name="ansible.builtin.ini",
-        #     module_args=module_args,
-        #     task_vars=task_vars,
-        #     tmp=tmp,
-        # )
 
         ret = dict()
-        # remote_date = None
-        # if not module_return.get("failed"):
-        #     for key, value in module_return["ansible_facts"].items():
-        #         if key == "ansible_date_time":
-        #             remote_date = value["iso8601"]
-
-        # if remote_date:
-        #     remote_date_obj = datetime.strptime(remote_date, "%Y-%m-%dT%H:%M:%SZ")
-        #     time_delta = datetime.utcnow() - remote_date_obj
-        #     ret["delta_seconds"] = time_delta.seconds
-        #     ret["delta_days"] = time_delta.days
-        #     ret["delta_microseconds"] = time_delta.microseconds
 
         ret["hello"] = task_vars["hostvars"]
 
         return dict(stdout=dict(ret))
-

--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -19,10 +19,10 @@ class ActionModule(ActionBase):
     _NODE_VALID_TYPES = {
         'automationcontroller': {
             'types': frozenset(('control', 'hybrid')),
-            'default_group': 'hybrid'},
+            'default_type': 'hybrid'},
         'execution_nodes': {
             'types': frozenset(('execution', 'hop')),
-            'default_group': 'execution'},
+            'default_type': 'execution'},
     }
 
     def ge(data=None):
@@ -101,7 +101,7 @@ class ActionModule(ActionBase):
         Members of given group_name must have a valid node_type.
         """
         if 'node_type' not in vars.keys():
-            return valid_types[group_name]['default_group']
+            return valid_types[group_name]['default_type']
 
         if vars['node_type'] not in valid_types[group_name]['types']:
             raise AnsibleError(

--- a/awx_collection/plugins/modules/calculate_mesh.py
+++ b/awx_collection/plugins/modules/calculate_mesh.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Ansible Automation Platform
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: calculate_mesh
+short_description: Calculates the connectivity of the receptor mesh
+description:
+  - This module inspects the inventory hosts for receptor nodes, expands out the list of
+    peers for each node, and does sanity checks for the connectivity of the mesh.
+options:
+  generate_dot_file:
+    description:
+      - Output a GraphViz dot-format file that can be rendered to show the graph of the mesh network.
+    type: str
+    default: mesh.dot
+author:
+  - Ansible Controller Team
+  - Sarabraj Singh
+  - Marcelo Moreira de Mello
+  - Jeff Bradberry
+  - Rebeccah Hunter
+"""
+
+EXAMPLES = """
+- name: Calculate the receptor mesh connectivity
+  awx.awx.calculate_mesh:
+  register: mesg
+  run_once: true
+
+- name: Output a GraphViz dot file
+  awx.awx.calculate_mesh:
+    generate_dot_file: /foo/bar/baz.dot
+  run_once: true
+"""
+
+RETURN = """
+mesh:
+  description: Information about the receptor mesh nodes and what nodes are peers.
+  returned: success
+  type: dict
+  sample:
+    node1:
+      node_type: control
+      peers:
+        - node2
+        - node3
+    node2:
+      node_type: control
+      peers:
+        - node3
+    node3:
+      node_type: hybrid
+      peers:
+"""


### PR DESCRIPTION
Upstream issue: https://github.com/ansible/tower-packaging/issues/1381

# TODO
- [ ] Nodes in `[automationcontroller]` automatically get connected with a one-way link between each pair
- [x] Nodes in `[automationcontroller]` are default of type `'hybrid'` and nodes in `[execution_nodes]` are default of type `'execution'` https://github.com/sarabrajsingh/awx/pull/1
- [x] The `peers` hostvar gets resolved into a list of hosts in the output, groups fully expanded, and comma-separated strings vs yaml lists dealt with
- [x] Output the structure to be used in the `jinja2` templates. (list of dicts  - one per host node) `[{'name': 'p70', 'peers': [...], 'node_type': 'hybrid', ...}, {...}, ...]`
- [ ] With an optional flag, the module dumps out a dot graph format file
- [ ] Preflight checks
  - [x] Ensure hosts cannot be members of `[automationcontroller]` and `[execution_nodes]` at the same time
  - [x] Ensure all hosts from `[automationcontroller]` and `[execution_nodes]` have a valid `node_type`
  - [ ] Whenever a node has the `deprovision` action, must have at least 2 hosts in the `[automationcontroller]` group 
- [ ] Create a skeleton module that contains documentation and usage examples