### PR TITLE
Validate that start/end datetime creates at least 1 schedule.

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -29,7 +29,7 @@
         "react-error-boundary": "^3.1.3",
         "react-router-dom": "^5.1.2",
         "react-virtualized": "^9.21.1",
-        "rrule": "^2.6.4",
+        "rrule": "2.6.4",
         "sanitize-html": "2.4.0",
         "styled-components": "5.3.0"
       },
@@ -20990,9 +20990,9 @@
       "dev": true
     },
     "node_modules/rrule": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.8.tgz",
-      "integrity": "sha512-cUaXuUPrz9d1wdyzHsBfT1hptKlGgABeCINFXFvulEPqh9Np9BnF3C3lrv9uO54IIr8VDb58tsSF3LhsW+4VRw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
+      "integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
       "dependencies": {
         "tslib": "^1.10.0"
       },
@@ -43726,9 +43726,9 @@
       }
     },
     "rrule": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.8.tgz",
-      "integrity": "sha512-cUaXuUPrz9d1wdyzHsBfT1hptKlGgABeCINFXFvulEPqh9Np9BnF3C3lrv9uO54IIr8VDb58tsSF3LhsW+4VRw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
+      "integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
       "requires": {
         "luxon": "^1.21.3",
         "tslib": "^1.10.0"

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -29,7 +29,7 @@
     "react-error-boundary": "^3.1.3",
     "react-router-dom": "^5.1.2",
     "react-virtualized": "^9.21.1",
-    "rrule": "^2.6.4",
+    "rrule": "2.6.4",
     "sanitize-html": "2.4.0",
     "styled-components": "5.3.0"
   },

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -30,6 +30,13 @@ import {
 import FrequencyDetailSubform from './FrequencyDetailSubform';
 import SchedulePromptableFields from './SchedulePromptableFields';
 import DateTimePicker from './DateTimePicker';
+import buildRuleObj from './buildRuleObj';
+
+const NUM_DAYS_PER_FREQUENCY = {
+  week: 7,
+  month: 31,
+  year: 365,
+};
 
 const generateRunOnTheDay = (days = []) => {
   if (
@@ -557,6 +564,19 @@ function ScheduleForm({
 
             if (
               end === 'onDate' &&
+              DateTime.fromISO(endDate)
+                .diff(DateTime.fromISO(startDate), 'days')
+                .toObject().days < NUM_DAYS_PER_FREQUENCY[frequency]
+            ) {
+              const rule = new RRule(buildRuleObj(values));
+              if (rule.all().length === 0) {
+                errors.startDate = t`Selected date range must have at least 1 schedule occurrence.`;
+                errors.endDate = t`Selected date range must have at least 1 schedule occurrence.`;
+              }
+            }
+
+            if (
+              end === 'onDate' &&
               DateTime.fromISO(startDate) >= DateTime.fromISO(endDate)
             ) {
               errors.endDate = t`Please select an end date/time that comes after the start date/time.`;
@@ -569,7 +589,6 @@ function ScheduleForm({
             ) {
               errors.runOn = t`Please select a day number between 1 and 31.`;
             }
-
             return errors;
           }}
         >


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #10718 

Include client-side validation for when a user is about to create a schedule set that has no entries. E.g. a schedule that repeats every Sunday however the start and end dates are Mon-Tues will result in an empty schedules list. We now show them a form error if such a scenario is encountered:

![rrule_validation](https://user-images.githubusercontent.com/2293210/129751176-e4daebe4-b861-4355-8ce3-c5b160faed1a.gif)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
