### PR TITLE
Always use controlplane as project update backup IG

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -628,7 +628,7 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
         selected_groups = template_groups + organization_groups
 
         controlplane_ig = self.control_plane_instance_group
-        if controlplane_ig[0] not in selected_groups:
+        if controlplane_ig and controlplane_ig[0] and controlplane_ig[0] not in selected_groups:
             selected_groups += controlplane_ig
 
         return selected_groups

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -615,16 +615,22 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
 
     @property
     def preferred_instance_groups(self):
+        '''
+        Project updates should pretty much always run on the control plane
+        however, we are not yet saying no to custom groupings within the control plane
+        Thus, we return custom groups and then unconditionally add the control plane
+        '''
         if self.organization is not None:
             organization_groups = [x for x in self.organization.instance_groups.all()]
         else:
             organization_groups = []
         template_groups = [x for x in super(ProjectUpdate, self).preferred_instance_groups]
         selected_groups = template_groups + organization_groups
-        if not any([not group.is_container_group for group in selected_groups]):
-            selected_groups = selected_groups + list(self.control_plane_instance_group)
-        if not selected_groups:
-            return self.global_instance_groups
+
+        controlplane_ig = self.control_plane_instance_group
+        if controlplane_ig[0] not in selected_groups:
+            selected_groups += controlplane_ig
+
         return selected_groups
 
     def save(self, *args, **kwargs):

--- a/awx/main/tests/conftest.py
+++ b/awx/main/tests/conftest.py
@@ -85,6 +85,11 @@ def default_instance_group(instance_factory, instance_group_factory):
 
 
 @pytest.fixture
+def controlplane_instance_group(instance_factory, instance_group_factory):
+    return create_instance_group("controlplane", instances=[create_instance("hostA")])
+
+
+@pytest.fixture
 def job_template_with_survey_passwords_factory(job_template_factory):
     def rf(persisted):
         "Returns job with linked JT survey with password survey questions"

--- a/awx/main/tests/functional/task_management/test_rampart_groups.py
+++ b/awx/main/tests/functional/task_management/test_rampart_groups.py
@@ -30,7 +30,7 @@ def test_multi_group_basic_job_launch(instance_factory, default_instance_group, 
 
 
 @pytest.mark.django_db
-def test_multi_group_with_shared_dependency(instance_factory, default_instance_group, mocker, instance_group_factory, job_template_factory):
+def test_multi_group_with_shared_dependency(instance_factory, controlplane_instance_group, mocker, instance_group_factory, job_template_factory):
     i1 = instance_factory("i1")
     i2 = instance_factory("i2")
     ig1 = instance_group_factory("ig1", instances=[i1])
@@ -54,7 +54,7 @@ def test_multi_group_with_shared_dependency(instance_factory, default_instance_g
     with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
         TaskManager().schedule()
         pu = p.project_updates.first()
-        TaskManager.start_task.assert_called_once_with(pu, default_instance_group, [j1, j2], default_instance_group.instances.all()[0])
+        TaskManager.start_task.assert_called_once_with(pu, controlplane_instance_group, [j1, j2], controlplane_instance_group.instances.all()[0])
         pu.finished = pu.created + timedelta(seconds=1)
         pu.status = "successful"
         pu.save()

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -314,15 +314,15 @@ class TestInstanceGroupOrdering:
         # API does not allow setting IGs on inventory source, so ignore those
         assert iu.preferred_instance_groups == [ig_inv, ig_org]
 
-    def test_project_update_instance_groups(self, instance_group_factory, project, default_instance_group):
+    def test_project_update_instance_groups(self, instance_group_factory, project, controlplane_instance_group):
         pu = ProjectUpdate.objects.create(project=project, organization=project.organization)
-        assert pu.preferred_instance_groups == [default_instance_group]
-        ig_org = instance_group_factory("OrgIstGrp", [default_instance_group.instances.first()])
-        ig_tmp = instance_group_factory("TmpIstGrp", [default_instance_group.instances.first()])
+        assert pu.preferred_instance_groups == [controlplane_instance_group]
+        ig_org = instance_group_factory("OrgIstGrp", [controlplane_instance_group.instances.first()])
+        ig_tmp = instance_group_factory("TmpIstGrp", [controlplane_instance_group.instances.first()])
         project.organization.instance_groups.add(ig_org)
-        assert pu.preferred_instance_groups == [ig_org]
+        assert pu.preferred_instance_groups == [ig_org, controlplane_instance_group]
         project.instance_groups.add(ig_tmp)
-        assert pu.preferred_instance_groups == [ig_tmp, ig_org]
+        assert pu.preferred_instance_groups == [ig_tmp, ig_org, controlplane_instance_group]
 
     def test_job_instance_groups(self, instance_group_factory, inventory, project, default_instance_group):
         jt = JobTemplate.objects.create(inventory=inventory, project=project)


### PR DESCRIPTION
To recap the scenario:

 - no IG in project update preferred instance groups have any "control" type capacity (they are all execution-only nodes)
 - project update gets stuck in the waiting state forever

These execution-only instance groups equate fairly well to the existing container groups. In both cases, the IG can run a job, but not run a project update. We do this check:

```python
not any([not group.is_container_group for group in selected_groups])
```

If you use boolean algebra on that, I think it's the same thing as saying "if any groups in selected_groups are container groups".

At this point, I think it's easier / simpler to just say that control plane should always be a backup for project updates.