### PR TITLE
Use the ansible-runner worker --worker-info to perform execution node capacity checks

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -131,6 +131,13 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         grace_period = 120
         return self.modified < ref_time - timedelta(seconds=grace_period)
 
+    def mark_offline(self, on_good_terms=False):
+        self.cpu = self.cpu_capacity = self.memory = self.mem_capacity = self.capacity = 0
+        update_fields = ['capacity', 'cpu', 'memory', 'cpu_capacity', 'mem_capacity']
+        if on_good_terms:
+            update_fields.append('modified')
+        self.save()
+
     def refresh_capacity(self):
         cpu = get_cpu_capacity()
         mem = get_mem_capacity()

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -52,9 +52,6 @@ from gitdb.exc import BadName as BadGitName
 # Runner
 import ansible_runner
 
-# Receptor
-from receptorctl.socket_interface import ReceptorControl
-
 # dateutil
 from dateutil.parser import parse as parse_date
 
@@ -112,6 +109,7 @@ from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
 from awx.main.utils.reload import stop_local_services
 from awx.main.utils.pglock import advisory_lock
 from awx.main.utils.handlers import SpecialInventoryHandler
+from awx.main.utils.receptor import get_receptor_ctl
 from awx.main.consumers import emit_channel_notification
 from awx.main import analytics
 from awx.conf import settings_registry
@@ -800,10 +798,6 @@ def with_path_cleanup(f):
             self.cleanup_paths = []
 
     return _wrapped
-
-
-def get_receptor_ctl():
-    return ReceptorControl('/var/run/receptor/receptor.sock')
 
 
 class BaseTask(object):

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -82,7 +82,7 @@ from awx.main.models import (
     SystemJobEvent,
     build_safe_env,
 )
-from awx.main.constants import ACTIVE_STATES, RECEPTOR_PENDING
+from awx.main.constants import ACTIVE_STATES
 from awx.main.exceptions import AwxTaskError, PostRunError
 from awx.main.queue import CallbackQueueDispatcher
 from awx.main.dispatch.publish import task
@@ -98,8 +98,8 @@ from awx.main.utils.common import (
     parse_yaml_or_json,
     cleanup_new_process,
     create_partition,
-    get_cpu_capacity,
-    get_mem_capacity,
+    get_cpu_effective_capacity,
+    get_mem_effective_capacity,
     get_system_task_capacity,
 )
 from awx.main.utils.execution_environments import get_default_execution_environment, get_default_pod_spec, CONTAINER_ROOT, to_container_path
@@ -109,7 +109,7 @@ from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
 from awx.main.utils.reload import stop_local_services
 from awx.main.utils.pglock import advisory_lock
 from awx.main.utils.handlers import SpecialInventoryHandler
-from awx.main.utils.receptor import get_receptor_ctl
+from awx.main.utils.receptor import get_receptor_ctl, worker_info
 from awx.main.consumers import emit_channel_notification
 from awx.main import analytics
 from awx.conf import settings_registry
@@ -405,7 +405,26 @@ def cleanup_execution_environment_images():
 
 @task(queue=get_local_queuename)
 def check_heartbeat(node):
-    AWXReceptorJob.check_heartbeat(node)
+    instance = Instance.objects.get(hostname=node)
+    data = worker_info(node)
+
+    if data['Errors']:
+        formatted_error = "\n".join(data["Errors"])
+        logger.warn(f'Failed to find capacity of execution node {node}, errors:\n{formatted_error}')
+    else:
+        # TODO: spin off new instance method from refresh_capacity that calculates derived fields
+        instance.cpu = data['CPU Capacity']  # TODO: rename field on runner side to not say "Capacity"
+        instance.cpu_capacity = get_cpu_effective_capacity(instance.cpu)
+        instance.memory = data['Memory Capacity'] * 1000  # TODO: double-check the multiplier here
+        instance.mem_capacity = get_mem_effective_capacity(instance.memory)
+        instance.capacity = get_system_task_capacity(
+            instance.capacity_adjustment,
+            instance.cpu_capacity,
+            instance.mem_capacity,
+        )
+        instance.version = data['Version']
+        instance.save(update_fields=['capacity', 'version', 'cpu', 'memory', 'cpu_capacity', 'mem_capacity'])
+        logger.info('Set capacity of execution node {} to {}, worker info data:\n{}'.format(node, instance.capacity, json.dumps(data, indent=2)))
 
 
 def discover_receptor_nodes():
