### PR TITLE
fixed module name to FQCN in example

### DIFF
--- a/awx_collection/plugins/modules/ad_hoc_command_cancel.py
+++ b/awx_collection/plugins/modules/ad_hoc_command_cancel.py
@@ -47,7 +47,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Cancel command
-  ad_hoc_command_cancel:
+  awx.awx.ad_hoc_command_cancel:
     command_id: command.id
 '''
 

--- a/awx_collection/plugins/modules/ad_hoc_command_wait.py
+++ b/awx_collection/plugins/modules/ad_hoc_command_wait.py
@@ -41,14 +41,14 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Launch an ad hoc command
-  ad_hoc_command:
+  awx.awx.ad_hoc_command:
     inventory: "Demo Inventory"
     credential: "Demo Credential"
     wait: false
   register: command
 
 - name: Wait for ad joc command max 120s
-  ad_hoc_command_wait:
+  awx.awx.ad_hoc_command_wait:
     command_id: "{{ command.id }}"
     timeout: 120
 '''

--- a/awx_collection/plugins/modules/application.py
+++ b/awx_collection/plugins/modules/application.py
@@ -69,7 +69,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add Foo application
-  application:
+  awx.awx.application:
     name: "Foo"
     description: "Foo bar application"
     organization: "test"
@@ -78,7 +78,7 @@ EXAMPLES = '''
     client-type: public
 
 - name: Add Foo application
-  application:
+  awx.awx.application:
     name: "Foo"
     description: "Foo bar application"
     organization: "test"

--- a/awx_collection/plugins/modules/controller_meta.py
+++ b/awx_collection/plugins/modules/controller_meta.py
@@ -49,7 +49,7 @@ version:
 
 
 EXAMPLES = '''
-- controller_meta:
+- awx.awx.controller_meta:
   register: result
 
 - name: Show details about the collection

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -203,7 +203,7 @@ notes:
 
 EXAMPLES = '''
 - name: Add machine credential
-  credential:
+  awx.awx.credential:
     name: Team Name
     description: Team Description
     organization: test-org
@@ -212,7 +212,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Create a valid SCM credential from a private_key file
-  credential:
+  awx.awx.credential:
     name: SCM Credential
     organization: Default
     state: present
@@ -229,7 +229,7 @@ EXAMPLES = '''
   register: aws_ssh_key
 
 - name: Add Credential
-  credential:
+  awx.awx.credential:
     name: Workshop Credential
     credential_type: Machine
     organization: Default
@@ -239,7 +239,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 - name: Add Credential with Custom Credential Type
-  credential:
+  awx.awx.credential:
     name: Workshop Credential
     credential_type: MyCloudCredential
     organization: Default
@@ -248,7 +248,7 @@ EXAMPLES = '''
     controller_host: https://localhost
 
 - name: Create a Vaiult credential (example for notes)
-  credential:
+  awx.awx.credential:
     name: Example password
     credential_type: Vault
     organization: Default
@@ -257,7 +257,7 @@ EXAMPLES = '''
       vault_id: 'My ID'
 
 - name: Bad password update (will replace vault_id)
-  credential:
+  awx.awx.credential:
     name: Example password
     credential_type: Vault
     organization: Default
@@ -265,14 +265,14 @@ EXAMPLES = '''
       vault_password: 'new_password'
 
 - name: Another bad password update (will replace vault_id)
-  credential:
+  awx.awx.credential:
     name: Example password
     credential_type: Vault
     organization: Default
     vault_password: 'new_password'
 
 - name: A safe way to update a password and keep vault_id
-  credential:
+  awx.awx.credential:
     name: Example password
     credential_type: Vault
     organization: Default
@@ -281,7 +281,7 @@ EXAMPLES = '''
       vault_id: 'My ID'
 
 - name: Copy Credential
-  credential:
+  awx.awx.credential:
     name: Copy password
     copy_from: Example password
     credential_type: Vault

--- a/awx_collection/plugins/modules/credential_input_source.py
+++ b/awx_collection/plugins/modules/credential_input_source.py
@@ -58,7 +58,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Use CyberArk Lookup credential as password source
-  credential_input_source:
+  awx.awx.credential_input_source:
     input_field_name: password
     target_credential: new_cred
     source_credential: cyberark_lookup

--- a/awx_collection/plugins/modules/credential_type.py
+++ b/awx_collection/plugins/modules/credential_type.py
@@ -62,7 +62,7 @@ extends_documentation_fragment: awx.awx.auth
 
 
 EXAMPLES = '''
-- credential_type:
+- awx.awx.credential_type:
     name: Nexus
     description: Credentials type for Nexus
     kind: cloud
@@ -71,7 +71,7 @@ EXAMPLES = '''
     state: present
     validate_certs: false
 
