### PR TITLE
Update awxkit random_title setting non_ascii to False

### DIFF
--- a/awxkit/awxkit/utils/__init__.py
+++ b/awxkit/awxkit/utils/__init__.py
@@ -277,7 +277,7 @@ def random_utf8(*args, **kwargs):
 
 def random_title(num_words=2, non_ascii=True):
     if os.getenv('AWXKIT_FORCE_ONLY_ASCII', False):
-        non_ascii=False
+        non_ascii = False
     base = ''.join([random.choice(words) for word in range(num_words)])
     if non_ascii:
         title = ''.join([base, random_utf8(1)])

--- a/awxkit/awxkit/utils/__init__.py
+++ b/awxkit/awxkit/utils/__init__.py
@@ -276,6 +276,8 @@ def random_utf8(*args, **kwargs):
 
 
 def random_title(num_words=2, non_ascii=True):
+    if os.getenv('AWXKIT_FORCE_ONLY_ASCII', False):
+        non_ascii=False
     base = ''.join([random.choice(words) for word in range(num_words)])
     if non_ascii:
         title = ''.join([base, random_utf8(1)])


### PR DESCRIPTION
##### SUMMARY

Working on Bumping Cypress version to latest, I realized that there is an [issue](https://github.com/cypress-io/cypress/issues/17055) with `cy.intercept()` and special chars.

I'm updating `random_title` and setting `non_ascii` default to False, based on the comment, this was because a bug related to selenium webdriver, however, Cypress works in a different way and this is not necessary.