@@ -2981,120 +3000,6 @@ class AWXReceptorJob:
             # Make sure to always release the work unit if we established it
             if self.unit_id is not None and settings.RECEPTOR_RELEASE_WORK:
                 receptor_ctl.simple_command(f"work release {self.unit_id}")
-
-    @classmethod
-    def check_heartbeat(cls, node):  # TODO: rename most of these "heartbeat" things
-        logger.info(f'Checking capacity of execution node {node}')
-        # make a private data dir and env dir
-        private_data_dir = tempfile.mkdtemp(prefix='awx_heartbeat_', dir=settings.AWX_ISOLATION_BASE_PATH)
-        env_path = os.path.join(private_data_dir, 'env')
-        os.makedirs(os.path.join(env_path), mode=0o700)
-        # write a cmdline file for adhoc
-        f = os.fdopen(os.open(os.path.join(env_path, 'cmdline'), os.O_RDWR | os.O_CREAT, stat.S_IREAD | stat.S_IWRITE), 'w')
-        f.write(ansible_runner.utils.args2cmdline('localhost'))
-        f.close()
-        # write a custom facts.d to report the runner version
-        facts_path = os.path.join(private_data_dir, 'facts.d')
-        os.makedirs(facts_path, mode=0o700)
-        with open(os.path.join(facts_path, 'ansible_runner.fact'), 'w') as f:
-            os.chmod(f.name, 0o700)
-            f.write("""#!/usr/bin/env sh\necho "{\\"version\\": \\"`ansible-runner --version`\\"}"\n""")  # noqa
-        # write a local inventory
-        inventory_path = os.path.join(private_data_dir, 'inventory')
-        os.makedirs(inventory_path, mode=0o700)
-        fn = os.path.join(inventory_path, 'hosts')
-        with open(fn, 'w') as f:
-            os.chmod(fn, stat.S_IRUSR | stat.S_IXUSR | stat.S_IWUSR)
-            f.write('localhost ansible_connection=local')
-        # we have to create the project directory because it is --workdir and crun needs it to exist
-        # https://github.com/ansible/ansible-runner/issues/758
-        project_path = os.path.join(private_data_dir, 'project')
-        os.makedirs(project_path, mode=0o700)
-
-        runner_params = {
-            'ident': str(uuid4()),
-            'private_data_dir': private_data_dir,
-            'module': 'setup',
-            'module_args': f'fact_path={private_data_dir}/facts.d',
-            'inventory': inventory_path,
-            'only_transmit_kwargs': False,
-            'settings': {
-                "container_image": get_default_execution_environment().image,
-                "container_options": ['--user=root'],
-                "process_isolation": True,
-            },
-        }
-
-        class _Instance(object):
-            pk = -1
-            job_env = {}
-
-            @property
-            def is_container_group_task(self):
-                return False
-
-            @property
-            def execution_node(self):
-                return node
-
-        class _BaseTask(object):
-            instance = _Instance()
-            cpus = 0
-            mem_mb = 0
-            version = RECEPTOR_PENDING
-
-            def build_execution_environment_params(self, instance, private_data_dir):
-                return {}
-
-            def event_handler(self, event_data):
-                if event_data.get('event') == 'runner_on_ok':
-                    facts = event_data.get('event_data', {}).get('res', {}).get('ansible_facts', {})
-                    if facts:
-                        self.cpus = facts.get('ansible_processor_vcpus', 0)
-                        self.mem_mb = facts.get('ansible_memtotal_mb', 0)
-                        version = facts.get('ansible_local', {}).get('ansible_runner', {}).get('version', '')  # noqa
-                        if version:
-                            self.version = f'ansible-runner-{version}'
-                # TODO: save event_data["stdout"] and log when errors happen
-
-            def finished_callback(self, runner_obj):
-                pass
-
-            def cancel_callback(self):
-                pass
-
-            def status_handler(self, status_data, runner_config):
-                # TODO: log error cases
-                pass
-
-            def update_model(self, *args, **kw):
-                pass
-
-        task = _BaseTask()
-        receptor_job = cls(task, runner_params)
-        res = receptor_job.run(work_type='ansible-runner')
-        if res.status == 'successful':
-            cpu = get_cpu_capacity(task.cpus)
-            mem = get_mem_capacity(task.mem_mb * 1000000)
-            logger.info(f'Calculated memory capacity: {task.mem_mb}, out: {mem}')
-            instance = Instance.objects.get(hostname=node)
-            instance.cpu = cpu[0]
-            instance.cpu_capacity = cpu[1]
-            instance.memory = mem[0]
-            instance.mem_capacity = mem[1]
-            instance.capacity = get_system_task_capacity(
-                instance.capacity_adjustment,
-                instance.cpu_capacity,
-                instance.mem_capacity,
-            )
-            instance.version = task.version
-            instance.save(update_fields=['capacity', 'version', 'cpu', 'memory', 'cpu_capacity', 'mem_capacity'])
-            logger.info(f'Updated capacity of {node} to cpu: {instance.cpu_capacity} mem: {instance.mem_capacity}')
-        else:
-            # TODO: error handling like we do with jobs
-            # receptorctl work results
-            # receptorctl work list
-            logger.info(f'Capacity check not successful for execution node {node}')
 
     def _run_internal(self, receptor_ctl, work_type=None):
         # Create a socketpair. Where the left side will be used for writing our payload

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -715,7 +715,7 @@ def get_cpu_effective_capacity(cpu_count):
     return cpu_count * forkcpu
 
 
