### PR TITLE
Generate a small random title size on awxkit when necessary

### DIFF
--- a/awxkit/awxkit/utils/__init__.py
+++ b/awxkit/awxkit/utils/__init__.py
@@ -276,13 +276,14 @@ def random_utf8(*args, **kwargs):
 
 
 def random_title(num_words=2, non_ascii=True):
-    if os.getenv('AWXKIT_FORCE_ONLY_ASCII', False):
-        non_ascii = False
     base = ''.join([random.choice(words) for word in range(num_words)])
-    if non_ascii:
-        title = ''.join([base, random_utf8(1)])
+    if os.getenv('AWXKIT_FORCE_ONLY_ASCII', False):
+        title = ''.join([base, ''.join(str(random_int(99)))])
     else:
-        title = ''.join([base, ''.join([str(random_int()) for _ in range(3)])])
+        if non_ascii:
+            title = ''.join([base, random_utf8(1)])
+        else:
+            title = ''.join([base, ''.join([str(random_int()) for _ in range(3)])])
     return title
 
 


### PR DESCRIPTION
##### SUMMARY
This is to avoid 
```
awxkit.exceptions.BadRequest: Bad Request (400) received - {'first_name': ['Ensure this field has no more than 30 characters.']}"
```
 
when `AWXKIT_FORCE_ONLY_ASCII` is set