### PR TITLE
add minikube to github bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,6 +47,7 @@ body:
       multiple: false
       options:
         - kubernetes
+        - minikube
         - openshift
         - minishift
         - docker on linux


### PR DESCRIPTION
##### SUMMARY
This adds "minikube" to the github bug template installation method options.

Minikube is the installation method covered in the [awx-operator installation document](https://github.com/ansible/awx-operator#basic-install). Therefore if any, it should be the one in the list.  
You could argue there is a "kubernetes" option in the list and to use that. However that logic doesn't hold up as the list differentiates between "openshift" and "minishift". So this discrepancy leads to confusion.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
N/A

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