-- credential_type:
+- awx.awx.credential_type:
     name: Nexus
     state: absent
 '''

--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -61,7 +61,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add EE to the controller instance
-  execution_environment:
+  awx.awx.execution_environment:
     name: "My EE"
     image: quay.io/ansible/awx-ee
 '''

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -83,15 +83,15 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Export all assets
-  export:
+  awx.awx.export:
     all: True
 
 - name: Export all inventories
-  export:
+  awx.awx.export:
     inventory: 'all'
 
 - name: Export a job template named "My Template" and all Credentials
-  export:
+  awx.awx.export:
     job_template: "My Template"
     credential: 'all'
 '''

--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -79,7 +79,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add group
-  group:
+  awx.awx.group:
     name: localhost
     description: "Local Host Group"
     inventory: "Local Inventory"
@@ -87,7 +87,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add group
-  group:
+  awx.awx.group:
     name: Cities
     description: "Local Host Group"
     inventory: Default Inventory

--- a/awx_collection/plugins/modules/host.py
+++ b/awx_collection/plugins/modules/host.py
@@ -60,7 +60,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add host
-  host:
+  awx.awx.host:
     name: localhost
     description: "Local Host Group"
     inventory: "Local Inventory"

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -35,16 +35,16 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Export all assets
-  export:
+  awx.awx.export:
     all: True
   register: export_output
 
 - name: Import all assets from our export
-  import:
+  awx.awx.import:
     assets: "{{ export_output.assets }}"
 
 - name: Load data from a json file created by a command like awx export --organization Default
-  import:
+  awx.awx.import:
     assets: "{{ lookup('file', 'org.json') | from_json() }}"
 '''
 

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -74,7 +74,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add inventory
-  inventory:
+  awx.awx.inventory:
     name: "Foo Inventory"
     description: "Our Foo Cloud Servers"
     organization: "Bar Org"
@@ -82,7 +82,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Copy inventory
-  inventory:
+  awx.awx.inventory:
     name: Copy Foo Inventory
     copy_from: Default Inventory
     description: "Our Foo Cloud Servers"

--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -138,7 +138,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add an inventory source
-  inventory_source:
+  awx.awx.inventory_source:
     name: "source-inventory"
     description: Source for inventory
     inventory: previously-created-inventory

--- a/awx_collection/plugins/modules/inventory_source_update.py
+++ b/awx_collection/plugins/modules/inventory_source_update.py
@@ -58,13 +58,13 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Update a single inventory source
-  inventory_source_update:
+  awx.awx.inventory_source_update:
     name: "Example Inventory Source"
     inventory: "My Inventory"
     organization: Default
 
 - name: Update all inventory sources
-  inventory_source_update:
+  awx.awx.inventory_source_update:
     name: "{{ item }}"
     inventory: "My Other Inventory"
   loop: "{{ query('awx.awx.controller_api', 'inventory_sources', query_params={ 'inventory': 30 }, return_ids=True ) }}"

--- a/awx_collection/plugins/modules/job_cancel.py
+++ b/awx_collection/plugins/modules/job_cancel.py
@@ -36,7 +36,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Cancel job
-  job_cancel:
+  awx.awx.job_cancel:
     job_id: job.id
 '''
 

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -107,12 +107,12 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Launch a job
-  job_launch:
+  awx.awx.job_launch:
     job_template: "My Job Template"
   register: job
 
 - name: Launch a job template with extra_vars on remote controller instance
-  job_launch:
+  awx.awx.job_launch:
     job_template: "My Job Template"
     extra_vars:
       var1: "My First Variable"
@@ -121,13 +121,13 @@ EXAMPLES = '''
     job_type: run
 
 - name: Launch a job with inventory and credential
-  job_launch:
+  awx.awx.job_launch:
     job_template: "My Job Template"
     inventory: "My Inventory"
     credential: "My Credential"
   register: job
 - name: Wait for job max 120s
-  job_wait:
+  awx.awx.job_wait:
     job_id: "{{ job.id }}"
     timeout: 120
 '''

--- a/awx_collection/plugins/modules/job_list.py
+++ b/awx_collection/plugins/modules/job_list.py
@@ -45,7 +45,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: List running jobs for the testing.yml playbook
-  job_list:
+  awx.awx.job_list:
     status: running
     query: {"playbook": "testing.yml"}
     controller_config_file: "~/tower_cli.cfg"

--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -290,7 +290,7 @@ notes:
 
 EXAMPLES = '''
 - name: Create Ping job template
