### PR TITLE
Add an option to create a cluster with control-only nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ VERSION := $(shell cat VERSION)
 # NOTE: This defaults the container image version to the branch that's active
 COMPOSE_TAG ?= $(GIT_BRANCH)
 COMPOSE_HOST ?= $(shell hostname)
+MAIN_NODE_TYPE ?= hybrid
 
 VENV_BASE ?= /var/lib/awx/venv/
 SCL_PREFIX ?=
@@ -172,7 +173,7 @@ init:
 	if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	$(MANAGEMENT_COMMAND) provision_instance --hostname=$(COMPOSE_HOST); \
+	$(MANAGEMENT_COMMAND) provision_instance --hostname=$(COMPOSE_HOST) --node_type=$(MAIN_NODE_TYPE); \
 	$(MANAGEMENT_COMMAND) register_queue --queuename=controlplane --instance_percent=100;\
 	if [ ! -f /etc/receptor/certs/awx.key ]; then \
 		rm -f /etc/receptor/certs/*; \

--- a/docs/receptor_mesh.md
+++ b/docs/receptor_mesh.md
@@ -96,9 +96,18 @@ This will not affect actual `Instance` record, but will just run the command and
 
 ### Development Environment
 
-A "toy" cluster with execution nodes and a hop node is created by the docker-compose Makefile target.
+A cluster (of containers) with execution nodes and a hop node is created by the docker-compose Makefile target.
 By default, it will create 1 hybrid node, 1 hop node, and 2 execution nodes.
-The number of nodes can be changed with environment variables, for example:
+You can switch the type of AWX nodes between hybrid and control with this syntax.
+
+```
+MAIN_NODE_TYPE=control COMPOSE_TAG=devel make docker-compose
+```
+
+Running the above command will create a cluster of 1 control node, 1 hop node, and 2 execution nodes.
+
+
+The number of nodes can be changed:
 
 ```
 CONTROL_PLANE_NODE_COUNT=2 EXECUTION_NODE_COUNT=3 COMPOSE_TAG=devel make docker-compose

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -17,6 +17,7 @@ services:
       SDB_HOST: 0.0.0.0
       SDB_PORT: {{ awx_sdb_port_start }}
       AWX_GROUP_QUEUES: tower
+      MAIN_NODE_TYPE: "${MAIN_NODE_TYPE:-hybrid}"
       RECEPTORCTL_SOCKET: /var/run/receptor/receptor.sock
 {% if loop.index == 1 %}
       RUN_MIGRATIONS: 1


### PR DESCRIPTION
Need has arisen to test this, so I thought we should make it a properly supported option.