-def get_cpu_capacity(raw=None):
+def get_cpu_capacity():
     from django.conf import settings
 
     settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
@@ -726,10 +726,9 @@ def get_cpu_capacity(raw=None):
     elif settings_abscpu is not None:
         return 0, int(settings_abscpu)
 
-    if raw is None:
-        raw = psutil.cpu_count()
+    cpu = psutil.cpu_count()
 
-    return (raw, get_cpu_effective_capacity(raw))
+    return (cpu, get_cpu_effective_capacity(cpu))
 
 
 def get_mem_effective_capacity(mem_mb):
@@ -748,7 +747,7 @@ def get_mem_effective_capacity(mem_mb):
     return max(1, ((mem_mb // 1024 // 1024) - 2048) // forkmem)
 
 
-def get_mem_capacity(raw_mb=None):
+def get_mem_capacity():
     from django.conf import settings
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
@@ -759,9 +758,8 @@ def get_mem_capacity(raw_mb=None):
     elif settings_absmem is not None:
         return 0, int(settings_absmem)
 
-    if raw_mb is None:
-        raw_mb = psutil.virtual_memory().total
-    return (raw_mb, get_mem_effective_capacity(raw_mb))
+    mem = psutil.virtual_memory().total
+    return (mem, get_mem_effective_capacity(mem))
 
 
 def get_system_task_capacity(scale=Decimal(1.0), cpu_capacity=None, mem_capacity=None):

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -1,5 +1,6 @@
 import logging
 import yaml
+import time
 
 from receptorctl.socket_interface import ReceptorControl
 
@@ -13,42 +14,55 @@ def get_receptor_ctl():
 
 def worker_info(node_name):
     receptor_ctl = get_receptor_ctl()
+    transmit_start = time.time()
+    error_list = []
+    data = {'Errors': error_list, 'transmit_timing': 0.0}
 
     result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": f"--worker-info"}, ttl='20s', node=node_name)
 
     unit_id = result['unitid']
+    run_start = time.time()
+    data['transmit_timing'] = run_start - transmit_start
+    data['run_timing'] = 0.0
 
     resultfile = receptor_ctl.get_work_results(unit_id)
 
     stdout = ''
 
-    while True:
-        line = resultfile.readline()
-        if line:
-            stdout += str(line, encoding='utf-8').strip()
-        else:
-            status = receptor_ctl.simple_command(f'work status {unit_id}')
-            state_name = status.get('StateName')
-            if state_name != 'Running':
-                break
+    while data['run_timing'] < 20.0:
+        status = receptor_ctl.simple_command(f'work status {unit_id}')
+        state_name = status.get('StateName')
+        if state_name not in ('Pending', 'Running'):
+            break
+        data['run_timing'] = time.time() - run_start
+        time.sleep(0.5)
+    else:
+        error_list.append(f'Timeout getting worker info on {node_name}, state remains in {state_name}')
 
-    data = {}
+    stdout = resultfile.read()
+    stdout = str(stdout, encoding='utf-8')
 
     if state_name.lower() == 'failed':
         work_detail = status.get('Detail', '')
         if not work_detail.startswith('exit status'):
-            logger.info(f'Mesh-level error getting worker info from {node_name}, detail:\n{work_detail}')
+            error_list.append(f'Receptor error getting worker info from {node_name}, detail:\n{work_detail}')
         elif 'unrecognized arguments: --worker-info' in stdout:
-            # 2.0.1 is the last version before --worker-info was introduced
-            logger.info(f'Old version of ansible-runner on node {node_name} without --worker-info')
+            error_list.append(f'Old version (2.0.1 or earlier) of ansible-runner on node {node_name} without --worker-info')
         else:
-            logger.warn(f'Unknown ansible-runner error on node {node_name}, stdout:\n{stdout}')
+            error_list.append(f'Unknown ansible-runner error on node {node_name}, stdout:\n{stdout}')
     else:
         yaml_stdout = stdout.strip()
+        remote_data = {}
         try:
-            data = yaml.safe_load(yaml_stdout)
+            remote_data = yaml.safe_load(yaml_stdout)
         except Exception as json_e:
-            logger.warn(f'Failed to parse node {node_name} worker info output as YAML, error: {json_e}, data:\n{yaml_stdout}')
+            error_list.append(f'Failed to parse node {node_name} --worker-info output as YAML, error: {json_e}, data:\n{yaml_stdout}')
+
+        if not isinstance(remote_data, dict):
+            error_list.append(f'Remote node {node_name} --worker-info output is not a YAML dict, output:{stdout}')
+        else:
+            error_list.extend(remote_data.pop('Errors'))  # merge both error lists
+            data.update(remote_data)
 
     res = receptor_ctl.simple_command(f"work release {unit_id}")
     if res != {'released': unit_id}:

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -14,7 +14,7 @@ def get_receptor_ctl():
 def worker_info(node_name):
     receptor_ctl = get_receptor_ctl()
 
-    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": f"--worker-info"}, node=node_name)
+    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": f"--worker-info"}, ttl='20s', node=node_name)
 
     unit_id = result['unitid']
 

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -1,0 +1,54 @@
+import logging
+import yaml
+
+from receptorctl.socket_interface import ReceptorControl
+
+
+logger = logging.getLogger('awx.main.utils.receptor')
+
+
+def get_receptor_ctl():
+    return ReceptorControl('/var/run/receptor/receptor.sock')
+
+
+def worker_info(node_name):
+    receptor_ctl = get_receptor_ctl()
+
+    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": f"--worker-info"}, node=node_name)
+
+    unit_id = result['unitid']
+
+    resultsock, resultfile = receptor_ctl.get_work_results(unit_id, return_socket=True, return_sockfile=True)
+
+    stdout = ''
+
+    while True:
+        line = resultfile.readline()
+        if line:
+            stdout += str(line, encoding='utf-8').strip()
+        else:
+            status = receptor_ctl.simple_command(f'work status {unit_id}')
+            state_name = status.get('StateName')
+            if state_name != 'Running':
+                break
+
+    # 2.0.1 is the last version before --worker-info was introduced
+    data = {}
+
+    if state_name.lower() == 'failed':
+        if 'unrecognized arguments: --worker-info' in stdout:
+            logger.info(f'Old version of ansible-runner on node {node_name} without --worker-info')
+        else:
+            logger.warn(f'Unknown ansible-runner error on node {node_name}, stdout:\n{stdout}')
+    else:
+        yaml_stdout = stdout.strip()
+        try:
+            data = yaml.safe_load(yaml_stdout)
+        except Exception as json_e:
+            logger.warn(f'Failed to parse node {node_name} worker info output as YAML, error: {json_e}, data:\n{yaml_stdout}')
+
+    res = receptor_ctl.simple_command(f"work release {unit_id}")
+    if res != {'released': unit_id}:
+        logger.warn(f'Could not confirm release of receptor work unit id {unit_id}, data: {res}')
+
+    return data

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -18,7 +18,7 @@ def worker_info(node_name):
 
     unit_id = result['unitid']
 
-    resultsock, resultfile = receptor_ctl.get_work_results(unit_id, return_socket=True, return_sockfile=True)
+    resultfile = receptor_ctl.get_work_results(unit_id)
 
     stdout = ''
 
@@ -32,11 +32,14 @@ def worker_info(node_name):
             if state_name != 'Running':
                 break
 
-    # 2.0.1 is the last version before --worker-info was introduced
     data = {}
 
     if state_name.lower() == 'failed':
-        if 'unrecognized arguments: --worker-info' in stdout:
+        work_detail = status.get('Detail', '')
+        if not work_detail.startswith('exit status'):
+            logger.info(f'Mesh-level error getting worker info from {node_name}, detail:\n{work_detail}')
+        elif 'unrecognized arguments: --worker-info' in stdout:
+            # 2.0.1 is the last version before --worker-info was introduced
             logger.info(f'Old version of ansible-runner on node {node_name} without --worker-info')
         else:
             logger.warn(f'Unknown ansible-runner error on node {node_name}, stdout:\n{stdout}')

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -42,6 +42,12 @@ def worker_info(node_name):
     stdout = resultfile.read()
     stdout = str(stdout, encoding='utf-8')
 
+    res = receptor_ctl.simple_command(f"work release {unit_id}")
+    if res != {'released': unit_id}:
+        logger.warn(f'Could not confirm release of receptor work unit id {unit_id} from {node_name}, data: {res}')
+
+    receptor_ctl.close()
+
     if state_name.lower() == 'failed':
         work_detail = status.get('Detail', '')
         if not work_detail.startswith('exit status'):
@@ -63,9 +69,5 @@ def worker_info(node_name):
         else:
             error_list.extend(remote_data.pop('Errors'))  # merge both error lists
             data.update(remote_data)
-
-    res = receptor_ctl.simple_command(f"work release {unit_id}")
-    if res != {'released': unit_id}:
-        logger.warn(f'Could not confirm release of receptor work unit id {unit_id}, data: {res}')
 
     return data

--- a/docs/receptor_mesh.md
+++ b/docs/receptor_mesh.md
@@ -72,8 +72,27 @@ Control nodes check the receptor network (reported via `receptorctl status`) whe
 Nodes on the receptor network are compared against the `Instance` model in the database.
 
 If a node appears in the mesh network which is not in the database, then a "health check" is started.
-This will submit a work unit to the execution node which then outputs important node data via `ansible-runner`.
 The `capacity` field will obtain a non-zero value through this process, which is necessary to run jobs.
+
+#### Health Check Mechanics
+
+All relevant data for health checks is reported from the ansible-runner command:
+
+```
+ansible-runner worker --worker-info
+```
+
+This will output YAML data to standard out containing CPU, memory, and other metrics used to compute `capacity`.
+
+AWX invokes this command by submitting a receptor work unit (of type `ansible-runner`) to the target execution node.
+If you have the development environment running, you can run a one-off health check of a node with this command:
+
+```
+echo "from awx.main.utils.receptor import worker_info; worker_info('receptor-1')" | awx-manage shell_plus --quiet
+```
+
+This must be ran as the awx user inside one of the hybrid or control nodes.
+This will not affect actual `Instance` record, but will just run the command and report the data.
 
 ### Development Environment
 

--- a/docs/receptor_mesh.md
+++ b/docs/receptor_mesh.md
@@ -108,13 +108,23 @@ This will spin up a topology represented below.
 (names are the receptor node names, which differ from the AWX Instance names and network address in some cases)
 
 ```
-<awx_1:2222>---v
- -----v
-<awx_2:2222>
-     <receptor-hop:5555>
-             ^-------------- <receptor-1>
-             ^-------------- <receptor-2>
-             ^-------------- <receptor-3>
+                                            ┌──────────────┐
+                                            │              │
+┌──────────────┐                 ┌──────────┤  receptor-1  │
+│              │                 │          │              │
+│    awx_1     │◄──────────┐     │          └──────────────┘
+│              │           │     ▼
+└──────┬───────┘    ┌──────┴───────┐        ┌──────────────┐
+       │            │              │        │              │
+       │            │ receptor-hop │◄───────┤  receptor-2  │
+       ▼            │              │        │              │
+┌──────────────┐    └──────────────┘        └──────────────┘
+│              │                 ▲
+│    awx_2     │                 │          ┌──────────────┐
+│              │                 │          │              │
+└──────────────┘                 └──────────┤  receptor-3  │
+                                            │              │
+                                            └──────────────┘
 ```
 
 All execution (`receptor-*`) nodes connect to the hop node.


### PR DESCRIPTION
What we had before was really more of a proof-of-concept than something polished. This still needs more polishing around the edges, but the overall flow is something I'm vastly more happy with.

This makes use of https://github.com/ansible/ansible-runner/pull/762

Advantages of this approach:

 - No image download to get capacity, so won't take 5 minutes, actually finishes in about 1 second
 - No temporary files
 - No processing of stuff in callback methods
 - More clearly establishing the pattern of interacting with receptor_ctl, which I hope can help influence job error handling too (see https://github.com/ansible/awx/pull/10823, but that's just scratching the surface), and eventually I'd like to move a lot of the functions performed here upstream to receptorctl

I have manually installed the `devel` branch of ansible-runner to node `receptor-1`. With that, a demo here of running this:

```
tools_awx_1     | awx-dispatcher stdout | 2021-08-06 13:36:04,763 WARNING  [1cb3cb74] awx.main.tasks Failed to find capacity of execution node receptor-2, errors:
tools_awx_1     | awx-dispatcher stdout | Old version (2.0.1 or earlier) of ansible-runner on node receptor-2 without --worker-info
tools_awx_1     | awx-dispatcher stdout | 2021-08-06 13:36:04,768 WARNING  [1cb3cb74] awx.main.tasks Failed to find capacity of execution node receptor-3, errors:
tools_awx_1     | awx-dispatcher stdout | Old version (2.0.1 or earlier) of ansible-runner on node receptor-3 without --worker-info
tools_awx_1     | awx-dispatcher stdout | 2021-08-06 13:36:04,785 INFO     [1cb3cb74] awx.main.tasks Set capacity of execution node receptor-1 to 290.00, worker info data:
tools_awx_1     | awx-dispatcher stdout | {
tools_awx_1     | awx-dispatcher stdout |   "Errors": [],
tools_awx_1     | awx-dispatcher stdout |   "transmit_timing": 0.011393308639526367,
tools_awx_1     | awx-dispatcher stdout |   "run_timing": 1.0031061172485352,
tools_awx_1     | awx-dispatcher stdout |   "CPU Capacity": 8,
tools_awx_1     | awx-dispatcher stdout |   "Memory Capacity": 32619828,
tools_awx_1     | awx-dispatcher stdout |   "Version": "2.0.0.0a4.dev90"
tools_awx_1     | awx-dispatcher stdout | }
```