-  job_template:
+  awx.awx.job_template:
     name: "Ping"
     job_type: "run"
     organization: "Default"
@@ -305,20 +305,20 @@ EXAMPLES = '''
     survey_spec: "{{ lookup('file', 'my_survey.json') }}"
 
 - name: Add start notification to Job Template
-  job_template:
+  awx.awx.job_template:
     name: "Ping"
     notification_templates_started:
       - Notification1
       - Notification2
 
 - name: Remove Notification1 start notification from Job Template
-  job_template:
+  awx.awx.job_template:
     name: "Ping"
     notification_templates_started:
       - Notification2
 
 - name: Copy Job Template
-  job_template:
+  awx.awx.job_template:
     name: copy job template
     copy_from: test job template
     job_type: "run"

--- a/awx_collection/plugins/modules/job_wait.py
+++ b/awx_collection/plugins/modules/job_wait.py
@@ -58,12 +58,12 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Launch a job
-  job_launch:
+  awx.awx.job_launch:
     job_template: "My Job Template"
   register: job
 
 - name: Wait for job max 120s
-  job_wait:
+  awx.awx.job_wait:
     job_id: "{{ job.id }}"
     timeout: 120
 '''

--- a/awx_collection/plugins/modules/label.py
+++ b/awx_collection/plugins/modules/label.py
@@ -48,7 +48,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add label to organization
-  label:
+  awx.awx.label:
     name: Custom Label
     organization: My Organization
 '''

--- a/awx_collection/plugins/modules/license.py
+++ b/awx_collection/plugins/modules/license.py
@@ -38,7 +38,7 @@ RETURN = ''' # '''
 
 EXAMPLES = '''
 - name: Set the license using a file
-  license:
+  awx.awx.license:
     manifest: "/tmp/my_manifest.zip"
 '''
 

--- a/awx_collection/plugins/modules/notification_template.py
+++ b/awx_collection/plugins/modules/notification_template.py
@@ -210,7 +210,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add Slack notification with custom messages
-  notification_template:
+  awx.awx.notification_template:
     name: slack notification
     organization: Default
     notification_type: slack
@@ -229,7 +229,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add webhook notification
-  notification_template:
+  awx.awx.notification_template:
     name: webhook notification
     notification_type: webhook
     notification_configuration:
@@ -240,7 +240,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add email notification
-  notification_template:
+  awx.awx.notification_template:
     name: email notification
     notification_type: email
     notification_configuration:
@@ -257,7 +257,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add twilio notification
-  notification_template:
+  awx.awx.notification_template:
     name: twilio notification
     notification_type: twilio
     notification_configuration:
@@ -270,7 +270,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add PagerDuty notification
-  notification_template:
+  awx.awx.notification_template:
     name: pagerduty notification
     notification_type: pagerduty
     notification_configuration:
@@ -282,7 +282,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add IRC notification
-  notification_template:
+  awx.awx.notification_template:
     name: irc notification
     notification_type: irc
     notification_configuration:
@@ -297,13 +297,13 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Delete notification
-  notification_template:
+  awx.awx.notification_template:
     name: old notification
     state: absent
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Copy webhook notification
-  notification_template:
+  awx.awx.notification_template:
     name: foo notification
     copy_from: email notification
     organization: Foo

--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -87,21 +87,21 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Create organization
-  organization:
+  awx.awx.organization:
     name: "Foo"
     description: "Foo bar organization"
     state: present
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Create organization using 'foo-venv' as default Python virtualenv
-  organization:
+  awx.awx.organization:
     name: "Foo"
     description: "Foo bar organization using foo-venv"
     state: present
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Create organization that pulls content from galaxy.ansible.com
-  organization:
+  awx.awx.organization:
     name: "Foo"
     state: present
     galaxy_credentials:

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -171,7 +171,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add project
-  project:
+  awx.awx.project:
     name: "Foo"
     description: "Foo bar project"
     organization: "test"
@@ -179,7 +179,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add Project with cache timeout
-  project:
+  awx.awx.project:
     name: "Foo"
     description: "Foo bar project"
     organization: "test"
