### PR TITLE
Use awx-ee:latest to get latest receptor and runner

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -182,13 +182,13 @@ DEFAULT_EXECUTION_ENVIRONMENT = None
 # Should be ordered from highest to lowest precedence.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE(s)
 # If a registry credential is needed to pull the image, that can be provided to the awx-manage command
-GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE 0.5.0', 'image': 'quay.io/ansible/awx-ee:0.5.0'}]
+GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE 0.5.0', 'image': 'quay.io/ansible/awx-ee:latest'}]
 # This setting controls which EE will be used for project updates.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE
 # This image is distinguished from others by having "managed" set to True and users have limited
 # ability to modify it through the API.
 # If a registry credential is needed to pull the image, that can be provided to the awx-manage command
-CONTROL_PLANE_EXECUTION_ENVIRONMENT = 'quay.io/ansible/awx-ee:0.5.0'
+CONTROL_PLANE_EXECUTION_ENVIRONMENT = 'quay.io/ansible/awx-ee:latest'
 
 # Note: This setting may be overridden by database settings.
 STDOUT_MAX_BYTES_DISPLAY = 1048576


### PR DESCRIPTION
We are updating the requirements to get the latest receptor and runner in the task container,
we should also have the latest in the EE

@simaishi @rooftopcellist 

Still need to do this in awx-operator and also make sure awx-ee devel branch is getting rebuilt more often and pushed to latest tag