### PR TITLE
Update workflow to use pull_request_target

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+workflows/e2e_test.yml @tiagodread @shanemcd @jakemcdermott

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,7 +1,7 @@
 ---
 name: E2E Tests
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 jobs:   
   e2e-test:


### PR DESCRIPTION
This update the github workflow to run on `pull_request_target` instead of `pull_request`

