### PR TITLE
Fix Broken Collections Docs

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -19,6 +19,8 @@ options:
             - name: CONTROLLER_HOST
             - name: TOWER_HOST
               deprecated:
+                removed_from_collection: 'awx.awx.controller'
+                removed_in_version: '4.0.0'
                 alternatives: 'CONTROLLER_HOST'
     username:
         description: The user that you plan to use to access inventories on the controller.
@@ -26,6 +28,8 @@ options:
             - name: CONTROLLER_USERNAME
             - name: TOWER_USERNAME
               deprecated:
+                removed_from_collection: 'awx.awx.controller'
+                removed_in_version: '4.0.0'
                 alternatives: 'CONTROLLER_USERNAME'
     password:
         description: The password for your controller user.
@@ -33,6 +37,8 @@ options:
             - name: CONTROLLER_PASSWORD
             - name: TOWER_PASSWORD
               deprecated:
+                removed_from_collection: 'awx.awx.controller'
+                removed_in_version: '4.0.0'
                 alternatives: 'CONTROLLER_PASSWORD'
     oauth_token:
         description:
@@ -41,6 +47,8 @@ options:
             - name: CONTROLLER_OAUTH_TOKEN
             - name: TOWER_OAUTH_TOKEN
               deprecated:
+                removed_from_collection: 'awx.awx.controller'
+                removed_in_version: '4.0.0'
                 alternatives: 'CONTROLLER_OAUTH_TOKEN'
     verify_ssl:
         description:
@@ -51,6 +59,8 @@ options:
             - name: CONTROLLER_VERIFY_SSL
             - name: TOWER_VERIFY_SSL
               deprecated:
+                removed_from_collection: 'awx.awx.controller'
+                removed_in_version: '4.0.0'
                 alternatives: 'CONTROLLER_VERIFY_SSL'
         aliases: [ validate_certs ]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Connecting https://github.com/ansible/awx/issues/10776

The documentation pages for `awx.awx.controller` and `awx.awx.controller_api` modules are broken; there are missing parameters for the deprecated module options pulled in by `extends_documentation_fragment: awx.awx.auth_plugin`, this PR should fix the displayed output of the documentation.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collections
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```