@@ -189,7 +189,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Copy project
-  project:
+  awx.awx.project:
     name: copy
     copy_from: test
     description: Foo copy project

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -67,12 +67,12 @@ status:
 
 EXAMPLES = '''
 - name: Launch a project with a timeout of 10 seconds
-  project_update:
+  awx.awx.project_update:
     project: "Networking Project"
     timeout: 10
 
 - name: Launch a Project with extra_vars without waiting
-  project_update:
+  awx.awx.project_update:
     project: "Networking Project"
     wait: False
 '''

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -131,14 +131,14 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add jdoe to the member role of My Team
-  role:
+  awx.awx.role:
     user: jdoe
     target_team: "My Team"
     role: member
     state: present
 
 - name: Add Joe to multiple job templates and a workflow
-  role:
+  awx.awx.role:
     user: joe
     role: execute
     workflow: test-role-workflow

--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -119,7 +119,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Build a schedule for Demo Job Template
-  schedule:
+  awx.awx.schedule:
     name: "{{ sched1 }}"
     state: present
     unified_job_template: "Demo Job Template"
@@ -127,7 +127,7 @@ EXAMPLES = '''
   register: result
 
 - name: Build the same schedule using the rrule plugin
-  schedule:
+  awx.awx.schedule:
     name: "{{ sched1 }}"
     state: present
     unified_job_template: "Demo Job Template"

--- a/awx_collection/plugins/modules/settings.py
+++ b/awx_collection/plugins/modules/settings.py
@@ -42,25 +42,25 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Set the value of AWX_ISOLATION_BASE_PATH
-  settings:
+  awx.awx.settings:
     name: AWX_ISOLATION_BASE_PATH
     value: "/tmp"
   register: testing_settings
 
 - name: Set the value of AWX_ISOLATION_SHOW_PATHS
-  settings:
+  awx.awx.settings:
     name: "AWX_ISOLATION_SHOW_PATHS"
     value: "'/var/lib/awx/projects/', '/tmp'"
   register: testing_settings
 
 - name: Set the LDAP Auth Bind Password
-  settings:
+  awx.awx.settings:
     name: "AUTH_LDAP_BIND_PASSWORD"
     value: "Password"
   no_log: true
 
 - name: Set all the LDAP Auth Bind Params
-  settings:
+  awx.awx.settings:
     settings:
       AUTH_LDAP_BIND_PASSWORD: "password"
       AUTH_LDAP_USER_ATTR_MAP:

--- a/awx_collection/plugins/modules/team.py
+++ b/awx_collection/plugins/modules/team.py
@@ -51,7 +51,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Create team
-  team:
+  awx.awx.team:
     name: Team Name
     description: Team Description
     organization: test-org

--- a/awx_collection/plugins/modules/token.py
+++ b/awx_collection/plugins/modules/token.py
@@ -66,19 +66,19 @@ extends_documentation_fragment: awx.awx.auth
 EXAMPLES = '''
 - block:
     - name: Create a new token using an existing token
-      token:
+      awx.awx.token:
         description: '{{ token_description }}'
         scope: "write"
         state: present
         controller_oauthtoken: "{{ my_existing_token }}"
 
     - name: Delete this token
-      token:
+      awx.awx.token:
         existing_token: "{{ token }}"
         state: absent
 
     - name: Create a new token using username/password
-      token:
+      awx.awx.token:
         description: '{{ token_description }}'
         scope: "write"
         state: present
@@ -86,18 +86,18 @@ EXAMPLES = '''
         controller_password: "{{ my_password }}"
 
     - name: Use our new token to make another call
-      job_list:
+      awx.awx.job_list:
         controller_oauthtoken: "{{ token }}"
 
   always:
     - name: Delete our Token with the token we created
-      token:
+      awx.awx.token:
         existing_token: "{{ token }}"
         state: absent
       when: token is defined
 
 - name: Delete a token by its id
-  token:
+  awx.awx.token:
     existing_token_id: 4
     state: absent
 '''

--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -72,7 +72,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Add user
-  user:
+  awx.awx.user:
     username: jdoe
     password: foobarbaz
     email: jdoe@example.org
@@ -82,7 +82,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add user as a system administrator
-  user:
+  awx.awx.user:
     username: jdoe
     password: foobarbaz
     email: jdoe@example.org
@@ -91,7 +91,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Add user as a system auditor
-  user:
+  awx.awx.user:
     username: jdoe
     password: foobarbaz
     email: jdoe@example.org
