### PR TITLE
Disable checkbox for instances with node type control.

### DIFF
--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -90,9 +90,14 @@ function InstanceList() {
     useCallback(
       () =>
         Promise.all(
-          selected.map((instance) =>
-            InstanceGroupsAPI.disassociateInstance(instanceGroupId, instance.id)
-          )
+          selected
+            .filter((s) => s.node_type !== 'control')
+            .map((instance) =>
+              InstanceGroupsAPI.disassociateInstance(
+                instanceGroupId,
+                instance.id
+              )
+            )
         ),
       [instanceGroupId, selected]
     ),
@@ -107,9 +112,11 @@ function InstanceList() {
     useCallback(
       async (instancesToAssociate) => {
         await Promise.all(
-          instancesToAssociate.map((instance) =>
-            InstanceGroupsAPI.associateInstance(instanceGroupId, instance.id)
-          )
+          instancesToAssociate
+            .filter((i) => i.node_type !== 'control')
+            .map((instance) =>
+              InstanceGroupsAPI.associateInstance(instanceGroupId, instance.id)
+            )
         );
         fetchInstances();
       },
@@ -187,7 +194,9 @@ function InstanceList() {
                 verifyCannotDisassociate={false}
                 key="disassociate"
                 onDisassociate={handleDisassociate}
-                itemsToDisassociate={selected}
+                itemsToDisassociate={selected.filter(
+                  (s) => s.node_type !== 'control'
+                )}
                 modalTitle={t`Disassociate instance from instance group?`}
               />,
             ]}

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
@@ -106,7 +106,7 @@ function InstanceListItem({
         <Td
           select={{
             rowIndex,
-            isSelected,
+            isSelected: isSelected && instance.node_type !== 'control',
             onSelect,
             disable: instance.node_type === 'control',
           }}

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
@@ -108,7 +108,7 @@ function InstanceListItem({
             rowIndex,
             isSelected,
             onSelect,
-            disable: false,
+            disable: instance.node_type === 'control',
           }}
           dataLabel={t`Selected`}
         />

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
@@ -38,6 +38,33 @@ const instance = [
     managed_by_policy: true,
     node_type: 'hybrid',
   },
+  {
+    id: 2,
+    type: 'instance',
+    url: '/api/v2/instances/1/',
+    related: {
+      jobs: '/api/v2/instances/1/jobs/',
+      instance_groups: '/api/v2/instances/1/instance_groups/',
+    },
+    uuid: '00000000-0000-0000-0000-000000000001',
+    hostname: 'awx-control',
+    created: '2020-07-14T19:03:49.000054Z',
+    modified: '2020-08-12T20:08:02.836748Z',
+    capacity_adjustment: '0.40',
+    version: '13.0.0',
+    capacity: 10,
+    consumed_capacity: 0,
+    percent_capacity_remaining: 60.0,
+    jobs_running: 0,
+    jobs_total: 68,
+    cpu: 6,
+    memory: 2087469056,
+    cpu_capacity: 24,
+    mem_capacity: 1,
+    enabled: true,
+    managed_by_policy: true,
+    node_type: 'control',
+  },
 ];
 
 describe('<InstanceListItem/>', () => {
@@ -165,6 +192,24 @@ describe('<InstanceListItem/>', () => {
     expect(wrapper.find('Td').first().prop('select').onSelect).toEqual(
       onSelect
     );
+  });
+
+  test('should disable checkbox', async () => {
+    const onSelect = jest.fn();
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <table>
+          <tbody>
+            <InstanceListItem
+              instance={instance[1]}
+              onSelect={onSelect}
+              fetchInstances={() => {}}
+            />
+          </tbody>
+        </table>
+      );
+    });
+    expect(wrapper.find('Td').first().prop('select').disable).toEqual(true);
   });
 
   test('should display instance toggle', () => {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #10853
Related #10830

Requires: https://github.com/ansible/awx/pull/10929

On the Instances Group > Instances tab, instances with a `node_type` of `control` should not be editable, deleted, disassociated, associated, etc. The API will validate this on their end. For the UI, we have now disabled the checkbox next to the instance to disableany user actions with control type nodes.

<img width="1673" alt="Screen Shot 2021-08-23 at 1 56 19 PM" src="https://user-images.githubusercontent.com/2293210/130503985-fdc2eb98-8dbb-41b8-b603-a478578dce43.png">


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.3.0
```

