### PR TITLE
Fixes several react warnings

### DIFF
--- a/awx/ui/src/components/Lookup/Lookup.js
+++ b/awx/ui/src/components/Lookup/Lookup.js
@@ -89,6 +89,11 @@ function Lookup(props) {
   }, [state.selectedItems, multiple]);
 
   const clearQSParams = () => {
+    if (!history.location.search) {
+      // This prevents "Warning: Hash history cannot PUSH the same path;
+      // a new entry will not be added to the history stack" from appearing in the console.
+      return;
+    }
     const parts = history.location.search.replace(/^\?/, '').split('&');
     const ns = qsConfig.namespace;
     const otherParts = parts.filter((param) => !param.startsWith(`${ns}.`));

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -256,8 +256,8 @@ function ActivityStream() {
             renderToolbar={(props) => (
               <DatalistToolbar {...props} qsConfig={QS_CONFIG} />
             )}
-            renderRow={(streamItem) => (
-              <ActivityStreamListItem streamItem={streamItem} />
+            renderRow={(streamItem, index) => (
+              <ActivityStreamListItem key={index} streamItem={streamItem} />
             )}
           />
         </Card>

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -66,7 +66,7 @@ function InstanceGroup({ setBreadcrumb }) {
       name: (
         <>
           <CaretLeftIcon />
-          {t`Back to instance groups`}
+          {t`Back to Instance Groups`}
         </>
       ),
       link: '/instance_groups',

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.test.js
@@ -32,7 +32,7 @@ describe('<InstanceGroup/>', () => {
 
   test('should render expected tabs', async () => {
     const expectedTabs = [
-      'Back to instance groups',
+      'Back to Instance Groups',
       'Details',
       'Instances',
       'Jobs',

--- a/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
+++ b/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
@@ -135,7 +135,10 @@ function OrganizationDetail({ organization }) {
             value={
               <ChipGroup numChips={5} totalChips={galaxy_credentials.length}>
                 {galaxy_credentials.map((credential) => (
-                  <Link to={`/credentials/${credential.id}/details`}>
+                  <Link
+                    key={credential.id}
+                    to={`/credentials/${credential.id}/details`}
+                  >
                     <CredentialChip
                       credential={credential}
                       key={credential.id}


### PR DESCRIPTION
##### SUMMARY
This addresses part of #10822.  There is still a warning to be addressed when logging out.  Interestingly I was only able to get these warnings to appear using FireFox. They did not appear on Chrome, though the `findDomNode` warning did.


```
Warning: Cannot update a component (`SessionProvider`) while rendering a different component (`ProtectedRoute`). To locate the bad setState() call inside `ProtectedRoute`, follow the stack trace as described in https://fb.me/setstate-in-render
    in ProtectedRoute (at App.js:166)
    in Switch (at App.js:156)
    in SessionProvider (at App.js:155)
    in Unknown (at App.js:154)
    in I18nProvider (at App.js:153)
    in App (at App.js:180)
    in Router (created by HashRouter)
    in HashRouter (at App.js:179)
    in Unknown (at src/index.js:10)
    in StrictMode (at src/index.js:9)
```
This warning is associated with a Patternfly component is 
```
Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of FindRefWrapper which is inside StrictMode. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://fb.me/react-strict-mode-find-node
    in div (created by PageHeaderToolsItem)
    in PageHeaderToolsItem (at PageHeaderToolbar.js:84)
    in FindRefWrapper (created by Popper)
    in Popper (created by Tooltip)
    in Tooltip (at PageHeaderToolbar.js:83)
    in div (created by PageHeaderToolsGroup)
    in PageHeaderToolsGroup (at PageHeaderToolbar.js:82)
    in div (created by PageHeaderTools)
    in PageHeaderTools (at PageHeaderToolbar.js:81)
    in PageHeaderToolbar (at AppContainer.js:63)
```

issue filed here https://github.com/patternfly/patternfly-react/issues/6050

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

##### ADDITIONAL INFORMATION