### PR TITLE
Install receptor and ansible-runner from devel branch

### DIFF
--- a/awx/main/tests/functional/test_licenses.py
+++ b/awx/main/tests/functional/test_licenses.py
@@ -60,6 +60,8 @@ def test_python_and_js_licenses():
                     (name, version) = reqt.link.filename.split('@', 1)
                     if name.endswith('.git'):
                         name = name[:-4]
+                    if name == 'receptor':
+                        name = 'receptorctl'
                 ret[name] = {'name': name, 'version': version}
         return ret
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,4 @@
 aiohttp
-ansible-runner==2.0.1
 ansiconv==1.0.0  # UPGRADE BLOCKER: from 2013, consider replacing instead of upgrading
 asciichartpy
 autobahn>=20.12.3  # CVE-2020-35678
@@ -46,7 +45,6 @@ python-dsv-sdk
 python-tss-sdk==1.0.0
 python-ldap>=3.3.1 # https://github.com/python-ldap/python-ldap/issues/270
 pyyaml>=5.4.1  # minimum to fix https://github.com/yaml/pyyaml/issues/478
-receptorctl==1.0.0
 schedule==0.6.0
 social-auth-core==3.3.1  # see UPGRADE BLOCKERs
 social-auth-app-django==3.1.0  # see UPGRADE BLOCKERs

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,7 @@ aiohttp==3.6.2
     # via -r /awx_devel/requirements/requirements.in
 aioredis==1.3.1
     # via channels-redis
-ansible-runner==2.0.1
-    # via -r /awx_devel/requirements/requirements.in
+    # via -r /awx_devel/requirements/requirements_git.txt
 ansiconv==1.0.0
     # via -r /awx_devel/requirements/requirements.in
 asciichartpy==1.5.25
@@ -303,8 +302,7 @@ pyyaml==5.4.1
     #   djangorestframework-yaml
     #   kubernetes
     #   receptorctl
-receptorctl==1.0.0
-    # via -r /awx_devel/requirements/requirements.in
+    # via -r /awx_devel/requirements/requirements_git.txt
 redis==3.4.1
     # via
     #   -r /awx_devel/requirements/requirements.in

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,1 +1,3 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
+git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
+git+https://github.com/ansible/receptor.git@devel#egg=receptorctl&subdirectory=receptorctl


### PR DESCRIPTION
Signed-off-by: Christian M. Adams <rooftopcellist@gmail.com>

##### SUMMARY
To keep pace with changes in receptor and ansible-runner during development, we are switching to installing directly from the devel branch for each.  


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Install

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.2.0
```

