### PR TITLE
Addresses permission problem on host group list and adds convergence data to Prompt Detail

### DIFF
--- a/awx/ui/src/api/models/Hosts.js
+++ b/awx/ui/src/api/models/Hosts.js
@@ -21,7 +21,7 @@ class Hosts extends Base {
   }
 
   readGroupsOptions(id) {
-    return this.http.options(`${this.baseUrl}${id}/all_groups/`);
+    return this.http.options(`${this.baseUrl}${id}/groups/`);
   }
 
   associateGroup(id, groupId) {

--- a/awx/ui/src/components/PromptDetail/PromptDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.js
@@ -87,7 +87,12 @@ function omitOverrides(resource, overrides, defaultConfig) {
   return clonedResource;
 }
 
-function PromptDetail({ resource, launchConfig = {}, overrides = {} }) {
+function PromptDetail({
+  resource,
+  launchConfig = {},
+  overrides = {},
+  workflowNode = false,
+}) {
   const VERBOSITY = {
     0: t`0 (Normal)`,
     1: t`1 (Verbose)`,
@@ -109,6 +114,12 @@ function PromptDetail({ resource, launchConfig = {}, overrides = {} }) {
           label={t`Type`}
           value={toTitleCase(details.unified_job_type || details.type)}
         />
+        {workflowNode && (
+          <Detail
+            label={t`Convergence`}
+            value={workflowNode?.all_parents_must_converge ? t`All` : t`Any`}
+          />
+        )}
         <Detail label={t`Timeout`} value={formatTimeout(details?.timeout)} />
         {details?.type === 'project' && (
           <PromptProjectDetail resource={details} />

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
@@ -192,6 +192,7 @@ function NodeViewModal({ readOnly }) {
         launchConfig={launchConfig}
         resource={fullUnifiedJobTemplate}
         overrides={overrides}
+        workflowNode={nodeToView.originalNodeObject}
       />
     );
   }


### PR DESCRIPTION

##### SUMMARY

Addresses #10628 and #10549.

Re: 10549-We essentially have 2 end points we can hit with an OPTIONS request to get the permissions data. They are `/hosts/id/groups` where both super users and system administrator erroneously have POST permissions, or `hosts/id/all_groups` where neither have POST permissions, which is also an error.  However, when hitting `/hosts/id/groups` a when associating or disassociating the api returns a 403 for system auditor.

##### ISSUE TYPE
 - Bugfix Pull Request
##### COMPONENT NAME
 - UI


##### ADDITIONAL INFORMATION
![Screen Shot 2021-08-06 at 11 07 27 AM](https://user-images.githubusercontent.com/39280967/128531706-028d1a0b-c6da-475c-b6b2-c001ff08dbec.png)
![Screen Shot 2021-08-06 at 11 07 22 AM](https://user-images.githubusercontent.com/39280967/128531709-51d62438-99f9-4bf5-910c-65d825876192.png)
![Screen Shot 2021-08-06 at 11 07 10 AM](https://user-images.githubusercontent.com/39280967/128531710-c4f86849-6085-497e-8d99-ebdd9a8e2f6b.png)