@@ -100,7 +100,7 @@ EXAMPLES = '''
     controller_config_file: "~/tower_cli.cfg"
 
 - name: Delete user
-  user:
+  awx.awx.user:
     username: jdoe
     email: jdoe@example.org
     state: absent

--- a/awx_collection/plugins/modules/workflow_approval.py
+++ b/awx_collection/plugins/modules/workflow_approval.py
@@ -58,13 +58,13 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = """
 - name: Launch a workflow with a timeout of 10 seconds
-  workflow_launch:
+  awx.awx.workflow_launch:
     workflow_template: "Test Workflow"
     wait: False
   register: workflow
 
 - name: Wait for approval node to activate and approve
-  workflow_approval:
+  awx.awx.workflow_approval:
     workflow_job_id: "{{ workflow.id }}"
     name: Approve Me
     interval: 10

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -325,7 +325,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Create a workflow job template
-  workflow_job_template:
+  awx.awx.workflow_job_template:
     name: example-workflow
     description: created by Ansible Playbook
     organization: Default
@@ -388,7 +388,7 @@ EXAMPLES = '''
   register: result
 
 - name: Copy a workflow job template
-  workflow_job_template:
+  awx.awx.workflow_job_template:
     name: copy-workflow
     copy_from: example-workflow
     organization: Foo

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -158,7 +158,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Create a node, follows workflow_job_template example
-  workflow_job_template_node:
+  awx.awx.workflow_job_template_node:
     identifier: my-first-node
     workflow: example-workflow
     unified_job_template: jt-for-node-use
@@ -167,7 +167,7 @@ EXAMPLES = '''
       foo_key: bar_value
 
 - name: Create parent node for prior node
-  workflow_job_template_node:
+  awx.awx.workflow_job_template_node:
     identifier: my-root-node
     workflow: example-workflow
     unified_job_template: jt-for-node-use
@@ -178,20 +178,20 @@ EXAMPLES = '''
 - name: Create workflow with 2 Job Templates and an approval node in between
   block:
   - name: Create a workflow job template
-    tower_workflow_job_template:
+    awx.awx.tower_workflow_job_template:
       name: my-workflow-job-template
       ask_scm_branch_on_launch: true
       organization: Default
 
   - name: Create 1st node
-    tower_workflow_job_template_node:
+    awx.awx.tower_workflow_job_template_node:
       identifier: my-first-node
       workflow_job_template: my-workflow-job-template
       unified_job_template: some_job_template
       organization: Default
 
   - name: Create 2nd approval node
-    tower_workflow_job_template_node:
+    awx.awx.tower_workflow_job_template_node:
       identifier: my-second-approval-node
       workflow_job_template: my-workflow-job-template
       organization: Default
@@ -201,14 +201,14 @@ EXAMPLES = '''
         timeout: 3600
 
   - name: Create 3rd node
-    tower_workflow_job_template_node:
+    awx.awx.tower_workflow_job_template_node:
       identifier: my-third-node
       workflow_job_template: my-workflow-job-template
       unified_job_template: some_other_job_template
       organization: Default
 
   - name: Link 1st node to 2nd Approval node
-    tower_workflow_job_template_node:
+    awx.awx.tower_workflow_job_template_node:
       identifier: my-first-node
       workflow_job_template: my-workflow-job-template
       organization: Default
@@ -216,7 +216,7 @@ EXAMPLES = '''
         - my-second-approval-node
 
   - name: Link 2nd Approval Node 3rd node
-    tower_workflow_job_template_node:
+    awx.awx.tower_workflow_job_template_node:
       identifier: my-second-approval-node
       workflow_job_template: my-workflow-job-template
       organization: Default

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -77,12 +77,12 @@ job_info:
 
 EXAMPLES = '''
 - name: Launch a workflow with a timeout of 10 seconds
-  workflow_launch:
+  awx.awx.workflow_launch:
     workflow_template: "Test Workflow"
     timeout: 10
 
 - name: Launch a Workflow with extra_vars without waiting
-  workflow_launch:
+  awx.awx.workflow_launch:
     workflow_template: "Test workflow"
     extra_vars:
       var1: My First Variable

--- a/awx_collection/plugins/modules/workflow_node_wait.py
+++ b/awx_collection/plugins/modules/workflow_node_wait.py
@@ -52,13 +52,13 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = """
 - name: Launch a workflow with a timeout of 10 seconds
-  workflow_launch:
+  awx.awx.workflow_launch:
     workflow_template: "Test Workflow"
     wait: False
   register: workflow
 
 - name: Wait for a workflow node to finish
-  workflow_node_wait:
+  awx.awx.workflow_node_wait:
     workflow_job_id: "{{ workflow.id }}"
     name: Approval Data Step
     timeout: 120


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed the example module name in the documentation to FQCN to avoid confusing for example  `awx.awx.user` and `ansible.builtin.user`.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx.awx collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
