### PR TITLE
Bump npm version inside container

### DIFF
--- a/awx/ui/README.md
+++ b/awx/ui/README.md
@@ -1,7 +1,7 @@
 # AWX-PF
 
 ## Requirements
-- node 14.x LTS, npm 6.x LTS, make, git
+- node 14.x LTS, npm 7.x LTS, make, git
 
 ## Development
 The API development server will need to be running. See [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -141,7 +141,7 @@ RUN dnf -y install \
     wget \
     diffutils \
     unzip && \
-    npm install -g n && n 14.15.1 && dnf remove -y nodejs
+    npm install -g n && n 14.15.1 && npm install -g npm@7.20.3 && dnf remove -y nodejs
 
 RUN pip3 install black git+https://github.com/coderanger/supervisor-stdout
 


### PR DESCRIPTION
Bump npm version inside container

See: https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#lockfileversion

With this change
```
base) ➜  ~ docker exec -it tools_awx_1 bash
bash-4.4$ npm -v
7.20.3
bash-4.4$ node -v
v14.15.1
bash-4.4$```