### PR TITLE
Add organization_alias to Org Mapping as intended

### DIFF
--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -614,6 +614,7 @@ class SocialSingleOrganizationMapField(HybridDictField):
     users = SocialMapField(allow_null=True, required=False)
     remove_admins = fields.BooleanField(required=False)
     remove_users = fields.BooleanField(required=False)
+    organization_alias = SocialMapField(allow_null=True, required=False)
 
     child = _Forbidden()
 
@@ -723,7 +724,6 @@ class SAMLTeamAttrTeamOrgMapField(HybridDictField):
     team = fields.CharField(required=True, allow_null=False)
     team_alias = fields.CharField(required=False, allow_null=True)
     organization = fields.CharField(required=True, allow_null=False)
-    organization_alias = fields.CharField(required=False, allow_null=True)
 
     child = _Forbidden()
 

--- a/awx/sso/tests/unit/test_fields.py
+++ b/awx/sso/tests/unit/test_fields.py
@@ -79,7 +79,7 @@ class TestSAMLTeamAttrField:
                 'remove': True,
                 'saml_attr': 'foobar',
                 'team_org_map': [
-                    {'team': 'Engineering', 'team_alias': 'Engineering Team', 'organization': 'Ansible', 'organization_alias': 'Awesome Org'},
+                    {'team': 'Engineering', 'team_alias': 'Engineering Team', 'organization': 'Ansible'},
                     {'team': 'Engineering', 'organization': 'Ansible2'},
                     {'team': 'Engineering2', 'organization': 'Ansible'},
                 ],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change allows users to map SAML organization_alias to organizations. This way, the attribute statement received doesn't need to match with the organization name.

If no organization_alias is not passed, it will be ignored.

A derivative of #6780
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Resolves https://github.com/ansible/awx/issues/10911
<!--- Paste verbatim command output below, e.g. before and after your change -->
As a result, should we also get rid of these lines?
```
        organization_alias = team_name_map.get('organization_alias', None)
...
            if organization_alias:
                organization_name = organization_alias
```
