### PR TITLE
Add auto discovered instances to default ig (also, mark as disabled)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ init:
 	fi; \
 	$(MANAGEMENT_COMMAND) provision_instance --hostname=$(COMPOSE_HOST); \
 	$(MANAGEMENT_COMMAND) register_queue --queuename=controlplane --instance_percent=100;\
+	$(MANAGEMENT_COMMAND) register_queue --queuename=default;
 	if [ ! -f /etc/receptor/certs/awx.key ]; then \
 		rm -f /etc/receptor/certs/*; \
 		receptor --cert-init commonname="AWX Test CA" bits=2048 outcert=/etc/receptor/certs/ca.crt outkey=/etc/receptor/certs/ca.key; \

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -464,7 +464,7 @@ def inspect_execution_nodes(instance_list):
                     default_ig = InstanceGroup.objects.get(name='default')
                     if instance.hostname not in default_ig.policy_instance_list:
                         default_ig.policy_instance_list += [instance.hostname]
-                        default_ig.save()
+                        default_ig.save(update_fields=['policy_instance_list'])
                         logger.warn("Updated `default` instance group's policy_instance_list to include execution node '{}'".format(hostname))
                     else:
                         logger.warn("`default` instance group's policy_instance_list already listed execution node '{}'".format(hostname))

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -429,7 +429,7 @@ def execution_node_health_check(node):
 
 
 def inspect_execution_nodes(instance_list):
-    with advisory_lock('inspect_execution_nodes_lock', wait=True):
+    with advisory_lock('inspect_execution_nodes_lock', wait=False):
         node_lookup = {}
         for inst in instance_list:
             if inst.node_type == 'execution':

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -449,7 +449,7 @@ def inspect_execution_nodes(instance_list):
             else:
                 defaults = dict(enabled=False)
                 (changed, instance) = Instance.objects.register(hostname=hostname, node_type='execution', defaults=defaults)
-                logger.warn("Registered execution node '{}' (marked disabled by default)".format(hostname))
+                logger.warn(f"Registered execution node '{hostname}' (marked disabled by default)")
 
             was_lost = instance.is_lost(ref_time=nowtime)
             last_seen = parse_date(ad['Time'])
@@ -461,15 +461,15 @@ def inspect_execution_nodes(instance_list):
 
             if changed:
                 try:
-                    default_ig = InstanceGroup.objects.get(name='default')
+                    default_ig = InstanceGroup.objects.get(name=settings.DEFAULT_EXECUTION_QUEUE_NAME)
                     if instance.hostname not in default_ig.policy_instance_list:
                         default_ig.policy_instance_list += [instance.hostname]
                         default_ig.save(update_fields=['policy_instance_list'])
-                        logger.warn("Updated `default` instance group's policy_instance_list to include execution node '{}'".format(hostname))
+                        logger.warn(f"Updated '{default_ig.name}' instance group's policy_instance_list to include execution node '{hostname}'")
                     else:
-                        logger.warn("`default` instance group's policy_instance_list already listed execution node '{}'".format(hostname))
+                        logger.warn(f"'{default_ig.name}' instance group's policy_instance_list already listed execution node '{hostname}'")
                 except InstanceGroup.DoesNotExist:
-                    logger.error(f"Unable to add execution node '{hostname}' to 'default' instance group; group not found.")
+                    logger.error(f"Unable to add execution node '{hostname}' to '{default_ig.name}' instance group; group not found.")
 
                 execution_node_health_check.apply_async([hostname])
             elif was_lost:

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -446,7 +446,8 @@ def inspect_execution_nodes(instance_list):
         if hostname in node_lookup:
             instance = node_lookup[hostname]
         else:
-            (changed, instance) = Instance.objects.register(hostname=hostname, node_type='execution')
+            defaults = dict(enabled=False)
+            (changed, instance) = Instance.objects.register(hostname=hostname, node_type='execution', defaults=defaults)
         was_lost = instance.is_lost(ref_time=nowtime)
         last_seen = parse_date(ad['Time'])
 


### PR DESCRIPTION
see https://github.com/ansible/awx/issues/10746

---

Need to add some tests for this, but ad hoc testing confirmed the following changes:

- [x] `default` instance group created
- [x] auto-discovered nodes marked as disabled by default
- [x] .. and assigned to `default` instance group (by way of `policy_instance_list` )