### PR TITLE
Fixes erroneous pluralization from rrule

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
@@ -138,10 +138,18 @@ function ScheduleDetail({ hasDaysToKeepField, schedule, surveyConfig }) {
   }, [fetchCredentialsAndPreview]);
 
   const rule = rrulestr(rrule);
-  const repeatFrequency =
+  let repeatFrequency =
     rule.options.freq === RRule.MINUTELY && dtstart === dtend
       ? t`None (Run Once)`
       : rule.toText().replace(/^\w/, (c) => c.toUpperCase());
+  // We should allow rrule tot handle this issue, and they have in version 2.6.8.
+  // (https://github.com/jakubroztocil/rrule/commit/ab9c564a83de2f9688d6671f2a6df273ceb902bf)
+  // However, we are unable to upgrade to that version because that
+  // version throws and unexpected warning.
+  // (https://github.com/jakubroztocil/rrule/issues/427)
+  if (repeatFrequency.split(' ')[1] === 'minutes') {
+    repeatFrequency = t`Every minute for ${rule.options.count} times`;
+  }
 
   const {
     ask_credential_on_launch,

--- a/awx/ui/src/locales/en/messages.po
+++ b/awx/ui/src/locales/en/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (project root)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0 (Normal)"
 
@@ -59,7 +59,7 @@ msgstr "1 (Info)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1 (Verbose)"
 
@@ -75,7 +75,7 @@ msgstr "2 (Debug)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2 (More Verbose)"
 
@@ -86,7 +86,7 @@ msgstr "2 (More Verbose)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3 (Debug)"
 
@@ -97,7 +97,7 @@ msgstr "3 (Debug)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4 (Connection Debug)"
 
@@ -141,7 +141,7 @@ msgid "About"
 msgstr ""
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -176,60 +176,63 @@ msgstr "Account token"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "Actions"
@@ -238,8 +241,8 @@ msgstr "Actions"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -249,12 +252,12 @@ msgid "Activity"
 msgstr "Activity"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "Activity Stream"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "Activity Stream type selector"
 
@@ -300,35 +303,35 @@ msgstr "Add a new node"
 msgid "Add a new node between these two nodes"
 msgstr "Add a new node between these two nodes"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "Add container group"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "Add existing group"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "Add existing host"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "Add instance group"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "Add inventory"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "Add job template"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "Add new group"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "Add new host"
 
@@ -336,24 +339,24 @@ msgstr "Add new host"
 msgid "Add resource type"
 msgstr "Add resource type"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "Add smart inventory"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "Add team permissions"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "Add user permissions"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "Add workflow template"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr ""
 
@@ -362,11 +365,11 @@ msgstr ""
 msgid "Advanced"
 msgstr "Advanced"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "Advanced search documentation"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "Advanced search value input"
 
@@ -432,7 +435,7 @@ msgstr "Allowed URIs list, space separated"
 msgid "Always"
 msgstr "Always"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -444,7 +447,7 @@ msgstr "An error occurred"
 msgid "An inventory must be selected"
 msgstr "An inventory must be selected"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -465,13 +468,13 @@ msgstr "Answer variable name"
 msgid "Any"
 msgstr "Any"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "Application"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr "Application Name"
 
@@ -480,8 +483,8 @@ msgstr "Application Name"
 msgid "Application information"
 msgstr "Application information"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "Application name"
 
@@ -489,17 +492,17 @@ msgstr "Application name"
 msgid "Application not found."
 msgstr "Application not found."
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "Applications & Tokens"
 
@@ -571,11 +574,11 @@ msgstr "Are you sure you want to remove this link?"
 msgid "Are you sure you want to remove this node?"
 msgstr "Are you sure you want to remove this node?"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
@@ -583,26 +586,26 @@ msgstr ""
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Are you sure you want to submit the request to cancel this job?"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "Artifacts"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "Associate"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "Associate role error"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "Association modal"
 
@@ -614,7 +617,7 @@ msgstr "At least one value must be selected for this field."
 msgid "August"
 msgstr "August"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr ""
 
@@ -635,7 +638,7 @@ msgstr "Auto"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Azure AD settings"
 
@@ -669,12 +672,16 @@ msgstr "Back to Groups"
 msgid "Back to Hosts"
 msgstr "Back to Hosts"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr "Back to Instance Groups"
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "Back to Inventories"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "Back to Jobs"
 
@@ -704,7 +711,7 @@ msgstr "Back to Schedules"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -748,7 +755,6 @@ msgid "Back to execution environments"
 msgstr "Back to execution environments"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "Back to instance groups"
 
@@ -756,7 +762,7 @@ msgstr "Back to instance groups"
 msgid "Back to management jobs"
 msgstr "Back to management jobs"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -784,7 +790,7 @@ msgstr ""
 "commit hashes and refs may not be available unless you also\n"
 "provide a custom refspec."
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr ""
 
@@ -822,8 +828,8 @@ msgstr "Cache timeout (seconds)"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -831,12 +837,12 @@ msgstr "Cache timeout (seconds)"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -854,17 +860,18 @@ msgstr "Cache timeout (seconds)"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr ""
 
@@ -900,7 +907,7 @@ msgstr "Cancel link changes"
 msgid "Cancel link removal"
 msgstr "Cancel link removal"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "Cancel lookup"
 
@@ -925,13 +932,13 @@ msgstr "Cancel selected jobs"
 msgid "Cancel subscription edit"
 msgstr "Cancel subscription edit"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "Cancel {0}"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -947,37 +954,37 @@ msgstr ""
 "Cannot enable log aggregator without providing\n"
 "logging aggregator host and logging aggregator type."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "Capacity"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr "Capacity Adjustment"
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "Case-insensitive version of contains"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "Case-insensitive version of endswith."
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "Case-insensitive version of exact."
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "Case-insensitive version of regex."
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "Case-insensitive version of startswith."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -999,15 +1006,15 @@ msgid "Channel"
 msgstr "Channel"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "Check"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "Check whether the given field or related object is null; expects a boolean value."
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 
@@ -1019,7 +1026,7 @@ msgstr "Choose a .json file"
 msgid "Choose a Notification Type"
 msgstr "Choose a Notification Type"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "Choose a Playbook Directory"
 
@@ -1032,11 +1039,11 @@ msgid "Choose a Webhook Service"
 msgstr "Choose a Webhook Service"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "Choose a job type"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "Choose a module"
 
@@ -1062,7 +1069,7 @@ msgstr ""
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 
@@ -1107,6 +1114,10 @@ msgstr "Click this button to verify connection to the secret management system u
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "Click to create a new link to this node."
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr "Click to rearrange the order of the survey questions"
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1155,13 +1166,13 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "Command"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "Compliant"
 
@@ -1169,7 +1180,7 @@ msgstr "Compliant"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "Concurrent Jobs"
 
@@ -1200,11 +1211,11 @@ msgstr "Confirm cancel job"
 msgid "Confirm cancellation"
 msgstr "Confirm cancellation"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "Confirm delete"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "Confirm disassociate"
 
@@ -1228,7 +1239,7 @@ msgstr "Confirm revert all"
 msgid "Confirm selection"
 msgstr "Confirm selection"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "Container Group"
 
@@ -1267,7 +1278,7 @@ msgstr ""
 "Control the level of output ansible\n"
 "will produce as the playbook executes."
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1322,11 +1333,11 @@ msgstr "Copy Template"
 msgid "Copy full revision to clipboard."
 msgstr "Copy full revision to clipboard."
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "Copyright"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "Create"
@@ -1439,14 +1450,14 @@ msgstr "Create new source"
 msgid "Create user token"
 msgstr "Create user token"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1456,7 +1467,7 @@ msgstr "Create user token"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1465,58 +1476,58 @@ msgstr "Create user token"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "Created By (Username)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "Created by (username)"
 
@@ -1546,7 +1557,7 @@ msgstr "Credential"
 msgid "Credential Input Sources"
 msgstr "Credential Input Sources"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "Credential Name"
 
@@ -1557,9 +1568,9 @@ msgid "Credential Type"
 msgstr "Credential Type"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1585,24 +1596,24 @@ msgstr "Credential to authenticate with a protected container registry."
 msgid "Credential type not found."
 msgstr "Credential type not found."
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr ""
@@ -1653,7 +1664,7 @@ msgstr "DELETED"
 msgid "Dashboard"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "Dashboard (all activity)"
 
@@ -1667,12 +1678,12 @@ msgstr "Date"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "Day"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "Days of Data to Keep"
 
@@ -1680,7 +1691,7 @@ msgstr "Days of Data to Keep"
 msgid "Days of data to be retained"
 msgstr "Days of data to be retained"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "Days remaining"
 
@@ -1697,12 +1708,20 @@ msgid "December"
 msgstr "December"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "Default"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr "Default Answer(s)"
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "Default Execution Environment"
 
@@ -1712,7 +1731,7 @@ msgstr "Default Execution Environment"
 msgid "Default answer"
 msgstr "Default answer"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "Define system-level features and functions"
 
@@ -1726,8 +1745,8 @@ msgstr "Define system-level features and functions"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1735,7 +1754,7 @@ msgstr "Define system-level features and functions"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1743,15 +1762,15 @@ msgstr "Define system-level features and functions"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1780,7 +1799,7 @@ msgstr "Delete Host"
 msgid "Delete Inventory"
 msgstr "Delete Inventory"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1794,7 +1813,7 @@ msgstr "Delete Job Template"
 msgid "Delete Notification"
 msgstr "Delete Notification"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "Delete Organization"
 
@@ -1802,15 +1821,15 @@ msgstr "Delete Organization"
 msgid "Delete Project"
 msgstr "Delete Project"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "Delete Questions"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "Delete Schedule"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "Delete Survey"
 
@@ -1864,6 +1883,10 @@ msgstr "Delete inventory source"
 msgid "Delete smart inventory"
 msgstr "Delete smart inventory"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr "Delete survey question"
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1899,16 +1922,16 @@ msgstr "Delete {pluralizedItemName}?"
 msgid "Deleted"
 msgstr "Deleted"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "Deletion Error"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "Deletion error"
 
@@ -1938,34 +1961,34 @@ msgid "Deprecated"
 msgstr "Deprecated"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1973,36 +1996,36 @@ msgstr "Deprecated"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr ""
 
@@ -2055,7 +2078,7 @@ msgstr "Destination channels or users"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2141,39 +2164,39 @@ msgstr "Disabled"
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "Disassociate"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "Disassociate group from host?"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "Disassociate host from group?"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "Disassociate instance from instance group?"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "Disassociate related group(s)?"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "Disassociate related team(s)?"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "Disassociate role"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "Disassociate role!"
 
@@ -2186,7 +2209,7 @@ msgstr "Disassociate?"
 msgid "Discard local changes before syncing"
 msgstr "Discard local changes before syncing"
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2259,8 +2282,8 @@ msgstr ""
 "Each time a job runs using this project, update the\n"
 "revision of the project prior to starting the job."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2279,8 +2302,8 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2302,7 +2325,7 @@ msgstr ""
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2378,8 +2401,8 @@ msgstr "Edit Execution Environment"
 msgid "Edit Group"
 msgstr "Edit Group"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2408,6 +2431,10 @@ msgstr "Edit Node"
 msgid "Edit Notification Template"
 msgstr "Edit Notification Template"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr "Edit Order"
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2432,7 +2459,7 @@ msgstr "Edit Schedule"
 msgid "Edit Source"
 msgstr "Edit Source"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr "Edit Survey"
 
@@ -2520,8 +2547,8 @@ msgstr "Elapsed Time"
 msgid "Elapsed time that the job ran"
 msgstr "Elapsed time that the job ran"
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2535,7 +2562,7 @@ msgstr "Email Options"
 msgid "Enable Concurrent Jobs"
 msgstr "Enable Concurrent Jobs"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "Enable Fact Storage"
 
@@ -2543,8 +2570,8 @@ msgstr "Enable Fact Storage"
 msgid "Enable HTTPS certificate verification"
 msgstr "Enable HTTPS certificate verification"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2562,8 +2589,8 @@ msgstr "Enable external logging"
 msgid "Enable log system tracking facts individually"
 msgstr "Enable log system tracking facts individually"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "Enable privilege escalation"
 
@@ -2571,15 +2598,15 @@ msgstr "Enable privilege escalation"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr "Enable simplified login for your {0} applications"
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr "Enable simplified login for your {brandName} applications"
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "Enable webhook for this template."
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "Enabled"
@@ -2618,7 +2645,7 @@ msgstr "Enabled Variable"
 #~ "and request a configuration update using this job\n"
 #~ "template."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2630,7 +2657,7 @@ msgstr ""
 "and request a configuration update using this job\n"
 "template"
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2656,7 +2683,7 @@ msgstr "End"
 msgid "End User License Agreement"
 msgstr "End User License Agreement"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "End did not match an expected value"
 
@@ -2776,21 +2803,21 @@ msgstr "Enter variables to configure the inventory source. For a detailed descri
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "Error"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr "Error fetching updated project"
 
@@ -2814,41 +2841,41 @@ msgstr "Error saving the workflow!"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2856,21 +2883,21 @@ msgstr "Error saving the workflow!"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2880,17 +2907,17 @@ msgstr "Error saving the workflow!"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "Error!"
 
@@ -2898,7 +2925,7 @@ msgstr "Error!"
 msgid "Error:"
 msgstr "Error:"
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2916,15 +2943,19 @@ msgstr "Event detail modal"
 msgid "Event summary not available"
 msgstr "Event summary not available"
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "Events"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr "Every minute for {0} times"
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "Exact match (default lookup if not specified)."
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr "Exact search on id field."
 
@@ -2960,15 +2991,15 @@ msgstr "Execute when the parent node results in a failure state."
 msgid "Execute when the parent node results in a successful state."
 msgstr "Execute when the parent node results in a successful state."
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "Execution Environment"
 
@@ -2977,22 +3008,22 @@ msgstr "Execution Environment"
 msgid "Execution Environment Missing"
 msgstr "Execution Environment Missing"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "Execution Node"
 
@@ -3026,24 +3057,24 @@ msgstr "Expand input"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "Expected at least one of client_email, project_id or private_key to be present in the file."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "Expires"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "Expires on"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "Expires on UTC"
 
@@ -3052,7 +3083,7 @@ msgstr "Expires on UTC"
 msgid "Expires on {0}"
 msgstr "Expires on {0}"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "Explanation"
@@ -3061,8 +3092,8 @@ msgstr "Explanation"
 msgid "External Secret Management System"
 msgstr "External Secret Management System"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "Extra variables"
 
@@ -3087,7 +3118,7 @@ msgstr "Fact Storage"
 msgid "Facts"
 msgstr "Facts"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3113,7 +3144,7 @@ msgstr "Failed hosts"
 msgid "Failed jobs"
 msgstr "Failed jobs"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "Failed to approve one or more workflow approval."
 
@@ -3121,21 +3152,21 @@ msgstr "Failed to approve one or more workflow approval."
 msgid "Failed to approve workflow approval."
 msgstr "Failed to approve workflow approval."
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "Failed to assign roles properly"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "Failed to associate role"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "Failed to associate."
 
@@ -3148,12 +3179,12 @@ msgstr "Failed to cancel Inventory Source Sync"
 msgid "Failed to cancel Project Sync"
 msgstr "Failed to cancel Project Sync"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "Failed to cancel one or more jobs."
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "Failed to cancel {0}"
@@ -3212,19 +3243,19 @@ msgstr "Failed to delete job template."
 msgid "Failed to delete notification."
 msgstr "Failed to delete notification."
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "Failed to delete one or more applications."
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "Failed to delete one or more credential types."
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "Failed to delete one or more credentials."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "Failed to delete one or more execution environments"
 
@@ -3232,16 +3263,16 @@ msgstr "Failed to delete one or more execution environments"
 msgid "Failed to delete one or more groups."
 msgstr "Failed to delete one or more groups."
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "Failed to delete one or more hosts."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "Failed to delete one or more instance groups."
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "Failed to delete one or more inventories."
 
@@ -3249,55 +3280,55 @@ msgstr "Failed to delete one or more inventories."
 msgid "Failed to delete one or more inventory sources."
 msgstr "Failed to delete one or more inventory sources."
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "Failed to delete one or more job templates."
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "Failed to delete one or more jobs."
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "Failed to delete one or more notification template."
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "Failed to delete one or more organizations."
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "Failed to delete one or more projects."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "Failed to delete one or more schedules."
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "Failed to delete one or more teams."
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "Failed to delete one or more templates."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "Failed to delete one or more tokens."
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "Failed to delete one or more user tokens."
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "Failed to delete one or more users."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "Failed to delete one or more workflow approval."
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "Failed to delete organization."
 
@@ -3305,16 +3336,16 @@ msgstr "Failed to delete organization."
 msgid "Failed to delete project."
 msgstr "Failed to delete project."
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "Failed to delete role"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "Failed to delete role."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "Failed to delete schedule."
 
@@ -3343,7 +3374,7 @@ msgstr "Failed to delete workflow job template."
 msgid "Failed to delete {name}."
 msgstr "Failed to delete {name}."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "Failed to deny one or more workflow approval."
 
@@ -3351,21 +3382,21 @@ msgstr "Failed to deny one or more workflow approval."
 msgid "Failed to deny workflow approval."
 msgstr "Failed to deny workflow approval."
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "Failed to disassociate one or more groups."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "Failed to disassociate one or more hosts."
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "Failed to disassociate one or more instances."
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "Failed to disassociate one or more teams."
 
@@ -3373,13 +3404,13 @@ msgstr "Failed to disassociate one or more teams."
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr "Failed to fetch the updated project data."
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "Failed to launch job."
 
@@ -3419,7 +3450,7 @@ msgstr "Failed to toggle host."
 msgid "Failed to toggle instance."
 msgstr "Failed to toggle instance."
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "Failed to toggle notification."
 
@@ -3450,7 +3481,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "False"
 
@@ -3458,11 +3489,11 @@ msgstr "False"
 msgid "February"
 msgstr "February"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "Field contains value."
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "Field ends with value."
 
@@ -3470,11 +3501,11 @@ msgstr "Field ends with value."
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "Field for passing a custom Kubernetes or OpenShift Pod specification."
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "Field matches the given regular expression."
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "Field starts with value."
 
@@ -3490,16 +3521,16 @@ msgstr "File Difference"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "File upload rejected. Please select a single .json file."
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "File, directory or script"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "Finish Time"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "Finished"
@@ -3510,25 +3541,25 @@ msgstr ""
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "First Name"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "First Run"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "First name"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "First, select a key"
 
@@ -3544,7 +3575,7 @@ msgstr "Float"
 msgid "Follow"
 msgstr "Follow"
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3570,11 +3601,11 @@ msgstr ""
 msgid "For more information, refer to the"
 msgstr "For more information, refer to the"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "Forks"
 
@@ -3582,12 +3613,12 @@ msgstr "Forks"
 msgid "Fourth"
 msgstr "Fourth"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "Frequency Details"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "Frequency did not match an expected value"
 
@@ -3600,11 +3631,11 @@ msgstr "Fri"
 msgid "Friday"
 msgstr "Friday"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr "Fuzzy search on id, name or description fields."
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr "Fuzzy search on name field."
 
@@ -3629,11 +3660,11 @@ msgstr "Get subscription"
 msgid "Get subscriptions"
 msgstr "Get subscriptions"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3672,7 +3703,7 @@ msgstr "GitHub Organization"
 msgid "GitHub Team"
 msgstr "GitHub Team"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "GitHub settings"
 
@@ -3681,7 +3712,7 @@ msgstr "GitHub settings"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "Global Default Execution Environment"
 
@@ -3710,11 +3741,11 @@ msgstr ""
 msgid "Go to previous page"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Google OAuth 2 settings"
 
@@ -3722,8 +3753,8 @@ msgstr "Google OAuth 2 settings"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3736,15 +3767,15 @@ msgstr "Grafana API key"
 msgid "Grafana URL"
 msgstr "Grafana URL"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "Greater than comparison."
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "Greater than or equal to comparison."
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "Group"
 
@@ -3752,20 +3783,20 @@ msgstr "Group"
 msgid "Group details"
 msgstr "Group details"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "Group type"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "Groups"
@@ -3793,8 +3824,8 @@ msgstr "Hide"
 msgid "Hide description"
 msgstr "Hide description"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "Hipchat"
 
@@ -3813,7 +3844,7 @@ msgstr "Host Async OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "Host Config Key"
 
@@ -3884,20 +3915,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "Host status information for this job is unavailable."
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3905,30 +3936,30 @@ msgstr "Host status information for this job is unavailable."
 msgid "Hosts"
 msgstr "Hosts"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr "Hosts automated"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "Hosts available"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr "Hosts imported"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "Hosts remaining"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "Hour"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3948,8 +3979,8 @@ msgstr "ID of the dashboard (optional)"
 msgid "ID of the panel (optional)"
 msgstr "ID of the panel (optional)"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -4016,7 +4047,7 @@ msgstr ""
 "created group to promote them into, they will be left in the \"all\"\n"
 "default group for the inventory."
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -4034,7 +4065,7 @@ msgstr ""
 "by Ansible tasks, where supported. This is equivalent to Ansible’s\n"
 "--diff mode."
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
@@ -4044,11 +4075,11 @@ msgstr ""
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -4060,7 +4091,7 @@ msgstr ""
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "If enabled, simultaneous runs of this workflow job template will be allowed."
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -4074,7 +4105,7 @@ msgstr ""
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "If you are ready to upgrade or renew, please <0>contact us.</0>"
 
@@ -4086,7 +4117,7 @@ msgstr ""
 "If you do not have a subscription, you can visit\n"
 "Red Hat to obtain a trial subscription."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "If you only want to remove access for this particular user, please remove them from the team."
 
@@ -4100,13 +4131,13 @@ msgstr ""
 "launch and on project update, click on Update on launch, and also go to"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "Image"
@@ -4133,13 +4164,13 @@ msgstr ""
 msgid "Initiated By"
 msgstr "Initiated By"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "Initiated by"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "Initiated by (username)"
 
@@ -4166,7 +4197,7 @@ msgstr "Insights for Ansible Automation Platform"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Insights for Ansible Automation Platform dashboard"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "Insights system ID"
 
@@ -4178,18 +4209,18 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Instance Filters"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "Instance Group"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4198,7 +4229,7 @@ msgstr "Instance Group"
 msgid "Instance Groups"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "Instance ID"
 
@@ -4220,11 +4251,11 @@ msgid "Instance groups"
 msgstr "Instance groups"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "Instances"
 
@@ -4254,11 +4285,11 @@ msgstr ""
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4269,41 +4300,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Inventories with sources cannot be copied"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "Inventory"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "Inventory (Name)"
 
@@ -4311,13 +4342,17 @@ msgstr "Inventory (Name)"
 msgid "Inventory File"
 msgstr "Inventory File"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "Inventory ID"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "Inventory Source"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr "Inventory Source Project"
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4334,15 +4369,15 @@ msgstr "Inventory Source Sync Error"
 msgid "Inventory Sources"
 msgstr "Inventory Sources"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "Inventory Sync"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr "Inventory Type"
 
@@ -4387,7 +4422,7 @@ msgstr "Item OK"
 msgid "Item Skipped"
 msgstr "Item Skipped"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "Items"
@@ -4419,20 +4454,20 @@ msgstr "JSON:"
 msgid "January"
 msgstr "January"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "Job"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "Job Cancel Error"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4446,19 +4481,19 @@ msgstr "Job ID"
 msgid "Job Runs"
 msgstr "Job Runs"
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "Job Slice"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr "Job Slice Parent"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "Job Slicing"
 
@@ -4470,20 +4505,20 @@ msgstr "Job Status"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "Job Tags"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "Job Template"
@@ -4508,15 +4543,15 @@ msgstr "Job Templates with a missing inventory or project cannot be selected whe
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "Job Type"
 
@@ -4529,15 +4564,15 @@ msgid "Job status graph tab"
 msgstr "Job status graph tab"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "Job templates"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4552,7 +4587,7 @@ msgstr "Job templates"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4560,7 +4595,7 @@ msgstr "Job templates"
 msgid "Jobs"
 msgstr ""
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "Jobs settings"
 
@@ -4572,19 +4607,19 @@ msgstr "July"
 msgid "June"
 msgstr "June"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "Key"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "Key select"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "Key typeahead"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "Keyword"
 
@@ -4617,7 +4652,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "LDAP Default"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "LDAP settings"
 
@@ -4641,18 +4676,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "Label Name"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "Labels"
@@ -4670,11 +4705,11 @@ msgid "Last Login"
 msgstr "Last Login"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4684,7 +4719,7 @@ msgstr "Last Login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4698,25 +4733,25 @@ msgstr ""
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "Last Ran"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "Last Run"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "Last job"
 
@@ -4727,7 +4762,7 @@ msgstr "Last job"
 msgid "Last modified"
 msgstr "Last modified"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "Last name"
@@ -4778,11 +4813,11 @@ msgstr "Launch workflow"
 msgid "Launch | {0}"
 msgstr "Launch | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "Launched By"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "Launched By (Username)"
 
@@ -4798,26 +4833,26 @@ msgstr "Leave this field blank to make the execution environment globally availa
 msgid "Legend"
 msgstr "Legend"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "Less than comparison."
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "Less than or equal to comparison."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "Limit"
@@ -4834,11 +4869,11 @@ msgstr "Loading"
 msgid "Local"
 msgstr "Local"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "Local Time Zone"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "Local time zone"
 
@@ -4850,7 +4885,7 @@ msgstr "Log In"
 msgid "Logging"
 msgstr "Logging"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "Logging settings"
 
@@ -4860,20 +4895,20 @@ msgstr "Logging settings"
 msgid "Logout"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "Lookup modal"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "Lookup select"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "Lookup type"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "Lookup typeahead"
 
@@ -4883,10 +4918,10 @@ msgstr "Lookup typeahead"
 msgid "MOST RECENT SYNC"
 msgstr "MOST RECENT SYNC"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "Machine Credential"
 
@@ -4899,8 +4934,8 @@ msgstr "Managed"
 msgid "Managed nodes"
 msgstr "Managed nodes"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4910,7 +4945,7 @@ msgid "Management Job"
 msgstr "Management Job"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr ""
 
@@ -4931,15 +4966,15 @@ msgstr "Management job not found."
 msgid "Management jobs"
 msgstr "Management jobs"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "Manual"
 
@@ -4947,8 +4982,8 @@ msgstr "Manual"
 msgid "March"
 msgstr "March"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4969,7 +5004,7 @@ msgstr "Maximum length"
 msgid "May"
 msgstr "May"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr ""
@@ -4986,7 +5021,7 @@ msgstr "Metric"
 msgid "Metrics"
 msgstr "Metrics"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -5014,7 +5049,7 @@ msgstr ""
 "Minimum percentage of all instances that will be automatically\n"
 "assigned to this group when new instances come online."
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "Minute"
 
@@ -5022,7 +5057,7 @@ msgstr "Minute"
 msgid "Miscellaneous Authentication"
 msgstr "Miscellaneous Authentication"
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr "Miscellaneous Authentication settings"
 
@@ -5030,7 +5065,7 @@ msgstr "Miscellaneous Authentication settings"
 msgid "Miscellaneous System"
 msgstr "Miscellaneous System"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "Miscellaneous System settings"
 
@@ -5045,70 +5080,70 @@ msgid "Missing resource"
 msgstr "Missing resource"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "Modified By (Username)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "Modified by (username)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "Module"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr "Module Arguments"
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr "Module Name"
 
@@ -5121,7 +5156,7 @@ msgstr "Mon"
 msgid "Monday"
 msgstr "Monday"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "Month"
 
@@ -5133,13 +5168,13 @@ msgstr "More information"
 msgid "More information for"
 msgstr "More information for"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "Multi-Select"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "Multiple Choice"
 
@@ -5155,57 +5190,57 @@ msgstr "Multiple Choice (single select)"
 msgid "Multiple Choice Options"
 msgstr "Multiple Choice Options"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5220,73 +5255,73 @@ msgstr "Multiple Choice Options"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5299,66 +5334,72 @@ msgstr "Multiple Choice Options"
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr ""
@@ -5382,7 +5423,7 @@ msgstr "Never Updated"
 msgid "Never expires"
 msgstr "Never expires"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "New"
@@ -5401,8 +5442,8 @@ msgstr "New"
 msgid "Next"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5445,7 +5486,7 @@ msgstr "No inventory sync failures."
 msgid "No items found."
 msgstr "No items found."
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr "No job data available"
 
@@ -5453,10 +5494,10 @@ msgstr "No job data available"
 msgid "No result found"
 msgstr "No result found"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "No results found"
 
@@ -5465,7 +5506,7 @@ msgstr "No results found"
 msgid "No subscriptions found"
 msgstr "No subscriptions found"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "No survey questions found."
 
@@ -5480,7 +5521,7 @@ msgstr "No {pluralizedItemName} Found"
 msgid "Node Alias"
 msgstr "Node Alias"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5498,7 +5539,7 @@ msgstr "None"
 msgid "None (Run Once)"
 msgstr "None (Run Once)"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "None (run once)"
 
@@ -5521,7 +5562,7 @@ msgstr "Not configured"
 msgid "Not configured for inventory sync."
 msgstr "Not configured for inventory sync."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
@@ -5531,8 +5572,8 @@ msgstr ""
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5544,7 +5585,7 @@ msgstr ""
 "children.  This list shows all groups the host is associated\n"
 "with directly and indirectly."
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 
@@ -5581,9 +5622,9 @@ msgstr "Notification Color"
 msgid "Notification Template not found."
 msgstr "Notification Template not found."
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5598,20 +5639,20 @@ msgstr "Notification Type"
 msgid "Notification color"
 msgstr "Notification color"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "Notification sent successfully"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "Notification timed out"
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "Notification type"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5646,39 +5687,37 @@ msgstr "Occurrences"
 msgid "October"
 msgstr "October"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "Off"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "On"
 
@@ -5708,7 +5747,7 @@ msgstr "On days"
 msgid "Only Group By"
 msgstr "Only Group By"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5716,7 +5755,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Option Details"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5731,20 +5770,26 @@ msgstr ""
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "Optionally select the credential to use to send status updates back to the webhook service."
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "Options"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr "Order"
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5755,15 +5800,15 @@ msgstr "Options"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5773,22 +5818,22 @@ msgstr "Options"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "Organization"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "Organization (Name)"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "Organization Name"
 
@@ -5798,9 +5843,9 @@ msgstr "Organization not found."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5815,11 +5860,11 @@ msgstr ""
 msgid "Other prompts"
 msgstr "Other prompts"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "Out of compliance"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "Output"
@@ -5850,8 +5895,8 @@ msgstr "POST"
 msgid "PUT"
 msgstr "PUT"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5883,11 +5928,11 @@ msgstr "Pan Right"
 msgid "Pan Up"
 msgstr "Pan Up"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "Pass extra command line changes. There are two ansible command line parameters:"
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5928,7 +5973,7 @@ msgstr "Past two weeks"
 msgid "Past week"
 msgstr "Past week"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5942,12 +5987,12 @@ msgstr "Pending Workflow Approvals"
 msgid "Pending delete"
 msgstr "Pending delete"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "Perform a search to define a host filter"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr "Personal Access Token"
 
@@ -5968,13 +6013,13 @@ msgid "Play Started"
 msgstr "Play Started"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Playbook"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Playbook Check"
@@ -5985,12 +6030,12 @@ msgstr "Playbook Complete"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Playbook Directory"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -6000,10 +6045,10 @@ msgstr "Playbook Run"
 msgid "Playbook Started"
 msgstr "Playbook Started"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Playbook name"
 
@@ -6015,15 +6060,15 @@ msgstr "Playbook run"
 msgid "Plays"
 msgstr "Plays"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr "Please add a Schedule to populate this list."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "Please add survey questions."
 
@@ -6047,23 +6092,23 @@ msgstr "Please enter a value."
 msgid "Please log in"
 msgstr "Please log in"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr "Please run a job to populate this list."
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "Please select a day number between 1 and 31."
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "Please select an Inventory or check the Prompt on Launch option"
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "Please select an end date/time that comes after the start date/time."
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "Please select an organization before editing the host filter"
 
@@ -6071,7 +6116,7 @@ msgstr "Please select an organization before editing the host filter"
 msgid "Pod spec override"
 msgstr "Pod spec override"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr "Policy Type"
@@ -6091,7 +6136,7 @@ msgstr "Policy instance percentage"
 msgid "Populate field from an external secret management system"
 msgstr "Populate field from an external secret management system"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6140,8 +6185,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "Preview"
 
@@ -6151,7 +6194,7 @@ msgstr "Private key passphrase"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "Privilege Escalation"
 
@@ -6159,17 +6202,16 @@ msgstr "Privilege Escalation"
 msgid "Privilege escalation password"
 msgstr "Privilege escalation password"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6177,7 +6219,7 @@ msgstr "Project"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "Project Base Path"
 
@@ -6205,10 +6247,10 @@ msgstr "Project sync failures"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6221,8 +6263,8 @@ msgstr ""
 msgid "Promote Child Groups and Hosts"
 msgstr "Promote Child Groups and Hosts"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "Prompt"
 
@@ -6241,11 +6283,11 @@ msgid "Prompt | {0}"
 msgstr "Prompt | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "Prompted Values"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6274,7 +6316,7 @@ msgstr ""
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "Provide a value for this field or select the Prompt on launch option."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6300,18 +6342,18 @@ msgstr "Provide your Red Hat or Red Hat Satellite credentials to enable Insights
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "Provisioning Callback URL"
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "Provisioning Callback details"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "Provisioning Callbacks"
 
@@ -6328,7 +6370,7 @@ msgstr "Question"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "RADIUS settings"
 
@@ -6358,7 +6400,7 @@ msgstr "Recent Templates list tab"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr "Recent jobs"
@@ -6371,19 +6413,19 @@ msgstr "Recipient List"
 msgid "Recipient list"
 msgstr "Recipient list"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Red Hat Virtualization"
 
@@ -6391,7 +6433,7 @@ msgstr "Red Hat Virtualization"
 msgid "Red Hat subscription manifest"
 msgstr "Red Hat subscription manifest"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6415,7 +6457,7 @@ msgstr "Redirecting to subscription detail"
 msgid "Refer to the"
 msgstr "Refer to the"
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6453,28 +6495,28 @@ msgstr "Regular expression where only matching host names will be imported. The 
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "Related Groups"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr "Related search type"
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr "Related search type typeahead"
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "Relaunch"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "Relaunch Job"
@@ -6492,16 +6534,16 @@ msgstr "Relaunch failed hosts"
 msgid "Relaunch on"
 msgstr "Relaunch on"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "Relaunch using host parameters"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "Remote Archive"
 
@@ -6528,7 +6570,7 @@ msgstr "Remove Node"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "Remove any local modifications prior to performing an update."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr ""
 
@@ -6544,7 +6586,7 @@ msgstr "Removing this link will orphan the rest of the branch and cause it to be
 msgid "Reorder"
 msgstr "Reorder"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "Repeat Frequency"
 
@@ -6561,7 +6603,7 @@ msgstr "Replace field with new value"
 msgid "Request subscription"
 msgstr "Request subscription"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "Required"
@@ -6569,7 +6611,7 @@ msgstr "Required"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "Resource Name"
 
@@ -6578,7 +6620,7 @@ msgid "Resource deleted"
 msgstr "Resource deleted"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr ""
 
@@ -6612,15 +6654,15 @@ msgstr "Return"
 msgid "Return to subscription management."
 msgstr "Return to subscription management."
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "Returns results that have values other than this one as well as other filters."
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "Returns results that satisfy this one or any other filters."
 
@@ -6651,8 +6693,8 @@ msgstr "Revert settings"
 msgid "Revert to factory default."
 msgstr "Revert to factory default."
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "Revision"
@@ -6661,25 +6703,25 @@ msgstr "Revision"
 msgid "Revision #"
 msgstr "Revision #"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "Role"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6693,7 +6735,7 @@ msgstr "Roles"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "Run"
 
@@ -6717,7 +6759,7 @@ msgstr "Run command"
 msgid "Run every"
 msgstr "Run every"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "Run frequency"
 
@@ -6729,7 +6771,7 @@ msgstr "Run on"
 msgid "Run type"
 msgstr "Run type"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6740,8 +6782,8 @@ msgstr "Running"
 msgid "Running Handlers"
 msgstr "Running Handlers"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "Running Jobs"
@@ -6754,7 +6796,7 @@ msgstr "Running jobs"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "SAML settings"
 
@@ -6797,18 +6839,19 @@ msgid "Saturday"
 msgstr "Saturday"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6846,7 +6889,7 @@ msgstr "Schedule is active"
 msgid "Schedule is inactive"
 msgstr "Schedule is inactive"
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "Schedule is missing rrule"
 
@@ -6854,10 +6897,10 @@ msgstr "Schedule is missing rrule"
 msgid "Schedule not found."
 msgstr "Schedule not found."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6871,11 +6914,11 @@ msgstr "Schedule not found."
 msgid "Schedules"
 msgstr ""
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6897,8 +6940,8 @@ msgstr "Scroll next"
 msgid "Scroll previous"
 msgstr "Scroll previous"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr ""
 
@@ -6906,7 +6949,7 @@ msgstr ""
 msgid "Search is disabled while the job is running"
 msgstr "Search is disabled while the job is running"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "Search submit button"
@@ -6930,9 +6973,9 @@ msgstr "Seconds"
 msgid "See errors on the left"
 msgstr "See errors on the left"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6942,13 +6985,13 @@ msgstr ""
 msgid "Select Credential Type"
 msgstr "Select Credential Type"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "Select Groups"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "Select Hosts"
 
@@ -6956,11 +6999,11 @@ msgstr "Select Hosts"
 msgid "Select Input"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "Select Instances"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "Select Items"
 
@@ -6976,7 +7019,7 @@ msgstr "Select Labels"
 msgid "Select Roles to Apply"
 msgstr "Select Roles to Apply"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "Select Teams"
 
@@ -6992,7 +7035,7 @@ msgstr "Select a Node Type"
 msgid "Select a Resource Type"
 msgstr "Select a Resource Type"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -7024,7 +7067,7 @@ msgstr "Select a job to cancel"
 msgid "Select a metric"
 msgstr "Select a metric"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "Select a module"
 
@@ -7033,16 +7076,20 @@ msgstr "Select a module"
 msgid "Select a playbook"
 msgstr "Select a playbook"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "Select a project before editing the execution environment."
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr "Select a question to delete"
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "Select a row to approve"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr ""
 
@@ -7063,8 +7110,8 @@ msgstr "Select a subscription"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -7084,7 +7131,7 @@ msgstr "Select a subscription"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -7097,11 +7144,11 @@ msgid "Select a webhook service."
 msgstr "Select a webhook service."
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "Select an activity type"
 
@@ -7121,7 +7168,7 @@ msgstr "Select an option"
 msgid "Select an organization before editing the default execution environment."
 msgstr "Select an organization before editing the default execution environment."
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -7135,7 +7182,7 @@ msgstr ""
 "credential at run time. If you select credentials and check \"Prompt on launch\", the selected\n"
 "credential(s) become the defaults that can be updated at run time."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7183,7 +7230,7 @@ msgstr "Select status"
 msgid "Select tags"
 msgstr "Select tags"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "Select the Execution Environment you want this command to run inside."
 
@@ -7191,7 +7238,7 @@ msgstr "Select the Execution Environment you want this command to run inside."
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Select the Instance Groups for this Inventory to run on."
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7211,16 +7258,16 @@ msgstr "Select the application that this token will belong to, or leave this fie
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "Select the application that this token will belong to."
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "Select the execution environment for this job template."
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7243,11 +7290,11 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr "Select the inventory that this host will belong to."
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "Select the playbook to be executed by this job."
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7259,7 +7306,7 @@ msgstr ""
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "Select your Ansible Automation Platform subscription to use."
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "Select {0}"
 
@@ -7268,7 +7315,7 @@ msgstr "Select {0}"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7280,7 +7327,7 @@ msgstr "Select {0}"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7292,17 +7339,23 @@ msgstr "Select {0}"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr ""
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "Selected Category"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr "Selected date range must have at least 1 schedule occurrence."
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7329,7 +7382,7 @@ msgstr "Set a value for this field"
 msgid "Set how many days of data should be retained."
 msgstr "Set how many days of data should be retained."
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "Set preferences for data collection, logos, and logins"
 
@@ -7345,19 +7398,19 @@ msgstr "Set the instance online or offline. If offline, jobs will not be assigne
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "Set to Public or Confidential depending on how secure the client device is."
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "Set type"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr "Set type disabled for related search field fuzzy searches"
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "Set type select"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "Set type typeahead"
 
@@ -7379,8 +7432,8 @@ msgstr "Setting name"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr ""
@@ -7392,9 +7445,9 @@ msgstr "Show"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "Show Changes"
 
@@ -7402,8 +7455,8 @@ msgstr "Show Changes"
 #~ msgid "Show all groups"
 #~ msgstr "Show all groups"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "Show changes"
 
@@ -7416,7 +7469,7 @@ msgstr "Show description"
 msgid "Show less"
 msgstr "Show less"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "Show only root groups"
 
@@ -7469,14 +7522,14 @@ msgstr "Simple key select"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "Skip Tags"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7506,15 +7559,15 @@ msgstr ""
 msgid "Skipped"
 msgstr "Skipped"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "Smart Inventory"
@@ -7523,7 +7576,7 @@ msgstr "Smart Inventory"
 msgid "Smart Inventory not found."
 msgstr "Smart Inventory not found."
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "Smart host filter"
@@ -7555,13 +7608,15 @@ msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "Sort question order"
+#~ msgid "Sort question order"
+#~ msgstr "Sort question order"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "Source"
 
@@ -7570,12 +7625,12 @@ msgstr "Source"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "Source Control Branch"
 
@@ -7608,19 +7663,19 @@ msgstr "Source Control Revision"
 msgid "Source Control Type"
 msgstr "Source Control Type"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "Source Control URL"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7634,8 +7689,8 @@ msgstr "Source Phone Number"
 msgid "Source Variables"
 msgstr "Source Variables"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "Source Workflow Job"
 
@@ -7656,7 +7711,7 @@ msgstr "Source phone number"
 msgid "Source variables"
 msgstr "Source variables"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "Sourced from a project"
 
@@ -7707,14 +7762,14 @@ msgstr "Standard out tab"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "Start"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "Start Time"
 
@@ -7736,27 +7791,27 @@ msgstr "Start sync process"
 msgid "Start sync source"
 msgstr "Start sync source"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "Started"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "Status"
@@ -7787,14 +7842,14 @@ msgstr ""
 "This is equivalent to specifying the --remote\n"
 "flag to git submodule update."
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "Subscription"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "Subscription Details"
 
@@ -7810,11 +7865,11 @@ msgstr "Subscription manifest"
 msgid "Subscription selection modal"
 msgstr "Subscription selection modal"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "Subscription settings"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "Subscription type"
 
@@ -7822,11 +7877,11 @@ msgstr "Subscription type"
 msgid "Subscriptions table"
 msgstr "Subscriptions table"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversion"
 
@@ -7846,7 +7901,7 @@ msgstr "Success message"
 msgid "Success message body"
 msgstr "Success message body"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7878,25 +7933,37 @@ msgstr "Sunday"
 msgid "Survey"
 msgstr "Survey"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr "Survey Disabled"
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr "Survey Enabled"
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "Survey List"
+#~ msgid "Survey List"
+#~ msgstr "Survey List"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "Survey Preview"
+#~ msgid "Survey Preview"
+#~ msgstr "Survey Preview"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr "Survey Question Order"
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "Survey Toggle"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "Survey preview modal"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "Survey questions"
+#~ msgid "Survey questions"
+#~ msgstr "Survey questions"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7934,15 +8001,15 @@ msgstr "Sync for revision"
 msgid "Syncing"
 msgstr "Syncing"
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "System Administrator"
@@ -7957,8 +8024,8 @@ msgstr "System Auditor"
 msgid "System Warning"
 msgstr "System Warning"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "System administrators have unrestricted access to all resources."
 
@@ -7966,7 +8033,7 @@ msgstr "System administrators have unrestricted access to all resources."
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "TACACS+ settings"
 
@@ -7975,7 +8042,7 @@ msgstr "TACACS+ settings"
 msgid "Tabs"
 msgstr "Tabs"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -8039,7 +8106,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr ""
 
@@ -8050,19 +8117,19 @@ msgstr "Team not found."
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -8073,12 +8140,12 @@ msgstr ""
 msgid "Template not found."
 msgstr "Template not found."
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -8107,12 +8174,12 @@ msgstr "Test notification"
 msgid "Test passed"
 msgstr "Test passed"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "Text"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "Text Area"
 
@@ -8150,7 +8217,7 @@ msgstr ""
 "notification stops trying to reach the host and times out. Ranges\n"
 "from 1 to 120 seconds."
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8212,7 +8279,7 @@ msgstr ""
 "Value defaults to 0 which means no limit. Refer to the Ansible\n"
 "documentation for more details."
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8226,16 +8293,16 @@ msgstr ""
 "usually 5. The default number of forks can be overwritten\n"
 "with a change to"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "The page you requested could not be found."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 
@@ -8283,7 +8350,7 @@ msgstr ""
 #~ "or have {0} directly retrieve your playbooks from\n"
 #~ "source control using the Source Control Type option above."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8323,19 +8390,19 @@ msgstr "There was an error saving the workflow."
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr "These are the modules that {0} supports running commands against."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr "These are the modules that {brandName} supports running commands against."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "These are the verbosity levels for standard out of the command run that are supported."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "These arguments are used with the specified module."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "These arguments are used with the specified module. You can find information about {0} by clicking"
 
@@ -8343,21 +8410,21 @@ msgstr "These arguments are used with the specified module. You can find informa
 msgid "Third"
 msgstr "Third"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "This Project needs to be updated"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "This action will delete the following:"
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "This action will disassociate all roles for this user from the selected teams."
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "This action will disassociate the following role from {0}:"
 
@@ -8459,7 +8526,7 @@ msgid "This field must be greater than 0"
 msgstr "This field must be greater than 0"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8511,7 +8578,7 @@ msgstr "This is the only time the token value and associated refresh token value
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "This job template is currently being used by other resources. Are you sure you want to delete it?"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "This organization is currently being by other resources. Are you sure you want to delete it?"
 
@@ -8523,11 +8590,11 @@ msgstr "This project is currently being used by other resources. Are you sure yo
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "This project is currently on sync and cannot be clicked until sync process completed"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "This schedule is missing an Inventory"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "This schedule is missing required survey values"
 
@@ -8564,8 +8631,8 @@ msgstr "Thu"
 msgid "Thursday"
 msgstr "Thursday"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8610,7 +8677,7 @@ msgstr "Timed out"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -8621,6 +8688,10 @@ msgstr "Timeout minutes"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "Timeout seconds"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr "To reoder the survey questions drag and drop them in the desired location."
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8688,11 +8759,11 @@ msgid "Token not found."
 msgstr "Token not found."
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "Tokens"
@@ -8705,8 +8776,8 @@ msgstr "Tools"
 msgid "Top Pagination"
 msgstr "Top Pagination"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "Total Jobs"
@@ -8729,20 +8800,20 @@ msgstr "Track submodules"
 msgid "Track submodules latest commit on branch"
 msgstr "Track submodules latest commit on branch"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "Trial"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "True"
 
@@ -8755,55 +8826,57 @@ msgstr "Tue"
 msgid "Tuesday"
 msgstr "Tuesday"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "Type"
@@ -8849,7 +8922,7 @@ msgstr "Undo"
 msgid "Unfollow"
 msgstr "Unfollow"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "Unlimited"
 
@@ -8866,7 +8939,7 @@ msgstr "Unreachable Host Count"
 msgid "Unreachable Hosts"
 msgstr "Unreachable Hosts"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "Unrecognized day string"
 
@@ -8903,7 +8976,7 @@ msgstr "Update revision on job launch"
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr "Update settings pertaining to Jobs within {0}"
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr "Update settings pertaining to Jobs within {brandName}"
 
@@ -8943,7 +9016,7 @@ msgstr ""
 "notifications sent when a job starts, succeeds, or fails. Use\n"
 "curly braces to access information about the job:"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr "Used Capacity"
 
@@ -8962,17 +9035,17 @@ msgstr ""
 msgid "User Details"
 msgstr ""
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr ""
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "User Interface settings"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr ""
 
@@ -8999,14 +9072,14 @@ msgstr "User details"
 msgid "User not found."
 msgstr "User not found."
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "User tokens"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -9019,8 +9092,8 @@ msgstr "User tokens"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -9033,16 +9106,16 @@ msgstr "Username / password"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -9053,7 +9126,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -9063,10 +9136,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "Variables"
@@ -9087,21 +9160,21 @@ msgstr "Vault password | {credId}"
 msgid "Verbose"
 msgstr "Verbose"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "Verbosity"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "Version"
 
@@ -9148,7 +9221,7 @@ msgstr "View Inventory Host Details"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "View JSON examples at <0>www.json.org</0>"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "View Job Details"
 
@@ -9261,7 +9334,7 @@ msgstr "View all Inventory Hosts."
 msgid "View all Jobs"
 msgstr "View all Jobs"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "View all Jobs."
 
@@ -9324,7 +9397,7 @@ msgstr "View all settings"
 msgid "View all tokens."
 msgstr "View all tokens."
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "View and edit your subscription information"
 
@@ -9350,7 +9423,7 @@ msgid "View smart inventory host details"
 msgstr "View smart inventory host details"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr ""
 
@@ -9360,11 +9433,11 @@ msgstr ""
 msgid "Visualizer"
 msgstr "Visualizer"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "WARNING:"
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9388,8 +9461,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "We were unable to locate subscriptions associated with this account."
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9429,7 +9502,7 @@ msgstr "Webhook Service"
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Webhook details"
@@ -9458,7 +9531,7 @@ msgstr "Wed"
 msgid "Wednesday"
 msgstr "Wednesday"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "Week"
 
@@ -9515,26 +9588,26 @@ msgid "Workflow Approval not found."
 msgstr "Workflow Approval not found."
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "Workflow Approvals"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "Workflow Job"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9555,8 +9628,8 @@ msgstr "Workflow Job Templates"
 msgid "Workflow Link"
 msgstr "Workflow Link"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "Workflow Template"
 
@@ -9625,7 +9698,7 @@ msgstr "Write"
 msgid "YAML:"
 msgstr "YAML:"
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "Year"
 
@@ -9641,11 +9714,11 @@ msgstr "You are unable to act on the following workflow approvals: {itemsUnableT
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 
@@ -9681,19 +9754,19 @@ msgstr "Zoom In"
 msgid "Zoom Out"
 msgstr "Zoom Out"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "a new webhook key will be generated on save."
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "a new webhook url will be generated on save."
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "actions"
+#~ msgid "actions"
+#~ msgstr "actions"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9709,7 +9782,7 @@ msgid "brand logo"
 msgstr "brand logo"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr ""
 
@@ -9717,17 +9790,17 @@ msgstr ""
 msgid "cancel edit login redirect"
 msgstr "cancel edit login redirect"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "command"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "confirm disassociate"
 
@@ -9761,16 +9834,16 @@ msgstr "documentation"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "edit"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr "edit survey"
+#~ msgid "edit survey"
+#~ msgstr "edit survey"
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "encrypted"
 
@@ -9782,16 +9855,16 @@ msgstr "for more info."
 msgid "for more information."
 msgstr "for more information."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "here"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "here."
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "hosts"
 
@@ -9812,12 +9885,12 @@ msgid "min"
 msgstr "min"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "move down"
+#~ msgid "move down"
+#~ msgstr "move down"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "move up"
+#~ msgid "move up"
+#~ msgstr "move up"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9828,7 +9901,7 @@ msgstr "new choice"
 msgid "of"
 msgstr "of"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "option to the"
 
@@ -9857,15 +9930,15 @@ msgstr "sec"
 msgid "seconds"
 msgstr "seconds"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "select module"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "select verbosity"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr "since"
 
@@ -9873,7 +9946,7 @@ msgstr "since"
 msgid "social login"
 msgstr "social login"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "source control branch"
@@ -9886,7 +9959,7 @@ msgstr "system"
 msgid "timed out"
 msgstr "timed out"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "toggle changes"
 
@@ -9906,39 +9979,39 @@ msgstr "{0, plural, one {Are you sure you want delete the group below?} other {A
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 
@@ -9946,15 +10019,15 @@ msgstr "{0, plural, one {This inventory is currently being used by some template
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 
@@ -10043,8 +10116,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr "{number} since {dateStr}"
+#~ msgid "{number} since {dateStr}"
+#~ msgstr "{number} since {dateStr}"
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr "{number} since {date}"
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/es/messages.po
+++ b/awx/ui/src/locales/es/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (raíz del proyecto)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0 (Normal)"
 
@@ -59,7 +59,7 @@ msgstr "1 (Información)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1 (Nivel de detalle)"
 
@@ -75,7 +75,7 @@ msgstr "2 (Depurar)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2 (Más nivel de detalle)"
 
@@ -86,7 +86,7 @@ msgstr "2 (Más nivel de detalle)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3 (Depurar)"
 
@@ -97,7 +97,7 @@ msgstr "3 (Depurar)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4 (Depuración de la conexión)"
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr "Acerca de"
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr "Cuenta Token"
 msgid "Action"
 msgstr "Acción"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "Acciones"
@@ -235,8 +238,8 @@ msgstr "Acciones"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr "Actividad"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "Flujo de actividad"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "Selector de tipo de flujo de actividad"
 
@@ -297,35 +300,35 @@ msgstr "Agregar un nuevo nodo"
 msgid "Add a new node between these two nodes"
 msgstr "Agregar un nuevo nodo entre estos dos nodos"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "Agregar grupo de contenedores"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "Agregar grupo existente"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "Agregar host existente"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "Agregar grupo de instancias"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "Agregar inventario"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "Agregar plantilla de trabajo"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "Agregar nuevo grupo"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "Agregar nuevo host"
 
@@ -333,24 +336,24 @@ msgstr "Agregar nuevo host"
 msgid "Add resource type"
 msgstr "Agregar tipo de recurso"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "Agregar inventario inteligente"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "Agregar permisos de equipo"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "Agregar permisos de usuario"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "Agregar plantilla de flujo de trabajo"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr "Administración"
 
@@ -359,11 +362,11 @@ msgstr "Administración"
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "Documentación de búsqueda avanzada"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "Entrada de valores de búsqueda avanzada"
 
@@ -423,7 +426,7 @@ msgstr "Lista de URI permitidos, separados por espacios"
 msgid "Always"
 msgstr "Siempre"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -435,7 +438,7 @@ msgstr "Se ha producido un error"
 msgid "An inventory must be selected"
 msgstr "Debe seleccionar un inventario"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -456,13 +459,13 @@ msgstr "Nombre de la variable de respuesta"
 msgid "Any"
 msgstr "Cualquiera"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "Aplicación"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr "Información de la aplicación"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "Nombre de la aplicación"
 
@@ -480,17 +483,17 @@ msgstr "Nombre de la aplicación"
 msgid "Application not found."
 msgstr "No se encontró la aplicación."
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr "Aplicaciones"
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "Aplicaciones y tokens"
 
@@ -562,11 +565,11 @@ msgstr "¿Está seguro de que desea eliminar este enlace?"
 msgid "Are you sure you want to remove this node?"
 msgstr "¿Está seguro de que desea eliminar este nodo?"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr "¿Está seguro de que desea eliminar el acceso de {1} a {0}?  Esto afecta a todos los miembros del equipo."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "¿Está seguro de que desea eliminar el acceso de {username} a {0}?"
 
@@ -574,26 +577,26 @@ msgstr "¿Está seguro de que desea eliminar el acceso de {username} a {0}?"
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "¿Está seguro de que desea enviar la solicitud para cancelar este trabajo?"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "Argumentos"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "Artefactos"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "Asociar"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "Asociar error del rol"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "Modal de asociación"
 
@@ -605,7 +608,7 @@ msgstr "Debe seleccionar al menos un valor para este campo."
 msgid "August"
 msgstr "Agosto"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr "Identificación"
 
@@ -626,7 +629,7 @@ msgstr "Auto"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Configuración de Azure AD"
 
@@ -660,12 +663,16 @@ msgstr "Volver a Grupos"
 msgid "Back to Hosts"
 msgstr "Volver a Hosts"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "Volver a Inventarios"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "Volver a Tareas"
 
@@ -695,7 +702,7 @@ msgstr "Volver a Programaciones"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr "Volver a los entornos de ejecución"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "Volver a los grupos de instancias"
 
@@ -747,7 +753,7 @@ msgstr "Volver a los grupos de instancias"
 msgid "Back to management jobs"
 msgstr "Volver a las tareas de gestión"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr "Rama para realizar la comprobación.  Además de las ramas, puede introducir etiquetas, hashes de commit y referencias arbitrarias. Es posible que algunos hashes y referencias de commit no estén disponibles, a menos que usted también proporcione un refspec personalizado."
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr "Imagen de marca"
 
@@ -805,8 +811,8 @@ msgstr "Tiempo de espera de la caché (segundos)"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr "Tiempo de espera de la caché (segundos)"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr "Tiempo de espera de la caché (segundos)"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -883,7 +890,7 @@ msgstr "Cancelar cambios de enlace"
 msgid "Cancel link removal"
 msgstr "Cancelar eliminación del enlace"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "Cancelar búsqueda"
 
@@ -908,13 +915,13 @@ msgstr "Cancelar las tareas seleccionadas"
 msgid "Cancel subscription edit"
 msgstr "Cancelar modificación de la suscripción"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "Cancelar {0}"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -930,37 +937,37 @@ msgstr ""
 "No se puede habilitar la agregación de registros sin proporcionar\n"
 "el host y el tipo de agregación de registros."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "Capacidad"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "Versión de contains que no distingue mayúsculas de minúsculas"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "Versión de endswith que no distingue mayúsculas de minúsculas."
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "Versión de exact que no distingue mayúsculas de minúsculas."
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "Versión de regex que no distingue mayúsculas de minúsculas."
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "Versión de startswith que no distingue mayúsculas de minúsculas."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -980,15 +987,15 @@ msgid "Channel"
 msgstr "Canal"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "Comprobar"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "Comprobar si el campo dado o el objeto relacionado son nulos; se espera un valor booleano."
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "Comprobar si el valor del campo dado está presente en la lista proporcionada; se espera una lista de elementos separada por comas."
 
@@ -1000,7 +1007,7 @@ msgstr "Elegir un archivo .json"
 msgid "Choose a Notification Type"
 msgstr "Elegir un tipo de notificación"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "Elegir un directorio de playbook"
 
@@ -1013,11 +1020,11 @@ msgid "Choose a Webhook Service"
 msgstr "Elegir un servicio de Webhook"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "Seleccionar un tipo de tarea"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "Elegir un módulo"
 
@@ -1040,7 +1047,7 @@ msgstr "Elija el tipo o formato de respuesta que desee como indicador para el us
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "Elija los roles que se aplicarán a los recursos seleccionados.  Tenga en cuenta que todos los roles seleccionados se aplicarán a todos los recursos seleccionados."
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "Elija los recursos que recibirán nuevos roles.  Podrá seleccionar los roles que se aplicarán en el siguiente paso.  Tenga en cuenta que los recursos elegidos aquí recibirán todos los roles elegidos en el siguiente paso."
 
@@ -1085,6 +1092,10 @@ msgstr "Haga clic en este botón para verificar la conexión con el sistema de g
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "Haga clic para crear un nuevo enlace a este nodo."
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1133,13 +1144,13 @@ msgstr "Nube"
 msgid "Collapse"
 msgstr "Contraer"
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "Comando"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "Compatible"
 
@@ -1147,7 +1158,7 @@ msgstr "Compatible"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "Tareas concurrentes"
 
@@ -1178,11 +1189,11 @@ msgstr "Confirmar cancelación de la tarea"
 msgid "Confirm cancellation"
 msgstr "Confirmar cancelación"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "Confirmar eliminación"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "Confirmar disociación"
 
@@ -1206,7 +1217,7 @@ msgstr "Confirmar la reversión de todo"
 msgid "Confirm selection"
 msgstr "Confirmar selección"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "Grupo de contenedores"
 
@@ -1241,7 +1252,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr "Controlar el nivel de salida que producirá Ansible al ejecutar playbooks."
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1294,11 +1305,11 @@ msgstr "Copiar plantilla"
 msgid "Copy full revision to clipboard."
 msgstr "Copie la revisión completa al portapapeles."
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "Copyright"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "Crear"
@@ -1411,14 +1422,14 @@ msgstr "Crear nueva fuente"
 msgid "Create user token"
 msgstr "Crear token de usuario"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1428,7 +1439,7 @@ msgstr "Crear token de usuario"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1437,58 +1448,58 @@ msgstr "Crear token de usuario"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr "Creado"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "Creado por (nombre de usuario)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "Creado por (nombre de usuario)"
 
@@ -1518,7 +1529,7 @@ msgstr "Credencial"
 msgid "Credential Input Sources"
 msgstr "Fuentes de entrada de la credencial"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "Nombre de la credencial"
 
@@ -1529,9 +1540,9 @@ msgid "Credential Type"
 msgstr "Tipo de credencial"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1557,24 +1568,24 @@ msgstr "Credencial para autenticarse con un registro de contenedores protegido."
 msgid "Credential type not found."
 msgstr "No se encontró el tipo de credencial."
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr "Credenciales"
@@ -1625,7 +1636,7 @@ msgstr "ELIMINADO"
 msgid "Dashboard"
 msgstr "Panel de control"
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "Panel de control (toda la actividad)"
 
@@ -1639,12 +1650,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "Día"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "Días de datos para mantener"
 
@@ -1652,7 +1663,7 @@ msgstr "Días de datos para mantener"
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "Días restantes"
 
@@ -1669,12 +1680,20 @@ msgid "December"
 msgstr "Diciembre"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "Predeterminado"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "Entorno de ejecución predeterminado"
 
@@ -1684,7 +1703,7 @@ msgstr "Entorno de ejecución predeterminado"
 msgid "Default answer"
 msgstr "Respuesta predeterminada"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "Defina características y funciones a nivel del sistema"
 
@@ -1698,8 +1717,8 @@ msgstr "Defina características y funciones a nivel del sistema"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1707,7 +1726,7 @@ msgstr "Defina características y funciones a nivel del sistema"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1715,15 +1734,15 @@ msgstr "Defina características y funciones a nivel del sistema"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1752,7 +1771,7 @@ msgstr "Borrar un host"
 msgid "Delete Inventory"
 msgstr "Eliminar inventario"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1766,7 +1785,7 @@ msgstr "Eliminar plantilla de trabajo"
 msgid "Delete Notification"
 msgstr "Eliminar notificación"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "Eliminar organización"
 
@@ -1774,15 +1793,15 @@ msgstr "Eliminar organización"
 msgid "Delete Project"
 msgstr "Eliminar proyecto"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "Eliminar pregunta"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "Eliminar planificación"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "BORRAR ENCUESTA"
 
@@ -1836,6 +1855,10 @@ msgstr "Eliminar fuente de inventario"
 msgid "Delete smart inventory"
 msgstr "Eliminar inventario inteligente"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1867,16 +1890,16 @@ msgstr "¿Eliminar {pluralizedItemName}?"
 msgid "Deleted"
 msgstr "Eliminado"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "Error de eliminación"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "Error de eliminación"
 
@@ -1906,34 +1929,34 @@ msgid "Deprecated"
 msgstr "Obsoleto"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1941,36 +1964,36 @@ msgstr "Obsoleto"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr "Descripción"
 
@@ -2023,7 +2046,7 @@ msgstr "Canales destinatarios o usuarios"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2109,39 +2132,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "Disociar"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "¿Disociar grupo del host?"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "¿Disociar host del grupo?"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "¿Disociar instancia del grupo de instancias?"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "¿Disociar grupos relacionados?"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "¿Disociar equipos relacionados?"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "Disociar rol"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "Disociar rol"
 
@@ -2154,7 +2177,7 @@ msgstr "¿Disociar?"
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2219,8 +2242,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr "Cada vez que una tarea se ejecute con este proyecto, actualice la revisión del proyecto antes de iniciar dicha tarea."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2239,8 +2262,8 @@ msgstr "Cada vez que una tarea se ejecute con este proyecto, actualice la revisi
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2262,7 +2285,7 @@ msgstr "Cada vez que una tarea se ejecute con este proyecto, actualice la revisi
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2338,8 +2361,8 @@ msgstr "Modificar entorno de ejecución"
 msgid "Edit Group"
 msgstr "Modificar grupo"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2368,6 +2391,10 @@ msgstr "Modificar nodo"
 msgid "Edit Notification Template"
 msgstr "Modificar plantilla de notificación"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2392,7 +2419,7 @@ msgstr "Modificar programación"
 msgid "Edit Source"
 msgstr "Modificar fuente"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2480,8 +2507,8 @@ msgstr "Tiempo transcurrido"
 msgid "Elapsed time that the job ran"
 msgstr "Tiempo transcurrido de la ejecución de la tarea "
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2495,7 +2522,7 @@ msgstr "Opciones de correo electrónico"
 msgid "Enable Concurrent Jobs"
 msgstr "Activar los trabajos concurrentes"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "Habilitar almacenamiento de eventos"
 
@@ -2503,8 +2530,8 @@ msgstr "Habilitar almacenamiento de eventos"
 msgid "Enable HTTPS certificate verification"
 msgstr "Habilitar verificación del certificado HTTPS"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2522,8 +2549,8 @@ msgstr "Habilitar registro externo"
 msgid "Enable log system tracking facts individually"
 msgstr "Habilitar eventos de seguimiento del sistema de registro de forma individual"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "Habilitar elevación de privilegios"
 
@@ -2531,15 +2558,15 @@ msgstr "Habilitar elevación de privilegios"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "Habilitar webhook para esta plantilla."
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "Habilitado"
@@ -2574,7 +2601,7 @@ msgstr "Variable habilitada"
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2582,7 +2609,7 @@ msgid ""
 "template"
 msgstr "Habilita la creación de una URL de callback de aprovisionamiento. Con la URL, un host puede contactar a {BrandName} y solicitar la actualización de la configuración utilizando esta plantilla de trabajo."
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2604,7 +2631,7 @@ msgstr "Fin"
 msgid "End User License Agreement"
 msgstr "Acuerdo de licencia de usuario final"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "La finalización no coincide con un valor esperado"
 
@@ -2710,21 +2737,21 @@ msgstr "Introduzca las variables para configurar la fuente de inventario. Consul
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "Ingrese variables con sintaxis JSON o YAML. Use el botón de selección para alternar entre los dos."
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "Error"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2748,41 +2775,41 @@ msgstr "Error al guardar el flujo de trabajo"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2790,21 +2817,21 @@ msgstr "Error al guardar el flujo de trabajo"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2814,17 +2841,17 @@ msgstr "Error al guardar el flujo de trabajo"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "¡Error!"
 
@@ -2832,7 +2859,7 @@ msgstr "¡Error!"
 msgid "Error:"
 msgstr "Error:"
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2850,15 +2877,19 @@ msgstr "Modal de detalles del evento"
 msgid "Event summary not available"
 msgstr "Resumen del evento no disponible."
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "Eventos"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "Coincidencia exacta (búsqueda predeterminada si no se especifica)."
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2894,15 +2925,15 @@ msgstr "Ejecutar cuando el nodo primario se encuentre en estado de error."
 msgid "Execute when the parent node results in a successful state."
 msgstr "Ejecutar cuando el nodo primario se encuentre en estado correcto."
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "Entorno de ejecución"
 
@@ -2911,22 +2942,22 @@ msgstr "Entorno de ejecución"
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "Entornos de ejecución"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "Nodo de ejecución"
 
@@ -2960,24 +2991,24 @@ msgstr "Expandir la entrada"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "Se esperaba que al menos uno de client_email, project_id o private_key estuviera presente en el archivo."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "Expira"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "Fecha de expiración:"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "Fecha de expiración (UTC):"
 
@@ -2986,7 +3017,7 @@ msgstr "Fecha de expiración (UTC):"
 msgid "Expires on {0}"
 msgstr "Fecha de expiración: {0}"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "Explicación"
@@ -2995,8 +3026,8 @@ msgstr "Explicación"
 msgid "External Secret Management System"
 msgstr "Sistema externo de gestión de claves secretas"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "Variables adicionales"
 
@@ -3021,7 +3052,7 @@ msgstr ""
 msgid "Facts"
 msgstr "Eventos"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3047,7 +3078,7 @@ msgstr "Hosts fallidos"
 msgid "Failed jobs"
 msgstr "Tareas fallidas"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "No se pudo aprobar uno o más flujos de trabajo."
 
@@ -3055,21 +3086,21 @@ msgstr "No se pudo aprobar uno o más flujos de trabajo."
 msgid "Failed to approve workflow approval."
 msgstr "No se pudo aprobar el flujo de trabajo."
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "No se pudieron asignar correctamente los roles"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "No se pudo asociar el rol"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "No se pudo asociar."
 
@@ -3082,12 +3113,12 @@ msgstr "No se pudo cancelar la sincronización de fuentes de inventario"
 msgid "Failed to cancel Project Sync"
 msgstr "No se pudo cancelar la sincronización de proyectos"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "No se pudo cancelar una o varias tareas."
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "No se pudo cancelar {0}"
@@ -3146,19 +3177,19 @@ msgstr "No se pudo eliminar la plantilla de trabajo."
 msgid "Failed to delete notification."
 msgstr "No se pudo eliminar la notificación."
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "No se pudo eliminar una o más aplicaciones."
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "No se pudo eliminar uno o más tipos de credenciales."
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "No se pudo eliminar una o más credenciales."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "No se pudo eliminar uno o más entornos de ejecución"
 
@@ -3166,16 +3197,16 @@ msgstr "No se pudo eliminar uno o más entornos de ejecución"
 msgid "Failed to delete one or more groups."
 msgstr "No se pudo eliminar uno o varios grupos."
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "No se pudo eliminar uno o más hosts."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "No se pudo eliminar uno o más grupos de instancias."
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "No se pudo eliminar uno o más inventarios."
 
@@ -3183,55 +3214,55 @@ msgstr "No se pudo eliminar uno o más inventarios."
 msgid "Failed to delete one or more inventory sources."
 msgstr "No se pudo eliminar una o más fuentes de inventario."
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "No se pudo eliminar una o más plantillas de trabajo."
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "No se pudo eliminar una o más tareas."
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "No se pudo eliminar una o más plantillas de notificación."
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "No se pudo eliminar una o más organizaciones."
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "No se pudo eliminar uno o más proyectos."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "No se pudo eliminar una o más programaciones."
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "No se pudo eliminar uno o más equipos."
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "No se pudo eliminar una o más plantillas."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "No se pudo eliminar uno o más tokens."
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "No se pudo eliminar uno o más tokens de usuario."
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "No se pudo eliminar uno o más usuarios."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "No se pudo eliminar una o más aprobaciones del flujo de trabajo."
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "No se pudo eliminar la organización."
 
@@ -3239,16 +3270,16 @@ msgstr "No se pudo eliminar la organización."
 msgid "Failed to delete project."
 msgstr "No se pudo eliminar el proyecto."
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "No se pudo eliminar el rol"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "No se pudo eliminar el rol."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "No se pudo eliminar la programación."
 
@@ -3277,7 +3308,7 @@ msgstr "No se pudo eliminar la plantilla de trabajo del flujo de trabajo."
 msgid "Failed to delete {name}."
 msgstr "No se pudo eliminar {nombre}."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "No se pudo denegar una o más aprobaciones del flujo de trabajo."
 
@@ -3285,21 +3316,21 @@ msgstr "No se pudo denegar una o más aprobaciones del flujo de trabajo."
 msgid "Failed to deny workflow approval."
 msgstr "No se pudo denegar la aprobación del flujo de trabajo."
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "No se pudo disociar uno o más grupos."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "No se pudo disociar uno o más hosts."
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "No se pudo disociar una o más instancias."
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "No se pudo disociar uno o más equipos."
 
@@ -3307,13 +3338,13 @@ msgstr "No se pudo disociar uno o más equipos."
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "No se pudo obtener la configuración de inicio de sesión personalizada.  En su lugar, se mostrarán los valores predeterminados del sistema."
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "No se pudo ejecutar la tarea."
 
@@ -3353,7 +3384,7 @@ msgstr "No se pudo alternar el host."
 msgid "Failed to toggle instance."
 msgstr "No se pudo alternar la instancia."
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "No se pudo alternar la notificación."
 
@@ -3384,7 +3415,7 @@ msgstr "Fallo"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "Falso"
 
@@ -3392,11 +3423,11 @@ msgstr "Falso"
 msgid "February"
 msgstr "Febrero"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "El campo contiene un valor."
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "El campo termina con un valor."
 
@@ -3404,11 +3435,11 @@ msgstr "El campo termina con un valor."
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "Campo para pasar una especificación personalizada de Kubernetes u OpenShift Pod."
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "El campo coincide con la expresión regular dada."
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "El campo comienza con un valor."
 
@@ -3424,16 +3455,16 @@ msgstr "Diferencias del fichero"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "Se rechazó la carga de archivos. Seleccione un único archivo .json."
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "Archivo, directorio o script"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "Hora de finalización"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "Finalizado"
@@ -3444,25 +3475,25 @@ msgstr "Primero"
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "Nombre"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "Primera ejecución"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "Nombre"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "Primero, seleccione una clave"
 
@@ -3478,7 +3509,7 @@ msgstr "Decimal corto"
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3497,11 +3528,11 @@ msgstr "Para las plantillas de trabajo, seleccione ejecutar para ejecutar el pla
 msgid "For more information, refer to the"
 msgstr "Para obtener más información, consulte la"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "Forks"
 
@@ -3509,12 +3540,12 @@ msgstr "Forks"
 msgid "Fourth"
 msgstr "Cuarto"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "Información sobre la frecuencia"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "La frecuencia no coincide con un valor esperado"
 
@@ -3527,11 +3558,11 @@ msgstr "Vie"
 msgid "Friday"
 msgstr "Viernes"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3556,11 +3587,11 @@ msgstr "Obtener suscripción"
 msgid "Get subscriptions"
 msgstr "Obtener suscripciones"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3599,7 +3630,7 @@ msgstr "Organización de GitHub"
 msgid "GitHub Team"
 msgstr "Equipo GitHub"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "Configuración de GitHub"
 
@@ -3608,7 +3639,7 @@ msgstr "Configuración de GitHub"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "Entorno de ejecución global predeterminado"
 
@@ -3637,11 +3668,11 @@ msgstr "Ir a la página siguiente"
 msgid "Go to previous page"
 msgstr "Ir a la página anterior"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Configuración de Google OAuth 2"
 
@@ -3649,8 +3680,8 @@ msgstr "Configuración de Google OAuth 2"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3663,15 +3694,15 @@ msgstr "Clave API de Grafana"
 msgid "Grafana URL"
 msgstr "URL de Grafana"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "Mayor que la comparación."
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "Mayor o igual que la comparación."
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "Grupo"
 
@@ -3679,20 +3710,20 @@ msgstr "Grupo"
 msgid "Group details"
 msgstr "Detalles del grupo"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "Tipo de grupo"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "Grupos"
@@ -3720,8 +3751,8 @@ msgstr "Ocultar"
 msgid "Hide description"
 msgstr "Ocultar descripción"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "HipChat"
 
@@ -3740,7 +3771,7 @@ msgstr "Servidor Async OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "Clave de configuración del servidor"
 
@@ -3811,20 +3842,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "La información de estado del host para esta tarea no se encuentra disponible."
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3832,30 +3863,30 @@ msgstr "La información de estado del host para esta tarea no se encuentra dispo
 msgid "Hosts"
 msgstr "Servidores"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "Hosts disponibles"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "Hosts restantes"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "Hora"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3875,8 +3906,8 @@ msgstr "ID del panel de control (opcional)"
 msgid "ID of the panel (optional)"
 msgstr "ID del panel (opcional)"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -3933,7 +3964,7 @@ msgid ""
 "default group for the inventory."
 msgstr "Si las opciones están marcadas, cualquier grupo o host que estuvo presente previamente en la fuente externa pero que ahora se eliminó, se eliminará del inventario. Los hosts y grupos que no fueron gestionados por la fuente de inventario serán promovidos al siguiente grupo creado manualmente o, si no existe uno al que puedan ser promovidos, se los dejará en el grupo predeterminado \"Todo\" para el inventario."
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3946,18 +3977,18 @@ msgid ""
 "--diff mode."
 msgstr "Si se habilita esta opción, muestre los cambios realizados por las tareas de Ansible, donde sea compatible. Esto es equivalente al modo --diff de Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr "Si se habilita esta opción, muestre los cambios realizados por las tareas de Ansible, donde sea compatible. Esto es equivalente al modo --diff de Ansible."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "Si se habilita esta opción, muestre los cambios realizados por las tareas de Ansible, donde sea compatible. Esto es equivalente al modo --diff de Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3967,7 +3998,7 @@ msgstr "Si se habilita esta opción, se permitirá la ejecución simultánea de 
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "Si se habilita esta opción, se permitirá la ejecución de esta plantilla de flujo de trabajo en paralelo."
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3980,7 +4011,7 @@ msgstr ""
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "Si está listo para la actualización o la renovación, <0>contáctenos.</0>"
 
@@ -3990,7 +4021,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr "Si no tiene una suscripción, puede visitar Red Hat para obtener una suscripción de prueba."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "Si solo desea eliminar el acceso de este usuario específico, elimínelo del equipo."
 
@@ -4004,13 +4035,13 @@ msgstr ""
 "ejecutar y en la actualización del proyecto, haga clic en Actualizar al ejecutar, y también vaya a"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "Imagen"
@@ -4037,13 +4068,13 @@ msgstr "Información"
 msgid "Initiated By"
 msgstr "Inicializado por"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "Inicializado por"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "Inicializado por (nombre de usuario)"
 
@@ -4070,7 +4101,7 @@ msgstr "Insight para Ansible Automation Platform"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Panel de control de Insight para Ansible Automation Platform"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "ID del sistema de Insights"
 
@@ -4082,18 +4113,18 @@ msgstr "Instancia"
 msgid "Instance Filters"
 msgstr "Filtros de instancias"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "Grupo de instancias"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4102,7 +4133,7 @@ msgstr "Grupo de instancias"
 msgid "Instance Groups"
 msgstr "Grupos de instancias"
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "ID de instancia"
 
@@ -4124,11 +4155,11 @@ msgid "Instance groups"
 msgstr "Grupos de instancias"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "Instancias"
 
@@ -4158,11 +4189,11 @@ msgstr "Nombre de usuario o contraseña no válidos. Intente de nuevo."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4173,41 +4204,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "No se pueden copiar los inventarios con fuentes"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "Inventario"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "Inventario (Nombre)"
 
@@ -4215,13 +4246,17 @@ msgstr "Inventario (Nombre)"
 msgid "Inventory File"
 msgstr "Archivo de inventario"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "ID de inventario"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "Fuente de inventario"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4238,15 +4273,15 @@ msgstr "Error en la sincronización de fuentes de inventario"
 msgid "Inventory Sources"
 msgstr "Fuentes de inventario"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "Sincronización de inventario"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4291,7 +4326,7 @@ msgstr "Elemento OK"
 msgid "Item Skipped"
 msgstr "Elemento omitido"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "Elementos"
@@ -4323,20 +4358,20 @@ msgstr "JSON:"
 msgid "January"
 msgstr "Enero"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "Tarea"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "Error en la cancelación de tarea"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4350,19 +4385,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "Fracción de tareas"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "Fraccionamiento de trabajos"
 
@@ -4374,20 +4409,20 @@ msgstr "Estado de la tarea"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "Etiquetas de trabajo"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "Plantilla de trabajo"
@@ -4412,15 +4447,15 @@ msgstr "Las plantillas de trabajo en las que falta un inventario o un proyecto n
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Las plantillas de trabajo con credenciales que solicitan contraseñas no pueden seleccionarse al crear o modificar nodos"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "Tipo de trabajo"
 
@@ -4433,15 +4468,15 @@ msgid "Job status graph tab"
 msgstr "Pestaña del gráfico de estado de la tarea"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "Plantillas de trabajo"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4456,7 +4491,7 @@ msgstr "Plantillas de trabajo"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4464,7 +4499,7 @@ msgstr "Plantillas de trabajo"
 msgid "Jobs"
 msgstr "Trabajos"
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "Configuración de las tareas"
 
@@ -4476,19 +4511,19 @@ msgstr "Julio"
 msgid "June"
 msgstr "Junio"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "Clave"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "Seleccionar clave"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "Escritura anticipada de la clave"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "Palabra clave"
 
@@ -4521,7 +4556,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "LDAP predeterminado"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "Configuración de LDAP"
 
@@ -4545,18 +4580,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "Nombre de la etiqueta"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "Etiquetas"
@@ -4574,11 +4609,11 @@ msgid "Last Login"
 msgstr "Último inicio de sesión"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4588,7 +4623,7 @@ msgstr "Último inicio de sesión"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4602,25 +4637,25 @@ msgstr "Último modificado"
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr "Apellido"
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "Último ejecutado"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "Última ejecución"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "Última tarea"
 
@@ -4631,7 +4666,7 @@ msgstr "Última tarea"
 msgid "Last modified"
 msgstr "Última modificación"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "Apellido"
@@ -4682,11 +4717,11 @@ msgstr "Ejecutar flujo de trabajo"
 msgid "Launch | {0}"
 msgstr "Ejecutar | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "Ejecutado por"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "Ejecutado por (nombre de usuario)"
 
@@ -4702,26 +4737,26 @@ msgstr "Deje este campo en blanco para que el entorno de ejecución esté dispon
 msgid "Legend"
 msgstr "Leyenda"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "Menor que la comparación."
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "Menor o igual que la comparación."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "Límite"
@@ -4738,11 +4773,11 @@ msgstr "Cargando"
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "Huso horario local"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "Huso horario local"
 
@@ -4754,7 +4789,7 @@ msgstr "Iniciar sesión"
 msgid "Logging"
 msgstr "Registros"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "Configuración del registro"
 
@@ -4764,20 +4799,20 @@ msgstr "Configuración del registro"
 msgid "Logout"
 msgstr "Finalización de la sesión"
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "Modal de búsqueda"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "Selección de búsqueda"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "Tipo de búsqueda"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "Escritura anticipada de la búsqueda"
 
@@ -4787,10 +4822,10 @@ msgstr "Escritura anticipada de la búsqueda"
 msgid "MOST RECENT SYNC"
 msgstr "ÚLTIMA SINCRONIZACIÓN"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "Credenciales de máquina"
 
@@ -4803,8 +4838,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr "Nodos gestionados"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4814,7 +4849,7 @@ msgid "Management Job"
 msgstr "Trabajo de gestión"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr "Trabajos de gestión"
 
@@ -4835,15 +4870,15 @@ msgstr "No se encontró la tarea de gestión."
 msgid "Management jobs"
 msgstr "Tareas de gestión"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "Manual"
 
@@ -4851,8 +4886,8 @@ msgstr "Manual"
 msgid "March"
 msgstr "Marzo"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4873,7 +4908,7 @@ msgstr "Longitud máxima"
 msgid "May"
 msgstr "Mayo"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr "Miembros"
@@ -4890,7 +4925,7 @@ msgstr "Métrica"
 msgid "Metrics"
 msgstr "Métrica"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -4914,7 +4949,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr "Porcentaje mínimo de todas las instancias que se asignará automáticamente a este grupo cuando aparezcan nuevas instancias en línea."
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "Minuto"
 
@@ -4922,7 +4957,7 @@ msgstr "Minuto"
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4930,7 +4965,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr "Sistemas varios"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "Configuración de sistemas varios"
 
@@ -4945,70 +4980,70 @@ msgid "Missing resource"
 msgstr "Recurso no encontrado"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr "Modificado"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "Modificado por (nombre de usuario)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "Modificado por (nombre de usuario)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "Módulo"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5021,7 +5056,7 @@ msgstr "Lun"
 msgid "Monday"
 msgstr "Lunes"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "Mes"
 
@@ -5033,13 +5068,13 @@ msgstr "Más información"
 msgid "More information for"
 msgstr "Más información para"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "Selección múltiple"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "Selección múltiple"
 
@@ -5055,57 +5090,57 @@ msgstr "Selección múltiple"
 msgid "Multiple Choice Options"
 msgstr "Opciones de selección múltiple"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5120,73 +5155,73 @@ msgstr "Opciones de selección múltiple"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5199,66 +5234,72 @@ msgstr "Opciones de selección múltiple"
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr "Nombre"
@@ -5282,7 +5323,7 @@ msgstr "Nunca actualizado"
 msgid "Never expires"
 msgstr "No expira nunca"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "Nuevo"
@@ -5301,8 +5342,8 @@ msgstr "Nuevo"
 msgid "Next"
 msgstr "Siguiente"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5345,7 +5386,7 @@ msgstr "No hay errores de sincronización de inventario."
 msgid "No items found."
 msgstr "No se encontraron elementos."
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5353,10 +5394,10 @@ msgstr ""
 msgid "No result found"
 msgstr "No se encontraron resultados"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "No se encontraron resultados"
 
@@ -5365,7 +5406,7 @@ msgstr "No se encontraron resultados"
 msgid "No subscriptions found"
 msgstr "No se encontraron suscripciones"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "No se encontraron preguntas de la encuesta."
 
@@ -5380,7 +5421,7 @@ msgstr "No se encontraron {pluralizedItemName}"
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5398,7 +5439,7 @@ msgstr "Ninguno"
 msgid "None (Run Once)"
 msgstr "Ninguno (se ejecuta una vez)"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "Ninguno (se ejecuta una vez)"
 
@@ -5421,15 +5462,15 @@ msgstr "No configurado"
 msgid "Not configured for inventory sync."
 msgstr "No configurado para la sincronización de inventario."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr "Tenga en cuenta que solo se pueden disociar los hosts asociados directamente a este grupo. Los hosts en subgrupos deben ser disociados del nivel de subgrupo al que pertenecen."
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5439,7 +5480,7 @@ msgstr ""
 "Tenga en cuenta que puede seguir viendo el grupo en la lista después de la disociación si el host también es un miembro de los elementos secundarios de ese grupo. Esta lista muestra todos los grupos a los que está asociado el host\n"
 "directa e indirectamente."
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5470,9 +5511,9 @@ msgstr "Color de notificación"
 msgid "Notification Template not found."
 msgstr "No se encontró ninguna plantilla de notificación."
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5487,20 +5528,20 @@ msgstr "Tipo de notificación"
 msgid "Notification color"
 msgstr "Color de la notificación"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "Notificación enviada correctamente"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "Caducó el tiempo de la notificación"
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "Tipo de notificación"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5535,39 +5576,37 @@ msgstr "Ocurrencias"
 msgid "October"
 msgstr "Octubre"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "Off"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "On"
 
@@ -5597,7 +5636,7 @@ msgstr "En los días"
 msgid "Only Group By"
 msgstr "Agrupar solo por"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5605,7 +5644,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Detalles de la opción"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5617,20 +5656,26 @@ msgstr "Etiquetas opcionales que describen esta plantilla de trabajo, como 'dev'
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "Opcionalmente, seleccione la credencial que se usará para devolver las actualizaciones de estado al servicio de Webhook."
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "Opciones"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5641,15 +5686,15 @@ msgstr "Opciones"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5659,22 +5704,22 @@ msgstr "Opciones"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "Organización"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "Organización (Nombre)"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "Nombre de la organización"
 
@@ -5684,9 +5729,9 @@ msgstr "No se encontró la organización."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5701,11 +5746,11 @@ msgstr "Organizaciones"
 msgid "Other prompts"
 msgstr "Otros avisos"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "No cumple con los requisitos"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "Salida"
@@ -5736,8 +5781,8 @@ msgstr "PUBLICAR"
 msgid "PUT"
 msgstr "COLOCAR"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5769,11 +5814,11 @@ msgstr "Desplazar hacia la derecha"
 msgid "Pan Up"
 msgstr "Desplazar hacia arriba"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "Trasladar cambios adicionales en la línea de comandos. Hay dos parámetros de línea de comandos de Ansible:"
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5810,7 +5855,7 @@ msgstr "Últimas dos semanas"
 msgid "Past week"
 msgstr "Semana pasada"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5824,12 +5869,12 @@ msgstr "Aprobaciones de flujos de trabajo pendientes"
 msgid "Pending delete"
 msgstr "Eliminación pendiente"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "Realice una búsqueda para definir un filtro de host"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5850,13 +5895,13 @@ msgid "Play Started"
 msgstr "Jugada iniciada"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Playbook"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Comprobación del playbook"
@@ -5867,12 +5912,12 @@ msgstr "Playbook terminado"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Directorio de playbook"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5882,10 +5927,10 @@ msgstr "Ejecución de playbook"
 msgid "Playbook Started"
 msgstr "Playbook iniciado"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Nombre del playbook"
 
@@ -5897,15 +5942,15 @@ msgstr "Ejecución de playbook"
 msgid "Plays"
 msgstr "Jugadas"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "Agregue preguntas de la encuesta."
 
@@ -5929,23 +5974,23 @@ msgstr "Por favor introduzca un valor."
 msgid "Please log in"
 msgstr "Inicie sesión"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "Seleccione un número de día entre 1 y 31."
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "Seleccione un inventario o marque la opción Preguntar al ejecutar."
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "Seleccione una fecha/hora de finalización que sea posterior a la fecha/hora de inicio."
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "Seleccione una organización antes de modificar el filtro del host"
 
@@ -5953,7 +5998,7 @@ msgstr "Seleccione una organización antes de modificar el filtro del host"
 msgid "Pod spec override"
 msgstr "Anulación de las especificaciones del pod"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5973,7 +6018,7 @@ msgstr "Porcentaje de instancias de políticas"
 msgid "Populate field from an external secret management system"
 msgstr "Completar el campo desde un sistema externo de gestión de claves secretas"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6016,8 +6061,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "Vista previa"
 
@@ -6027,7 +6070,7 @@ msgstr "Frase de paso para llave privada"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "Elevación de privilegios"
 
@@ -6035,17 +6078,16 @@ msgstr "Elevación de privilegios"
 msgid "Privilege escalation password"
 msgstr "Contraseña para la elevación de privilegios"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6053,7 +6095,7 @@ msgstr "Proyecto"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "Ruta base del proyecto"
 
@@ -6081,10 +6123,10 @@ msgstr "Errores de sincronización del proyecto"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6097,8 +6139,8 @@ msgstr "Proyectos"
 msgid "Promote Child Groups and Hosts"
 msgstr "Promover grupos secundarios y hosts"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "Aviso"
 
@@ -6117,11 +6159,11 @@ msgid "Prompt | {0}"
 msgstr "Aviso | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "Valores solicitados"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6142,7 +6184,7 @@ msgstr "Proporcione un patrón de host para limitar aun más la lista de hosts q
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "Proporcione un valor para este campo o seleccione la opción Preguntar al ejecutar."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6164,18 +6206,18 @@ msgstr "Proporcione sus credenciales de Red Hat o Red Hat Satellite para habilit
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "Dirección URL para las llamadas callback"
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "Detalles de callback de aprovisionamiento"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "Callbacks de aprovisionamiento"
 
@@ -6192,7 +6234,7 @@ msgstr "Pregunta"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "Configuración de RADIUS"
 
@@ -6222,7 +6264,7 @@ msgstr "Pestaña de la lista de plantillas recientes"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6235,19 +6277,19 @@ msgstr "Lista de destinatarios"
 msgid "Recipient list"
 msgstr "Lista de destinatarios"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Virtualización de Red Hat"
 
@@ -6255,7 +6297,7 @@ msgstr "Virtualización de Red Hat"
 msgid "Red Hat subscription manifest"
 msgstr "Manifiesto de suscripción de Red Hat"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6279,7 +6321,7 @@ msgstr "Redirigir al detalle de la suscripción"
 msgid "Refer to the"
 msgstr "Consulte"
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6315,28 +6357,28 @@ msgstr "Expresión regular en la que solo se importarán los nombres de host que
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "Grupos relacionados"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "Relanzar"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "Volver a ejecutar la tarea"
@@ -6354,16 +6396,16 @@ msgstr "Volver a ejecutar hosts fallidos"
 msgid "Relaunch on"
 msgstr "Volver a ejecutar el"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "Relanzar utilizando los parámetros de host"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "Archivo remoto"
 
@@ -6390,7 +6432,7 @@ msgstr "Quitar nodo"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "Eliminar cualquier modificación local antes de realizar una actualización."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr "Quitar acceso de {0}"
 
@@ -6406,7 +6448,7 @@ msgstr "Si quita este enlace, el resto de la rama quedará huérfano y hará que
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "Frecuencia de repetición"
 
@@ -6423,7 +6465,7 @@ msgstr "Reemplazar el campo con un valor nuevo"
 msgid "Request subscription"
 msgstr "Solicitar subscripción"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "Obligatorio"
@@ -6431,7 +6473,7 @@ msgstr "Obligatorio"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "Nombre del recurso"
 
@@ -6440,7 +6482,7 @@ msgid "Resource deleted"
 msgstr "Recurso eliminado"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr "Recursos"
 
@@ -6472,15 +6514,15 @@ msgstr "Volver"
 msgid "Return to subscription management."
 msgstr "Volver a la gestión de suscripciones."
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "Muestra los resultados que tienen valores distintos a éste y otros filtros."
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "Muestra los resultados que cumple con este y otros filtros.  Este es el tipo de conjunto predeterminado si no se selecciona nada."
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "Muestra los resultados que cumplen con este o cualquier otro filtro."
 
@@ -6511,8 +6553,8 @@ msgstr "Revertir configuración"
 msgid "Revert to factory default."
 msgstr "Revertir a los valores predeterminados de fábrica."
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "Revisión"
@@ -6521,25 +6563,25 @@ msgstr "Revisión"
 msgid "Revision #"
 msgstr "Revisión n°"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "Rol"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6553,7 +6595,7 @@ msgstr "Roles"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "Ejecutar"
 
@@ -6577,7 +6619,7 @@ msgstr "Ejecutar comando"
 msgid "Run every"
 msgstr "Ejecutar cada"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "Frecuencia de ejecución"
 
@@ -6589,7 +6631,7 @@ msgstr "Ejecutar el"
 msgid "Run type"
 msgstr "Tipo de ejecución"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6600,8 +6642,8 @@ msgstr "Ejecutándose"
 msgid "Running Handlers"
 msgstr "Handlers ejecutándose"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "Tareas en ejecución"
@@ -6614,7 +6656,7 @@ msgstr "Tareas en ejecución"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "Configuración de SAML"
 
@@ -6657,18 +6699,19 @@ msgid "Saturday"
 msgstr "Sábado"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6706,7 +6749,7 @@ msgstr "La programación está activa"
 msgid "Schedule is inactive"
 msgstr "La programación está inactiva"
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "Falta una regla de programación"
 
@@ -6714,10 +6757,10 @@ msgstr "Falta una regla de programación"
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6731,11 +6774,11 @@ msgstr ""
 msgid "Schedules"
 msgstr "Programaciones"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6757,8 +6800,8 @@ msgstr "Desplazarse hasta el siguiente"
 msgid "Scroll previous"
 msgstr "Desplazarse hasta el anterior"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr "Buscar"
 
@@ -6766,7 +6809,7 @@ msgstr "Buscar"
 msgid "Search is disabled while the job is running"
 msgstr "La búsqueda se desactiva durante la ejecución de la tarea"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "Botón de envío de la búsqueda"
@@ -6790,9 +6833,9 @@ msgstr "Segundos"
 msgid "See errors on the left"
 msgstr "Ver errores a la izquierda"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6802,13 +6845,13 @@ msgstr "Seleccionar"
 msgid "Select Credential Type"
 msgstr "Seleccionar tipo de credencial"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "Seleccionar grupos"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "Seleccionar hosts"
 
@@ -6816,11 +6859,11 @@ msgstr "Seleccionar hosts"
 msgid "Select Input"
 msgstr "Seleccionar entrada"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "Seleccionar instancias"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "Seleccionar elementos"
 
@@ -6836,7 +6879,7 @@ msgstr "Seleccionar etiquetas"
 msgid "Select Roles to Apply"
 msgstr "Seleccionar los roles para aplicar"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "Seleccionar equipos"
 
@@ -6852,7 +6895,7 @@ msgstr "Seleccionar un tipo de nodo"
 msgid "Select a Resource Type"
 msgstr "Seleccionar un tipo de recurso"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6882,7 +6925,7 @@ msgstr "Seleccionar una tarea para cancelar"
 msgid "Select a metric"
 msgstr "Seleccionar una métrica"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "Seleccionar un módulo"
 
@@ -6891,16 +6934,20 @@ msgstr "Seleccionar un módulo"
 msgid "Select a playbook"
 msgstr "Seleccionar un playbook"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "Seleccione un proyecto antes de modificar el entorno de ejecución."
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "Seleccionar una fila para aprobar"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr "Seleccionar una fila para eliminar"
 
@@ -6921,8 +6968,8 @@ msgstr "Seleccionar una suscripción"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6942,7 +6989,7 @@ msgstr "Seleccionar una suscripción"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6955,11 +7002,11 @@ msgid "Select a webhook service."
 msgstr "Seleccione un servicio de webhook."
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr "Seleccionar todo"
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "Seleccionar un tipo de actividad"
 
@@ -6979,7 +7026,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr "Seleccione una organización antes de modificar el entorno de ejecución predeterminado."
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6988,7 +7035,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr "Seleccione las credenciales para acceder a los nodos en función de los cuales se ejecutará este trabajo. Solo puede seleccionar una credencial de cada tipo. Para las credenciales de máquina (SSH), si marca \"Preguntar al ejecutar\" sin seleccionar las credenciales, se le pedirá que seleccione una credencial de máquina en el momento de la ejecución. Si selecciona las credenciales y marca \"Preguntar al ejecutar\", las credenciales seleccionadas se convierten en las credenciales predeterminadas que pueden actualizarse en tiempo de ejecución."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7036,7 +7083,7 @@ msgstr "Seleccionar estado"
 msgid "Select tags"
 msgstr "Seleccionar etiquetas"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "Seleccione el entorno de ejecución en el que desea que se ejecute este comando."
 
@@ -7044,7 +7091,7 @@ msgstr "Seleccione el entorno de ejecución en el que desea que se ejecute este 
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Seleccione los grupos de instancias en los que se ejecutará este inventario."
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7062,16 +7109,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "Seleccione la aplicación a la que pertenecerá este token."
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "Seleccione la credencial que desea utilizar cuando acceda a los hosts remotos para ejecutar el comando. Elija una credencial que contenga el nombre de usuario y la clave SSH o la contraseña que Ansible necesitará para iniciar sesión en los hosts remotos."
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "Seleccione el entorno de ejecución para esta plantilla de trabajo."
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7089,11 +7136,11 @@ msgstr "Seleccione el archivo del inventario que sincronizará esta fuente. Pued
 msgid "Select the inventory that this host will belong to."
 msgstr "Seleccione el inventario al que pertenecerá este host."
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "Seleccionar el playbook a ser ejecutado por este trabajo."
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7103,7 +7150,7 @@ msgstr "Seleccione el proyecto que contiene el playbook que desea que ejecute es
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "Seleccione su suscripción a Ansible Automation Platform para utilizarla."
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "Seleccionar {0}"
 
@@ -7112,7 +7159,7 @@ msgstr "Seleccionar {0}"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7124,7 +7171,7 @@ msgstr "Seleccionar {0}"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7136,17 +7183,23 @@ msgstr "Seleccionar {0}"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr "Seleccionado"
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "Categoría seleccionada"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7173,7 +7226,7 @@ msgstr "Establecer un valor para este campo"
 msgid "Set how many days of data should be retained."
 msgstr "Establecer cuántos días de datos debería ser retenidos."
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "Establezca preferencias para la recopilación de datos, los logotipos y los inicios de sesión"
 
@@ -7189,19 +7242,19 @@ msgstr "Establecer la instancia en línea o fuera de línea. Si está fuera de l
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "Establecer como Público o Confidencial según cuán seguro sea el dispositivo del cliente."
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "Establecer tipo"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "Establecer selección del tipo"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "Establecer escritura anticipada del tipo"
 
@@ -7223,8 +7276,8 @@ msgstr "Nombre de la configuración"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr "Ajustes"
@@ -7236,9 +7289,9 @@ msgstr "Mostrar"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "Mostrar cambios"
 
@@ -7246,8 +7299,8 @@ msgstr "Mostrar cambios"
 #~ msgid "Show all groups"
 #~ msgstr "Mostrar todos los grupos"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "Mostrar cambios"
 
@@ -7260,7 +7313,7 @@ msgstr "Mostrar descripción"
 msgid "Show less"
 msgstr "Mostrar menos"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "Mostrar solo los grupos raíz"
 
@@ -7313,14 +7366,14 @@ msgstr "Selección de clave simple"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "Omitir etiquetas"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7341,15 +7394,15 @@ msgstr "La omisión de etiquetas resulta útil cuando tiene un playbook de gran 
 msgid "Skipped"
 msgstr "Omitido"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "Inventario inteligente"
@@ -7358,7 +7411,7 @@ msgstr "Inventario inteligente"
 msgid "Smart Inventory not found."
 msgstr "No se encontró el inventario inteligente."
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "Filtro de host inteligente"
@@ -7390,13 +7443,15 @@ msgstr "Ordenar"
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "Ordenar las preguntas"
+#~ msgid "Sort question order"
+#~ msgstr "Ordenar las preguntas"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "Fuente"
 
@@ -7405,12 +7460,12 @@ msgstr "Fuente"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "Rama de fuente de control"
 
@@ -7443,19 +7498,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr "Tipo de fuente de control"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "URL de fuente de control"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7469,8 +7524,8 @@ msgstr "Número de teléfono de la fuente"
 msgid "Source Variables"
 msgstr "Variables de fuente"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "Tarea del flujo de trabajo de origen"
 
@@ -7491,7 +7546,7 @@ msgstr "Número de teléfono de la fuente"
 msgid "Source variables"
 msgstr "Variables de fuente"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "Extraído de un proyecto"
 
@@ -7538,14 +7593,14 @@ msgstr "Pestaña de salida estándar"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "Iniciar"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "Hora de inicio"
 
@@ -7567,27 +7622,27 @@ msgstr "Iniciar proceso de sincronización"
 msgid "Start sync source"
 msgstr "Iniciar fuente de sincronización"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "Iniciado"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "Estado"
@@ -7617,14 +7672,14 @@ msgstr ""
 "la revisión especificada.\n"
 "Esto es equivalente a especificar el indicador --remote para la actualización del submódulo Git."
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "Subscripción"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "Detalles de la suscripción"
 
@@ -7640,11 +7695,11 @@ msgstr "Manifiesto de suscripción"
 msgid "Subscription selection modal"
 msgstr "Modal de selección de suscripción"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "Configuración de la suscripción"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "Tipo de suscripción"
 
@@ -7652,11 +7707,11 @@ msgstr "Tipo de suscripción"
 msgid "Subscriptions table"
 msgstr "Tabla de suscripciones"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversion"
 
@@ -7676,7 +7731,7 @@ msgstr "Mensaje de éxito"
 msgid "Success message body"
 msgstr "Cuerpo del mensaje de éxito"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7708,25 +7763,37 @@ msgstr "Domingo"
 msgid "Survey"
 msgstr "Encuesta"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "Lista de encuestas"
+#~ msgid "Survey List"
+#~ msgstr "Lista de encuestas"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "Vista previa de la encuesta"
+#~ msgid "Survey Preview"
+#~ msgstr "Vista previa de la encuesta"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "Alternancia de encuestas"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "Modal de vista previa de la encuesta"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "Preguntas de la encuesta"
+#~ msgid "Survey questions"
+#~ msgstr "Preguntas de la encuesta"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7764,15 +7831,15 @@ msgstr "Sincronizar para revisión"
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr "Sistema"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "Administrador del sistema"
@@ -7787,8 +7854,8 @@ msgstr "Auditor del sistema"
 msgid "System Warning"
 msgstr "Advertencia del sistema"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "Los administradores del sistema tienen acceso ilimitado a todos los recursos."
 
@@ -7796,7 +7863,7 @@ msgstr "Los administradores del sistema tienen acceso ilimitado a todos los recu
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "Configuración de TACACS+"
 
@@ -7805,7 +7872,7 @@ msgstr "Configuración de TACACS+"
 msgid "Tabs"
 msgstr "Pestañas"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7860,7 +7927,7 @@ msgid "Team"
 msgstr "Equipo"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr "Roles de equipo"
 
@@ -7871,19 +7938,19 @@ msgstr "No se encontró la tarea."
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7894,12 +7961,12 @@ msgstr "Equipos"
 msgid "Template not found."
 msgstr "No se encontró la plantilla."
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7928,12 +7995,12 @@ msgstr "Probar notificación"
 msgid "Test passed"
 msgstr "Prueba superada"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "Texto"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "Área de texto"
 
@@ -7968,7 +8035,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr "La cantidad de tiempo (en segundos) antes de que la notificación de correo electrónico deje de intentar conectarse con el host y caduque el tiempo de espera. Rangos de 1 a 120 segundos."
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8015,7 +8082,7 @@ msgid ""
 "documentation for more details."
 msgstr "La cantidad máxima de hosts que puede administrar esta organización. El valor predeterminado es 0, que significa sin límite. Consulte la documentación de Ansible para obtener más información detallada."
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8024,16 +8091,16 @@ msgid ""
 "with a change to"
 msgstr "La cantidad de procesos paralelos o simultáneos para utilizar durante la ejecución del playbook. Un valor vacío, o un valor menor que 1, usará el valor predeterminado de Ansible que normalmente es 5. La cantidad predeterminada de bifurcaciones puede sobreescribirse con un cambio a"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "La cantidad de procesos paralelos o simultáneos para utilizar durante la ejecución del playbook. Si no ingresa un valor, se utilizará el valor predeterminado del archivo de configuración de Ansible.  Para obtener más información,"
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "No se pudo encontrar la página solicitada."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "El patrón utilizado para dirigir los hosts en el inventario. Si se deja el campo en blanco, todos y * se dirigirán a todos los hosts del inventario. Para encontrar más información sobre los patrones de hosts de Ansible,"
 
@@ -8072,7 +8139,7 @@ msgstr "El formato sugerido para los nombres de variables es minúsculas y separ
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8106,19 +8173,19 @@ msgstr "Se produjo un error al guardar el flujo de trabajo."
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "Estos son los niveles de detalle para la ejecución de comandos estándar que se admiten."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "Estos argumentos se utilizan con el módulo especificado."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "Estos argumentos se utilizan con el módulo especificado. Para encontrar información sobre {0}, haga clic en"
 
@@ -8126,21 +8193,21 @@ msgstr "Estos argumentos se utilizan con el módulo especificado. Para encontrar
 msgid "Third"
 msgstr "Tercero"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "Este proyecto debe actualizarse"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "Esta acción eliminará lo siguiente:"
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "Esta acción disociará todos los roles de este usuario de los equipos seleccionados."
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "Esta acción disociará el siguiente rol de {0}:"
 
@@ -8239,7 +8306,7 @@ msgid "This field must be greater than 0"
 msgstr "Este campo debe ser mayor que 0"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8291,7 +8358,7 @@ msgstr "Esta es la única vez que se mostrará el valor del token y el valor del
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "Esta plantilla de trabajo está siendo utilizada por otros recursos. ¿Está seguro de que desea eliminarla?"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "Esta organización está siendo utilizada por otros recursos. ¿Está seguro de que desea eliminarla?"
 
@@ -8303,11 +8370,11 @@ msgstr "Este proyecto está siendo utilizado por otros recursos. ¿Está seguro 
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "Este proyecto se está sincronizando y no se puede hacer clic en él hasta que el proceso de sincronización se haya completado"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "Falta un inventario en esta programación"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "Faltan los valores de la encuesta requeridos en esta programación"
 
@@ -8342,8 +8409,8 @@ msgstr "Jue"
 msgid "Thursday"
 msgstr "Jueves"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8377,7 +8444,7 @@ msgstr "Tiempo de espera agotado"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "Tiempo de espera"
 
@@ -8388,6 +8455,10 @@ msgstr "Tiempo de espera en minutos"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "Tiempo de espera en segundos"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8455,11 +8526,11 @@ msgid "Token not found."
 msgstr "No se encontró el token."
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "Tokens"
@@ -8472,8 +8543,8 @@ msgstr "Herramientas"
 msgid "Top Pagination"
 msgstr "Paginación superior"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "Tareas totales"
@@ -8496,20 +8567,20 @@ msgstr "Seguimiento de submódulos"
 msgid "Track submodules latest commit on branch"
 msgstr "Seguimiento del último commit de los submódulos en la rama"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "Prueba"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "Verdadero"
 
@@ -8522,55 +8593,57 @@ msgstr "Mar"
 msgid "Tuesday"
 msgstr "Martes"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "Tipo"
@@ -8614,7 +8687,7 @@ msgstr "Deshacer"
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "Ilimitado"
 
@@ -8631,7 +8704,7 @@ msgstr "Recuento de hosts inaccesibles"
 msgid "Unreachable Hosts"
 msgstr "Host inaccesibles"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "Cadena de días no reconocida"
 
@@ -8668,7 +8741,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8707,7 +8780,7 @@ msgstr ""
 "Utilice los mensajes personalizados para cambiar el contenido de las notificaciones enviadas cuando una tarea se inicie, se realice correctamente o falle. Utilice llaves\n"
 "para acceder a la información sobre la tarea:"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8726,17 +8799,17 @@ msgstr "Usuario"
 msgid "User Details"
 msgstr "Detalles del usuario"
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr "Interfaz de usuario"
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "Configuración de la interfaz de usuario"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr "Roles de los usuarios"
 
@@ -8763,14 +8836,14 @@ msgstr "Detalles del usuario"
 msgid "User not found."
 msgstr "No se encontró el usuario."
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "Tokens de usuario"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8783,8 +8856,8 @@ msgstr "Tokens de usuario"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8797,16 +8870,16 @@ msgstr "Nombre de usuario/contraseña"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr "Usuarios"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -8817,7 +8890,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8827,10 +8900,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "Variables"
@@ -8851,21 +8924,21 @@ msgstr "Contraseña Vault | {credId}"
 msgid "Verbose"
 msgstr "Nivel de detalle"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "Nivel de detalle"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "Versión"
 
@@ -8912,7 +8985,7 @@ msgstr "Ver detalles del host del inventario"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "Ver ejemplos de JSON en <0>www.json.org</0>"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "Ver detalles de la tarea"
 
@@ -9025,7 +9098,7 @@ msgstr "Ver todos los hosts de inventario."
 msgid "View all Jobs"
 msgstr "Ver todas las tareas"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "Ver todas las tareas."
 
@@ -9088,7 +9161,7 @@ msgstr "Ver todas las configuraciones"
 msgid "View all tokens."
 msgstr "Ver todos los tokens."
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "Ver y modificar su información de suscripción"
 
@@ -9114,7 +9187,7 @@ msgid "View smart inventory host details"
 msgstr "Ver detalles del host de inventario inteligente"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr "Vistas"
 
@@ -9124,11 +9197,11 @@ msgstr "Vistas"
 msgid "Visualizer"
 msgstr "Visualizador"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "ADVERTENCIA:"
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9152,8 +9225,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "No pudimos localizar las suscripciones asociadas a esta cuenta."
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9193,7 +9266,7 @@ msgstr "Servicio de Webhook"
 msgid "Webhook URL"
 msgstr "URL de Webhook"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Detalles de Webhook"
@@ -9222,7 +9295,7 @@ msgstr "Mié"
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "Semana"
 
@@ -9271,26 +9344,26 @@ msgid "Workflow Approval not found."
 msgstr "No se encontró la aprobación del flujo de trabajo."
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "Aprobaciones del flujo de trabajo"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "Tarea en flujo de trabajo"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9311,8 +9384,8 @@ msgstr "Plantillas de trabajos de flujo de trabajo"
 msgid "Workflow Link"
 msgstr "Enlace del flujo de trabajo"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "Plantilla de flujo de trabajo"
 
@@ -9381,7 +9454,7 @@ msgstr "Escribir"
 msgid "YAML:"
 msgstr "YAML:"
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "Año"
 
@@ -9397,11 +9470,11 @@ msgstr "No puede realizar ninguna acción sobre las siguientes aprobaciones del 
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "No puede realizar ninguna acción sobre las siguientes aprobaciones del flujo de trabajo: {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "No se pueden seleccionar varias credenciales con el mismo ID de Vault, ya que anulará automáticamente la selección de la otra con el mismo ID de Vault."
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "No tiene permiso para eliminar los siguientes grupos: {itemsUnableToDelete}"
 
@@ -9437,19 +9510,19 @@ msgstr "Acercar"
 msgid "Zoom Out"
 msgstr "Alejar"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "se generará una nueva clave de Webhook al guardar."
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "se generará una nueva URL de Webhook al guardar."
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "acciones"
+#~ msgid "actions"
+#~ msgstr "acciones"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9465,7 +9538,7 @@ msgid "brand logo"
 msgstr "logotipo de la marca"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr "cancelar eliminación"
 
@@ -9473,17 +9546,17 @@ msgstr "cancelar eliminación"
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "comando"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr "confirmar eliminación"
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "confirmar disociación"
 
@@ -9517,16 +9590,16 @@ msgstr "documentación"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "modificar"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "cifrado"
 
@@ -9538,16 +9611,16 @@ msgstr "para obtener más información."
 msgid "for more information."
 msgstr "para obtener más información."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "aquí"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "aquí."
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "hosts"
 
@@ -9568,12 +9641,12 @@ msgid "min"
 msgstr "min"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "bajar"
+#~ msgid "move down"
+#~ msgstr "bajar"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "subir"
+#~ msgid "move up"
+#~ msgstr "subir"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9584,7 +9657,7 @@ msgstr "nueva elección"
 msgid "of"
 msgstr "de"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "opción a"
 
@@ -9613,15 +9686,15 @@ msgstr "seg"
 msgid "seconds"
 msgstr "segundos"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "seleccionar módulo"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "seleccionar nivel de detalle"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9629,7 +9702,7 @@ msgstr ""
 msgid "social login"
 msgstr "inicio de sesión social"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "rama de fuente de control"
@@ -9642,7 +9715,7 @@ msgstr "sistema"
 msgid "timed out"
 msgstr "agotado"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "alternar cambios"
 
@@ -9662,39 +9735,39 @@ msgstr "{0, plural, one {¿Está seguro de que desea eliminar el siguiente grupo
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {¿Borrar grupo?} other {¿Borrar grupos?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {El inventario estará en estado pendiente hasta que se procese la eliminación final.} other {Los inventarios estarán en estado pendiente hasta que se procese la eliminación final.}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {No se puede eliminar la tarea seleccionada debido a permisos insuficientes o a que la tarea se está ejecutando} other {No se pueden eliminar las tareas seleccionadas debido a permisos insuficientes o a que las tareas se están ejecutando}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {No se puede eliminar esta aprobación debido a permisos insuficientes o a que la tarea está pendiente} other {No se pueden eliminar estas aprobaciones debido a permisos insuficientes o a que las tareas están pendientes}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Esta credencial está siendo utilizada por otros recursos. ¿Está seguro de que desea eliminarla?} other {Eliminar estas credenciales podría afectar a otros recursos que dependen de ellas. ¿Está seguro de que desea eliminarlas de todos modos?}}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Este tipo de credencial está siendo utilizado por algunas credenciales y no se puede eliminar.} other {No se pueden eliminar los tipos de credencial que están siendo utilizados por credenciales. ¿Está seguro de que desea eliminarlos de todos modos?}}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {Este entorno de ejecución está siendo utilizado por otros recursos. ¿Estás seguro de que desea eliminarlo?} other {Estos entornos de ejecución podrían estar siendo utilizados por otros recursos que dependen de ellos. ¿Está seguro de que desea eliminarlos de todos modos?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Este grupo de instancias está siendo utilizado por otros recursos. ¿Está seguro de que desea eliminarlo?} other {Eliminar estos grupos de instancia podría afectar a otros recursos que dependen de ellos. ¿Está seguro de que desea eliminarlos de todos modos?}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Este inventario está siendo utilizado actualmente por algunas plantillas. ¿Estás seguro de que desea eliminarlo?} other {Eliminar estos inventarios podría afectar a algunas plantillas que dependen de ellos. ¿Está seguro de que desea eliminarlos de todos modos?}}"
 
@@ -9702,15 +9775,15 @@ msgstr "{0, plural, one {Este inventario está siendo utilizado actualmente por 
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {Esta fuente de inventario está siendo utilizada por otros recursos que dependen de ella. ¿Estás seguro de que desea eliminarla?} other {Eliminar estas fuentes de inventario podría afectar a otros recursos que dependen de ellas. ¿Está seguro de que desea eliminarlas de todos modos?}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Esta organización está siendo utilizada por otros recursos. ¿Está seguro de que desea eliminarla?} other {Eliminar estas organizaciones podría afectar a otros recursos que dependen de ellas. ¿Está seguro de que desea eliminarlas de todos modos?}}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Este proyecto está siendo utilizado por otros recursos. ¿Está seguro de que desea eliminarlo?} other {Eliminar estos proyectos podría afectar a otros recursos que dependen de ellos. ¿Está seguro de que desea eliminarlos de todos modos?}}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Esta plantilla está siendo utilizada por algunos nodos del flujo de trabajo. ¿Está seguro de que desea eliminarla?} other {Eliminar estas plantillas podría afectar a algunos nodos del flujo de trabajo que dependen de ellas. ¿Está seguro de que desea eliminarlas de todos modos?}}"
 
@@ -9799,8 +9872,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/fr/messages.po
+++ b/awx/ui/src/locales/fr/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (project root)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0 (Normal)"
 
@@ -59,7 +59,7 @@ msgstr "1 (info)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1 (Verbeux)"
 
@@ -75,7 +75,7 @@ msgstr "2 (Déboguer)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2 (Verbeux +)"
 
@@ -86,7 +86,7 @@ msgstr "2 (Verbeux +)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3 (Déboguer)"
 
@@ -97,7 +97,7 @@ msgstr "3 (Déboguer)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4 (Débogage de la connexion)"
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr "À propos de "
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr "Token de compte"
 msgid "Action"
 msgstr "Action"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "Actions"
@@ -235,8 +238,8 @@ msgstr "Actions"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr "Activité"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "Flux d’activité"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "Sélecteur de type de flux d'activité"
 
@@ -297,35 +300,35 @@ msgstr "Ajouter un nouveau noeud"
 msgid "Add a new node between these two nodes"
 msgstr "Ajouter un nouveau nœud entre ces deux nœuds"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "Ajouter un groupe de conteneurs"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "Ajouter un groupe existant"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "Ajouter une hôte existant"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "Ajouter un groupe d'instances"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "Ajouter un inventaire"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "Ajouter un modèle de job"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "Ajouter un nouveau groupe"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "Ajouter un nouvel hôte"
 
@@ -333,24 +336,24 @@ msgstr "Ajouter un nouvel hôte"
 msgid "Add resource type"
 msgstr "Ajouter un type de ressource"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "Ajouter un inventaire smart"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "Ajouter les permissions de l'équipe"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "Ajouter les permissions de l’utilisateur"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "Ajouter un modèle de flux de travail"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr "Administration"
 
@@ -359,11 +362,11 @@ msgstr "Administration"
 msgid "Advanced"
 msgstr "Avancé"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "Documentation sur la recherche avancée"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "Saisie de la valeur de la recherche avancée"
 
@@ -423,7 +426,7 @@ msgstr "Liste des URI autorisés, séparés par des espaces"
 msgid "Always"
 msgstr "Toujours"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -435,7 +438,7 @@ msgstr "Une erreur est survenue"
 msgid "An inventory must be selected"
 msgstr "Un inventaire doit être sélectionné"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -456,13 +459,13 @@ msgstr "Nom de variable de réponse"
 msgid "Any"
 msgstr "Quelconque"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "Application"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr "Informations sur l’application"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "Nom de l'application"
 
@@ -480,17 +483,17 @@ msgstr "Nom de l'application"
 msgid "Application not found."
 msgstr "Application non trouvée."
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr "Applications"
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "Applications & Jetons"
 
@@ -562,11 +565,11 @@ msgstr "Êtes-vous sûr de vouloir supprimer ce lien ?"
 msgid "Are you sure you want to remove this node?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce nœud ?"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr "Êtes-vous sûr de vouloir supprimer l'accès {0} de {1} ?  Cela affectera tous les membres de l'équipe."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Etes-vous sûr de vouloir supprimer l'accès à {0} de {username} ?"
 
@@ -574,26 +577,26 @@ msgstr "Etes-vous sûr de vouloir supprimer l'accès à {0} de {username} ?"
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Voulez-vous vraiment demander l'annulation de ce job ?"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "Arguments"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "Artefacts"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "Associé"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "Erreur de rôle d’associé"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "Association modale"
 
@@ -605,7 +608,7 @@ msgstr "Au moins une valeur doit être sélectionnée pour ce champ."
 msgid "August"
 msgstr "Août"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -626,7 +629,7 @@ msgstr "Auto"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Paramètres AD Azure"
 
@@ -660,12 +663,16 @@ msgstr "Retour aux groupes"
 msgid "Back to Hosts"
 msgstr "Retour aux hôtes"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "Retour aux inventaires"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "Retour Jobs"
 
@@ -695,7 +702,7 @@ msgstr "Retour aux horaires"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr "Retour aux environnements d'exécution"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "Retour aux groupes d'instances"
 
@@ -747,7 +753,7 @@ msgstr "Retour aux groupes d'instances"
 msgid "Back to management jobs"
 msgstr "Retour aux Jobs de gestion"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr "Branche à extraire.  En plus des branches, vous pouvez saisir des balises, des hachages de validation et des références arbitraires.  Certains hachages et références de validation peuvent ne pas être disponibles à moins que vous ne fournissiez également une refspec personnalisée."
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr "Brand Image"
 
@@ -805,8 +811,8 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr "Expiration du délai d’attente du cache (secondes)"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -883,7 +890,7 @@ msgstr "Annuler les changements de liens"
 msgid "Cancel link removal"
 msgstr "Annuler la suppression d'un lien"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "Annuler la recherche"
 
@@ -908,13 +915,13 @@ msgstr "Annuler les jobs sélectionnés"
 msgid "Cancel subscription edit"
 msgstr "Annuler l'édition de l'abonnement"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "Annuler {0}"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -928,37 +935,37 @@ msgid ""
 "logging aggregator host and logging aggregator type."
 msgstr "Impossible d'activer l'agrégateur de logs sans fournir l'hôte de l'agrégateur de logs et le type d'agrégateur de logs."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "Capacité"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "La version non sensible à la casse de contains"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "Version non sensible à la casse de endswith."
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "Version non sensible à la casse de exact."
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "Version non sensible à la casse de regex"
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "Version non sensible à la casse de startswith."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -980,15 +987,15 @@ msgid "Channel"
 msgstr "Canal"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "Vérifier"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "Vérifiez si le champ donné ou l'objet connexe est nul ; attendez-vous à une valeur booléenne."
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "Vérifiez si la valeur du champ donné est présente dans la liste fournie ; attendez-vous à une liste d'éléments séparés par des virgules."
 
@@ -1000,7 +1007,7 @@ msgstr "Choisissez un fichier .json"
 msgid "Choose a Notification Type"
 msgstr "Choisissez un type de notification"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "Choisissez un répertoire Playbook"
 
@@ -1013,11 +1020,11 @@ msgid "Choose a Webhook Service"
 msgstr "Choisir un service de webhook"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "Choisir un type de job"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "Choisissez un module"
 
@@ -1040,7 +1047,7 @@ msgstr "Spécifiez le type de format ou de type de réponse que vous souhaitez p
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "Choisissez les rôles à appliquer aux ressources sélectionnées.  Notez que tous les rôles sélectionnés seront appliqués à toutes les ressources sélectionnées."
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "Choisissez les ressources qui recevront de nouveaux rôles.  Vous pourrez sélectionner les rôles à postuler lors de l'étape suivante.  Notez que les ressources choisies ici recevront tous les rôles choisis à l'étape suivante."
 
@@ -1085,6 +1092,10 @@ msgstr "Cliquez sur ce bouton pour vérifier la connexion au système de gestion
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "Cliquez pour créer un nouveau lien vers ce nœud."
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1133,13 +1144,13 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr "Effondrement"
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "Commande"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "Conforme"
 
@@ -1147,7 +1158,7 @@ msgstr "Conforme"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "Jobs parallèles"
 
@@ -1178,11 +1189,11 @@ msgstr "Confirmer l'annulation du job"
 msgid "Confirm cancellation"
 msgstr "Confirmer l'annulation"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "Confirmer la suppression"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "Confirmer dissocier"
 
@@ -1206,7 +1217,7 @@ msgstr "Confirmer annuler tout"
 msgid "Confirm selection"
 msgstr "Confirmer la sélection"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "Groupe de conteneurs"
 
@@ -1241,7 +1252,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr "Contrôlez le niveau de sortie qu’Ansible génère lors de l’exécution du playbook."
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1294,11 +1305,11 @@ msgstr "Copier le modèle"
 msgid "Copy full revision to clipboard."
 msgstr "Copier la révision complète dans le Presse-papiers."
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "Copyright"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "Créer"
@@ -1411,14 +1422,14 @@ msgstr "Créer une nouvelle source"
 msgid "Create user token"
 msgstr "Créer un jeton d'utilisateur"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1428,7 +1439,7 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1437,58 +1448,58 @@ msgstr "Créer un jeton d'utilisateur"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr "Créé"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "Créé par (Nom d'utilisateur)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "Créé par (nom d'utilisateur)"
 
@@ -1518,7 +1529,7 @@ msgstr "Information d’identification"
 msgid "Credential Input Sources"
 msgstr "Sources en entrée des informations d'identification"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "Nom d’identification"
 
@@ -1529,9 +1540,9 @@ msgid "Credential Type"
 msgstr "Type d'informations d’identification"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1557,24 +1568,24 @@ msgstr "Identifiant pour s'authentifier auprès d'un registre de conteneur prot�
 msgid "Credential type not found."
 msgstr "Type d'informations d’identification non trouvé."
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr "Informations d’identification"
@@ -1625,7 +1636,7 @@ msgstr "SUPPRIMÉ"
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "Tableau de bord (toutes les activités)"
 
@@ -1639,12 +1650,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "Jour"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "Nombre de jours pendant lesquels on peut conserver les données"
 
@@ -1652,7 +1663,7 @@ msgstr "Nombre de jours pendant lesquels on peut conserver les données"
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "Jours restants"
 
@@ -1669,12 +1680,20 @@ msgid "December"
 msgstr "Décembre"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "Par défaut"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "Environnement d'exécution par défaut"
 
@@ -1684,7 +1703,7 @@ msgstr "Environnement d'exécution par défaut"
 msgid "Default answer"
 msgstr "Réponse par défaut"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "Définir les fonctions et fonctionnalités niveau système"
 
@@ -1698,8 +1717,8 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1707,7 +1726,7 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1715,15 +1734,15 @@ msgstr "Définir les fonctions et fonctionnalités niveau système"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1752,7 +1771,7 @@ msgstr "Supprimer l'hôte"
 msgid "Delete Inventory"
 msgstr "Supprimer l’inventaire"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1766,7 +1785,7 @@ msgstr "Modèle de découpage de Job"
 msgid "Delete Notification"
 msgstr "Supprimer la notification"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "Supprimer l'organisation"
 
@@ -1774,15 +1793,15 @@ msgstr "Supprimer l'organisation"
 msgid "Delete Project"
 msgstr "Suppression du projet"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "Supprimer les questions"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "Supprimer la programmation"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "Supprimer le questionnaire"
 
@@ -1836,6 +1855,10 @@ msgstr "Supprimer la source de l'inventaire"
 msgid "Delete smart inventory"
 msgstr "Supprimer l'inventaire smart"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1867,16 +1890,16 @@ msgstr "Supprimer  {pluralizedItemName} ?"
 msgid "Deleted"
 msgstr "Supprimé"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "Erreur de suppression"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "Erreur de suppression"
 
@@ -1906,34 +1929,34 @@ msgid "Deprecated"
 msgstr "Obsolète"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1941,36 +1964,36 @@ msgstr "Obsolète"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr "Description"
 
@@ -2023,7 +2046,7 @@ msgstr "Canaux ou utilisateurs de destination"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2109,39 +2132,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "Dissocier"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "Dissocier le groupe de l'hôte ?"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "Dissocier Hôte du Groupe"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "Dissocier l'instance du groupe d'instances ?"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "Dissocier le(s) groupe(s) lié(s) ?"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "Dissocier la ou les équipes liées ?"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "Dissocier le rôle"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "Dissocier le rôle !"
 
@@ -2154,7 +2177,7 @@ msgstr "Dissocier ?"
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2219,8 +2242,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr "Chaque fois qu’un job s’exécute avec ce projet, réalisez une mise à jour du projet avant de démarrer le job."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2239,8 +2262,8 @@ msgstr "Chaque fois qu’un job s’exécute avec ce projet, réalisez une mise 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2262,7 +2285,7 @@ msgstr "Chaque fois qu’un job s’exécute avec ce projet, réalisez une mise 
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2338,8 +2361,8 @@ msgstr "Modifier l'environnement d'exécution"
 msgid "Edit Group"
 msgstr "Modifier le groupe"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2368,6 +2391,10 @@ msgstr "Modifier le nœud"
 msgid "Edit Notification Template"
 msgstr "Modèle de notification de modification"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2392,7 +2419,7 @@ msgstr "Modifier la programmation"
 msgid "Edit Source"
 msgstr "Modifier la source"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2480,8 +2507,8 @@ msgstr "Temps écoulé"
 msgid "Elapsed time that the job ran"
 msgstr "Temps écoulé (en secondes) pendant lequel la tâche s'est exécutée."
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2495,7 +2522,7 @@ msgstr "Options d'email"
 msgid "Enable Concurrent Jobs"
 msgstr "Activer les tâches parallèles"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "Utiliser le cache des faits"
 
@@ -2503,8 +2530,8 @@ msgstr "Utiliser le cache des faits"
 msgid "Enable HTTPS certificate verification"
 msgstr "Activer/désactiver la vérification de certificat HTTPS"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2522,8 +2549,8 @@ msgstr "Activer la journalisation externe"
 msgid "Enable log system tracking facts individually"
 msgstr "Activer le système de journalisation traçant des facts individuellement"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "Activer l’élévation des privilèges"
 
@@ -2531,15 +2558,15 @@ msgstr "Activer l’élévation des privilèges"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "Activez le webhook pour ce modèle de tâche."
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "Activé"
@@ -2574,7 +2601,7 @@ msgstr "Variable activée"
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2586,7 +2613,7 @@ msgstr ""
 "et demander une mise à jour de la configuration en utilisant ce\n"
 "modèle de job."
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2608,7 +2635,7 @@ msgstr "Fin"
 msgid "End User License Agreement"
 msgstr "Contrat de licence utilisateur"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "La fin ne correspondait pas à une valeur attendue"
 
@@ -2714,21 +2741,21 @@ msgstr "Entrez des variables pour configurer la source d'inventaire. Pour une de
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "Entrez les variables avec la syntaxe JSON ou YAML. Utilisez le bouton radio pour basculer entre les deux."
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "Erreur"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2752,41 +2779,41 @@ msgstr "Erreur lors de la sauvegarde du flux de travail !"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2794,21 +2821,21 @@ msgstr "Erreur lors de la sauvegarde du flux de travail !"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2818,17 +2845,17 @@ msgstr "Erreur lors de la sauvegarde du flux de travail !"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "Erreur !"
 
@@ -2836,7 +2863,7 @@ msgstr "Erreur !"
 msgid "Error:"
 msgstr "Erreur :"
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2854,15 +2881,19 @@ msgstr "Détail de l'événement modal"
 msgid "Event summary not available"
 msgstr "Récapitulatif de l’événement non disponible"
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "Événements"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "Correspondance exacte (recherche par défaut si non spécifiée)."
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2898,15 +2929,15 @@ msgstr "Exécuter lorsque le nœud parent se trouve dans un état de défaillanc
 msgid "Execute when the parent node results in a successful state."
 msgstr "Exécuter lorsque le nœud parent se trouve dans un état de réussite."
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "Environnement d'exécution"
 
@@ -2915,22 +2946,22 @@ msgstr "Environnement d'exécution"
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "Environnements d'exécution"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "Nœud d'exécution"
 
@@ -2964,24 +2995,24 @@ msgstr "Développer l'entrée"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "On s'attendait à ce qu'au moins un des éléments suivants soit présent dans le fichier : client_email, project_id ou private_key."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "Expire"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "Expire le"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "Expire UTC"
 
@@ -2990,7 +3021,7 @@ msgstr "Expire UTC"
 msgid "Expires on {0}"
 msgstr "Expire le {0}"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "Explication"
@@ -2999,8 +3030,8 @@ msgstr "Explication"
 msgid "External Secret Management System"
 msgstr "Système externe de gestion des secrets"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "Variables supplémentaires"
 
@@ -3025,7 +3056,7 @@ msgstr ""
 msgid "Facts"
 msgstr "Faits"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3051,7 +3082,7 @@ msgstr "Échec des hôtes"
 msgid "Failed jobs"
 msgstr "Jobs ayant échoué"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "N'a pas approuvé un ou plusieurs flux de travail."
 
@@ -3059,21 +3090,21 @@ msgstr "N'a pas approuvé un ou plusieurs flux de travail."
 msgid "Failed to approve workflow approval."
 msgstr "N'a pas approuvé le flux de travail."
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "Impossible d'assigner les rôles correctement"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "N'a pas réussi à associer le rôle"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "N'a pas réussi à associer."
 
@@ -3086,12 +3117,12 @@ msgstr "N'a pas réussi à annuler la synchronisation des sources d'inventaire."
 msgid "Failed to cancel Project Sync"
 msgstr "Échec de l'annulation de Project Sync"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs"
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "Échec de l'annulation {0}"
@@ -3150,19 +3181,19 @@ msgstr "N'a pas réussi à supprimer le modèle de Job."
 msgid "Failed to delete notification."
 msgstr "N'a pas réussi à supprimer la notification."
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "N'a pas réussi à supprimer une ou plusieurs applications"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "N'a pas réussi à supprimer un ou plusieurs types d’identifiants."
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "N'a pas réussi à supprimer un ou plusieurs identifiants."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "Échec de la suppression d'un ou plusieurs environnements d'exécution"
 
@@ -3170,16 +3201,16 @@ msgstr "Échec de la suppression d'un ou plusieurs environnements d'exécution"
 msgid "Failed to delete one or more groups."
 msgstr "N'a pas réussi à supprimer un ou plusieurs groupes."
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "N'a pas réussi à supprimer un ou plusieurs hôtes."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "N'a pas réussi à supprimer un ou plusieurs groupes d'instances."
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "N'a pas réussi à supprimer un ou plusieurs inventaires."
 
@@ -3187,55 +3218,55 @@ msgstr "N'a pas réussi à supprimer un ou plusieurs inventaires."
 msgid "Failed to delete one or more inventory sources."
 msgstr "N'a pas réussi à supprimer une ou plusieurs sources d'inventaire."
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles de Jobs."
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "N'a pas réussi à supprimer un ou plusieurs Jobs."
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles de notification."
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "N'a pas réussi à supprimer une ou plusieurs organisations."
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "N'a pas réussi à supprimer un ou plusieurs projets."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "N'a pas réussi à supprimer une ou plusieurs progammations."
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "N'a pas réussi à supprimer une ou plusieurs équipes."
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "N'a pas réussi à supprimer un ou plusieurs modèles."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "N'a pas réussi à supprimer un ou plusieurs jetons."
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "N'a pas réussi à supprimer un ou plusieurs jetons d'utilisateur."
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "N'a pas réussi à supprimer un ou plusieurs utilisateurs."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "N'a pas réussi à supprimer une ou plusieurs approbations de flux de travail."
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "N'a pas réussi à supprimer l'organisation."
 
@@ -3243,16 +3274,16 @@ msgstr "N'a pas réussi à supprimer l'organisation."
 msgid "Failed to delete project."
 msgstr "N'a pas réussi à supprimer le projet."
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "N'a pas réussi à supprimer le rôle"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "N'a pas réussi à supprimer le rôle."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "N'a pas réussi à supprimer la programmation."
 
@@ -3281,7 +3312,7 @@ msgstr "N'a pas réussi à supprimer le modèle de flux de travail."
 msgid "Failed to delete {name}."
 msgstr "Échec de la suppression de {nom}."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "N'a pas refusé d'approuver un ou plusieurs flux de travail."
 
@@ -3289,21 +3320,21 @@ msgstr "N'a pas refusé d'approuver un ou plusieurs flux de travail."
 msgid "Failed to deny workflow approval."
 msgstr "N'a pas refusé l'approbation du flux de travail."
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "N'a pas réussi à dissocier un ou plusieurs groupes."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "N'a pas réussi à dissocier un ou plusieurs hôtes."
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "N'a pas réussi à dissocier une ou plusieurs instances."
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "N'a pas réussi à dissocier une ou plusieurs équipes."
 
@@ -3311,13 +3342,13 @@ msgstr "N'a pas réussi à dissocier une ou plusieurs équipes."
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "Impossible de récupérer les paramètres de configuration de connexion personnalisés.  Les paramètres par défaut du système seront affichés à la place."
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "Echec du lancement du Job."
 
@@ -3357,7 +3388,7 @@ msgstr "Impossible de changer d'hôte."
 msgid "Failed to toggle instance."
 msgstr "N'a pas réussi à faire basculer l'instance."
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "N'a pas réussi à basculer la notification."
 
@@ -3388,7 +3419,7 @@ msgstr "Échec"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "Faux"
 
@@ -3396,11 +3427,11 @@ msgstr "Faux"
 msgid "February"
 msgstr "Février"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "Le champ contient une valeur."
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "Le champ se termine par une valeur."
 
@@ -3408,11 +3439,11 @@ msgstr "Le champ se termine par une valeur."
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "Champ permettant de passer une spécification de pod Kubernetes ou OpenShift personnalisée."
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "Le champ correspond à l'expression régulière donnée."
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "Le champ commence par la valeur."
 
@@ -3428,16 +3459,16 @@ msgstr "Écart entre les fichiers"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "Téléchargement de fichier rejeté. Veuillez sélectionner un seul fichier .json."
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "Fichier, répertoire ou script"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "Heure de Fin"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "Terminé"
@@ -3448,25 +3479,25 @@ msgstr "Première"
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "Prénom"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "Première exécution"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "Prénom"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "Tout d'abord, sélectionnez une clé"
 
@@ -3482,7 +3513,7 @@ msgstr "Flottement"
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3501,11 +3532,11 @@ msgstr "Pour les modèles de job, sélectionner «run» (exécuter) pour exécut
 msgid "For more information, refer to the"
 msgstr "Pour plus d'informations, reportez-vous à"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "Forks"
 
@@ -3513,12 +3544,12 @@ msgstr "Forks"
 msgid "Fourth"
 msgstr "Quatrième"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "Informations sur la fréquence"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "La fréquence ne correspondait pas à une valeur attendue"
 
@@ -3531,11 +3562,11 @@ msgstr "Ven."
 msgid "Friday"
 msgstr "Vendredi"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3560,11 +3591,11 @@ msgstr "Obtenir un abonnement"
 msgid "Get subscriptions"
 msgstr "Obtenir des abonnements"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3603,7 +3634,7 @@ msgstr "Organisation GitHub"
 msgid "GitHub Team"
 msgstr "GitHub Team"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "Paramètres de GitHub"
 
@@ -3612,7 +3643,7 @@ msgstr "Paramètres de GitHub"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "Environnement d'exécution global par défaut"
 
@@ -3641,11 +3672,11 @@ msgstr "Allez à la page suivante de la liste"
 msgid "Go to previous page"
 msgstr "Obtenir la page précédente"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Paramètres de Google OAuth 2"
 
@@ -3653,8 +3684,8 @@ msgstr "Paramètres de Google OAuth 2"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3667,15 +3698,15 @@ msgstr "Clé API Grafana"
 msgid "Grafana URL"
 msgstr "URL Grafana"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "Supérieur à la comparaison."
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "Supérieur ou égal à la comparaison."
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "Groupe"
 
@@ -3683,20 +3714,20 @@ msgstr "Groupe"
 msgid "Group details"
 msgstr "Détails du groupe"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "Type de groupe"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "Groupes"
@@ -3724,8 +3755,8 @@ msgstr "Masquer"
 msgid "Hide description"
 msgstr "Masquer la description"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "HipChat"
 
@@ -3744,7 +3775,7 @@ msgstr "Désynchronisation des hôtes OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "Clé de configuration de l’hôte"
 
@@ -3815,20 +3846,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas disponibles."
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3836,30 +3867,30 @@ msgstr "Les informations relatives au statut d'hôte pour ce Job ne sont pas dis
 msgid "Hosts"
 msgstr "Hôtes"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "Hôtes disponibles"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "Hôtes restants"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "Heure"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3879,8 +3910,8 @@ msgstr "ID du tableau de bord (facultatif)"
 msgid "ID of the panel (optional)"
 msgstr "ID du panneau (facultatif)"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -3937,7 +3968,7 @@ msgid ""
 "default group for the inventory."
 msgstr "Si cochés, tous les hôtes et groupes qui étaient présent auparavant sur la source externe, mais qui sont maintenant supprimés, seront supprimés de l'inventaire. Les hôtes et les groupes qui n'étaient pas gérés par la source de l'inventaire seront promus au prochain groupe créé manuellement ou s'il n'y a pas de groupe créé manuellement dans lequel les promouvoir, ils devront rester dans le groupe \"all\" par défaut de cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3950,18 +3981,18 @@ msgid ""
 "--diff mode."
 msgstr "Si activé, afficher les changements faits par les tâches Ansible, si supporté. C'est équivalent au mode --diff d’Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr "Si activé, afficher les changements faits par les tâches Ansible, si supporté. C'est équivalent au mode --diff d’Ansible."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "Si activé, afficher les changements faits par les tâches Ansible, si supporté. C'est équivalent au mode --diff d’Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3971,7 +4002,7 @@ msgstr "Si activé, il sera possible d’avoir des exécutions de ce modèle de 
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "Si activé, il sera possible d’avoir des exécutions de ce modèle de job de flux de travail en simultané."
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3982,7 +4013,7 @@ msgstr "Si cette option est activée, les données recueillies seront stockées 
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "Si vous êtes prêt à mettre à niveau ou à renouveler, veuillez <0>nous contacter.</0>"
 
@@ -3992,7 +4023,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr "Si vous ne disposez pas d'un abonnement, vous pouvez vous rendre sur le site de Red Hat pour obtenir un abonnement d'essai."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "Si vous souhaitez uniquement supprimer l'accès de cet utilisateur particulier, veuillez le supprimer de l'équipe."
 
@@ -4004,13 +4035,13 @@ msgid ""
 msgstr "Si vous voulez que la source de l'inventaire soit mise à jour au lancement et à la mise à jour du projet, cliquez sur Mettre à jour au lancement, et aller à"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "Image"
@@ -4034,13 +4065,13 @@ msgstr "Info"
 msgid "Initiated By"
 msgstr "Initié par"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "Initié par"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "Initié par (nom d'utilisateur)"
 
@@ -4067,7 +4098,7 @@ msgstr "Insights - Plateforme d'automatisation Ansible"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Insights - Tableau de bord de la plate-forme d'automatisation Ansible"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "ID du système Insights"
 
@@ -4079,18 +4110,18 @@ msgstr "Instance"
 msgid "Instance Filters"
 msgstr "Filtres de l'instance"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "Groupe d'instance"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4099,7 +4130,7 @@ msgstr "Groupe d'instance"
 msgid "Instance Groups"
 msgstr "Groupes d'instances"
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "ID d'instance"
 
@@ -4121,11 +4152,11 @@ msgid "Instance groups"
 msgstr "Groupes d'instances"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "Instances"
 
@@ -4155,11 +4186,11 @@ msgstr "Nom d’utilisateur et/ou mot de passe non valide. Veuillez réessayer."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4170,41 +4201,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Les inventaires et les sources ne peuvent pas être copiés"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "Inventaire (nom)"
 
@@ -4212,13 +4243,17 @@ msgstr "Inventaire (nom)"
 msgid "Inventory File"
 msgstr "Fichier d'inventaire"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "ID Inventaire"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "Sources d'inventaire"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4235,15 +4270,15 @@ msgstr "Erreur de synchronisation de la source de l'inventaire"
 msgid "Inventory Sources"
 msgstr "Sources d'inventaire"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "Sync Inventaires"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4288,7 +4323,7 @@ msgstr "Élément OK"
 msgid "Item Skipped"
 msgstr "Élément ignoré"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "Éléments"
@@ -4320,20 +4355,20 @@ msgstr "JSON :"
 msgid "January"
 msgstr "Janvier"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "Job"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "Erreur d'annulation d'un Job"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4347,19 +4382,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "Découpage de job"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "Découpage de job"
 
@@ -4371,20 +4406,20 @@ msgstr "Statut Job"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "Balises Job"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "Modèle de Job"
@@ -4409,15 +4444,15 @@ msgstr "Les modèles de Job dont l'inventaire ou le projet est manquant ne peuve
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Les modèles de Job dont les informations d'identification demandent un mot de passe ne peuvent pas être sélectionnés lors de la création ou de la modification de nœuds"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "Type de Job"
 
@@ -4430,15 +4465,15 @@ msgid "Job status graph tab"
 msgstr "Onglet Graphique de l'état des Jobs"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "Modèles de Jobs"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4453,7 +4488,7 @@ msgstr "Modèles de Jobs"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4461,7 +4496,7 @@ msgstr "Modèles de Jobs"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "Paramètres Job"
 
@@ -4473,19 +4508,19 @@ msgstr "Juillet"
 msgid "June"
 msgstr "Juin"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "Clé"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "Sélection de la clé"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "En-tête de la clé"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "Mot-clé "
 
@@ -4518,7 +4553,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "Défaut LDAP"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "Paramètres LDAP"
 
@@ -4542,18 +4577,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "Nom du label"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "Libellés"
@@ -4571,11 +4606,11 @@ msgid "Last Login"
 msgstr "Dernière connexion"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4585,7 +4620,7 @@ msgstr "Dernière connexion"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4599,25 +4634,25 @@ msgstr "Dernière modification"
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr "Nom"
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "Dernière exécution"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "Dernier Job"
 
@@ -4628,7 +4663,7 @@ msgstr "Dernier Job"
 msgid "Last modified"
 msgstr "Dernière modification"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "Nom"
@@ -4679,11 +4714,11 @@ msgstr "Lancer le flux de travail"
 msgid "Launch | {0}"
 msgstr "Lancement | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "Lancé par"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "Lancé par (Nom d'utilisateur)"
 
@@ -4699,26 +4734,26 @@ msgstr "Laissez ce champ vide pour rendre l'environnement d'exécution globaleme
 msgid "Legend"
 msgstr "Légende"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "Moins que la comparaison."
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "Moins ou égal à la comparaison."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "Limite"
@@ -4735,11 +4770,11 @@ msgstr "Chargement en cours..."
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "Fuseau horaire local"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "Fuseau horaire local"
 
@@ -4751,7 +4786,7 @@ msgstr "Connexion"
 msgid "Logging"
 msgstr "Journalisation"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "Paramètres de journalisation"
 
@@ -4761,20 +4796,20 @@ msgstr "Paramètres de journalisation"
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "Recherche modale"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "Sélection de la recherche"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "Type de recherche"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "Recherche par type"
 
@@ -4784,10 +4819,10 @@ msgstr "Recherche par type"
 msgid "MOST RECENT SYNC"
 msgstr "DERNIÈRE SYNCHRONISATION"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "Informations d’identification de la machine"
 
@@ -4800,8 +4835,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr "Nœuds gérés"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4811,7 +4846,7 @@ msgid "Management Job"
 msgstr "Job de gestion"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr "Jobs de gestion"
 
@@ -4832,15 +4867,15 @@ msgstr "Job de gestion non trouvé."
 msgid "Management jobs"
 msgstr "Jobs de gestion"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "Manuel"
 
@@ -4848,8 +4883,8 @@ msgstr "Manuel"
 msgid "March"
 msgstr "Mars"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4870,7 +4905,7 @@ msgstr "Longueur maximale"
 msgid "May"
 msgstr "Mai"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr "Membres"
@@ -4887,7 +4922,7 @@ msgstr "Métrique"
 msgid "Metrics"
 msgstr "Métriques"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -4911,7 +4946,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr "Le pourcentage minimum de toutes les instances qui seront automatiquement assignées à ce groupe lorsque de nouvelles instances seront mises en ligne."
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "Minute"
 
@@ -4919,7 +4954,7 @@ msgstr "Minute"
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4927,7 +4962,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr "Système divers"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "Réglages divers du système"
 
@@ -4942,70 +4977,70 @@ msgid "Missing resource"
 msgstr "Ressource manquante"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr "Modifié"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "Modifié par (nom d'utilisateur)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "Modifié par (nom d'utilisateur)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "Module"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5018,7 +5053,7 @@ msgstr "Lun."
 msgid "Monday"
 msgstr "Lundi"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "Mois"
 
@@ -5030,13 +5065,13 @@ msgstr "Plus d'informations"
 msgid "More information for"
 msgstr "Plus d'informations pour"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "Multi-Select"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "Options à choix multiples."
 
@@ -5052,57 +5087,57 @@ msgstr "Options à choix multiples (une seule sélection)"
 msgid "Multiple Choice Options"
 msgstr "Options à choix multiples."
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5117,73 +5152,73 @@ msgstr "Options à choix multiples."
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5196,66 +5231,72 @@ msgstr "Options à choix multiples."
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr "Nom"
@@ -5279,7 +5320,7 @@ msgstr "Jamais mis à jour"
 msgid "Never expires"
 msgstr "N'expire jamais"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "Nouveau"
@@ -5298,8 +5339,8 @@ msgstr "Nouveau"
 msgid "Next"
 msgstr "Suivant"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5342,7 +5383,7 @@ msgstr "Aucune erreurs de synchronisation des inventaires"
 msgid "No items found."
 msgstr "Aucun objet trouvé."
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5350,10 +5391,10 @@ msgstr ""
 msgid "No result found"
 msgstr "Aucun résultat trouvé"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
@@ -5362,7 +5403,7 @@ msgstr "Aucun résultat trouvé"
 msgid "No subscriptions found"
 msgstr "Aucun abonnement trouvé"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "Aucune question d'enquête trouvée."
 
@@ -5377,7 +5418,7 @@ msgstr "Aucun {pluralizedItemName} trouvé"
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5395,7 +5436,7 @@ msgstr "Aucun"
 msgid "None (Run Once)"
 msgstr "Aucun (Éxecution unique)"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "Aucune (éxecution unique)"
 
@@ -5418,15 +5459,15 @@ msgstr "Non configuré"
 msgid "Not configured for inventory sync."
 msgstr "Non configuré pour la synchronisation de l'inventaire."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr "Notez que seuls les hôtes qui sont directement dans ce groupe peuvent être dissociés. Les hôtes qui se trouvent dans les sous-groupes doivent être dissociés directement au niveau du sous-groupe auquel ils appartiennent."
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5434,7 +5475,7 @@ msgid ""
 "with directly and indirectly."
 msgstr "Notez que vous pouvez toujours voir le groupe dans la liste après l'avoir dissocié si l'hôte est également membre des dépendants de ce groupe.  Cette liste montre tous les groupes auxquels l'hôte est associé directement et indirectement."
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5465,9 +5506,9 @@ msgstr "Couleur des notifications"
 msgid "Notification Template not found."
 msgstr "Modèle de notification introuvable."
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5482,20 +5523,20 @@ msgstr "Type de notification"
 msgid "Notification color"
 msgstr "Couleur de la notification"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "Notification envoyée avec succès"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "La notification a expiré."
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "Type de notification"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5530,39 +5571,37 @@ msgstr "Occurrences"
 msgid "October"
 msgstr "Octobre"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "Désactivé"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "Le"
 
@@ -5592,7 +5631,7 @@ msgstr "Tels jours"
 msgid "Only Group By"
 msgstr "Grouper seulement par"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5600,7 +5639,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Détails de l'option"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5612,20 +5651,26 @@ msgstr "Libellés facultatifs décrivant ce modèle de job, par exemple 'dev' ou
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "En option, sélectionnez les informations d'identification à utiliser pour renvoyer les mises à jour de statut au service webhook."
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "Options"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5636,15 +5681,15 @@ msgstr "Options"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5654,22 +5699,22 @@ msgstr "Options"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "Organisation"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "Organisation (Nom)"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "Nom de l'organisation"
 
@@ -5679,9 +5724,9 @@ msgstr "Organisation non trouvée."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5696,11 +5741,11 @@ msgstr "Organisations"
 msgid "Other prompts"
 msgstr "Autres invites"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "Non-conformité"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "Sortie"
@@ -5731,8 +5776,8 @@ msgstr "PUBLICATION"
 msgid "PUT"
 msgstr "PLACER"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5764,11 +5809,11 @@ msgstr "Pan droite"
 msgid "Pan Up"
 msgstr "Pan En haut"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "Passez des changements supplémentaires en ligne de commande. Il y a deux paramètres de ligne de commande possibles :"
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5805,7 +5850,7 @@ msgstr "Les deux dernières semaines"
 msgid "Past week"
 msgstr "La semaine dernière"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5819,12 +5864,12 @@ msgstr "En attente d'approbation des flux de travail"
 msgid "Pending delete"
 msgstr "En attente de suppression"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "Effectuez une recherche ci-dessus pour définir un filtre d'hôte"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5845,13 +5890,13 @@ msgid "Play Started"
 msgstr "Scène démarrée"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Playbook"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Vérification du Playbook"
@@ -5862,12 +5907,12 @@ msgstr "Playbook terminé"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Répertoire de playbook"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5877,10 +5922,10 @@ msgstr "Exécution du playbook"
 msgid "Playbook Started"
 msgstr "Playbook démarré"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Nom du playbook"
 
@@ -5892,15 +5937,15 @@ msgstr "Exécution du playbook"
 msgid "Plays"
 msgstr "Lancements"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "Veuillez ajouter des questions d'enquête."
 
@@ -5924,23 +5969,23 @@ msgstr "Entrez une valeur."
 msgid "Please log in"
 msgstr "Veuillez vous connecter"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "Veuillez choisir un numéro de jour entre 1 et 31."
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "Sélectionnez un inventaire ou cochez l’option Me le demander au lancement."
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "Veuillez choisir une date/heure de fin qui vient après la date/heure de début."
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "Veuillez sélectionner une organisation avant d'éditer le filtre de l'hôte."
 
@@ -5948,7 +5993,7 @@ msgstr "Veuillez sélectionner une organisation avant d'éditer le filtre de l'h
 msgid "Pod spec override"
 msgstr "Remplacement des spécifications du pod"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5968,7 +6013,7 @@ msgstr "Pourcentage d'instances de stratégie"
 msgid "Populate field from an external secret management system"
 msgstr "Remplir le champ à partir d'un système de gestion des secrets externes"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6006,8 +6051,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "Prévisualisation"
 
@@ -6017,7 +6060,7 @@ msgstr "Phrase de passe pour la clé privée"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "Élévation des privilèges"
 
@@ -6025,17 +6068,16 @@ msgstr "Élévation des privilèges"
 msgid "Privilege escalation password"
 msgstr "Mot de passe pour l’élévation des privilèges"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6043,7 +6085,7 @@ msgstr "Projet"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "Chemin de base du projet"
 
@@ -6071,10 +6113,10 @@ msgstr "Erreurs de synchronisation du projet"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6087,8 +6129,8 @@ msgstr "Projets"
 msgid "Promote Child Groups and Hosts"
 msgstr "Promouvoir les groupes de dépendants et les hôtes"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "Invite"
 
@@ -6107,11 +6149,11 @@ msgid "Prompt | {0}"
 msgstr "Invitation | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "Valeurs incitatrices"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6132,7 +6174,7 @@ msgstr "Entrez un modèle d’hôte pour limiter davantage la liste des hôtes q
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "Indiquez une valeur pour ce champ ou sélectionnez l'option Me le demander au lancement."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6152,18 +6194,18 @@ msgstr "Fournissez vos informations d'identification Red Hat ou Red Hat Satellit
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "URL de rappel d’exécution "
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "Détails de rappel d’exécution"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "Rappels d’exécution "
 
@@ -6180,7 +6222,7 @@ msgstr "Question"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "Paramètres RADIUS"
 
@@ -6210,7 +6252,7 @@ msgstr "Onglet Liste des modèles récents"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6223,19 +6265,19 @@ msgstr "Liste de destinataires"
 msgid "Recipient list"
 msgstr "Liste de destinataires"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Red Hat Virtualization"
 
@@ -6243,7 +6285,7 @@ msgstr "Red Hat Virtualization"
 msgid "Red Hat subscription manifest"
 msgstr "Manifeste de souscription à Red Hat"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6267,7 +6309,7 @@ msgstr "Redirection vers le détail de l'abonnement"
 msgid "Refer to the"
 msgstr "Reportez-vous à "
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6303,28 +6345,28 @@ msgstr "Expression régulière où seuls les noms d'hôtes correspondants seront
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "Groupes liés"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "Relancer"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "Relancer le Job"
@@ -6342,16 +6384,16 @@ msgstr "Relancer les hôtes défaillants"
 msgid "Relaunch on"
 msgstr "Relancer sur"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "Relancer en utilisant les paramètres de l'hôte"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "Archive à distance"
 
@@ -6378,7 +6420,7 @@ msgstr "Supprimer le nœud"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "Supprimez toutes les modifications locales avant d’effectuer une mise à jour."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr "Supprimer l'accès {0}"
 
@@ -6394,7 +6436,7 @@ msgstr "La suppression de ce lien rendra le reste de la branche orphelin et entr
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "Fréquence de répétition"
 
@@ -6411,7 +6453,7 @@ msgstr "Remplacer le champ par la nouvelle valeur"
 msgid "Request subscription"
 msgstr "Demande d’abonnement"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "Obligatoire"
@@ -6419,7 +6461,7 @@ msgstr "Obligatoire"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "Nom de la ressource"
 
@@ -6428,7 +6470,7 @@ msgid "Resource deleted"
 msgstr "Ressource supprimée"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr "Ressources"
 
@@ -6460,15 +6502,15 @@ msgstr "Renvoi"
 msgid "Return to subscription management."
 msgstr "Retour à la gestion des abonnements."
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "Renvoie les résultats qui ont des valeurs autres que celle-ci ainsi que d'autres filtres."
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "Retourne des résultats qui satisfont à ce filtre ainsi qu'à d'autres filtres.  Il s'agit du type d'ensemble par défaut si rien n'est sélectionné."
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "Retourne les résultats qui satisfont à ce filtre ou à tout autre filtre."
 
@@ -6499,8 +6541,8 @@ msgstr "Inverser les paramètres"
 msgid "Revert to factory default."
 msgstr "Revenir à la valeur usine par défaut."
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "Révision"
@@ -6509,25 +6551,25 @@ msgstr "Révision"
 msgid "Revision #"
 msgstr "Révision n°"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "Rôle"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6541,7 +6583,7 @@ msgstr "Rôles"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "Exécuter"
 
@@ -6565,7 +6607,7 @@ msgstr "Éxecuter Commande"
 msgid "Run every"
 msgstr "Exécutez tous les"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "Fréquence d'exécution"
 
@@ -6577,7 +6619,7 @@ msgstr "Continuer"
 msgid "Run type"
 msgstr "Type d’exécution"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6588,8 +6630,8 @@ msgstr "En cours d'exécution"
 msgid "Running Handlers"
 msgstr "Descripteurs d'exécution"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "Jobs en cours d'exécution"
@@ -6602,7 +6644,7 @@ msgstr "Jobs en cours d'exécution"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "Paramètres SAML"
 
@@ -6645,18 +6687,19 @@ msgid "Saturday"
 msgstr "Samedi"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6694,7 +6737,7 @@ msgstr "Le planning est actif."
 msgid "Schedule is inactive"
 msgstr "Le planning est inactif."
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "La programmation manque de règles"
 
@@ -6702,10 +6745,10 @@ msgstr "La programmation manque de règles"
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6719,11 +6762,11 @@ msgstr ""
 msgid "Schedules"
 msgstr "Programmations"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6745,8 +6788,8 @@ msgstr "Faites défiler la page suivante"
 msgid "Scroll previous"
 msgstr "Faire défiler la page précédente"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr "Rechercher"
 
@@ -6754,7 +6797,7 @@ msgstr "Rechercher"
 msgid "Search is disabled while the job is running"
 msgstr "La recherche est désactivée pendant que le job est en cours"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "Bouton de soumission de recherche"
@@ -6778,9 +6821,9 @@ msgstr "Secondes"
 msgid "See errors on the left"
 msgstr "Voir les erreurs sur la gauche"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6790,13 +6833,13 @@ msgstr "Sélectionner"
 msgid "Select Credential Type"
 msgstr "Modifier le type d’identification"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "Sélectionner les groupes"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "Sélectionner les hôtes"
 
@@ -6804,11 +6847,11 @@ msgstr "Sélectionner les hôtes"
 msgid "Select Input"
 msgstr "Sélectionnez une entrée"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "Sélectionner les instances"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "Sélectionnez les éléments"
 
@@ -6824,7 +6867,7 @@ msgstr "Sélectionner les étiquettes"
 msgid "Select Roles to Apply"
 msgstr "Sélectionnez les rôles à appliquer"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "Sélectionner des équipes"
 
@@ -6840,7 +6883,7 @@ msgstr "Sélectionnez un type de nœud"
 msgid "Select a Resource Type"
 msgstr "Sélectionnez un type de ressource"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6870,7 +6913,7 @@ msgstr "Sélectionnez un Job à annuler"
 msgid "Select a metric"
 msgstr "Sélectionnez une métrique"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "Sélectionnez un module"
 
@@ -6879,16 +6922,20 @@ msgstr "Sélectionnez un module"
 msgid "Select a playbook"
 msgstr "Choisir un playbook"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "Sélectionnez un projet avant de modifier l'environnement d'exécution."
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "Sélectionnez une ligne à approuver"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr "Sélectionnez une ligne à supprimer"
 
@@ -6909,8 +6956,8 @@ msgstr "Sélectionnez un abonnement"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6930,7 +6977,7 @@ msgstr "Sélectionnez un abonnement"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6943,11 +6990,11 @@ msgid "Select a webhook service."
 msgstr "Sélectionnez un service webhook."
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr "Tout sélectionner"
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "Sélectionnez un type d'activité"
 
@@ -6967,7 +7014,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr "Sélectionnez une organisation avant de modifier l'environnement d'exécution par défaut."
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6976,7 +7023,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr "Sélectionnez les informations d'identification pour que le Job puisse accéder aux nœuds selon qui déterminent l'exécution de cette tâche. Vous pouvez uniquement sélectionner une information d'identification de chaque type. Pour les informations d'identification machine (SSH), cocher la case \"Me demander au lancement\" sans la sélection des informations d'identification vous obligera à sélectionner des informations d'identification au moment de l’exécution. Si vous sélectionnez \"Me demander au lancement\", les informations d'identification sélectionnées deviennent les informations d'identification par défaut qui peuvent être mises à jour au moment de l'exécution."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7021,7 +7068,7 @@ msgstr "Sélectionner le statut"
 msgid "Select tags"
 msgstr "Sélectionner des balises"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "Sélectionnez l'environnement d'exécution dans lequel vous voulez que cette commande soit exécutée."
 
@@ -7029,7 +7076,7 @@ msgstr "Sélectionnez l'environnement d'exécution dans lequel vous voulez que c
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Sélectionnez les groupes d'instances sur lesquels exécuter cet inventaire."
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7047,16 +7094,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "Sélectionnez l'application à laquelle ce jeton appartiendra."
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "Sélectionnez les informations d’identification qu’il vous faut utiliser lors de l’accès à des hôtes distants pour exécuter la commande. Choisissez les informations d’identification contenant le nom d’utilisateur et la clé SSH ou le mot de passe dont Ansible aura besoin pour se connecter aux hôtes distants."
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "Sélectionnez l'environnement d'exécution pour ce modèle de Job."
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7076,11 +7123,11 @@ msgstr "Sélectionnez le fichier d'inventaire à synchroniser par cette source. 
 msgid "Select the inventory that this host will belong to."
 msgstr "Sélectionnez l'inventaire auquel cet hôte appartiendra."
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "Sélectionnez le playbook qui devra être exécuté par cette tâche."
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7090,7 +7137,7 @@ msgstr "Sélectionnez le projet contenant le playbook que ce job devra exécuter
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "Sélectionnez votre abonnement à la Plateforme d'Automatisation Ansible à utiliser."
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "Sélectionnez {0}"
 
@@ -7099,7 +7146,7 @@ msgstr "Sélectionnez {0}"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7111,7 +7158,7 @@ msgstr "Sélectionnez {0}"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7123,17 +7170,23 @@ msgstr "Sélectionnez {0}"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr "Sélectionné"
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "Catégorie sélectionnée"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7160,7 +7213,7 @@ msgstr "Définir une valeur pour ce champ"
 msgid "Set how many days of data should be retained."
 msgstr "Définissez le nombre de jours pendant lesquels les données doivent être conservées."
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "Définissez des préférences pour la collection des données, les logos et logins."
 
@@ -7176,19 +7229,19 @@ msgstr "Mettez l'instance en ligne ou hors ligne. Si elle est hors ligne, les Jo
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "Définir sur sur Public ou Confidentiel selon le degré de sécurité du périphérique client."
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "Type d'ensemble"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "Sélection du type d’ensemble"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "En-tête du type d'ensemble"
 
@@ -7210,8 +7263,8 @@ msgstr "Nom du paramètre"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr "Paramètres"
@@ -7223,9 +7276,9 @@ msgstr "Afficher"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "Afficher les modifications"
 
@@ -7233,8 +7286,8 @@ msgstr "Afficher les modifications"
 #~ msgid "Show all groups"
 #~ msgstr "Afficher tous les groupes"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "Afficher les modifications"
 
@@ -7247,7 +7300,7 @@ msgstr "Afficher la description"
 msgid "Show less"
 msgstr "Afficher moins de détails"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "Afficher uniquement les groupes racines"
 
@@ -7300,14 +7353,14 @@ msgstr "Sélection par simple pression d'une touche"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "Balises de saut"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7328,15 +7381,15 @@ msgstr "Les balises de saut sont utiles si votre playbook est important et que v
 msgid "Skipped"
 msgstr "Sauter"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "Inventaire smart"
@@ -7345,7 +7398,7 @@ msgstr "Inventaire smart"
 msgid "Smart Inventory not found."
 msgstr "Inventaire smart non trouvé."
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "Filtre d'hôte smart"
@@ -7377,13 +7430,15 @@ msgstr "Trier"
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "Trier l'ordre des questions"
+#~ msgid "Sort question order"
+#~ msgstr "Trier l'ordre des questions"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "Source"
 
@@ -7392,12 +7447,12 @@ msgstr "Source"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "Branche Contrôle de la source"
 
@@ -7430,19 +7485,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr "Type de Contrôle de la source"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "URL Contrôle de la source"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7456,8 +7511,8 @@ msgstr "Numéro de téléphone de la source"
 msgid "Source Variables"
 msgstr "Variables Source"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "Flux de travail Source"
 
@@ -7478,7 +7533,7 @@ msgstr "Numéro de téléphone de la source"
 msgid "Source variables"
 msgstr "Variables sources"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "Provenance d'un projet"
 
@@ -7525,14 +7580,14 @@ msgstr "Onglet Standard Out"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "Démarrer"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "Heure Début"
 
@@ -7554,27 +7609,27 @@ msgstr "Démarrer le processus de synchronisation"
 msgid "Start sync source"
 msgstr "Démarrer la source de synchronisation"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "Démarré"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "État"
@@ -7605,14 +7660,14 @@ msgstr ""
 "Cela équivaut à spécifier l'option --remote\n"
 "à git submodule update."
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "Abonnement"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "Détails d’abonnement"
 
@@ -7628,11 +7683,11 @@ msgstr "Manifeste de souscription"
 msgid "Subscription selection modal"
 msgstr "Modalité de sélection de l'abonnement"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "Paramètres d'abonnement"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "Type d’abonnement"
 
@@ -7640,11 +7695,11 @@ msgstr "Type d’abonnement"
 msgid "Subscriptions table"
 msgstr "Table des abonnements"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversion"
 
@@ -7664,7 +7719,7 @@ msgstr "Message de réussite"
 msgid "Success message body"
 msgstr "Corps du message de réussite"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7696,25 +7751,37 @@ msgstr "Dimanche"
 msgid "Survey"
 msgstr "Questionnaire"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "Liste des enquêtes"
+#~ msgid "Survey List"
+#~ msgstr "Liste des enquêtes"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "Aperçu de l'enquête"
+#~ msgid "Survey Preview"
+#~ msgstr "Aperçu de l'enquête"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "Basculement d'enquête"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "Aperçu de l'enquête modale"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "Questions de l'enquête"
+#~ msgid "Survey questions"
+#~ msgstr "Questions de l'enquête"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7752,15 +7819,15 @@ msgstr "Synchronisation pour la révision"
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr "Système"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "Administrateur du système"
@@ -7775,8 +7842,8 @@ msgstr "Auditeur système"
 msgid "System Warning"
 msgstr "Avertissement système"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "Les administrateurs système ont un accès illimité à toutes les ressources."
 
@@ -7784,7 +7851,7 @@ msgstr "Les administrateurs système ont un accès illimité à toutes les resso
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "Paramètres de la TACACS"
 
@@ -7793,7 +7860,7 @@ msgstr "Paramètres de la TACACS"
 msgid "Tabs"
 msgstr "Onglets"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7848,7 +7915,7 @@ msgid "Team"
 msgstr "Équipe"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr "Rôles d’équipe"
 
@@ -7859,19 +7926,19 @@ msgstr "Équipe non trouvée."
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7882,12 +7949,12 @@ msgstr "Équipes"
 msgid "Template not found."
 msgstr "Mise à jour introuvable"
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7916,12 +7983,12 @@ msgstr "Notification test"
 msgid "Test passed"
 msgstr "Test réussi."
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "Texte"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "Zone de texte"
 
@@ -7956,7 +8023,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr "Délai (en secondes) avant que la notification par e-mail cesse d'essayer de joindre l'hôte et expire. Compris entre 1 et 120 secondes."
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8003,7 +8070,7 @@ msgid ""
 "documentation for more details."
 msgstr "Nombre maximal d'hôtes pouvant être gérés par cette organisation. La valeur par défaut est 0, ce qui signifie aucune limite. Reportez-vous à la documentation Ansible pour plus de détails."
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8012,16 +8079,16 @@ msgid ""
 "with a change to"
 msgstr "Le nombre de processus parallèles ou simultanés à utiliser lors de l'exécution du playbook. Une valeur vide, ou une valeur inférieure à 1 utilisera la valeur par défaut Ansible qui est généralement 5. Le nombre de fourches par défaut peut être remplacé par un changement vers"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "Nombre de processus parallèles ou simultanés à utiliser lors de l'exécution du playbook. La saisie d'aucune valeur entraînera l'utilisation de la valeur par défaut du fichier de configuration ansible. Vous pourrez trouver plus d’informations."
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "La page que vous avez demandée n'a pas été trouvée."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "Le modèle utilisé pour cibler les hôtes dans l'inventaire. En laissant le champ vide, tous et * cibleront tous les hôtes de l'inventaire. Vous pouvez trouver plus d'informations sur les modèles d'hôtes d'Ansible"
 
@@ -8060,7 +8127,7 @@ msgstr "Le format suggéré pour les noms de variables est en minuscules avec de
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8094,19 +8161,19 @@ msgstr "Une erreur s'est produite lors de la sauvegarde du flux de travail."
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "Il s'agit des niveaux de verbosité pour les standards hors du cycle de commande qui sont pris en charge."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "Ces arguments sont utilisés avec le module spécifié."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "Ces arguments sont utilisés avec le module spécifié. Vous pouvez trouver des informations sur {0} en cliquant sur"
 
@@ -8114,21 +8181,21 @@ msgstr "Ces arguments sont utilisés avec le module spécifié. Vous pouvez trou
 msgid "Third"
 msgstr "Troisième"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "Ce projet doit être mis à jour"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "Cette action supprimera les éléments suivants :"
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "Cette action permettra de dissocier tous les rôles de cet utilisateur des équipes sélectionnées."
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "Cette action va dissocier le rôle suivant de {0} :"
 
@@ -8230,7 +8297,7 @@ msgid "This field must be greater than 0"
 msgstr "Ce champ doit être supérieur à 0"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8282,7 +8349,7 @@ msgstr "C'est la seule fois où la valeur du jeton et la valeur du jeton de rafr
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "Ce modèle de poste est actuellement utilisé par d'autres ressources. Êtes-vous sûr de vouloir le supprimer ?"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "Cette organisation est actuellement en cours de traitement par d'autres ressources. Êtes-vous sûr de vouloir la supprimer ?"
 
@@ -8294,11 +8361,11 @@ msgstr "Ce projet est actuellement utilisé par d'autres ressources. Êtes-vous 
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "Ce projet est actuellement en cours de synchronisation et ne peut être cliqué tant que le processus de synchronisation n'est pas terminé"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "Il manque un inventaire dans ce calendrier"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "Ce tableau ne contient pas les valeurs d'enquête requises"
 
@@ -8335,8 +8402,8 @@ msgstr "Jeu."
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8370,7 +8437,7 @@ msgstr "Expiré"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "Délai d'attente"
 
@@ -8381,6 +8448,10 @@ msgstr "Délai d'attente (minutes)"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "Délai d’attente (secondes)"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8448,11 +8519,11 @@ msgid "Token not found."
 msgstr "Jeton non trouvé."
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "Jetons"
@@ -8465,8 +8536,8 @@ msgstr "Outils"
 msgid "Top Pagination"
 msgstr "Top Pagination"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "Total Jobs"
@@ -8489,20 +8560,20 @@ msgstr "Suivi des sous-modules"
 msgid "Track submodules latest commit on branch"
 msgstr "Suivre le dernier commit des sous-modules sur la branche"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "Essai"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "Vrai"
 
@@ -8515,55 +8586,57 @@ msgstr "Mar."
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "Type"
@@ -8607,7 +8680,7 @@ msgstr "Annuler"
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "Illimité"
 
@@ -8624,7 +8697,7 @@ msgstr "Nombre d'hôtes inaccessibles"
 msgid "Unreachable Hosts"
 msgstr "Hôtes inaccessibles"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "Chaîne du jour non reconnue"
 
@@ -8661,7 +8734,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8698,7 +8771,7 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr "Utilisez des messages personnalisés pour modifier le contenu des notifications envoyées lorsqu'un job démarre, réussit ou échoue. Utilisez des parenthèses en accolade pour accéder aux informations sur le job :"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8717,17 +8790,17 @@ msgstr "Utilisateur"
 msgid "User Details"
 msgstr "Détails de l'erreur"
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr "Interface utilisateur"
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "Paramètres de l'interface utilisateur"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr "Rôles des utilisateurs"
 
@@ -8754,14 +8827,14 @@ msgstr "Informations sur l'utilisateur"
 msgid "User not found."
 msgstr "Utilisateur non trouvé."
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "Jetons d'utilisateur"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8774,8 +8847,8 @@ msgstr "Jetons d'utilisateur"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8788,16 +8861,16 @@ msgstr "Nom d'utilisateur / mot de passe"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -8808,7 +8881,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8818,10 +8891,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "Variables"
@@ -8842,21 +8915,21 @@ msgstr "Mot de passe Vault | {credId}"
 msgid "Verbose"
 msgstr "Verbeux"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "Verbosité"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "Version"
 
@@ -8903,7 +8976,7 @@ msgstr "Voir les détails de l'hôte de l'inventaire"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "Voir des exemples JSON dans <0>www.json.org</0>"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "Voir les détails de Job"
 
@@ -9016,7 +9089,7 @@ msgstr "Voir tous les hôtes de l'inventaire."
 msgid "View all Jobs"
 msgstr "Voir tous les Jobs"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "Voir tous les Jobs."
 
@@ -9079,7 +9152,7 @@ msgstr "Voir tous les paramètres"
 msgid "View all tokens."
 msgstr "Voir tous les jetons."
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "Afficher et modifier les informations relatives à votre abonnement"
 
@@ -9105,7 +9178,7 @@ msgid "View smart inventory host details"
 msgstr "Voir les détails de l'hôte de l'inventaire smart"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr "Affichages"
 
@@ -9115,11 +9188,11 @@ msgstr "Affichages"
 msgid "Visualizer"
 msgstr "Visualiseur"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "AVERTISSEMENT :"
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9143,8 +9216,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "Nous n'avons pas pu localiser les abonnements associés à ce compte."
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9184,7 +9257,7 @@ msgstr "Service webhook"
 msgid "Webhook URL"
 msgstr "URL du webhook"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Détails de webhook"
@@ -9213,7 +9286,7 @@ msgstr "Mer."
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "Semaine"
 
@@ -9262,26 +9335,26 @@ msgid "Workflow Approval not found."
 msgstr "Approbation du flux de travail non trouvée."
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "Approbations des flux de travail"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "Job de flux de travail"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9302,8 +9375,8 @@ msgstr "Modèles de Jobs de flux de travail"
 msgid "Workflow Link"
 msgstr "Lien vers le flux de travail"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "Modèle de flux de travail"
 
@@ -9372,7 +9445,7 @@ msgstr "Écriture"
 msgid "YAML:"
 msgstr "YAML :"
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "Année"
 
@@ -9388,11 +9461,11 @@ msgstr "Vous ne pouvez pas agir sur les approbations de flux de travail suivante
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "Vous ne pouvez pas agir sur les approbations de flux de travail suivantes : {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "Vous ne pouvez pas sélectionner plusieurs identifiants d’archivage sécurisé (Vault) avec le même identifiant de Vault. Cela désélectionnerait automatiquement les autres identifiants de Vault."
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "Vous n'avez pas la permission de supprimer les groupes suivants : {itemsUnableToDelete}"
 
@@ -9426,19 +9499,19 @@ msgstr "Zoom avant"
 msgid "Zoom Out"
 msgstr "Zoom arrière"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "une nouvelle clé webhook sera générée lors de la sauvegarde."
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "une nouvelle url de webhook sera générée lors de la sauvegarde."
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "actions"
+#~ msgid "actions"
+#~ msgstr "actions"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9454,7 +9527,7 @@ msgid "brand logo"
 msgstr "logo de la marque"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr "annuler supprimer"
 
@@ -9462,17 +9535,17 @@ msgstr "annuler supprimer"
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "commande"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr "confirmer supprimer"
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "confirmer dissocier"
 
@@ -9506,16 +9579,16 @@ msgstr "documentation"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "Modifier"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "crypté"
 
@@ -9527,16 +9600,16 @@ msgstr "pour plus d'infos."
 msgid "for more information."
 msgstr "pour plus d'informations."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "ici"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "ici."
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "hôtes"
 
@@ -9557,12 +9630,12 @@ msgid "min"
 msgstr "min"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "se déplacer vers le bas"
+#~ msgid "move down"
+#~ msgstr "se déplacer vers le bas"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "monter"
+#~ msgid "move up"
+#~ msgstr "monter"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9573,7 +9646,7 @@ msgstr "nouveau choix"
 msgid "of"
 msgstr "de"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "l'option à la"
 
@@ -9602,15 +9675,15 @@ msgstr "sec"
 msgid "seconds"
 msgstr "secondes"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "sélectionner un module"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "choisir la verbosité"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9618,7 +9691,7 @@ msgstr ""
 msgid "social login"
 msgstr "social login"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "branche du contrôle de la source"
@@ -9631,7 +9704,7 @@ msgstr "système"
 msgid "timed out"
 msgstr "expiré"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "changements d'affectation"
 
@@ -9651,39 +9724,39 @@ msgstr "{0, plural, one {Est-ce que vous êtes sûr de vouloir supprimer le grou
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {Suppression de groupe?} other {Suppression de groupe?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {L'inventaire sera en attente jusqu'à ce que la suppression finale soit traitée.} other {L'inventaire sera en attente jusqu'à ce que la suppression finale soit traitée.}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {Le job sélectionné ne peut pas être supprimé en raison d'une autorisation insuffisante ou d'un statut de job en cours} other {Les jobs sélectionnés ne peuvent pas être supprimés en raison d'autorisations insuffisantes ou d'un statut de job en cours}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {Cette autorisation peut être supprimée en raison d'autorisations insuffisantes ou d'un job en cours} other {Ces autorisations ne peuvent être supprimées en raison d'autorisations insuffisantes ou d'un travail en cours}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Cette information d'identification est actuellement utilisée par d'autres ressources. Êtes-vous sûr de vouloir le supprimer ? } other {La suppression de ces informations d'identification pourrait avoir un impact sur les autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même ? }}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Ce type de justificatif est actuellement utilisé par certains justificatifs et ne peut être supprimé.} other {Les types de justificatifs qui sont utilisés par des justificatifs ne peuvent être supprimés. Etes-vous sûr de vouloir supprimer quand même ? }}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {Cet environnement d'exécution est actuellement utilisé par d'autres ressources. Êtes-vous sûr de vouloir le supprimer ? } other {Ces environnements d'exécution pourraient être utilisés par d'autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer de toute façon ? }}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Ce groupe d'instance est actuellement utilisé par d'autres ressources. Êtes-vous sûr de vouloir le supprimer ? } other {La suppression de ces groupes d'instances pourrait avoir un impact sur d'autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même ? }}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Cet inventaire est actuellement utilisé par certains modèles. Êtes-vous sûr de vouloir le supprimer ? } other {La suppression de ces inventaires pourrait avoir un impact sur certains modèles qui en dépendent. Êtes-vous sûr de vouloir les supprimer de toute façon ? }}"
 
@@ -9691,15 +9764,15 @@ msgstr "{0, plural, one {Cet inventaire est actuellement utilisé par certains m
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {Cette source d'inventaire est actuellement utilisée par d'autres ressources qui en dépendent. Êtes-vous sûr de vouloir la supprimer ? } other {La suppression de ces sources d'inventaire pourrait avoir un impact sur d'autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Cette organisation est actuellement utilisée par d'autres ressources. Êtes-vous sûr de vouloir la supprimer ? } other {La suppression de ces organisations pourrait avoir un impact sur les autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même ? }}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Ce projet est actuellement utilisé par d'autres ressources. Êtes-vous sûr de vouloir le supprimer ? } other {La suppression de ces projets pourrait avoir un impact sur les autres ressources qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même ? }}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Ce modèle est actuellement utilisé par certains noeuds de flux de travail. Êtes-vous sûr de vouloir le supprimer ? } other {La suppression de ces modèles pourrait avoir un impact sur certains nœuds de flux de travail qui en dépendent. Êtes-vous sûr de vouloir les supprimer quand même ? }}"
 
@@ -9788,8 +9861,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/ja/messages.po
+++ b/awx/ui/src/locales/ja/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (プロジェクト root)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0 (正常)"
 
@@ -59,7 +59,7 @@ msgstr "1 (情報)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1 (詳細)"
 
@@ -75,7 +75,7 @@ msgstr "2 (デバッグ)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2 (より詳細)"
 
@@ -86,7 +86,7 @@ msgstr "2 (より詳細)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3 (デバッグ)"
 
@@ -97,7 +97,7 @@ msgstr "3 (デバッグ)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4 (接続デバッグ)"
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr "情報"
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr "アカウントトークン"
 msgid "Action"
 msgstr "アクション"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "アクション"
@@ -235,8 +238,8 @@ msgstr "アクション"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr "アクティビティー"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "アクティビティーストリーム"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "アクティビティーストリームのタイプセレクター"
 
@@ -297,35 +300,35 @@ msgstr "新規ノードの追加"
 msgid "Add a new node between these two nodes"
 msgstr "これら 2 つのノードの間に新しいノードを追加します"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "コンテナーグループの追加"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "既存グループの追加"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "既存ホストの追加"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "インスタンスグループの追加"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "インベントリーの追加"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "新規ジョブテンプレートの追加"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "新規グループの追加"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "新規ホストの追加"
 
@@ -333,24 +336,24 @@ msgstr "新規ホストの追加"
 msgid "Add resource type"
 msgstr "リソースタイプの追加"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "スマートインベントリーの追加"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "チームパーミッションの追加"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "ユーザー権限の追加"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "ワークフローテンプレートの追加"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr "管理"
 
@@ -359,11 +362,11 @@ msgstr "管理"
 msgid "Advanced"
 msgstr "詳細"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "高度な検索に関するドキュメント"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "詳細な検索値の入力"
 
@@ -423,7 +426,7 @@ msgstr "許可された URI リスト (スペース区切り)"
 msgid "Always"
 msgstr "常時"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -435,7 +438,7 @@ msgstr "エラーが発生しました"
 msgid "An inventory must be selected"
 msgstr "インベントリーを選択する必要があります"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -456,13 +459,13 @@ msgstr "回答の変数名"
 msgid "Any"
 msgstr "任意"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "アプリケーション"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr "アプリケーション情報"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "アプリケーション名"
 
@@ -480,17 +483,17 @@ msgstr "アプリケーション名"
 msgid "Application not found."
 msgstr "アプリケーションが見つかりません。"
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr "アプリケーション"
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "アプリケーションおよびトークン"
 
@@ -562,11 +565,11 @@ msgstr "このリンクを削除してもよろしいですか?"
 msgid "Are you sure you want to remove this node?"
 msgstr "このノードを削除してもよろしいですか?"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr "{1} から {0} のアクセスを削除しますか? これを行うと、チームのすべてのメンバーに影響します。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "{username} からの {0} のアクセスを削除してもよろしいですか?"
 
@@ -574,26 +577,26 @@ msgstr "{username} からの {0} のアクセスを削除してもよろしい�
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "このジョブを取り消す要求を送信してよろしいですか?"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "引数"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "アーティファクト"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "関連付け"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "関連付けのロールエラー"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "関連付けモーダル"
 
@@ -605,7 +608,7 @@ msgstr "このフィールドには、少なくとも 1 つの値を選択する
 msgid "August"
 msgstr "8 月"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr "認証"
 
@@ -626,7 +629,7 @@ msgstr "自動"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Azure AD の設定"
 
@@ -660,12 +663,16 @@ msgstr "グループに戻る"
 msgid "Back to Hosts"
 msgstr "ホストに戻る"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "インベントリーに戻る"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "ジョブに戻る"
 
@@ -695,7 +702,7 @@ msgstr "スケジュールに戻る"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr "実行環境に戻る"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "インスタンスグループに戻る"
 
@@ -747,7 +753,7 @@ msgstr "インスタンスグループに戻る"
 msgid "Back to management jobs"
 msgstr "管理ジョブに戻る"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr "チェックアウトするブランチです。ブランチ以外に、タグ、コミットハッシュ値、任意の参照 (refs) を入力できます。カスタムの refspec も指定しない限り、コミットハッシュ値や参照で利用できないものもあります。"
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr "ブランドイメージ"
 
@@ -805,8 +811,8 @@ msgstr "キャッシュのタイムアウト (秒)"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr "キャッシュのタイムアウト (秒)"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr "取り消し"
 
@@ -883,7 +890,7 @@ msgstr "リンク変更の取り消し"
 msgid "Cancel link removal"
 msgstr "リンク削除の取り消し"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "ルックアップの取り消し"
 
@@ -908,13 +915,13 @@ msgstr "選択したジョブの取り消し"
 msgid "Cancel subscription edit"
 msgstr "サブスクリプションの編集の取り消し"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "{0} の取り消し"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -928,37 +935,37 @@ msgid ""
 "logging aggregator host and logging aggregator type."
 msgstr "ログアグリゲーターホストとログアグリゲータータイプを指定せずにログアグリゲーターを有効にすることはできません。"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "容量"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "contains で大文字小文字の区別なし。"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "endswith で大文字小文字の区別なし。"
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "exact で大文字小文字の区別なし。"
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "regex で大文字小文字の区別なし。"
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "startswith で大文字小文字の区別なし。"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -978,15 +985,15 @@ msgid "Channel"
 msgstr "チャネル"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "チェック"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "特定フィールドもしくは関連オブジェクトが null かどうかをチェック。ブール値を想定。"
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "特定フィールドの値が提供されたリストに存在するかどうかをチェック (項目のコンマ区切りのリストを想定)。"
 
@@ -998,7 +1005,7 @@ msgstr ".json ファイルの選択"
 msgid "Choose a Notification Type"
 msgstr "通知タイプの選択"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "Playbook ディレクトリーの選択"
 
@@ -1011,11 +1018,11 @@ msgid "Choose a Webhook Service"
 msgstr "Webhook サービスの選択"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "ジョブタイプの選択"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "モジュールの選択"
 
@@ -1038,7 +1045,7 @@ msgstr "ユーザーのプロンプトが表示される際に、必要な回答
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "選択したリソースに適用するロールを選択します。選択したすべてのロールが、選択したすべてのリソースに適用されることに注意してください。"
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "新しいロールを受け取るリソースを選択します。次のステップで適用するロールを選択できます。ここで選択したリソースは、次のステップで選択したすべてのロールを受け取ることに注意してください。"
 
@@ -1083,6 +1090,10 @@ msgstr "このボタンをクリックして、選択した認証情報と指定
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "クリックして、このノードへの新しいリンクを作成します。"
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1131,13 +1142,13 @@ msgstr "クラウド"
 msgid "Collapse"
 msgstr "折りたたむ"
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "コマンド"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "準拠"
 
@@ -1145,7 +1156,7 @@ msgstr "準拠"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "同時実行ジョブ"
 
@@ -1176,11 +1187,11 @@ msgstr "取り消しジョブの確認"
 msgid "Confirm cancellation"
 msgstr "取り消しの確認"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "削除の確認"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "関連付けの解除の確認"
 
@@ -1204,7 +1215,7 @@ msgstr "すべて元に戻すことを確認"
 msgid "Confirm selection"
 msgstr "選択の確認"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "コンテナーグループ"
 
@@ -1239,7 +1250,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr "Playbook の実行時に Ansible が生成する出力のレベルを制御します。"
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1292,11 +1303,11 @@ msgstr "テンプレートのコピー"
 msgid "Copy full revision to clipboard."
 msgstr "完全なリビジョンをクリップボードにコピーします。"
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "著作権"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "作成"
@@ -1409,14 +1420,14 @@ msgstr "新規ソースの作成"
 msgid "Create user token"
 msgstr "ユーザートークンの作成"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1426,7 +1437,7 @@ msgstr "ユーザートークンの作成"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1435,58 +1446,58 @@ msgstr "ユーザートークンの作成"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr "作成済み"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "作成者 (ユーザー名)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "作成者 (ユーザー名)"
 
@@ -1516,7 +1527,7 @@ msgstr "認証情報"
 msgid "Credential Input Sources"
 msgstr "認証情報の入力ソース"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "認証情報名"
 
@@ -1527,9 +1538,9 @@ msgid "Credential Type"
 msgstr "認証情報タイプ"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1555,24 +1566,24 @@ msgstr "保護されたコンテナーレジストリーで認証するための
 msgid "Credential type not found."
 msgstr "認証情報タイプが見つかりません。"
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr "認証情報"
@@ -1623,7 +1634,7 @@ msgstr "削除済み"
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "ダッシュボード (すべてのアクティビティー)"
 
@@ -1637,12 +1648,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "日"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "データの保持日数"
 
@@ -1650,7 +1661,7 @@ msgstr "データの保持日数"
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "残りの日数"
 
@@ -1667,12 +1678,20 @@ msgid "December"
 msgstr "12 月"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "デフォルト"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "デフォルトの実行環境"
 
@@ -1682,7 +1701,7 @@ msgstr "デフォルトの実行環境"
 msgid "Default answer"
 msgstr "デフォルトの応答"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "システムレベルの機能および関数の定義"
 
@@ -1696,8 +1715,8 @@ msgstr "システムレベルの機能および関数の定義"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1705,7 +1724,7 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1713,15 +1732,15 @@ msgstr "システムレベルの機能および関数の定義"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1750,7 +1769,7 @@ msgstr "ホストの削除"
 msgid "Delete Inventory"
 msgstr "インベントリーの削除"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1764,7 +1783,7 @@ msgstr "ジョブテンプレートの削除"
 msgid "Delete Notification"
 msgstr "通知の削除"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "組織の削除"
 
@@ -1772,15 +1791,15 @@ msgstr "組織の削除"
 msgid "Delete Project"
 msgstr "プロジェクトの削除"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "質問の削除"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "スケジュールの削除"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "Survey の削除"
 
@@ -1834,6 +1853,10 @@ msgstr "インベントリーソースの削除"
 msgid "Delete smart inventory"
 msgstr "スマートインベントリーの削除"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1865,16 +1888,16 @@ msgstr "{pluralizedItemName} を削除しますか?"
 msgid "Deleted"
 msgstr "削除済み"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "削除エラー"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "削除エラー"
 
@@ -1904,34 +1927,34 @@ msgid "Deprecated"
 msgstr "非推奨"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1939,36 +1962,36 @@ msgstr "非推奨"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr "説明"
 
@@ -2021,7 +2044,7 @@ msgstr "送信先チャネルまたはユーザー"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2107,39 +2130,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "関連付けの解除"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "グループのホストとの関連付けを解除しますか?"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "ホストのグループとの関連付けを解除しますか?"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "インスタンスグループへのインスタンスの関連付けを解除しますか?"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "関連するグループの関連付けを解除しますか?"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "関連するチームの関連付けを解除しますか?"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "ロールの関連付けの解除"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "ロールの関連付けの解除!"
 
@@ -2152,7 +2175,7 @@ msgstr "関連付けを解除しますか?"
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2217,8 +2240,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr "このプロジェクトでジョブを実行する際は常に、ジョブの開始前にプロジェクトのリビジョンを更新します。"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2237,8 +2260,8 @@ msgstr "このプロジェクトでジョブを実行する際は常に、ジョ
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2260,7 +2283,7 @@ msgstr "このプロジェクトでジョブを実行する際は常に、ジョ
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2336,8 +2359,8 @@ msgstr "実行環境の編集"
 msgid "Edit Group"
 msgstr "グループの編集"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2366,6 +2389,10 @@ msgstr "ノードの編集"
 msgid "Edit Notification Template"
 msgstr "通知テンプレートの編集"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2390,7 +2417,7 @@ msgstr "スケジュールの編集"
 msgid "Edit Source"
 msgstr "ソースの編集"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2478,8 +2505,8 @@ msgstr "経過時間"
 msgid "Elapsed time that the job ran"
 msgstr "ジョブ実行の経過時間"
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2493,7 +2520,7 @@ msgstr "メールオプション"
 msgid "Enable Concurrent Jobs"
 msgstr "同時実行ジョブの有効化"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "ファクトストレージの有効化"
 
@@ -2501,8 +2528,8 @@ msgstr "ファクトストレージの有効化"
 msgid "Enable HTTPS certificate verification"
 msgstr "HTTPS 証明書の検証を有効化"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2520,8 +2547,8 @@ msgstr "外部ログの有効化"
 msgid "Enable log system tracking facts individually"
 msgstr "システムトラッキングファクトを個別に有効化"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "権限昇格の有効化"
 
@@ -2529,15 +2556,15 @@ msgstr "権限昇格の有効化"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "このテンプレートの Webhook を有効にします。"
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "有効化"
@@ -2572,7 +2599,7 @@ msgstr "有効な変数"
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2580,7 +2607,7 @@ msgid ""
 "template"
 msgstr "プロビジョニングコールバック URL の作成を有効にします。ホストは、この URL を使用して {brandName} に接続でき、このジョブテンプレートを使用して設定の更新を要求できます。"
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2602,7 +2629,7 @@ msgstr "終了"
 msgid "End User License Agreement"
 msgstr "使用許諾契約書"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "終了が期待値と一致しませんでした"
 
@@ -2708,21 +2735,21 @@ msgstr "変数を入力して、インベントリーソースを設定します
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "JSON または YAML 構文のいずれかを使用して変数を入力します。ラジオボタンを使用してこの構文を切り替えます。"
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "エラー"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2746,41 +2773,41 @@ msgstr "ワークフローの保存中にエラー!"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2788,21 +2815,21 @@ msgstr "ワークフローの保存中にエラー!"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2812,17 +2839,17 @@ msgstr "ワークフローの保存中にエラー!"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "エラー!"
 
@@ -2830,7 +2857,7 @@ msgstr "エラー!"
 msgid "Error:"
 msgstr "エラー:"
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2848,15 +2875,19 @@ msgstr "イベント詳細モーダル"
 msgid "Event summary not available"
 msgstr "イベントの概要はありません"
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "イベント"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "完全一致 (指定されない場合のデフォルトのルックアップ)"
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2892,15 +2923,15 @@ msgstr "親ノードが障害状態になったときに実行します。"
 msgid "Execute when the parent node results in a successful state."
 msgstr "親ノードが正常な状態になったときに実行します。"
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "実行環境"
 
@@ -2909,22 +2940,22 @@ msgstr "実行環境"
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "実行環境"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "実行ノード"
 
@@ -2958,24 +2989,24 @@ msgstr "入力の展開"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "client_email、project_id、または private_key の少なくとも 1 つがファイルに存在する必要があります。"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "有効期限"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "有効期限:"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "UTC の有効期限"
 
@@ -2984,7 +3015,7 @@ msgstr "UTC の有効期限"
 msgid "Expires on {0}"
 msgstr "{0} の有効期限"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "説明"
@@ -2993,8 +3024,8 @@ msgstr "説明"
 msgid "External Secret Management System"
 msgstr "外部シークレット管理システム"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "追加変数"
 
@@ -3019,7 +3050,7 @@ msgstr ""
 msgid "Facts"
 msgstr "ファクト"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3045,7 +3076,7 @@ msgstr "失敗したホスト"
 msgid "Failed jobs"
 msgstr "失敗したジョブ"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "1 つ以上のワークフロー承認を承認できませんでした。"
 
@@ -3053,21 +3084,21 @@ msgstr "1 つ以上のワークフロー承認を承認できませんでした�
 msgid "Failed to approve workflow approval."
 msgstr "ワークフローの承認を承認できませんでした。"
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "ロールを正しく割り当てられませんでした"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "ロールの関連付けに失敗しました"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "関連付けに失敗しました。"
 
@@ -3080,12 +3111,12 @@ msgstr "インベントリーソースの同期の取り消しに失敗しまし
 msgid "Failed to cancel Project Sync"
 msgstr "プロジェクトの同期の取り消しに失敗しました。"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "1 つ以上のジョブを取り消すことができませんでした。"
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "{0} を取り消すことができませんでした。"
@@ -3144,19 +3175,19 @@ msgstr "ジョブテンプレートを削除できませんでした。"
 msgid "Failed to delete notification."
 msgstr "通知を削除できませんでした。"
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "1 つ以上のアプリケーションを削除できませんでした。"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "1 つ以上の認証情報タイプを削除できませんでした。"
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "1 つ以上の認証情報を削除できませんでした。"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "1 つ以上の実行環境を削除できませんでした。"
 
@@ -3164,16 +3195,16 @@ msgstr "1 つ以上の実行環境を削除できませんでした。"
 msgid "Failed to delete one or more groups."
 msgstr "1 つ以上のグループを削除できませんでした。"
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "1 つ以上のホストを削除できませんでした。"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "1 つ以上のインスタンスグループを削除できませんでした。"
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "1 つ以上のインベントリーを削除できませんでした。"
 
@@ -3181,55 +3212,55 @@ msgstr "1 つ以上のインベントリーを削除できませんでした。"
 msgid "Failed to delete one or more inventory sources."
 msgstr "1 つ以上のインベントリーリソースを削除できませんでした。"
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "1 つ以上のジョブテンプレートを削除できませんでした"
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "1 つ以上のジョブを削除できませんでした。"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "1 つ以上の通知テンプレートを削除できませんでした。"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "1 つ以上の組織を削除できませんでした。"
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "1 つ以上のプロジェクトを削除できませんでした。"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "1 つ以上のスケジュールを削除できませんでした。"
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "1 つ以上のチームを削除できませんでした。"
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "1 つ以上のテンプレートを削除できませんでした。"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "1 つ以上のトークンを削除できませんでした。"
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "1 つ以上のユーザートークンを削除できませんでした。"
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "1 人以上のユーザーを削除できませんでした。"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "1 つ以上のワークフロー承認を削除できませんでした。"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "組織を削除できませんでした。"
 
@@ -3237,16 +3268,16 @@ msgstr "組織を削除できませんでした。"
 msgid "Failed to delete project."
 msgstr "プロジェクトを削除できませんでした。"
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "ロールを削除できませんでした。"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "ロールを削除できませんでした。"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "スケジュールを削除できませんでした。"
 
@@ -3275,7 +3306,7 @@ msgstr "ワークフロージョブテンプレートを削除できませんで
 msgid "Failed to delete {name}."
 msgstr "{name} を削除できませんでした。"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "1 つ以上のワークフロー承認を拒否できませんでした。"
 
@@ -3283,21 +3314,21 @@ msgstr "1 つ以上のワークフロー承認を拒否できませんでした�
 msgid "Failed to deny workflow approval."
 msgstr "ワークフローの承認を拒否できませんでした。"
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "1 つ以上のグループの関連付けを解除できませんでした。"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "1 つ以上のホストの関連付けを解除できませんでした。"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "1 つ以上のインスタンスの関連付けを解除できませんでした。"
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "1 つ以上のチームの関連付けを解除できませんでした。"
 
@@ -3305,13 +3336,13 @@ msgstr "1 つ以上のチームの関連付けを解除できませんでした�
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "カスタムログイン構成設定を取得できません。代わりに、システムのデフォルトが表示されます。"
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "ジョブを起動できませんでした。"
 
@@ -3351,7 +3382,7 @@ msgstr "ホストの切り替えに失敗しました。"
 msgid "Failed to toggle instance."
 msgstr "インスタンスの切り替えに失敗しました。"
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "通知の切り替えに失敗しました。"
 
@@ -3382,7 +3413,7 @@ msgstr "失敗"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "False"
 
@@ -3390,11 +3421,11 @@ msgstr "False"
 msgid "February"
 msgstr "2 月"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "値を含むフィールド。"
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "値で終了するフィールド。"
 
@@ -3402,11 +3433,11 @@ msgstr "値で終了するフィールド。"
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "カスタムの Kubernetes または OpenShift Pod 仕様を渡すためのフィールド。"
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "特定の正規表現に一致するフィールド。"
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "値で開始するフィールド。"
 
@@ -3422,16 +3453,16 @@ msgstr "ファイルの相違点"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "ファイルのアップロードが拒否されました。単一の .json ファイルを選択してください。"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "ファイル、ディレクトリー、またはスクリプト"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "終了時間"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "終了日時"
@@ -3442,25 +3473,25 @@ msgstr "最初"
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "名"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "初回実行日時"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "名"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "最初に、キーを選択します"
 
@@ -3476,7 +3507,7 @@ msgstr "浮動"
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3495,11 +3526,11 @@ msgstr "ジョブテンプレートについて、Playbook を実行するため
 msgid "For more information, refer to the"
 msgstr "詳しい情報は以下の情報を参照してください:"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "フォーク"
 
@@ -3507,12 +3538,12 @@ msgstr "フォーク"
 msgid "Fourth"
 msgstr "第 4"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "頻度の詳細"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "頻度が期待値と一致しませんでした"
 
@@ -3525,11 +3556,11 @@ msgstr "金"
 msgid "Friday"
 msgstr "金曜"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3554,11 +3585,11 @@ msgstr "サブスクリプションの取得"
 msgid "Get subscriptions"
 msgstr "サブスクリプションの取得"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3597,7 +3628,7 @@ msgstr "GitHub 組織"
 msgid "GitHub Team"
 msgstr "GitHub チーム"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "GitHub 設定"
 
@@ -3606,7 +3637,7 @@ msgstr "GitHub 設定"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "グローバルなデフォルトの実行環境"
 
@@ -3635,11 +3666,11 @@ msgstr "次のページに移動"
 msgid "Go to previous page"
 msgstr "前のページに移動"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Google OAuth2 の設定"
 
@@ -3647,8 +3678,8 @@ msgstr "Google OAuth2 の設定"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3661,15 +3692,15 @@ msgstr "Grafana API キー"
 msgid "Grafana URL"
 msgstr "Grafana URL"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "Greater than の比較条件"
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "Greater than or equal to の比較条件"
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "グループ"
 
@@ -3677,20 +3708,20 @@ msgstr "グループ"
 msgid "Group details"
 msgstr "グループの詳細"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "グループタイプ"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "グループ"
@@ -3718,8 +3749,8 @@ msgstr "非表示"
 msgid "Hide description"
 msgstr "説明の非表示"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "Hipchat"
 
@@ -3738,7 +3769,7 @@ msgstr "ホストの非同期 OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "ホスト設定キー"
 
@@ -3809,20 +3840,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "このジョブのホストのステータス情報は利用できません。"
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3830,30 +3861,30 @@ msgstr "このジョブのホストのステータス情報は利用できませ
 msgid "Hosts"
 msgstr "ホスト"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "利用可能なホスト"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "残りのホスト"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "時間"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3873,8 +3904,8 @@ msgstr "ダッシュボード ID (オプション)"
 msgid "ID of the panel (optional)"
 msgstr "パネル ID (オプション)"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -3931,7 +3962,7 @@ msgid ""
 "default group for the inventory."
 msgstr "チェックを付けると、以前は外部ソースにあり、現在は削除されているホストおよびグループがインベントリーから削除されます。インベントリーソースで管理されていなかったホストおよびグループは、次に手動で作成したグループにプロモートされます。プロモート先となる、手動で作成したグループがない場合、ホストおよびグループは、インベントリーの \"すべて\" のデフォルトグループに残ります。"
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3944,18 +3975,18 @@ msgid ""
 "--diff mode."
 msgstr "有効で、サポートされている場合は、Ansible タスクで加えられた変更を表示します。これは Ansible の --diff モードに相当します。"
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr "有効で、サポートされている場合は、Ansible タスクで加えられた変更を表示します。これは Ansible の --diff モードに相当します。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "有効で、サポートされている場合は、Ansible タスクで加えられた変更を表示します。これは Ansible の --diff モードに相当します。"
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3965,7 +3996,7 @@ msgstr "有効な場合は、このジョブテンプレートの同時実行が
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "有効な場合は、このワークフロージョブテンプレートの同時実行が許可されます。"
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3976,7 +4007,7 @@ msgstr "有効にすると、収集されたファクトが保存されるため
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "アップグレードまたは更新の準備ができましたら、<0>お問い合わせください</0>。"
 
@@ -3986,7 +4017,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr "サブスクリプションをお持ちでない場合は、Red Hat にアクセスしてトライアルサブスクリプションを取得できます。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "この特定のユーザーのアクセスのみを削除する場合は、チームから削除してください。"
 
@@ -3998,13 +4029,13 @@ msgid ""
 msgstr "起動時およびプロジェクトの更新時にインベントリーソースを更新する場合は、起動時に更新をクリックして移動します"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "イメージ"
@@ -4028,13 +4059,13 @@ msgstr "情報"
 msgid "Initiated By"
 msgstr "開始:"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "開始:"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "開始者 (ユーザー名)"
 
@@ -4061,7 +4092,7 @@ msgstr "Insights for Ansible Automation Platform"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Insights for Ansible Automation Platform ダッシュボード"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "Insights システム ID"
 
@@ -4073,18 +4104,18 @@ msgstr "インスタンス"
 msgid "Instance Filters"
 msgstr "インスタンスフィルター"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "インスタンスグループ"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4093,7 +4124,7 @@ msgstr "インスタンスグループ"
 msgid "Instance Groups"
 msgstr "インスタンスグループ"
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "インスタンス ID"
 
@@ -4115,11 +4146,11 @@ msgid "Instance groups"
 msgstr "インスタンスグループ"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "インスタンス"
 
@@ -4149,11 +4180,11 @@ msgstr "無効なユーザー名またはパスワードです。やり直して
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4164,41 +4195,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "ソースを含むインベントリーはコピーできません。"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "インベントリー"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "インベントリー (名前)"
 
@@ -4206,13 +4237,17 @@ msgstr "インベントリー (名前)"
 msgid "Inventory File"
 msgstr "インベントリーファイル"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "インベントリー ID"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "インベントリーソース"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4229,15 +4264,15 @@ msgstr "インベントリーソース同期エラー"
 msgid "Inventory Sources"
 msgstr "インベントリーソース"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "インベントリー同期"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4282,7 +4317,7 @@ msgstr "項目 OK"
 msgid "Item Skipped"
 msgstr "項目のスキップ"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "項目"
@@ -4314,20 +4349,20 @@ msgstr "JSON:"
 msgid "January"
 msgstr "1 月"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "ジョブ"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "ジョブキャンセルエラー"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4341,19 +4376,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "ジョブスライス"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "ジョブスライス"
 
@@ -4365,20 +4400,20 @@ msgstr "ジョブステータス"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "ジョブタグ"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "ジョブテンプレート"
@@ -4403,15 +4438,15 @@ msgstr "ノードの作成時または編集時に、インベントリーまた
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "ノードの作成時または編集時に、パスワードの入力を求める認証情報を持つジョブテンプレートを選択できない"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "ジョブタイプ"
 
@@ -4424,15 +4459,15 @@ msgid "Job status graph tab"
 msgstr "ジョブステータスのグラフタブ"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "ジョブテンプレート"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4447,7 +4482,7 @@ msgstr "ジョブテンプレート"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4455,7 +4490,7 @@ msgstr "ジョブテンプレート"
 msgid "Jobs"
 msgstr "ジョブ"
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "ジョブ設定"
 
@@ -4467,19 +4502,19 @@ msgstr "7 月"
 msgid "June"
 msgstr "6 月"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "キー"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "キー選択"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "キー先行入力"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "キーワード"
 
@@ -4512,7 +4547,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "LDAP のデフォルト"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "LDAP 設定"
 
@@ -4536,18 +4571,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "ラベル名"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "ラベル"
@@ -4565,11 +4600,11 @@ msgid "Last Login"
 msgstr "前回のログイン"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4579,7 +4614,7 @@ msgstr "前回のログイン"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4593,25 +4628,25 @@ msgstr "最終更新日"
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr "姓"
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "最終実行日時"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "最終実行"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "最後のジョブ"
 
@@ -4622,7 +4657,7 @@ msgstr "最後のジョブ"
 msgid "Last modified"
 msgstr "最終更新日"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "姓"
@@ -4673,11 +4708,11 @@ msgstr "ワークフローの起動"
 msgid "Launch | {0}"
 msgstr "起動 | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "起動者"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "起動者 (ユーザー名)"
 
@@ -4693,26 +4728,26 @@ msgstr "実行環境を世界中で利用できるようにするには、この
 msgid "Legend"
 msgstr "凡例"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "Less than の比較条件"
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "Less than or equal to の比較条件"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "制限"
@@ -4729,11 +4764,11 @@ msgstr "ロード中"
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "ローカルタイムゾーン"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "ローカルタイムゾーン"
 
@@ -4745,7 +4780,7 @@ msgstr "ログイン"
 msgid "Logging"
 msgstr "ロギング"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "ロギング設定"
 
@@ -4755,20 +4790,20 @@ msgstr "ロギング設定"
 msgid "Logout"
 msgstr "ログアウト"
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "ルックアップモーダル"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "ルックアップ選択"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "ルックアップタイプ"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "ルックアップの先行入力"
 
@@ -4778,10 +4813,10 @@ msgstr "ルックアップの先行入力"
 msgid "MOST RECENT SYNC"
 msgstr "直近の同期"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "マシンの認証情報"
 
@@ -4794,8 +4829,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr "管理ノード"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4805,7 +4840,7 @@ msgid "Management Job"
 msgstr "管理ジョブ"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr "管理ジョブ"
 
@@ -4826,15 +4861,15 @@ msgstr "管理ジョブが見つかりません。"
 msgid "Management jobs"
 msgstr "管理ジョブ"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "手動"
 
@@ -4842,8 +4877,8 @@ msgstr "手動"
 msgid "March"
 msgstr "3 月"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4864,7 +4899,7 @@ msgstr "最大長"
 msgid "May"
 msgstr "5 月"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr "メンバー"
@@ -4881,7 +4916,7 @@ msgstr "メトリック"
 msgid "Metrics"
 msgstr "メトリックス"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -4905,7 +4940,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr "新規インスタンスがオンラインになると、このグループに自動的に最小限割り当てられるインスタンスの割合"
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "分"
 
@@ -4913,7 +4948,7 @@ msgstr "分"
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4921,7 +4956,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr "その他のシステム"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "その他のシステム設定"
 
@@ -4936,70 +4971,70 @@ msgid "Missing resource"
 msgstr "不足しているリソース"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr "修正済み"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "変更者 (ユーザー名)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "変更者 (ユーザー名)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "モジュール"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5012,7 +5047,7 @@ msgstr "月"
 msgid "Monday"
 msgstr "月曜"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "月"
 
@@ -5024,13 +5059,13 @@ msgstr "詳細情報"
 msgid "More information for"
 msgstr "詳細情報: "
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "複数選択"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "複数選択"
 
@@ -5046,57 +5081,57 @@ msgstr "複数の選択 (単一の選択)"
 msgid "Multiple Choice Options"
 msgstr "複数の選択オプション"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5111,73 +5146,73 @@ msgstr "複数の選択オプション"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5190,66 +5225,72 @@ msgstr "複数の選択オプション"
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr "名前"
@@ -5273,7 +5314,7 @@ msgstr "未更新"
 msgid "Never expires"
 msgstr "期限切れなし"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "新規"
@@ -5292,8 +5333,8 @@ msgstr "新規"
 msgid "Next"
 msgstr "次へ"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5336,7 +5377,7 @@ msgstr "インベントリー同期の失敗はありません。"
 msgid "No items found."
 msgstr "項目は見つかりません。"
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5344,10 +5385,10 @@ msgstr ""
 msgid "No result found"
 msgstr "結果が見つかりません"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "結果が見つかりません"
 
@@ -5356,7 +5397,7 @@ msgstr "結果が見つかりません"
 msgid "No subscriptions found"
 msgstr "サブスクリプションが見つかりません"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "Survey の質問は見つかりません。"
 
@@ -5371,7 +5412,7 @@ msgstr "{pluralizedItemName} が見つかりません"
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5389,7 +5430,7 @@ msgstr "なし"
 msgid "None (Run Once)"
 msgstr "なし (1回実行)"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "なし (1回実行)"
 
@@ -5412,15 +5453,15 @@ msgstr "設定されていません"
 msgid "Not configured for inventory sync."
 msgstr "インベントリーの同期に設定されていません。"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr "このグループに直接含まれるホストのみの関連付けを解除できることに注意してください。サブグループのホストの関連付けの解除については、それらのホストが属するサブグループのレベルで直接実行する必要があります。"
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5428,7 +5469,7 @@ msgid ""
 "with directly and indirectly."
 msgstr "ホストがそのグループの子のメンバーでもある場合は、関連付けを解除した後も一覧にグループが表示される場合があることに注意してください。この一覧には、ホストが直接的および間接的に関連付けられているすべてのグループが表示されます。"
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5459,9 +5500,9 @@ msgstr "通知の色"
 msgid "Notification Template not found."
 msgstr "通知テンプレートテストは見つかりません。"
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5476,20 +5517,20 @@ msgstr "通知タイプ"
 msgid "Notification color"
 msgstr "通知の色"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "通知が正常に送信されました"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "通知がタイムアウトしました"
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "通知タイプ"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5524,39 +5565,37 @@ msgstr "実行回数"
 msgid "October"
 msgstr "10 月"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "オフ"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "オン"
 
@@ -5586,7 +5625,7 @@ msgstr "曜日"
 msgid "Only Group By"
 msgstr "グループ化のみ"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5594,7 +5633,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "オプションの詳細"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5606,20 +5645,26 @@ msgstr "「dev」、「test」などのこのジョブテンプレートを説�
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "必要に応じて、ステータスの更新を Webhook サービスに送信しなおすのに使用する認証情報を選択します。"
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "オプション"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5630,15 +5675,15 @@ msgstr "オプション"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5648,22 +5693,22 @@ msgstr "オプション"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "組織"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "組織 (名前)"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "組織名"
 
@@ -5673,9 +5718,9 @@ msgstr "組織が見つかりません。"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5690,11 +5735,11 @@ msgstr "組織"
 msgid "Other prompts"
 msgstr "他のプロンプト"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "コンプライアンス違反"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "出力"
@@ -5725,8 +5770,8 @@ msgstr "POST"
 msgid "PUT"
 msgstr "PUT"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5758,11 +5803,11 @@ msgstr "パンライト"
 msgid "Pan Up"
 msgstr "パンアップ"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "追加のコマンドライン変更を渡します。2 つの Ansible コマンドラインパラメーターがあります。"
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5799,7 +5844,7 @@ msgstr "過去 2 週間"
 msgid "Past week"
 msgstr "過去 1 週間"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5813,12 +5858,12 @@ msgstr "保留中のワークフロー承認"
 msgid "Pending delete"
 msgstr "保留中の削除"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "検索を実行して、ホストフィルターを定義します。"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5839,13 +5884,13 @@ msgid "Play Started"
 msgstr "プレイの開始"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Playbook"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Playbook チェック"
@@ -5856,12 +5901,12 @@ msgstr "Playbook の完了"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Playbook ディレクトリー"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5871,10 +5916,10 @@ msgstr "Playbook 実行"
 msgid "Playbook Started"
 msgstr "Playbook の開始"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Playbook 名"
 
@@ -5886,15 +5931,15 @@ msgstr "Playbook 実行"
 msgid "Plays"
 msgstr "プレイ"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "Survey の質問を追加してください。"
 
@@ -5918,23 +5963,23 @@ msgstr "値を入力してください。"
 msgid "Please log in"
 msgstr "ログインしてください"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "1 から 31 までの日付を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "インベントリーを選択するか、または起動プロンプトオプションにチェックを付けてください。"
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "開始日時より後の終了日時を選択してください。"
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "組織を選択してからホストフィルターを編集します。"
 
@@ -5942,7 +5987,7 @@ msgstr "組織を選択してからホストフィルターを編集します。
 msgid "Pod spec override"
 msgstr "Pod 仕様の上書き"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5962,7 +6007,7 @@ msgstr "ポリシーインスタンスの割合"
 msgid "Populate field from an external secret management system"
 msgstr "外部のシークレット管理システムからフィールドにデータを入力します"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6000,8 +6045,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "プレビュー"
 
@@ -6011,7 +6054,7 @@ msgstr "秘密鍵のパスフレーズ"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "権限昇格"
 
@@ -6019,17 +6062,16 @@ msgstr "権限昇格"
 msgid "Privilege escalation password"
 msgstr "権限昇格のパスワード"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6037,7 +6079,7 @@ msgstr "プロジェクト"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "プロジェクトのベースパス"
 
@@ -6065,10 +6107,10 @@ msgstr "プロジェクトの同期の失敗"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6081,8 +6123,8 @@ msgstr "プロジェクト"
 msgid "Promote Child Groups and Hosts"
 msgstr "子グループおよびホストのプロモート"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "プロンプト"
 
@@ -6101,11 +6143,11 @@ msgid "Prompt | {0}"
 msgstr "プロンプト | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "プロンプト値"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6126,7 +6168,7 @@ msgstr "Playbook によって管理されるか、またはその影響を受け
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "このフィールドに値を入力するか、起動プロンプトを表示するオプションを選択します。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6146,18 +6188,18 @@ msgstr "Red Hat または Red Hat Satellite の認証情報を提供して、Ins
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "プロビジョニングコールバック URL"
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "プロビジョニングコールバックの詳細"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "プロビジョニングコールバック"
 
@@ -6174,7 +6216,7 @@ msgstr "質問"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "RADIUS 設定"
 
@@ -6204,7 +6246,7 @@ msgstr "最近のテンプレートリストタブ"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6217,19 +6259,19 @@ msgstr "受信者リスト"
 msgid "Recipient list"
 msgstr "受信者リスト"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Red Hat Virtualization"
 
@@ -6237,7 +6279,7 @@ msgstr "Red Hat Virtualization"
 msgid "Red Hat subscription manifest"
 msgstr "Red Hat サブスクリプションマニュフェスト"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6261,7 +6303,7 @@ msgstr "サブスクリプションの詳細へのリダイレクト"
 msgid "Refer to the"
 msgstr "参照:"
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6297,28 +6339,28 @@ msgstr "一致するホスト名のみがインポートされる正規表現。
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "関連するグループ"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "再起動"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "ジョブの再起動"
@@ -6336,16 +6378,16 @@ msgstr "失敗したホストの再起動"
 msgid "Relaunch on"
 msgstr "再起動時"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "ホストパラメーターを使用した再起動"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "リモートアーカイブ"
 
@@ -6372,7 +6414,7 @@ msgstr "ノードの削除"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "更新の実行前にローカルの変更を削除します。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr "{0} アクセスの削除"
 
@@ -6388,7 +6430,7 @@ msgstr "このリンクを削除すると、ブランチの残りの部分が孤
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "繰り返しの頻度"
 
@@ -6405,7 +6447,7 @@ msgstr "フィールドを新しい値に置き換え"
 msgid "Request subscription"
 msgstr "サブスクリプションの要求"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "必須"
@@ -6413,7 +6455,7 @@ msgstr "必須"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "リソース名"
 
@@ -6422,7 +6464,7 @@ msgid "Resource deleted"
 msgstr "リソースが削除されました"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr "リソース"
 
@@ -6454,15 +6496,15 @@ msgstr "戻る"
 msgid "Return to subscription management."
 msgstr "サブスクリプション管理へ戻る"
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "これ以外の値と他のフィルターが含まれる結果を返します。"
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "このフィルターおよび他のフィルターを満たす結果を返します。何も選択されていない場合は、これがデフォルトのセットタイプです。"
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "この 1 つまたは他のフィルターを満たす結果を返します。"
 
@@ -6493,8 +6535,8 @@ msgstr "設定を元に戻す"
 msgid "Revert to factory default."
 msgstr "工場出荷時のデフォルトに戻します。"
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "リビジョン"
@@ -6503,25 +6545,25 @@ msgstr "リビジョン"
 msgid "Revision #"
 msgstr "リビジョン #"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "ロール"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6535,7 +6577,7 @@ msgstr "ロール"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "実行"
 
@@ -6559,7 +6601,7 @@ msgstr "コマンドの実行"
 msgid "Run every"
 msgstr "実行する間隔"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "実行頻度"
 
@@ -6571,7 +6613,7 @@ msgstr "実行:"
 msgid "Run type"
 msgstr "実行タイプ"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6582,8 +6624,8 @@ msgstr "実行中"
 msgid "Running Handlers"
 msgstr "実行中のハンドラー"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "実行中のジョブ"
@@ -6596,7 +6638,7 @@ msgstr "実行中のジョブ"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "SAML 設定"
 
@@ -6639,18 +6681,19 @@ msgid "Saturday"
 msgstr "土曜"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6688,7 +6731,7 @@ msgstr "スケジュールはアクティブです"
 msgid "Schedule is inactive"
 msgstr "スケジュールは非アクティブです"
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "スケジュールにルールがありません"
 
@@ -6696,10 +6739,10 @@ msgstr "スケジュールにルールがありません"
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6713,11 +6756,11 @@ msgstr ""
 msgid "Schedules"
 msgstr "スケジュール"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6739,8 +6782,8 @@ msgstr "次へスクロール"
 msgid "Scroll previous"
 msgstr "前にスクロール"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr "検索"
 
@@ -6748,7 +6791,7 @@ msgstr "検索"
 msgid "Search is disabled while the job is running"
 msgstr "ジョブの実行中は検索が無効になっています"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "検索送信ボタン"
@@ -6772,9 +6815,9 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "左側のエラーを参照してください"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6784,13 +6827,13 @@ msgstr "選択"
 msgid "Select Credential Type"
 msgstr "認証情報タイプの選択"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "グループの選択"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "ホストの選択"
 
@@ -6798,11 +6841,11 @@ msgstr "ホストの選択"
 msgid "Select Input"
 msgstr "入力の選択"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "インスタンスの選択"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "アイテムの選択"
 
@@ -6818,7 +6861,7 @@ msgstr "ラベルの選択"
 msgid "Select Roles to Apply"
 msgstr "適用するロールの選択"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "チームの選択"
 
@@ -6834,7 +6877,7 @@ msgstr "ノードタイプの選択"
 msgid "Select a Resource Type"
 msgstr "リソースタイプの選択"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6864,7 +6907,7 @@ msgstr "取り消すジョブの選択"
 msgid "Select a metric"
 msgstr "メトリックの選択"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "モジュールの選択"
 
@@ -6873,16 +6916,20 @@ msgstr "モジュールの選択"
 msgid "Select a playbook"
 msgstr "Playbook の選択"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "実行環境を編集する前にプロジェクトを選択してください。"
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "承認する行の選択"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr "削除する行の選択"
 
@@ -6903,8 +6950,8 @@ msgstr "サブスクリプションの選択"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6924,7 +6971,7 @@ msgstr "サブスクリプションの選択"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6937,11 +6984,11 @@ msgid "Select a webhook service."
 msgstr "Webhook サービスを選択します。"
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr "すべて選択"
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "アクティビティータイプの選択"
 
@@ -6961,7 +7008,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr "デフォルトの実行環境を編集する前に、組織を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6970,7 +7017,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr "このジョブが実行されるノードへのアクセスを許可する認証情報を選択します。各タイプにつき 1 つの認証情報のみを選択できます。マシンの認証情報 (SSH) については、認証情報を選択せずに「起動プロンプト」を選択すると、実行時にマシン認証情報を選択する必要があります。認証情報を選択し、「起動プロンプト」にチェックを付けている場合は、選択した認証情報が実行時に更新できるデフォルトになります。"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7015,7 +7062,7 @@ msgstr "状態の選択"
 msgid "Select tags"
 msgstr "タグの選択"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "このコマンドを内部で実行する実行環境を選択します。"
 
@@ -7023,7 +7070,7 @@ msgstr "このコマンドを内部で実行する実行環境を選択します
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "このインベントリーを実行するインスタンスグループを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7041,16 +7088,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "このトークンが属するアプリケーションを選択します。"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "そのコマンドを実行するためにリモートホストへのアクセス時に使用する認証情報を選択します。Ansible がリモートホストにログインするために必要なユーザー名および SSH キーまたはパスワードが含まれる認証情報を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "このジョブテンプレートの実行環境を選択します。"
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7068,11 +7115,11 @@ msgstr "このソースで同期されるインベントリーファイルを選
 msgid "Select the inventory that this host will belong to."
 msgstr "このホストが属するインベントリーを選択します。"
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "このジョブで実行される Playbook を選択してください。"
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7082,7 +7129,7 @@ msgstr "このジョブで実行する Playbook が含まれるプロジェク�
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "使用する Ansible Automation Platform サブスクリプションを選択します。"
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "{0} の選択"
 
@@ -7091,7 +7138,7 @@ msgstr "{0} の選択"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7103,7 +7150,7 @@ msgstr "{0} の選択"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7115,17 +7162,23 @@ msgstr "{0} の選択"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr "選択済み"
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "選択したカテゴリー"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7152,7 +7205,7 @@ msgstr "このフィールドに値を設定します"
 msgid "Set how many days of data should be retained."
 msgstr "データの保持日数を設定します。"
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "データ収集、ロゴ、およびログイン情報の設定"
 
@@ -7168,19 +7221,19 @@ msgstr "インスタンスをオンラインまたはオフラインに設定し
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "クライアントデバイスのセキュリティーレベルに応じて「公開」または「機密」に設定します。"
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "タイプの設定"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "タイプ選択の設定"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "タイプ先行入力の設定"
 
@@ -7202,8 +7255,8 @@ msgstr "名前の設定"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr "設定"
@@ -7215,9 +7268,9 @@ msgstr "表示"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "変更の表示"
 
@@ -7225,8 +7278,8 @@ msgstr "変更の表示"
 #~ msgid "Show all groups"
 #~ msgstr "すべてのグループの表示"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "変更の表示"
 
@@ -7239,7 +7292,7 @@ msgstr "説明の表示"
 msgid "Show less"
 msgstr "簡易表示"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "root グループのみを表示"
 
@@ -7292,14 +7345,14 @@ msgstr "簡易キー選択"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "スキップタグ"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7320,15 +7373,15 @@ msgstr "スキップタグは、Playbook のサイズが大きい場合にプレ
 msgid "Skipped"
 msgstr "スキップ済"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "スマートインベントリー"
@@ -7337,7 +7390,7 @@ msgstr "スマートインベントリー"
 msgid "Smart Inventory not found."
 msgstr "スマートインベントリーは見つかりません。"
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "スマートホストフィルター"
@@ -7369,13 +7422,15 @@ msgstr "並び替え"
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "質問の順序の並べ替え"
+#~ msgid "Sort question order"
+#~ msgstr "質問の順序の並べ替え"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "ソース"
 
@@ -7384,12 +7439,12 @@ msgstr "ソース"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "ソースコントロールブランチ"
 
@@ -7422,19 +7477,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr "ソースコントロールのタイプ"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "ソースコントロールの URL"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7448,8 +7503,8 @@ msgstr "発信元の電話番号"
 msgid "Source Variables"
 msgstr "ソース変数"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "ソースワークフローのジョブ"
 
@@ -7470,7 +7525,7 @@ msgstr "発信元の電話番号"
 msgid "Source variables"
 msgstr "ソース変数"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "プロジェクトから取得"
 
@@ -7517,14 +7572,14 @@ msgstr "標準出力タブ"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "開始"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "開始時間"
 
@@ -7546,27 +7601,27 @@ msgstr "同期プロセスの開始"
 msgid "Start sync source"
 msgstr "同期ソースの開始"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "開始"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "ステータス"
@@ -7591,14 +7646,14 @@ msgid ""
 "flag to git submodule update."
 msgstr "サブモジュールは、マスターブランチ (または .gitmodules で指定された他のブランチ) の最新のコミットを追跡します。いいえの場合、サブモジュールはメインプロジェクトで指定されたリビジョンで保持されます。これは、git submodule update に --remote フラグを指定するのと同じです。"
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "サブスクリプション"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "サブスクリプションの詳細"
 
@@ -7614,11 +7669,11 @@ msgstr "サブスクリプションマニュフェスト"
 msgid "Subscription selection modal"
 msgstr "サブスクリプション選択モーダル"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "サブスクリプション設定"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "サブスクリプションタイプ"
 
@@ -7626,11 +7681,11 @@ msgstr "サブスクリプションタイプ"
 msgid "Subscriptions table"
 msgstr "サブスクリプションテーブル"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversion"
 
@@ -7650,7 +7705,7 @@ msgstr "成功メッセージ"
 msgid "Success message body"
 msgstr "成功メッセージボディー"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7682,25 +7737,37 @@ msgstr "日曜"
 msgid "Survey"
 msgstr "Survey"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "Survey 一覧"
+#~ msgid "Survey List"
+#~ msgstr "Survey 一覧"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "Survey プレビュー"
+#~ msgid "Survey Preview"
+#~ msgstr "Survey プレビュー"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "Survey の切り替え"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "Survey プレビューモーダル"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "Survey の質問"
+#~ msgid "Survey questions"
+#~ msgstr "Survey の質問"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7738,15 +7805,15 @@ msgstr "リビジョンの同期"
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr "システム"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "システム管理者"
@@ -7761,8 +7828,8 @@ msgstr "システム監査者"
 msgid "System Warning"
 msgstr "システム警告"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "システム管理者は、すべてのリソースに無制限にアクセスできます。"
 
@@ -7770,7 +7837,7 @@ msgstr "システム管理者は、すべてのリソースに無制限にアク
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "TACACS+ 設定"
 
@@ -7779,7 +7846,7 @@ msgstr "TACACS+ 設定"
 msgid "Tabs"
 msgstr "タブ"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7834,7 +7901,7 @@ msgid "Team"
 msgstr "チーム"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr "チームロール"
 
@@ -7845,19 +7912,19 @@ msgstr "チームが見つかりません。"
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7868,12 +7935,12 @@ msgstr "チーム"
 msgid "Template not found."
 msgstr "更新が見つかりません。"
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7902,12 +7969,12 @@ msgstr "テスト通知"
 msgid "Test passed"
 msgstr "テストに成功"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "テキスト"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "テキストエリア"
 
@@ -7942,7 +8009,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr "メール通知が、ホストへの到達を試行するのをやめてタイムアウトするまでの時間 (秒単位)。範囲は 1 から 120 秒です。"
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -7989,7 +8056,7 @@ msgid ""
 "documentation for more details."
 msgstr "この組織で管理可能な最大ホスト数。デフォルト値は 0 で、管理可能な数に制限がありません。詳細は、Ansible ドキュメントを参照してください。"
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -7998,16 +8065,16 @@ msgid ""
 "with a change to"
 msgstr "Playbook の実行中に使用する並列または同時プロセスの数。値が空白または 1 未満の場合は、Ansible のデフォルト値 (通常は 5) を使用します。フォークのデフォルトの数は、以下を変更して上書きできます。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "Playbook の実行中に使用する並列または同時プロセスの数。いずれの値も入力しないと、Ansible 設定ファイルのデフォルト値が使用されます。より多くの情報を確認できます。"
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "要求したページが見つかりませんでした。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "インベントリー内のホストをターゲットにするために使用されるパターン。フィールドを空白のままにすると、all、および * はすべて、インベントリー内のすべてのホストを対象とします。Ansible のホストパターンに関する詳細情報を確認できます。"
 
@@ -8046,7 +8113,7 @@ msgstr "推奨される変数名の形式は小文字のみを使用し、それ
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8080,19 +8147,19 @@ msgstr "ワークフローの保存中にエラーが発生しました。"
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "これらは、サポートされているコマンド実行の標準の詳細レベルです。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "これらの引数は、指定されたモジュールで使用されます。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "これらの引数は、指定されたモジュールで使用されます。クリックすると {0} の情報を表示できます。"
 
@@ -8100,21 +8167,21 @@ msgstr "これらの引数は、指定されたモジュールで使用されま
 msgid "Third"
 msgstr "第 3"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "このプロジェクトは更新する必要があります"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "このアクションにより、以下が削除されます。"
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "このアクションにより、このユーザーのすべてのロールと選択したチームの関連付けが解除されます。"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "このアクションにより、{0} から次のロールの関連付けが解除されます:"
 
@@ -8210,7 +8277,7 @@ msgid "This field must be greater than 0"
 msgstr "このフィールドは 0 より大きくなければなりません"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8262,7 +8329,7 @@ msgstr "この時だけ唯一、トークンの値と、関連する更新トー
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "このジョブテンプレートは、現在他のリソースで使用されています。削除してもよろしいですか?"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "この組織は、現在他のリソースで使用されています。削除してもよろしいですか?"
 
@@ -8274,11 +8341,11 @@ msgstr "このプロジェクトは、現在他のリソースで使用されて
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "このプロジェクトは現在同期中で、同期プロセスが完了するまでクリックできません"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "このスケジュールにはインベントリーがありません"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "このスケジュールには、必要な Survey 値がありません"
 
@@ -8313,8 +8380,8 @@ msgstr "木"
 msgid "Thursday"
 msgstr "木曜"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8348,7 +8415,7 @@ msgstr "タイムアウト"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "タイムアウト"
 
@@ -8359,6 +8426,10 @@ msgstr "タイムアウト (分)"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "タイムアウトの秒"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8426,11 +8497,11 @@ msgid "Token not found."
 msgstr "ジョブが見つかりません。"
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "トークン"
@@ -8443,8 +8514,8 @@ msgstr "ツール"
 msgid "Top Pagination"
 msgstr "トップページネーション"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "ジョブの合計"
@@ -8467,20 +8538,20 @@ msgstr "サブモジュールを追跡する"
 msgid "Track submodules latest commit on branch"
 msgstr "ブランチでのサブモジュールの最新のコミットを追跡する"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "トライアル"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "True"
 
@@ -8493,55 +8564,57 @@ msgstr "火"
 msgid "Tuesday"
 msgstr "火曜"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "タイプ"
@@ -8585,7 +8658,7 @@ msgstr "元に戻す"
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "制限なし"
 
@@ -8602,7 +8675,7 @@ msgstr "到達不能なホスト数"
 msgid "Unreachable Hosts"
 msgstr "到達不能なホスト"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "認識されない日付の文字列"
 
@@ -8639,7 +8712,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8676,7 +8749,7 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr "カスタムメッセージを使用して、ジョブの開始時、成功時、または失敗時に送信する通知内容を変更します。波括弧を使用してジョブに関する情報にアクセスします:"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8695,17 +8768,17 @@ msgstr "ユーザー"
 msgid "User Details"
 msgstr "ユーザーの詳細"
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr "ユーザーインターフェース"
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "ユーザーインターフェースの設定"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr "ユーザーロール"
 
@@ -8732,14 +8805,14 @@ msgstr "エラーの詳細"
 msgid "User not found."
 msgstr "ジョブが見つかりません。"
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "ユーザートークン"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8752,8 +8825,8 @@ msgstr "ユーザートークン"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8766,16 +8839,16 @@ msgstr "ユーザー名 / パスワード"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr "ユーザー"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -8786,7 +8859,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8796,10 +8869,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "変数"
@@ -8820,21 +8893,21 @@ msgstr "Vault パスワード | {credId}"
 msgid "Verbose"
 msgstr "詳細"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "詳細"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "バージョン"
 
@@ -8881,7 +8954,7 @@ msgstr "インベントリーホストの詳細の表示"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "JSON のサンプルについては、<0>www.json.org</0> を参照してください。"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "ジョブの詳細の表示"
 
@@ -8994,7 +9067,7 @@ msgstr "すべてのインベントリーホストを表示します。"
 msgid "View all Jobs"
 msgstr "すべてのジョブを表示"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "すべてのジョブを表示します。"
 
@@ -9057,7 +9130,7 @@ msgstr "すべての設定の表示"
 msgid "View all tokens."
 msgstr "すべてのトークンを表示します。"
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "サブスクリプション情報の表示および編集"
 
@@ -9083,7 +9156,7 @@ msgid "View smart inventory host details"
 msgstr "スマートインベントリーホストの詳細の表示"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr "ビュー"
 
@@ -9093,11 +9166,11 @@ msgstr "ビュー"
 msgid "Visualizer"
 msgstr "ビジュアライザー"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "警告:"
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9121,8 +9194,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "このアカウントに関連するサブスクリプションを見つけることができませんでした。"
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9162,7 +9235,7 @@ msgstr "Webhook サービス"
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Webhook の詳細"
@@ -9191,7 +9264,7 @@ msgstr "水"
 msgid "Wednesday"
 msgstr "水曜"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "週"
 
@@ -9240,26 +9313,26 @@ msgid "Workflow Approval not found."
 msgstr "ワークフローの承認が見つかりません。"
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "ワークフローの承認"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "ワークフロージョブ"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9280,8 +9353,8 @@ msgstr "ワークフロージョブテンプレート"
 msgid "Workflow Link"
 msgstr "ワークフローのリンク"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "ワークフローテンプレート"
 
@@ -9350,7 +9423,7 @@ msgstr "書き込み"
 msgid "YAML:"
 msgstr "YAML:"
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "年"
 
@@ -9366,11 +9439,11 @@ msgstr "次のワークフロー承認に基づいて行動することはでき
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "次のワークフロー承認に基づいて行動することはできません: {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "同じ Vault ID を持つ複数の Vault 認証情報を選択することはできません。これを行うと、同じ Vault ID を持つもう一方の選択が自動的に解除されます。"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "次のグループを削除する権限がありません: {itemsUnableToDelete}"
 
@@ -9404,19 +9477,19 @@ msgstr "ズームイン"
 msgid "Zoom Out"
 msgstr "ズームアウト"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "新規 Webhook キーは保存時に生成されます。"
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "新規 Webhook URL は保存時に生成されます。"
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "アクション"
+#~ msgid "actions"
+#~ msgstr "アクション"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9432,7 +9505,7 @@ msgid "brand logo"
 msgstr "ブランドロゴ"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr "削除のキャンセル"
 
@@ -9440,17 +9513,17 @@ msgstr "削除のキャンセル"
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "command"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr "削除の確認"
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "関連付けの解除の確認"
 
@@ -9484,16 +9557,16 @@ msgstr "ドキュメント"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "編集"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "暗号化"
 
@@ -9505,16 +9578,16 @@ msgstr "(詳細情報)"
 msgid "for more information."
 msgstr "(詳細情報)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "ここ"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "ここ"
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "hosts"
 
@@ -9535,12 +9608,12 @@ msgid "min"
 msgstr "分"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "下に移動"
+#~ msgid "move down"
+#~ msgstr "下に移動"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "上に移動"
+#~ msgid "move up"
+#~ msgstr "上に移動"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9551,7 +9624,7 @@ msgstr "新しい選択"
 msgid "of"
 msgstr "/"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "以下へのオプション:"
 
@@ -9580,15 +9653,15 @@ msgstr "秒"
 msgid "seconds"
 msgstr "秒"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "モジュールの選択"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "冗長性の選択"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9596,7 +9669,7 @@ msgstr ""
 msgid "social login"
 msgstr "ソーシャルログイン"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "ソースコントロールのブランチ"
@@ -9609,7 +9682,7 @@ msgstr "システム"
 msgid "timed out"
 msgstr "タイムアウト"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "変更の切り替え"
 
@@ -9629,39 +9702,39 @@ msgstr "{0, plural, one {以下のグループを削除してもよろしいで�
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {グループを削除しますか?} other {グループを削除しますか?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {インベントリーは最終的な削除が処理されるまで保留中のステータスになります。} other {インベントリーは最終的な削除が処理されるまで保留中のステータスになります。}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {選択したジョブは、不十分な権限または実行中のジョブステータスのために削除できません} other {選択したジョブは、不十分な権限または実行中のジョブステータスのために削除できません}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {この承認は、権限が不十分であるか、ジョブステータスが保留中であるため、削除できません} other {この承認は、権限が不十分であるか、ジョブステータスが保留中であるため、削除できません}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {この認証情報は、現在他のリソースで使用されています。削除してもよろしいですか?} other {これらの認証情報を削除すると、その認証情報に依存している他のリソースに影響を与える可能性があります。削除してもよろしいですか?}}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {この認証情報タイプは、現在いくつかの認証情報で使用されているため、削除できません。} other {認証で使用されている認証タイプは削除できません。削除してもよろしいですか?}}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {この実行環境は、現在他のリソースによって使用されています。削除してもよろしいですか?} other {これらの実行環境は、それらに依存する他のリソースによって使用されている可能性があります。削除してもよろしいですか?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {このインスタンスグループは、現在他のリソースで使用されています。削除してもよろしいですか?} other {これらのインスタンスグループを削除すると、そのインスタンスグループに依存している他のリソースに影響を与える可能性があります。削除してもよろしいですか?}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {このインベントリーは、現在いくつかのテンプレートで使用されています。削除してもよろしいですか?} other {これらのインベントリーを削除すると、そのインベントリーに依存しているいくつかのテンプレートに影響を与える可能性があります。削除してもよろしいですか?}}"
 
@@ -9669,15 +9742,15 @@ msgstr "{0, plural, one {このインベントリーは、現在いくつかの�
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {このインベントリーソースは、現在、そのインベントリーソースに依存している他のリソースで使用されています。削除してもよろしいですか?} other {これらのインベントリーソースを削除すると、そのインベントリーソースに依存している他のリソースに影響を与える可能性があります。削除してもよろしいですか}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {この組織は、現在他のリソースで使用されています。削除してもよろしいですか?} other {これらの組織を削除すると、その組織に依存している他のリソースに影響を与える可能性があります。削除してもよろしいですか?}}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {このプロジェクトは、現在他のリソースで使用されています。削除してもよろしいですか?} other {これらのプロジェクトを削除すると、そのプロジェクトに依存している他のリソースに影響を与える可能性があります。削除してもよろしいですか?}}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {このテンプレートは、現在いくつかのワークフローノードで使用されています。削除してもよろしいですか?} other {これらのテンプレートを削除すると、そのテンプレートに依存しているいくつかのワークフローノードに影響を与える可能性があります。削除してもよろしいですか?}}"
 
@@ -9766,8 +9839,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/nl/messages.po
+++ b/awx/ui/src/locales/nl/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (projectroot)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0 (Normaal)"
 
@@ -59,7 +59,7 @@ msgstr "1 (Info)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1 (Uitgebreid)"
 
@@ -75,7 +75,7 @@ msgstr "2 (Foutopsporing)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2 (Meer verbaal)"
 
@@ -86,7 +86,7 @@ msgstr "2 (Meer verbaal)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3 (Foutopsporing)"
 
@@ -97,7 +97,7 @@ msgstr "3 (Foutopsporing)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4 (Foutopsporing verbinding)"
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr "Over"
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr "Accounttoken"
 msgid "Action"
 msgstr "Actie"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "Acties"
@@ -235,8 +238,8 @@ msgstr "Acties"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr "Activiteit"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "Activiteitenlogboek"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "Keuzeschakelaar type activiteitenlogboek"
 
@@ -297,35 +300,35 @@ msgstr "Een nieuw knooppunt toevoegen"
 msgid "Add a new node between these two nodes"
 msgstr "Nieuw knooppunt toevoegen tussen deze twee knooppunten"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "Containergroep toevoegen"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "Bestaande groep toevoegen"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "Bestaande host toevoegen"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "Instantiegroep toevoegen"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "Inventaris toevoegen"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "Taaksjabloon toevoegen"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "Nieuwe groep toevoegen"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "Nieuwe host toevoegen"
 
@@ -333,24 +336,24 @@ msgstr "Nieuwe host toevoegen"
 msgid "Add resource type"
 msgstr "Brontype toevoegen"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "Smart-inventaris toevoegen"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "Teammachtigingen toevoegen"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "Gebruikersmachtigingen toevoegen"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "Workflowsjabloon toevoegen"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr "Beheer"
 
@@ -359,11 +362,11 @@ msgstr "Beheer"
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "Documentatie over geavanceerd zoeken"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "Geavanceerde invoer zoekwaarden"
 
@@ -423,7 +426,7 @@ msgstr "Lijst met toegestane URI's, door spaties gescheiden"
 msgid "Always"
 msgstr "Altijd"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -435,7 +438,7 @@ msgstr "Er is een fout opgetreden"
 msgid "An inventory must be selected"
 msgstr "Er moet een inventaris worden gekozen"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -456,13 +459,13 @@ msgstr "Antwoord naam variabele"
 msgid "Any"
 msgstr "Iedere"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "Toepassing"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr "Toepassingsinformatie"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "Toepassingsnaam"
 
@@ -480,17 +483,17 @@ msgstr "Toepassingsnaam"
 msgid "Application not found."
 msgstr "Toepassing niet gevonden."
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr "Toepassingen"
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "Toepassingen en tokens"
 
@@ -562,11 +565,11 @@ msgstr "Weet u zeker dat u deze link wilt verwijderen?"
 msgid "Are you sure you want to remove this node?"
 msgstr "Weet u zeker dat u dit knooppunt wilt verwijderen?"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr "Weet u zeker dat u de toegang van {0} wilt verwijderen uit {1}?  Als u dat doet, heeft dat gevolgen voor alle leden van het team."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "Weet u zeker dat u de toegang tot {0} wilt verwijderen uit de {username}?"
 
@@ -574,26 +577,26 @@ msgstr "Weet u zeker dat u de toegang tot {0} wilt verwijderen uit de {username}
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "Weet u zeker dat u het verzoek om deze taak te annuleren in wilt dienen?"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "Argumenten"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "Artefacten"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "Associate"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "Fout in geassocieerde rol"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "Associatiemodus"
 
@@ -605,7 +608,7 @@ msgstr "Voor dit veld moet ten minste één waarde worden geselecteerd."
 msgid "August"
 msgstr "Augustus"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr "Authenticatie"
 
@@ -626,7 +629,7 @@ msgstr "Auto"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Azure AD-instellingen"
 
@@ -660,12 +663,16 @@ msgstr "Terug naar groepen"
 msgid "Back to Hosts"
 msgstr "Terug naar hosts"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "Terug naar inventarissen"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "Terug naar taken"
 
@@ -695,7 +702,7 @@ msgstr "Terug naar schema's"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr "Terug naar uitvoeringsomgevingen"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "Terug naar instantiegroepen"
 
@@ -747,7 +753,7 @@ msgstr "Terug naar instantiegroepen"
 msgid "Back to management jobs"
 msgstr "Terug naar beheerderstaken"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr "Vertakking naar de kassa. Naast vertakkingen kunt u ook tags, commit hashes en willekeurige refs invoeren. Sommige commit hashes en refs zijn mogelijk niet beschikbaar, tenzij u ook een aangepaste refspec aanlevert."
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr "Merkimago"
 
@@ -805,8 +811,8 @@ msgstr "Cache time-out (seconden)"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr "Cache time-out (seconden)"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr "Cache time-out (seconden)"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -883,7 +890,7 @@ msgstr "Linkwijzigingen annuleren"
 msgid "Cancel link removal"
 msgstr "Verwijdering van link annuleren"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "Opzoeken annuleren"
 
@@ -908,13 +915,13 @@ msgstr "Geselecteerde taken annuleren"
 msgid "Cancel subscription edit"
 msgstr "Abonnement bewerken annuleren"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "{0} annuleren"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -928,37 +935,37 @@ msgid ""
 "logging aggregator host and logging aggregator type."
 msgstr "Kan aggregator logboekregistraties niet inschakelen zonder de host en het type ervan te verstrekken."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "Capaciteit"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "Hoofdletterongevoelige versie van bevat"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "Hoofdletterongevoelige versie van endswith."
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "Hoofdletterongevoelige versie van exact."
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "Hoofdletterongevoelige versie van regex."
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "Hoofdletterongevoelige versie van startswith."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -978,15 +985,15 @@ msgid "Channel"
 msgstr "Kanaal"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "Controleren"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "Controleert of het gegeven veld of verwante object null is; verwacht een booleaanse waarde."
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "Controleert of de waarde van het opgegeven veld voorkomt in de opgegeven lijst; verwacht een door komma's gescheiden lijst met items."
 
@@ -998,7 +1005,7 @@ msgstr "Kies een .json-bestand"
 msgid "Choose a Notification Type"
 msgstr "Kies een type bericht"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "Kies een draaiboekmap"
 
@@ -1011,11 +1018,11 @@ msgid "Choose a Webhook Service"
 msgstr "Kies een Webhookservice"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "Kies een soort taak"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "Kies een module"
 
@@ -1038,7 +1045,7 @@ msgstr "Kies een antwoordtype of -formaat dat u als melding voor de gebruiker wi
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "Kies de rollen die op de geselecteerde bronnen moeten worden toegepast. Alle geselecteerde rollen worden toegepast op alle geselecteerde bronnen."
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "Kies de bronnen die nieuwe rollen gaan ontvangen.  U kunt de rollen selecteren die u in de volgende stap wilt toepassen.  Merk op dat de hier gekozen bronnen alle rollen ontvangen die in de volgende stap worden gekozen."
 
@@ -1083,6 +1090,10 @@ msgstr "Klik op deze knop om de verbinding met het geheimbeheersysteem te verifi
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "Klik om een nieuwe link naar dit knooppunt te maken."
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1131,13 +1142,13 @@ msgstr "Cloud"
 msgid "Collapse"
 msgstr "Samenvouwen"
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "Opdracht"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "Compliant"
 
@@ -1145,7 +1156,7 @@ msgstr "Compliant"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "Gelijktijdige taken"
 
@@ -1176,11 +1187,11 @@ msgstr "Taak annuleren bevestigen"
 msgid "Confirm cancellation"
 msgstr "Annuleren bevestigen"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "Verwijderen bevestigen"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "Loskoppelen bevestigen"
 
@@ -1204,7 +1215,7 @@ msgstr "Alles terugzetten bevestigen"
 msgid "Confirm selection"
 msgstr "Selectie bevestigen"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "Containergroep"
 
@@ -1239,7 +1250,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr "Stel in hoeveel output Ansible produceert bij het uitvoeren van het draaiboek."
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1292,11 +1303,11 @@ msgstr "Sjabloon kopiëren"
 msgid "Copy full revision to clipboard."
 msgstr "Volledige herziening kopiëren naar klembord."
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "Copyright"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "Maken"
@@ -1409,14 +1420,14 @@ msgstr "Nieuwe bron maken"
 msgid "Create user token"
 msgstr "Gebruikerstoken maken"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1426,7 +1437,7 @@ msgstr "Gebruikerstoken maken"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1435,58 +1446,58 @@ msgstr "Gebruikerstoken maken"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr "Gemaakt"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "Gemaakt door (Gebruikersnaam)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "Gemaakt door (gebruikersnaam)"
 
@@ -1516,7 +1527,7 @@ msgstr "Toegangsgegeven"
 msgid "Credential Input Sources"
 msgstr "Inputbronnen toegangsgegevens"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "Naam toegangsgegevens"
 
@@ -1527,9 +1538,9 @@ msgid "Credential Type"
 msgstr "Type toegangsgegevens"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1555,24 +1566,24 @@ msgstr "Toegangsgegevens voor authenticatie met een beschermd containerregister.
 msgid "Credential type not found."
 msgstr "Type toegangsgegevens niet gevonden."
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr "Toegangsgegevens"
@@ -1623,7 +1634,7 @@ msgstr "VERWIJDERD"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "Dashboard (alle activiteit)"
 
@@ -1637,12 +1648,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "Dag"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "Dagen om gegevens te bewaren"
 
@@ -1650,7 +1661,7 @@ msgstr "Dagen om gegevens te bewaren"
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "Resterende dagen"
 
@@ -1667,12 +1678,20 @@ msgid "December"
 msgstr "December"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "Standaard"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "Standaarduitvoeringsomgeving"
 
@@ -1682,7 +1701,7 @@ msgstr "Standaarduitvoeringsomgeving"
 msgid "Default answer"
 msgstr "Standaardantwoord"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "Kenmerken en functies op systeemniveau definiëren"
 
@@ -1696,8 +1715,8 @@ msgstr "Kenmerken en functies op systeemniveau definiëren"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1705,7 +1724,7 @@ msgstr "Kenmerken en functies op systeemniveau definiëren"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1713,15 +1732,15 @@ msgstr "Kenmerken en functies op systeemniveau definiëren"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1750,7 +1769,7 @@ msgstr "Host verwijderen"
 msgid "Delete Inventory"
 msgstr "Inventaris verwijderen"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1764,7 +1783,7 @@ msgstr "Taaksjabloon verwijderen"
 msgid "Delete Notification"
 msgstr "Bericht verwijderen"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "Organisatie verwijderen"
 
@@ -1772,15 +1791,15 @@ msgstr "Organisatie verwijderen"
 msgid "Delete Project"
 msgstr "Project verwijderen"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "Vragen verwijderen"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "Schema verwijderen"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "Vragenlijst verwijderen"
 
@@ -1834,6 +1853,10 @@ msgstr "Inventarisbron maken"
 msgid "Delete smart inventory"
 msgstr "Smart-inventaris maken"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1865,16 +1888,16 @@ msgstr "{pluralizedItemName} verwijderen?"
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "Fout bij verwijderen"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "Fout bij verwijderen"
 
@@ -1904,34 +1927,34 @@ msgid "Deprecated"
 msgstr "Afgeschaft"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1939,36 +1962,36 @@ msgstr "Afgeschaft"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr "Omschrijving"
 
@@ -2021,7 +2044,7 @@ msgstr "Bestemmingskanalen of -gebruikers"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2107,39 +2130,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "Loskoppelen"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "Groep van host loskoppelen?"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "Host van groep loskoppelen?"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "Instantie van instantiegroep loskoppelen?"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "Verwante groep(en) loskoppelen?"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "Verwant(e) team(s) loskoppelen?"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "Rol loskoppelen"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "Koppel host los!"
 
@@ -2152,7 +2175,7 @@ msgstr "Loskoppelen?"
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2217,8 +2240,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr "Voer iedere keer dat een taak uitgevoerd wordt met dit project een update uit voor de herziening van het project voordat u de taak start."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2237,8 +2260,8 @@ msgstr "Voer iedere keer dat een taak uitgevoerd wordt met dit project een updat
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2260,7 +2283,7 @@ msgstr "Voer iedere keer dat een taak uitgevoerd wordt met dit project een updat
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2336,8 +2359,8 @@ msgstr "Uitvoeringsomgeving bewerken"
 msgid "Edit Group"
 msgstr "Groep bewerken"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2366,6 +2389,10 @@ msgstr "Knooppunt bewerken"
 msgid "Edit Notification Template"
 msgstr "Berichtsjabloon bewerken"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2390,7 +2417,7 @@ msgstr "Schema bewerken"
 msgid "Edit Source"
 msgstr "Bron bewerken"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2478,8 +2505,8 @@ msgstr "Verstreken tijd"
 msgid "Elapsed time that the job ran"
 msgstr "Verstreken tijd in seconden dat de taak is uitgevoerd."
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2493,7 +2520,7 @@ msgstr "E-mailopties"
 msgid "Enable Concurrent Jobs"
 msgstr "Gelijktijdige taken inschakelen"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "Feitenopslag inschakelen"
 
@@ -2501,8 +2528,8 @@ msgstr "Feitenopslag inschakelen"
 msgid "Enable HTTPS certificate verification"
 msgstr "HTTPS-certificaatcontrole inschakelen"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2520,8 +2547,8 @@ msgstr "Externe logboekregistratie inschakelen"
 msgid "Enable log system tracking facts individually"
 msgstr "Logboeksysteem dat feiten individueel bijhoudt inschakelen"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "Verhoging van rechten inschakelen"
 
@@ -2529,15 +2556,15 @@ msgstr "Verhoging van rechten inschakelen"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "Webhook inschakelen voor deze sjabloon."
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "Ingeschakeld"
@@ -2572,7 +2599,7 @@ msgstr "Ingeschakelde variabele"
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2580,7 +2607,7 @@ msgid ""
 "template"
 msgstr "Maakt het mogelijk een provisioning terugkoppelings-URL aan te maken. Met deze URL kan een host contact opnemen met {brandName} en een verzoek indienen voor een configuratie-update met behulp van deze taaksjabloon."
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2602,7 +2629,7 @@ msgstr "Einde"
 msgid "End User License Agreement"
 msgstr "Licentie-overeenkomst voor eindgebruikers"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "Einde kwam niet overeen met een verwachte waarde"
 
@@ -2708,21 +2735,21 @@ msgstr "Voer variabelen in om de inventarisbron te configureren. Voor een gedeta
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "Voer variabelen in met JSON- of YAML-syntaxis. Gebruik de radioknop om tussen de twee te wisselen."
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "Fout"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2746,41 +2773,41 @@ msgstr "Fout bij het opslaan van de workflow!"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2788,21 +2815,21 @@ msgstr "Fout bij het opslaan van de workflow!"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2812,17 +2839,17 @@ msgstr "Fout bij het opslaan van de workflow!"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "Fout!"
 
@@ -2830,7 +2857,7 @@ msgstr "Fout!"
 msgid "Error:"
 msgstr "Fout:"
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2848,15 +2875,19 @@ msgstr "Modus gebeurtenisdetails"
 msgid "Event summary not available"
 msgstr "Samenvatting van de gebeurtenis niet beschikbaar"
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "Exacte overeenkomst (standaard-opzoeken indien niet opgegeven)."
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2892,15 +2923,15 @@ msgstr "Uitvoeren wanneer het bovenliggende knooppunt in een storingstoestand ko
 msgid "Execute when the parent node results in a successful state."
 msgstr "Uitvoeren wanneer het bovenliggende knooppunt in een succesvolle status resulteert."
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "Uitvoeringsomgeving"
 
@@ -2909,22 +2940,22 @@ msgstr "Uitvoeringsomgeving"
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "Uitvoeringsomgevingen"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "Uitvoeringsknooppunt"
 
@@ -2958,24 +2989,24 @@ msgstr "Input uitbreiden"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "Minstens één van client_email, project_id of private_key werd verwacht aanwezig te zijn in het bestand."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "Verloopt"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "Verloopt op"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "Verloopt op UTC"
 
@@ -2984,7 +3015,7 @@ msgstr "Verloopt op UTC"
 msgid "Expires on {0}"
 msgstr "Verloopt op {0}"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "Uitleg"
@@ -2993,8 +3024,8 @@ msgstr "Uitleg"
 msgid "External Secret Management System"
 msgstr "Extern geheimbeheersysteem"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "Extra variabelen"
 
@@ -3019,7 +3050,7 @@ msgstr ""
 msgid "Facts"
 msgstr "Feiten"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3045,7 +3076,7 @@ msgstr "Mislukte hosts"
 msgid "Failed jobs"
 msgstr "Mislukte taken."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "Eén of meer workflowgoedkeuringen goed te zijn niet goedgekeurd."
 
@@ -3053,21 +3084,21 @@ msgstr "Eén of meer workflowgoedkeuringen goed te zijn niet goedgekeurd."
 msgid "Failed to approve workflow approval."
 msgstr "Workflowgoedkeuring is mislukt."
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "Kan rollen niet goed toewijzen"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "Kan rol niet koppelen"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "Kan niet koppelen."
 
@@ -3080,12 +3111,12 @@ msgstr "Kan de synchronisatie van de inventarisbron niet annuleren"
 msgid "Failed to cancel Project Sync"
 msgstr "Kan projectsynchronisatie niet annuleren"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "Kan een of meer taken niet annuleren."
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "Kan {0} niet annuleren"
@@ -3144,19 +3175,19 @@ msgstr "Kan taaksjabloon niet verwijderen."
 msgid "Failed to delete notification."
 msgstr "Kan bericht niet verwijderen"
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "Een of meer toepassingen kunnen niet worden verwijderd."
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "Een of meer typen toegangsgegevens kunnen niet worden verwijderd."
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "Een of meer toegangsgegevens kunnen niet worden verwijderd."
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "Een of meer uitvoeringsomgevingen kunnen niet worden verwijderd"
 
@@ -3164,16 +3195,16 @@ msgstr "Een of meer uitvoeringsomgevingen kunnen niet worden verwijderd"
 msgid "Failed to delete one or more groups."
 msgstr "Een of meer groepen kunnen niet worden verwijderd."
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "Een of meer hosts kunnen niet worden verwijderd."
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "Een of meer instantiegroepen kunnen niet worden verwijderd."
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "Een of meer inventarissen kunnen niet worden verwijderd."
 
@@ -3181,55 +3212,55 @@ msgstr "Een of meer inventarissen kunnen niet worden verwijderd."
 msgid "Failed to delete one or more inventory sources."
 msgstr "Een of meer inventarisbronnen kunnen niet worden verwijderd."
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "Een of meer taaksjablonen kunnen niet worden verwijderd."
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "Een of meer taken kunnen niet worden verwijderd."
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "Een of meer berichtsjablonen kunnen niet worden verwijderd."
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "Een of meer organisaties kunnen niet worden verwijderd."
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "Een of meer projecten kunnen niet worden verwijderd."
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "Een of meer schema's kunnen niet worden verwijderd."
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "Een of meer teams kunnen niet worden verwijderd."
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "Een of meer sjablonen kunnen niet worden verwijderd."
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "Een of meer tokens kunnen niet worden verwijderd."
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "Een of meer gebruikerstokens kunnen niet worden verwijderd."
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "Een of meer gebruikers kunnen niet worden verwijderd."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "Een of meer workflowgoedkeuringen kunnen niet worden verwijderd."
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "Kan organisatie niet verwijderen."
 
@@ -3237,16 +3268,16 @@ msgstr "Kan organisatie niet verwijderen."
 msgid "Failed to delete project."
 msgstr "Kan project niet verwijderen."
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "Kan rol niet verwijderen"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "Kan rol niet verwijderen."
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "Kan schema niet verwijderen."
 
@@ -3275,7 +3306,7 @@ msgstr "Kan workflow-taaksjabloon niet verwijderen."
 msgid "Failed to delete {name}."
 msgstr "Kan {naam} niet verwijderen."
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "Een of meer workflowgoedkeuringen kunnen niet worden geweigerd."
 
@@ -3283,21 +3314,21 @@ msgstr "Een of meer workflowgoedkeuringen kunnen niet worden geweigerd."
 msgid "Failed to deny workflow approval."
 msgstr "Kan workflowgoedkeuring niet weigeren."
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "Een of meer groepen kunnen niet worden losgekoppeld."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "Een of meer hosts kunnen niet worden losgekoppeld."
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "Een of meer instanties kunnen niet worden losgekoppeld."
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "Een of meer teams kunnen niet worden losgekoppeld."
 
@@ -3305,13 +3336,13 @@ msgstr "Een of meer teams kunnen niet worden losgekoppeld."
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "Kan de aangepaste configuratie-instellingen voor inloggen niet ophalen. De standaardsysteeminstellingen worden in plaats daarvan getoond."
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "Kan de taak niet starten."
 
@@ -3351,7 +3382,7 @@ msgstr "Kan niet van host wisselen."
 msgid "Failed to toggle instance."
 msgstr "Kan niet van instantie wisselen."
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "Kan niet van bericht wisselen."
 
@@ -3382,7 +3413,7 @@ msgstr "Mislukking"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "False"
 
@@ -3390,11 +3421,11 @@ msgstr "False"
 msgid "February"
 msgstr "Februari"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "Veld bevat waarde."
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "Veld eindigt op waarde."
 
@@ -3402,11 +3433,11 @@ msgstr "Veld eindigt op waarde."
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "Veld voor het opgeven van een aangepaste Kubernetes of OpenShift Pod-specificatie."
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "Het veld komt overeen met de opgegeven reguliere expressie."
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "Veld begint met waarde."
 
@@ -3422,16 +3453,16 @@ msgstr "Bestandsverschil"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "Bestand uploaden geweigerd. Selecteer één .json-bestand."
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "Bestand, map of script"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "Voltooiingstijd"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "Voltooid"
@@ -3442,25 +3473,25 @@ msgstr "Eerste"
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "Voornaam"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "Eerste uitvoering"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "Voornaam"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "Selecteer eerst een sleutel"
 
@@ -3476,7 +3507,7 @@ msgstr "Drijven"
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3495,11 +3526,11 @@ msgstr "Voor taaksjablonen selecteer \"uitvoeren\" om het draaiboek uit te voere
 msgid "For more information, refer to the"
 msgstr "Bekijk voor meer informatie de"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "Vorken"
 
@@ -3507,12 +3538,12 @@ msgstr "Vorken"
 msgid "Fourth"
 msgstr "Vierde"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "Frequentie-informatie"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "Frequentie kwam niet overeen met een verwachte waarde"
 
@@ -3525,11 +3556,11 @@ msgstr "Vrij"
 msgid "Friday"
 msgstr "Vrijdag"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3554,11 +3585,11 @@ msgstr "Abonnement ophalen"
 msgid "Get subscriptions"
 msgstr "Abonnementen ophalen"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3597,7 +3628,7 @@ msgstr "GitHub-organisatie"
 msgid "GitHub Team"
 msgstr "GitHub-team"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "GitHub-instellingen"
 
@@ -3606,7 +3637,7 @@ msgstr "GitHub-instellingen"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "Wereldwijde standaarduitvoeringsomgeving"
 
@@ -3635,11 +3666,11 @@ msgstr "Ga naar de volgende pagina"
 msgid "Go to previous page"
 msgstr "Ga naar de vorige pagina"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Google OAuth 2-instellingen"
 
@@ -3647,8 +3678,8 @@ msgstr "Google OAuth 2-instellingen"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3661,15 +3692,15 @@ msgstr "Grafana API-sleutel"
 msgid "Grafana URL"
 msgstr "Grafana URL"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "Groter dan vergelijking."
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "Groter dan of gelijk aan vergelijking."
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "Groep"
 
@@ -3677,20 +3708,20 @@ msgstr "Groep"
 msgid "Group details"
 msgstr "Groepsdetails"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "Type groep"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "Groepen"
@@ -3718,8 +3749,8 @@ msgstr "Verbergen"
 msgid "Hide description"
 msgstr "Omschrijving verbergen"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "Hipchat"
 
@@ -3738,7 +3769,7 @@ msgstr "Host Async OK"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "Configuratiesleutel host"
 
@@ -3809,20 +3840,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "Statusinformatie van de host is niet beschikbaar voor deze taak."
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3830,30 +3861,30 @@ msgstr "Statusinformatie van de host is niet beschikbaar voor deze taak."
 msgid "Hosts"
 msgstr "Hosts"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "Beschikbare hosts"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "Resterende hosts"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "Uur"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3873,8 +3904,8 @@ msgstr "ID van het dashboard (optioneel)"
 msgid "ID of the panel (optional)"
 msgstr "ID van het paneel (optioneel)"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -3931,7 +3962,7 @@ msgid ""
 "default group for the inventory."
 msgstr "Als dit vakje is ingeschakeld, worden alle groepen en hosts die eerder aanwezig waren in de externe bron, maar die nu verwijderd zijn, verwijderd uit de inventaris. Hosts en groepen die niet beheerd werden door de inventarisbron, worden omhoog verplaatst naar de volgende handmatig gemaakte groep. Als er geen handmatig gemaakte groep is waar ze naartoe kunnen worden verplaatst, blijven ze staan in de standaard inventarisgroep 'Alle'."
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3944,18 +3975,18 @@ msgid ""
 "--diff mode."
 msgstr "Als deze mogelijkheid ingeschakeld is, worden de wijzigingen die aangebracht zijn door Ansible-taken weergegeven, waar ondersteund. Dit staat gelijk aan de diff-modus van Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr "Als deze mogelijkheid ingeschakeld is, worden de wijzigingen die aangebracht zijn door Ansible-taken weergegeven, waar ondersteund. Dit staat gelijk aan de diff-modus van Ansible."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "Als deze mogelijkheid ingeschakeld is, worden de wijzigingen die aangebracht zijn door Ansible-taken weergegeven, waar ondersteund. Dit staat gelijk aan de diff-modus van Ansible."
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3965,7 +3996,7 @@ msgstr "Indien deze mogelijkheid ingeschakeld is, zijn gelijktijdige uitvoeringe
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "Indien deze mogelijkheid ingeschakeld is, zijn gelijktijdige uitvoeringen van deze workflow-taaksjabloon toegestaan."
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3978,7 +4009,7 @@ msgstr ""
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "Neem zodra u klaar bent om te updaten of te verlengen <0>contact met ons op.</0>"
 
@@ -3988,7 +4019,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr "Als u geen abonnement heeft, kunt u bij Red Hat terecht voor een proefabonnement."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "Als u alleen de toegang voor deze specifieke gebruiker wilt verwijderen, verwijder deze dan uit het team."
 
@@ -4002,13 +4033,13 @@ msgstr ""
 "het opstarten en bij projectupdates, klik op Update bij opstarten, en ga ook naar"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "Image"
@@ -4034,13 +4065,13 @@ msgstr "Info"
 msgid "Initiated By"
 msgstr "Gestart door"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "Gestart door"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "Gestart door (gebruikersnaam)"
 
@@ -4067,7 +4098,7 @@ msgstr "Insights for Ansible Automation Platform"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Dashboard Insights for Ansible Automation Platform"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "Systeem-ID Insights"
 
@@ -4079,18 +4110,18 @@ msgstr "Instantie"
 msgid "Instance Filters"
 msgstr "Instantiefilters"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "Instantiegroep"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4099,7 +4130,7 @@ msgstr "Instantiegroep"
 msgid "Instance Groups"
 msgstr "Instantiegroepen"
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "Instantie-id"
 
@@ -4121,11 +4152,11 @@ msgid "Instance groups"
 msgstr "Instantiegroepen"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "Instanties"
 
@@ -4155,11 +4186,11 @@ msgstr "Ongeldige gebruikersnaam of wachtwoord. Probeer het opnieuw."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4170,41 +4201,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "Inventarissen met bronnen kunnen niet gekopieerd worden"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "Inventaris"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "Inventaris (naam)"
 
@@ -4212,13 +4243,17 @@ msgstr "Inventaris (naam)"
 msgid "Inventory File"
 msgstr "Inventarisbestand"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "Inventaris-id"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "Inventarisbron"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4235,15 +4270,15 @@ msgstr "Fout tijdens synchronisatie inventarisbronnen"
 msgid "Inventory Sources"
 msgstr "Inventarisbronnen"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "Inventarissynchronisatie"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4288,7 +4323,7 @@ msgstr "Item OK"
 msgid "Item Skipped"
 msgstr "Item overgeslagen"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "Items"
@@ -4320,20 +4355,20 @@ msgstr "JSON:"
 msgid "January"
 msgstr "Januari"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "Taak"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "Fout bij annuleren taak"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4347,19 +4382,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "Taken verdelen"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "Taken verdelen"
 
@@ -4371,20 +4406,20 @@ msgstr "Taakstatus"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "Taaktags"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "Taaksjabloon"
@@ -4409,15 +4444,15 @@ msgstr "Taaksjablonen met een ontbrekende inventaris of een ontbrekend project k
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "Taaksjablonen met toegangsgegevens die om een wachtwoord vragen, kunnen niet worden geselecteerd tijdens het maken of bewerken van knooppunten"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "Soort taak"
 
@@ -4430,15 +4465,15 @@ msgid "Job status graph tab"
 msgstr "Grafiektabblad Taakstatus"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "Taaksjablonen"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4453,7 +4488,7 @@ msgstr "Taaksjablonen"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4461,7 +4496,7 @@ msgstr "Taaksjablonen"
 msgid "Jobs"
 msgstr "Taken"
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "Taakinstellingen"
 
@@ -4473,19 +4508,19 @@ msgstr "Juli"
 msgid "June"
 msgstr "Juni"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "Sleutel"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "Sleutel selecteren"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "Sleutel typeahead"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "Trefwoord"
 
@@ -4518,7 +4553,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "LDAP-standaard"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "LDAP-instellingen"
 
@@ -4542,18 +4577,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "Labelnaam"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "Labels"
@@ -4571,11 +4606,11 @@ msgid "Last Login"
 msgstr "Laatste login"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4585,7 +4620,7 @@ msgstr "Laatste login"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4599,25 +4634,25 @@ msgstr "Laatst aangepast"
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr "Achternaam"
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "Laatst uitgevoerd"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "Laatste uitvoering"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "Laatste taak"
 
@@ -4628,7 +4663,7 @@ msgstr "Laatste taak"
 msgid "Last modified"
 msgstr "Laatste wijziging"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "Achternaam"
@@ -4679,11 +4714,11 @@ msgstr "Workflow opstarten"
 msgid "Launch | {0}"
 msgstr "Opstarten | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "Gestart door"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "Opgestart door (gebruikersnaam)"
 
@@ -4699,26 +4734,26 @@ msgstr "Laat dit veld leeg om de uitvoeringsomgeving globaal beschikbaar te make
 msgid "Legend"
 msgstr "Legenda"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "Minder dan vergelijking."
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "Minder dan of gelijk aan vergelijking."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "Limiet"
@@ -4735,11 +4770,11 @@ msgstr "Laden"
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "Lokale tijdzone"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "Lokale tijdzone"
 
@@ -4751,7 +4786,7 @@ msgstr "Inloggen"
 msgid "Logging"
 msgstr "Logboekregistratie"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "Instellingen voor logboekregistratie"
 
@@ -4761,20 +4796,20 @@ msgstr "Instellingen voor logboekregistratie"
 msgid "Logout"
 msgstr "Afmelden"
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "Opzoekmodus"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "Opzoeken selecteren"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "Type opzoeken"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "Typeahead opzoeken"
 
@@ -4784,10 +4819,10 @@ msgstr "Typeahead opzoeken"
 msgid "MOST RECENT SYNC"
 msgstr "MEEST RECENTE SYNCHRONISATIE"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "Toegangsgegevens machine"
 
@@ -4800,8 +4835,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr "Beheerde knooppunten"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4811,7 +4846,7 @@ msgid "Management Job"
 msgstr "Beheertaak"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr "Beheerderstaken"
 
@@ -4832,15 +4867,15 @@ msgstr "Beheertaak niet gevonden."
 msgid "Management jobs"
 msgstr "Beheertaken"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "Handmatig"
 
@@ -4848,8 +4883,8 @@ msgstr "Handmatig"
 msgid "March"
 msgstr "Maart"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4870,7 +4905,7 @@ msgstr "Maximumlengte"
 msgid "May"
 msgstr "Mei"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr "Leden"
@@ -4887,7 +4922,7 @@ msgstr "Metrisch"
 msgid "Metrics"
 msgstr "Meetwaarden"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -4911,7 +4946,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr "Minimumpercentage van alle instanties die automatisch toegewezen worden aan deze groep wanneer nieuwe instanties online komen."
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "Minuut"
 
@@ -4919,7 +4954,7 @@ msgstr "Minuut"
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4927,7 +4962,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr "Divers systeem"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "Diverse systeeminstellingen"
 
@@ -4942,70 +4977,70 @@ msgid "Missing resource"
 msgstr "Ontbrekende bron"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr "Gewijzigd"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "Gewijzigd door (gebruikersnaam)"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "Gewijzigd door (gebruikersnaam)"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "Module"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5018,7 +5053,7 @@ msgstr "Ma"
 msgid "Monday"
 msgstr "Maandag"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "Maand"
 
@@ -5030,13 +5065,13 @@ msgstr "Meer informatie"
 msgid "More information for"
 msgstr "Meer informatie voor"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "Multi-Select"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "Meerkeuze"
 
@@ -5052,57 +5087,57 @@ msgstr "Meerkeuze-opties (één keuze mogelijk)"
 msgid "Multiple Choice Options"
 msgstr "Meerkeuze-opties"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5117,73 +5152,73 @@ msgstr "Meerkeuze-opties"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5196,66 +5231,72 @@ msgstr "Meerkeuze-opties"
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr "Naam"
@@ -5279,7 +5320,7 @@ msgstr "Nooit bijgewerkt"
 msgid "Never expires"
 msgstr "Verloopt nooit"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "Nieuw"
@@ -5298,8 +5339,8 @@ msgstr "Nieuw"
 msgid "Next"
 msgstr "Volgende"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5342,7 +5383,7 @@ msgstr "Geen fouten bij inventarissynchronisatie."
 msgid "No items found."
 msgstr "Geen items gevonden."
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5350,10 +5391,10 @@ msgstr ""
 msgid "No result found"
 msgstr "Geen resultaat gevonden"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "Geen resultaten gevonden"
 
@@ -5362,7 +5403,7 @@ msgstr "Geen resultaten gevonden"
 msgid "No subscriptions found"
 msgstr "Geen abonnementen gevonden"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "Geen vragenlijstvragen gevonden."
 
@@ -5377,7 +5418,7 @@ msgstr "Geen {pluralizedItemName} gevonden"
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5395,7 +5436,7 @@ msgstr "Geen"
 msgid "None (Run Once)"
 msgstr "Geen (eenmaal uitgevoerd)"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "Geen (eenmaal uitgevoerd)"
 
@@ -5418,15 +5459,15 @@ msgstr "Niet geconfigureerd"
 msgid "Not configured for inventory sync."
 msgstr "Niet geconfigureerd voor inventarissynchronisatie."
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr "Let op: Alleen hosts die zich direct in deze groep bevinden, kunnen worden losgekoppeld. Hosts in subgroepen moeten rechtstreeks worden losgekoppeld van het subgroepniveau waar ze bij horen."
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5434,7 +5475,7 @@ msgid ""
 "with directly and indirectly."
 msgstr "Merk op dat u de groep na het ontkoppelen nog steeds in de lijst kunt zien als de host ook lid is van de onderliggende elementen van die groep. Deze lijst toont alle groepen waaraan de host is direct en indirect is gekoppeld."
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5465,9 +5506,9 @@ msgstr "Berichtkleur"
 msgid "Notification Template not found."
 msgstr "Berichtsjabloon niet gevonden"
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5482,20 +5523,20 @@ msgstr "Berichttype"
 msgid "Notification color"
 msgstr "Berichtkleur"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "Bericht is verzonden"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "Time-out voor bericht."
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "Berichttype"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5530,39 +5571,37 @@ msgstr "Voorvallen"
 msgid "October"
 msgstr "Oktober"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "Uit"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "Aan"
 
@@ -5592,7 +5631,7 @@ msgstr "Aan-dagen"
 msgid "Only Group By"
 msgstr "Alleen ordenen op"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5600,7 +5639,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "Optie Details"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5612,20 +5651,26 @@ msgstr "Optionele labels die de taaksjabloon beschrijven, zoals 'dev' of 'test'.
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "Optioneel: selecteer de toegangsgegevens die u wilt gebruiken om statusupdates terug te sturen naar de webhookservice."
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "Opties"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5636,15 +5681,15 @@ msgstr "Opties"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5654,22 +5699,22 @@ msgstr "Opties"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "Organisatie"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "Organisatie (naam)"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "Naam van organisatie"
 
@@ -5679,9 +5724,9 @@ msgstr "Organisatie niet gevonden."
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5696,11 +5741,11 @@ msgstr "Organisaties"
 msgid "Other prompts"
 msgstr "Overige meldingen"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "Niet compliant"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "Output"
@@ -5731,8 +5776,8 @@ msgstr "BERICHT"
 msgid "PUT"
 msgstr "PUT"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5764,11 +5809,11 @@ msgstr "Naar rechts pannen"
 msgid "Pan Up"
 msgstr "Omhoog pannen"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "Geef extra opdrachtregelwijzigingen in door. Er zijn twee opdrachtregelparameters voor Ansible:"
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5805,7 +5850,7 @@ msgstr "Afgelopen twee weken"
 msgid "Past week"
 msgstr "Afgelopen week"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5819,12 +5864,12 @@ msgstr "In afwachting van workflowgoedkeuringen"
 msgid "Pending delete"
 msgstr "In afwachting om verwijderd te worden"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "Voer een zoekopdracht uit om een hostfilter te definiëren"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5845,13 +5890,13 @@ msgid "Play Started"
 msgstr "Afspelen gestart"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Draaiboek"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Draaiboek controleren"
@@ -5862,12 +5907,12 @@ msgstr "Draaiboek voltooid"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Draaiboekmap"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5877,10 +5922,10 @@ msgstr "Draaiboek uitvoering"
 msgid "Playbook Started"
 msgstr "Draaiboek gestart"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Naam van draaiboek"
 
@@ -5892,15 +5937,15 @@ msgstr "Uitvoering van draaiboek"
 msgid "Plays"
 msgstr "Uitvoeringen van het draaiboek"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "Voeg vragenlijstvragen toe."
 
@@ -5924,23 +5969,23 @@ msgstr "Voer een waarde in."
 msgid "Please log in"
 msgstr "Log in"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "Selecteer een getal tussen 1 en 31"
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "Selecteer een inventaris of schakel de optie Melding bij opstarten in."
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "Kies een einddatum/-tijd die na de begindatum/-tijd komt."
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "Selecteer een organisatie voordat u het hostfilter bewerkt."
 
@@ -5948,7 +5993,7 @@ msgstr "Selecteer een organisatie voordat u het hostfilter bewerkt."
 msgid "Pod spec override"
 msgstr "Overschrijven Podspec"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5968,7 +6013,7 @@ msgstr "Beleid instantiepercentage"
 msgid "Populate field from an external secret management system"
 msgstr "Vul veld vanuit een extern geheimbeheersysteem"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6010,8 +6055,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "Voorvertoning"
 
@@ -6021,7 +6064,7 @@ msgstr "Privésleutel wachtwoordzin"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "Verhoging van rechten"
 
@@ -6029,17 +6072,16 @@ msgstr "Verhoging van rechten"
 msgid "Privilege escalation password"
 msgstr "Wachtwoord verhoging van rechten"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6047,7 +6089,7 @@ msgstr "Project"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "Basispad project"
 
@@ -6075,10 +6117,10 @@ msgstr "Mislukte projectsynchronisaties"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6091,8 +6133,8 @@ msgstr "Projecten"
 msgid "Promote Child Groups and Hosts"
 msgstr "Onderliggende groepen en hosts promoveren"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "Melding"
 
@@ -6111,11 +6153,11 @@ msgid "Prompt | {0}"
 msgstr "Melding | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "Invoerwaarden"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6136,7 +6178,7 @@ msgstr "Geef een hostpatroon op om de lijst van hosts die beheerd of beïnvloed 
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "Geef een waarde op voor dit veld of selecteer de optie Melding bij opstarten."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6156,18 +6198,18 @@ msgstr "Geef uw Red Hat- of Red Hat Satellite-toegangsgegevens op om het Insight
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "Provisioning terugkoppelings-URL"
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "Provisioning terugkoppelingsdetails"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "Provisioning terugkoppelingen"
 
@@ -6184,7 +6226,7 @@ msgstr "Vraag"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "RADIUS-instellingen"
 
@@ -6214,7 +6256,7 @@ msgstr "Tabblad Lijst met recente sjablonen"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6227,19 +6269,19 @@ msgstr "Lijst met ontvangers"
 msgid "Recipient list"
 msgstr "Lijst met ontvangers"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Red Hat-virtualizering"
 
@@ -6247,7 +6289,7 @@ msgstr "Red Hat-virtualizering"
 msgid "Red Hat subscription manifest"
 msgstr "Red Hat-abonnementsmanifest"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6271,7 +6313,7 @@ msgstr "Doorverwijzen naar abonnementsdetails"
 msgid "Refer to the"
 msgstr "Raadpleeg de"
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6307,28 +6349,28 @@ msgstr "Reguliere expressie waarbij alleen overeenkomende hostnamen worden geïm
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "Gerelateerde groepen"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "Opnieuw starten"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "Taak opnieuw starten"
@@ -6346,16 +6388,16 @@ msgstr "Mislukte hosts opnieuw starten"
 msgid "Relaunch on"
 msgstr "Opnieuw starten bij"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "Opnieuw opstarten met hostparameters"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "Extern archief"
 
@@ -6382,7 +6424,7 @@ msgstr "Knooppunt verwijderen"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "Verwijder alle plaatselijke aanpassingen voordat een update uitgevoerd wordt."
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr "{0} toegang verwijderen"
 
@@ -6398,7 +6440,7 @@ msgstr "Als u deze link verwijdert, wordt de rest van de vertakking zwevend en w
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "Frequentie herhalen"
 
@@ -6415,7 +6457,7 @@ msgstr "Veld vervangen door nieuwe waarde"
 msgid "Request subscription"
 msgstr "Abonnement aanvragen"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "Vereist"
@@ -6423,7 +6465,7 @@ msgstr "Vereist"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "Bronnaam"
 
@@ -6432,7 +6474,7 @@ msgid "Resource deleted"
 msgstr "Bron verwijderd"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr "Hulpbronnen"
 
@@ -6464,15 +6506,15 @@ msgstr "Teruggeven"
 msgid "Return to subscription management."
 msgstr "Terug naar abonnementenbeheer"
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "Retourneert resultaten die andere waarden hebben dan deze, evenals andere filters."
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "Retourneert resultaten die voldoen aan dit filter en aan andere filters. Dit is het standaard ingestelde type als er niets is geselecteerd."
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "Retourneert resultaten die voldoen aan dit filter of aan andere filters."
 
@@ -6503,8 +6545,8 @@ msgstr "Instellingen terugzetten"
 msgid "Revert to factory default."
 msgstr "Terugzetten op fabrieksinstellingen."
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "Herziening"
@@ -6513,25 +6555,25 @@ msgstr "Herziening"
 msgid "Revision #"
 msgstr "Herziening #"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "Rol"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6545,7 +6587,7 @@ msgstr "Rollen"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "Uitvoeren"
 
@@ -6569,7 +6611,7 @@ msgstr "Opdracht uitvoeren"
 msgid "Run every"
 msgstr "Uitvoeren om de"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "Uitvoerfrequentie"
 
@@ -6581,7 +6623,7 @@ msgstr "Uitvoeren op"
 msgid "Run type"
 msgstr "Uitvoertype"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6592,8 +6634,8 @@ msgstr "In uitvoering"
 msgid "Running Handlers"
 msgstr "Handlers die worden uitgevoerd"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "Taken in uitvoering"
@@ -6606,7 +6648,7 @@ msgstr "Taken in uitvoering"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "SAML-instellingen"
 
@@ -6649,18 +6691,19 @@ msgid "Saturday"
 msgstr "Zaterdag"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6698,7 +6741,7 @@ msgstr "Schema is actief"
 msgid "Schedule is inactive"
 msgstr "Schema is actief"
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "Er ontbreekt een regel in het schema"
 
@@ -6706,10 +6749,10 @@ msgstr "Er ontbreekt een regel in het schema"
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6723,11 +6766,11 @@ msgstr ""
 msgid "Schedules"
 msgstr "Schema's"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6749,8 +6792,8 @@ msgstr "Volgende scrollen"
 msgid "Scroll previous"
 msgstr "Vorige scrollen"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr "Zoeken"
 
@@ -6758,7 +6801,7 @@ msgstr "Zoeken"
 msgid "Search is disabled while the job is running"
 msgstr "Zoeken is uitgeschakeld terwijl de taak wordt uitgevoerd"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "Knop Zoekopdracht verzenden"
@@ -6782,9 +6825,9 @@ msgstr "Seconden"
 msgid "See errors on the left"
 msgstr "Zie fouten links"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6794,13 +6837,13 @@ msgstr "Selecteren"
 msgid "Select Credential Type"
 msgstr "Type toegangsgegevens selecteren"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "Groepen selecteren"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "Hosts selecteren"
 
@@ -6808,11 +6851,11 @@ msgstr "Hosts selecteren"
 msgid "Select Input"
 msgstr "Input selecteren"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "Instanties selecteren"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "Items selecteren"
 
@@ -6828,7 +6871,7 @@ msgstr "Labels selecteren"
 msgid "Select Roles to Apply"
 msgstr "Rollen selecteren om toe te passen"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "Teams selecteren"
 
@@ -6844,7 +6887,7 @@ msgstr "Selecteer een knooppunttype"
 msgid "Select a Resource Type"
 msgstr "Selecteer een brontype"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6874,7 +6917,7 @@ msgstr "Taak selecteren om deze te annuleren"
 msgid "Select a metric"
 msgstr "Metriek selecteren"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "Module selecteren"
 
@@ -6883,16 +6926,20 @@ msgstr "Module selecteren"
 msgid "Select a playbook"
 msgstr "Draaiboek selecteren"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "Selecteer een project voordat u de uitvoeringsomgeving bewerkt."
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "Rij selecteren om deze goed te keuren"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr "Rij selecteren om deze te verwijderen"
 
@@ -6913,8 +6960,8 @@ msgstr "Abonnement selecteren"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6934,7 +6981,7 @@ msgstr "Abonnement selecteren"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6947,11 +6994,11 @@ msgid "Select a webhook service."
 msgstr "Selecteer een webhookservice."
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr "Alles selecteren"
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "Type activiteit selecteren"
 
@@ -6971,7 +7018,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr "Selecteer een organisatie voordat u de standaard uitvoeringsomgeving bewerkt."
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6980,7 +7027,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr "Selecteer toegangsgegevens om toegang te krijgen tot de knooppunten waartegen deze taak uitgevoerd zal worden. U kunt slechts één set toegangsgegevens van iedere soort kiezen. In het geval van machine-toegangsgegevens (SSH) moet u, als u 'melding bij opstarten' aanvinkt zonder toegangsgegevens te kiezen, bij het opstarten de machinetoegangsgegevens kiezen. Als u toegangsgegevens selecteert en 'melding bij opstarten' aanvinkt, worden de geselecteerde toegangsgegevens de standaardtoegangsgegevens en kunnen deze bij het opstarten gewijzigd worden."
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7025,7 +7072,7 @@ msgstr "Status selecteren"
 msgid "Select tags"
 msgstr "Tags selecteren"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "Selecteer de uitvoeromgeving waarbinnen u deze opdracht wilt uitvoeren."
 
@@ -7033,7 +7080,7 @@ msgstr "Selecteer de uitvoeromgeving waarbinnen u deze opdracht wilt uitvoeren."
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "Selecteer de instantiegroepen waar deze inventaris op uitgevoerd wordt."
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7051,16 +7098,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "Selecteer de toepassing waartoe dit token zal behoren."
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "Selecteer de toegangsgegevens die u wilt gebruiken bij het aanspreken van externe hosts om de opdracht uit te voeren. Kies de toegangsgegevens die de gebruikersnaam en de SSH-sleutel of het wachtwoord bevatten die Ansible nodig heeft om aan te melden bij de hosts of afstand."
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "Selecteer de uitvoeringsomgeving voor deze taaksjabloon."
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7078,11 +7125,11 @@ msgstr "Selecteer het inventarisbestand dat gesynchroniseerd moet worden door de
 msgid "Select the inventory that this host will belong to."
 msgstr "Selecteer de inventaris waartoe deze host zal behoren."
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "Selecteer het draaiboek dat uitgevoerd moet worden door deze taak."
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7092,7 +7139,7 @@ msgstr "Selecteer het project dat het draaiboek bevat waarvan u wilt dat deze ta
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "Selecteer het Ansible Automation Platform-abonnement dat u wilt gebruiken"
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "Selecteer {0}"
 
@@ -7101,7 +7148,7 @@ msgstr "Selecteer {0}"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7113,7 +7160,7 @@ msgstr "Selecteer {0}"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7125,17 +7172,23 @@ msgstr "Selecteer {0}"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr "Geselecteerd"
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "Geselecteerde categorie"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7162,7 +7215,7 @@ msgstr "Waarde instellen voor dit veld"
 msgid "Set how many days of data should be retained."
 msgstr "Stel in hoeveel dagen aan gegevens er moet worden bewaard."
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "Stel voorkeuren in voor gegevensverzameling, logo's en aanmeldingen"
 
@@ -7178,19 +7231,19 @@ msgstr "Zet de instantie online of offline. Indien offline, zullen er geen taken
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "Ingesteld op openbaar of vertrouwelijk, afhankelijk van de beveiliging van het toestel van de klant."
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "Type instellen"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "Type instellen selecteren"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "Typeahead type instellen"
 
@@ -7212,8 +7265,8 @@ msgstr "Naam instellen"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr "Instellingen"
@@ -7225,9 +7278,9 @@ msgstr "Tonen"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "Wijzigingen tonen"
 
@@ -7235,8 +7288,8 @@ msgstr "Wijzigingen tonen"
 #~ msgid "Show all groups"
 #~ msgstr "Alle groepen tonen"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "Wijzigingen tonen"
 
@@ -7249,7 +7302,7 @@ msgstr "Beschrijving tonen"
 msgid "Show less"
 msgstr "Minder tonen"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "Alleen wortelgroepen tonen"
 
@@ -7302,14 +7355,14 @@ msgstr "Eenvoudige sleutel selecteren"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "Tags overslaan"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7330,15 +7383,15 @@ msgstr "Tags overslaan is nuttig wanneer u een groot draaiboek heeft en specifie
 msgid "Skipped"
 msgstr "Overgeslagen"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "Smart-inventaris"
@@ -7347,7 +7400,7 @@ msgstr "Smart-inventaris"
 msgid "Smart Inventory not found."
 msgstr "Smart-inventaris niet gevonden."
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "Smart-hostfilter"
@@ -7379,13 +7432,15 @@ msgstr "Sorteren"
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "Vraagvolgorde sorteren"
+#~ msgid "Sort question order"
+#~ msgstr "Vraagvolgorde sorteren"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "Bron"
 
@@ -7394,12 +7449,12 @@ msgstr "Bron"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "Vertakking broncontrole"
 
@@ -7432,19 +7487,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr "Type broncontrole"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "URL broncontrole"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7458,8 +7513,8 @@ msgstr "Brontelefoonnummer"
 msgid "Source Variables"
 msgstr "Bronvariabelen"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "Taak bronworkflow"
 
@@ -7480,7 +7535,7 @@ msgstr "Brontelefoonnummer"
 msgid "Source variables"
 msgstr "Bronvariabelen"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "Afkomstig uit een project"
 
@@ -7527,14 +7582,14 @@ msgstr "Tabblad Standaardoutput"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "Starten"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "Starttijd"
 
@@ -7556,27 +7611,27 @@ msgstr "Start het synchronisatieproces"
 msgid "Start sync source"
 msgstr "Start synchronisatie bron"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "Gestart"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "Status"
@@ -7605,14 +7660,14 @@ msgstr ""
 ".gitmodules). Als dat niet zo is, dan worden de submodules bewaard tijdens de revisie die door het hoofdproject gespecificeerd is.\n"
 "Dit is gelijk aan het specificeren van de vlag --remote bij de update van de git-submodule."
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "Abonnement"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "Details abonnement"
 
@@ -7628,11 +7683,11 @@ msgstr "Abonnementsmanifest"
 msgid "Subscription selection modal"
 msgstr "Modus Abonnement selecteren"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "Abonnementsinstellingen"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "Type abonnement"
 
@@ -7640,11 +7695,11 @@ msgstr "Type abonnement"
 msgid "Subscriptions table"
 msgstr "Tabel Abonnementen"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversie"
 
@@ -7664,7 +7719,7 @@ msgstr "Succesbericht"
 msgid "Success message body"
 msgstr "Body succesbericht"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7696,25 +7751,37 @@ msgstr "Zondag"
 msgid "Survey"
 msgstr "Vragenlijst"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "Vragenlijst"
+#~ msgid "Survey List"
+#~ msgstr "Vragenlijst"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "Voorbeeld van vragenlijst"
+#~ msgid "Survey Preview"
+#~ msgstr "Voorbeeld van vragenlijst"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "Vragenlijst schakelen"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "Modus Voorbeeld van vragenlijst"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "Vragenlijstvragen"
+#~ msgid "Survey questions"
+#~ msgstr "Vragenlijstvragen"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7752,15 +7819,15 @@ msgstr "Synchroniseren voor revisie"
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr "Systeem"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "Systeembeheerder"
@@ -7775,8 +7842,8 @@ msgstr "Systeemcontroleur"
 msgid "System Warning"
 msgstr "Systeemwaarschuwing"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "Systeembeheerders hebben onbeperkte toegang tot alle bronnen."
 
@@ -7784,7 +7851,7 @@ msgstr "Systeembeheerders hebben onbeperkte toegang tot alle bronnen."
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "TACACS+ instellingen"
 
@@ -7793,7 +7860,7 @@ msgstr "TACACS+ instellingen"
 msgid "Tabs"
 msgstr "Tabbladen"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7848,7 +7915,7 @@ msgid "Team"
 msgstr "Team"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr "Teamrollen"
 
@@ -7859,19 +7926,19 @@ msgstr "Taak niet gevonden."
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7882,12 +7949,12 @@ msgstr "Teams"
 msgid "Template not found."
 msgstr "Sjabloon niet gevonden."
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7916,12 +7983,12 @@ msgstr "Testbericht"
 msgid "Test passed"
 msgstr "Test geslaagd"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "Tekst"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "Tekstgebied"
 
@@ -7956,7 +8023,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr "De tijd (in seconden) voordat de e-mailmelding de host probeert te bereiken en een time-out oplevert. Varieert van 1 tot 120 seconden."
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -8003,7 +8070,7 @@ msgid ""
 "documentation for more details."
 msgstr "Maximumaantal hosts dat beheerd mag worden door deze organisatie. De standaardwaarde is 0, wat betekent dat er geen limiet is. Raadpleeg de Ansible-documentatie voor meer informatie."
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8012,16 +8079,16 @@ msgid ""
 "with a change to"
 msgstr "Het aantal parallelle of gelijktijdige processen dat tijdens de uitvoering van het draaiboek gebruikt wordt. Een lege waarde, of een waarde minder dan 1 zal de Ansible-standaard gebruiken die meestal 5 is. Het standaard aantal vorken kan overgeschreven worden met een wijziging naar"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "Het aantal parallelle of gelijktijdige processen dat gebruikt wordt bij het uitvoeren van het draaiboek. Als u geen waarde invoert, wordt de standaardwaarde van het Ansible-configuratiebestand gebruikt. U vindt meer informatie"
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "De door u opgevraagde pagina kan niet worden gevonden."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "Het patroon dat gebruikt wordt om hosts in de inventaris te targeten. Door het veld leeg te laten, worden met alle en * alle hosts in de inventaris getarget. U kunt meer informatie vinden over hostpatronen van Ansible"
 
@@ -8060,7 +8127,7 @@ msgstr "De voorgestelde indeling voor namen van variabelen: kleine letters en ge
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8094,19 +8161,19 @@ msgstr "Er is een fout opgetreden bij het opslaan van de workflow."
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "Dit zijn de verbositeitsniveaus voor standaardoutput van de commando-uitvoering die worden ondersteund."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "Deze argumenten worden gebruikt met de gespecificeerde module."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "Deze argumenten worden gebruikt met de gespecificeerde module. U kunt informatie over {0} vinden door te klikken op"
 
@@ -8114,21 +8181,21 @@ msgstr "Deze argumenten worden gebruikt met de gespecificeerde module. U kunt in
 msgid "Third"
 msgstr "Derde"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "Dit project moet worden bijgewerkt"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "Met deze actie wordt het volgende verwijderd:"
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "Deze actie ontkoppelt alle rollen voor deze gebruiker van de geselecteerde teams."
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "Deze actie ontkoppelt de volgende rol van {0}:"
 
@@ -8227,7 +8294,7 @@ msgid "This field must be greater than 0"
 msgstr "Dit veld moet groter zijn dan 0"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8279,7 +8346,7 @@ msgstr "Dit is de enige keer dat de tokenwaarde en de bijbehorende ververste tok
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "Deze taaksjabloon wordt momenteel door andere bronnen gebruikt. Weet u zeker dat u hem wilt verwijderen?"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "Deze organisatie wordt momenteel door andere bronnen gebruikt. Weet u zeker dat u haar wilt verwijderen?"
 
@@ -8291,11 +8358,11 @@ msgstr "Dit project wordt momenteel gebruikt door andere bronnen. Weet u zeker d
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "Dit project wordt momenteel gesynchroniseerd en er kan pas op worden geklikt nadat het synchronisatieproces is voltooid"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "In dit schema ontbreekt een Inventaris"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "In dit schema ontbreken de vereiste vragenlijstwaarden"
 
@@ -8330,8 +8397,8 @@ msgstr "Do"
 msgid "Thursday"
 msgstr "Donderdag"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8365,7 +8432,7 @@ msgstr "Er is een time-out opgetreden"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "Time-out"
 
@@ -8376,6 +8443,10 @@ msgstr "Time-out minuten"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "Time-out seconden"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8443,11 +8514,11 @@ msgid "Token not found."
 msgstr "Token niet gevonden."
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "Tokens"
@@ -8460,8 +8531,8 @@ msgstr "Gereedschap"
 msgid "Top Pagination"
 msgstr "Bovenkant paginering"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "Totale taken"
@@ -8484,20 +8555,20 @@ msgstr "Submodules tracken"
 msgid "Track submodules latest commit on branch"
 msgstr "Submodules laatste binding op vertakking tracken"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "Proefperiode"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "True"
 
@@ -8510,55 +8581,57 @@ msgstr "Di"
 msgid "Tuesday"
 msgstr "Dinsdag"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "Soort"
@@ -8602,7 +8675,7 @@ msgstr "Ongedaan maken"
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "Onbeperkt"
 
@@ -8619,7 +8692,7 @@ msgstr "Aantal onbereikbare hosts"
 msgid "Unreachable Hosts"
 msgstr "Hosts onbereikbaar"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "Tekenreeks niet-herkende dag"
 
@@ -8656,7 +8729,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8693,7 +8766,7 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr "Gebruik aangepaste berichten om de inhoud te wijzigen van berichten die worden verzonden wanneer een taak start, slaagt of mislukt. Gebruik accolades om informatie over de taak te openen:"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8712,17 +8785,17 @@ msgstr "Gebruiker"
 msgid "User Details"
 msgstr "Gebruikersdetails"
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr "Gebruikersinterface"
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "Instellingen gebruikersinterface"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr "Gebruikersrollen"
 
@@ -8749,14 +8822,14 @@ msgstr "Gebruikersdetails"
 msgid "User not found."
 msgstr "Gebruiker niet gevonden."
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "Gebruikerstokens"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8769,8 +8842,8 @@ msgstr "Gebruikerstokens"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8783,16 +8856,16 @@ msgstr "Gebruikersnaam/wachtwoord"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr "Gebruikers"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -8803,7 +8876,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8813,10 +8886,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "Variabelen"
@@ -8837,21 +8910,21 @@ msgstr "Wachtwoord kluis | {credId}"
 msgid "Verbose"
 msgstr "Uitgebreid"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "Verbositeit"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "Versie"
 
@@ -8898,7 +8971,7 @@ msgstr "Hostdetails van inventaris weergeven"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "JSON-voorbeelden op <0>www.json.org</0> weergeven"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "Taakdetails weergeven"
 
@@ -9011,7 +9084,7 @@ msgstr "Geef alle inventarishosts weer."
 msgid "View all Jobs"
 msgstr "Alle taken weergeven"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "Geef alle taken weer."
 
@@ -9074,7 +9147,7 @@ msgstr "Alle instellingen weergeven"
 msgid "View all tokens."
 msgstr "Geef alle tokens weer."
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "Uw abonnementsgegevens weergeven en bewerken"
 
@@ -9100,7 +9173,7 @@ msgid "View smart inventory host details"
 msgstr "Hostdetails Smart-inventaris weergeven"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr "Weergaven"
 
@@ -9110,11 +9183,11 @@ msgstr "Weergaven"
 msgid "Visualizer"
 msgstr "Visualizer"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "WAARSCHUWING:"
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9138,8 +9211,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "We waren niet in staat om de aan deze account gekoppelde abonnementen te lokaliseren."
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9179,7 +9252,7 @@ msgstr "Webhookservice"
 msgid "Webhook URL"
 msgstr "Webhook-URL"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Webhookdetails"
@@ -9208,7 +9281,7 @@ msgstr "Wo"
 msgid "Wednesday"
 msgstr "Woensdag"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "Week"
 
@@ -9259,26 +9332,26 @@ msgid "Workflow Approval not found."
 msgstr "Workflowgoedkeuring niet gevonden."
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "Workflowgoedkeuringen"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "Workflowtaak"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9299,8 +9372,8 @@ msgstr "Workflowtaaksjablonen"
 msgid "Workflow Link"
 msgstr "Workflowlink"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "Workflowsjabloon"
 
@@ -9369,7 +9442,7 @@ msgstr "Schrijven"
 msgid "YAML:"
 msgstr "YAML:"
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "Jaar"
 
@@ -9385,11 +9458,11 @@ msgstr "U kunt niet reageren op de volgende workflowgoedkeuringen: {itemsUnableT
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "U kunt niet reageren op de volgende workflowgoedkeuringen: {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "U kunt niet meerdere kluisreferenties met delfde kluis-ID selecteren. Als u dat wel doet, worden de andere met delfde kluis-ID automatisch gedeselecteerd."
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "U heeft geen rechten om de volgende groepen te verwijderen: {itemsUnableToDelete}"
 
@@ -9425,19 +9498,19 @@ msgstr "Inzoomen"
 msgid "Zoom Out"
 msgstr "Uitzoomen"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "Er wordt een nieuwe webhooksleutel gegenereerd bij het opslaan."
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "Er wordt een nieuwe webhook-URL gegenereerd bij het opslaan."
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "acties"
+#~ msgid "actions"
+#~ msgstr "acties"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9453,7 +9526,7 @@ msgid "brand logo"
 msgstr "merklogo"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr "verwijderen annuleren"
 
@@ -9461,17 +9534,17 @@ msgstr "verwijderen annuleren"
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "opdracht"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr "verwijderen bevestigen"
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "loskoppelen bevestigen"
 
@@ -9505,16 +9578,16 @@ msgstr "documentatie"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "bewerken"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "versleuteld"
 
@@ -9526,16 +9599,16 @@ msgstr "voor meer info."
 msgid "for more information."
 msgstr "voor meer informatie."
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "hier"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "hier."
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "hosts"
 
@@ -9556,12 +9629,12 @@ msgid "min"
 msgstr "min"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "omlaag verplaatsen"
+#~ msgid "move down"
+#~ msgstr "omlaag verplaatsen"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "omhoog verplaatsen"
+#~ msgid "move up"
+#~ msgstr "omhoog verplaatsen"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9572,7 +9645,7 @@ msgstr "nieuwe keuze"
 msgid "of"
 msgstr "van"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "optie aan de"
 
@@ -9601,15 +9674,15 @@ msgstr "sec"
 msgid "seconds"
 msgstr "seconden"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "module selecteren"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "verbositeit selecteren"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9617,7 +9690,7 @@ msgstr ""
 msgid "social login"
 msgstr "sociale aanmelding"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "Broncontrolevertakking"
@@ -9630,7 +9703,7 @@ msgstr "systeem"
 msgid "timed out"
 msgstr "time-out"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "wijzigingen wisselen"
 
@@ -9650,39 +9723,39 @@ msgstr "{0, plural, one {Weet u zeker dat u de groep hieronder wilt verwijderen?
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {Groep verwijderen?} other {Groep verwijderen?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {De inventaris zal de status 'in afwachting' hebben totdat het laatste verwijderproces verwerkt is.} other {De inventarissen zullen de status 'in afwachting' hebben totdat het laatste verwijderproces verwerkt is.}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {De geselecteerde taak kan niet worden verwijderd wegens onvoldoende rechten of een lopende taakstatus} other {De geselecteerde taken kunnen niet worden verwijderd wegens onvoldoende rechten of een lopende taakstatus}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {Deze goedkeuring kan niet worden verwijderd wegens onvoldoende rechten of een taakstatus 'in afwachting'}} other {Deze goedkeuringen kunnen niet worden verwijderd wegens onvoldoende rechten of een taakstatus 'in afwachting'}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Deze inloggegevens worden momenteel gebruikt door andere bronnen. Weet u zeker dat u ze wilt verwijderen?} other {Het verwijderen van deze referenties kan impact hebben op andere bronnen die er op vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Dit type toegangsgegevens wordt momenteel gebruikt door sommige toegangsgegevens en kan niet worden verwijderd.} other {Typen toegangsgegevens die worden gebruikt door toegangsgegevens kunnen niet worden verwijderd. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {Deze uitvoeringsomgeving wordt momenteel gebruikt door andere bronnen. Weet u zeker dat je deze wilt verwijderen?} other {Deze uitvoeringsomgevingen kunnen in gebruik zijn door andere bronnen die er op vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Deze instantiegroep wordt momenteel door andere bronnen gebruikt. Weet je zeker dat u deze wilt verwijderen?} other {Het verwijderen van deze instantiegroepen kan gevolgen hebben voor andere bronnen die ervan afhankelijk zijn. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Deze inventaris wordt momenteel gebruikt door sommige sjablonen. Weet u zeker dat je hem wilt verwijderen?} other {Het verwijderen van deze inventarissen kan gevolgen hebben voor sommige sjablonen die erop vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
@@ -9690,15 +9763,15 @@ msgstr "{0, plural, one {Deze inventaris wordt momenteel gebruikt door sommige s
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {Deze inventarisbron wordt momenteel gebruikt door andere bronnen die erop vertrouwen. Weet u zeker dat u deze wilt verwijderen?} other {Het verwijderen van deze inventarisbronnen kan impact hebben op andere bronnen die er op vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Deze organisatie wordt momenteel door andere bronnen gebruikt. Weet je zeker dat u deze wilt verwijderen?} other {Het verwijderen van deze organisaties kan gevolgen hebben voor andere bronnen die ervan afhankelijk zijn. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Dit project wordt momenteel gebruikt door andere bronnen. Weet u zeker dat u het wilt verwijderen?} other {Het verwijderen van deze projecten kan impact hebben op andere bronnen die er op vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {Deze sjabloon wordt momenteel gebruikt door sommige workflowknooppunten. Weet u zeker dat u deze wilt verwijderen?} other {Het verwijderen van deze sjablonen kan gevolgen hebben voor sommige workflowknooppunten die erop vertrouwen. Weet u zeker dat u ze toch wilt verwijderen?}}"
 
@@ -9787,8 +9860,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/zh/messages.po
+++ b/awx/ui/src/locales/zh/messages.po
@@ -38,7 +38,7 @@ msgstr "/ (project root)"
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr "0（正常）"
 
@@ -59,7 +59,7 @@ msgstr "1（信息）"
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr "1（详细）"
 
@@ -75,7 +75,7 @@ msgstr "2（调试）"
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr "2（更多详细内容）"
 
@@ -86,7 +86,7 @@ msgstr "2（更多详细内容）"
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr "3（调试）"
 
@@ -97,7 +97,7 @@ msgstr "3（调试）"
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr "4（连接调试）"
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr "关于"
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr "帐户令牌"
 msgid "Action"
 msgstr "操作"
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr "操作"
@@ -235,8 +238,8 @@ msgstr "操作"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr "活动"
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr "活动流"
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr "活动流类型选择器"
 
@@ -297,35 +300,35 @@ msgstr "添加新令牌"
 msgid "Add a new node between these two nodes"
 msgstr "在这两个节点间添加新节点"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr "添加容器组"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr "添加现有组"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr "添加现有主机"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr "添加实例组"
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr "添加清单"
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr "添加作业模板"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr "添加新组"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr "添加新主机"
 
@@ -333,24 +336,24 @@ msgstr "添加新主机"
 msgid "Add resource type"
 msgstr "添加资源类型"
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr "添加智能清单"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr "添加团队权限"
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr "添加用户权限"
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr "添加工作流模板"
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr "管理"
 
@@ -359,11 +362,11 @@ msgstr "管理"
 msgid "Advanced"
 msgstr "高级"
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr "高级搜索文档"
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr "高级搜索值输入"
 
@@ -423,7 +426,7 @@ msgstr "允许的 URI 列表，以空格分开"
 msgid "Always"
 msgstr "始终"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr "Amazon EC2"
 
@@ -435,7 +438,7 @@ msgstr "发生错误"
 msgid "An inventory must be selected"
 msgstr "必须选择一个清单"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr "Ansible Tower"
 
@@ -456,13 +459,13 @@ msgstr "回答变量名称"
 msgid "Any"
 msgstr "任何"
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr "应用程序"
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr "应用程序信息"
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr "应用程序名"
 
@@ -480,17 +483,17 @@ msgstr "应用程序名"
 msgid "Application not found."
 msgstr "未找到应用程序。"
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr "应用程序"
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr "应用程序和令牌"
 
@@ -562,11 +565,11 @@ msgstr "您确定要从删除这个链接吗？"
 msgid "Are you sure you want to remove this node?"
 msgstr "您确定要从删除这个节点吗？"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr "您确定要从 {1} 中删除访问 {0} 吗？这样做会影响团队的所有成员。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr "您确定要从 {username} 中删除 {0} 访问吗？"
 
@@ -574,26 +577,26 @@ msgstr "您确定要从 {username} 中删除 {0} 访问吗？"
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr "您确定要提交取消此作业的请求吗？"
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr "参数"
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr "工件"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr "关联"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr "关联角色错误"
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr "关联模态"
 
@@ -605,7 +608,7 @@ msgstr "此字段至少选择一个值。"
 msgid "August"
 msgstr "8 月"
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr "身份验证"
 
@@ -626,7 +629,7 @@ msgstr "Auto"
 msgid "Azure AD"
 msgstr "Azure AD"
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr "Azure AD 设置"
 
@@ -660,12 +663,16 @@ msgstr "返回到组"
 msgid "Back to Hosts"
 msgstr "返回到主机"
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr "返回到清单"
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr "返回到作业"
 
@@ -695,7 +702,7 @@ msgstr "返回到调度"
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr "返回到执行环境"
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr "返回到实例组"
 
@@ -747,7 +753,7 @@ msgstr "返回到实例组"
 msgid "Back to management jobs"
 msgstr "返回到管理作业"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr "要签出的分支。除了分支外，您可以输入标签、提交散列和任意 refs。除非你还提供了自定义 refspec，否则某些提交散列和 refs 可能无法使用。"
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr "品牌图像"
 
@@ -805,8 +811,8 @@ msgstr "缓存超时（秒）"
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr "缓存超时（秒）"
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr "缓存超时（秒）"
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr "取消"
 
@@ -883,7 +890,7 @@ msgstr "取消链路更改"
 msgid "Cancel link removal"
 msgstr "取消链接删除"
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr "取消查找"
 
@@ -908,13 +915,13 @@ msgstr "取消所选作业"
 msgid "Cancel subscription edit"
 msgstr "取消订阅编辑"
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr "取消 {0}"
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -928,37 +935,37 @@ msgid ""
 "logging aggregator host and logging aggregator type."
 msgstr "在不提供日志记录聚合器主机和日志记录聚合器类型的情况下，无法启用日志聚合器。"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr "容量"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr "包含不区分大小写的版本。"
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr "结尾不区分大小写的版本。"
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr "完全相同不区分大小写的版本。"
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr "regex 不区分大小写的版本。"
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr "开头不区分大小写的版本。"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -978,15 +985,15 @@ msgid "Channel"
 msgstr "频道"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr "检查"
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr "检查给定字段或相关对象是否为 null；需要布尔值。"
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr "检查给定字段的值是否出现在提供的列表中；需要一个以逗号分隔的项目列表。"
 
@@ -998,7 +1005,7 @@ msgstr "选择 .json 文件"
 msgid "Choose a Notification Type"
 msgstr "选择通知类型"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr "选择 Playbook 目录"
 
@@ -1011,11 +1018,11 @@ msgid "Choose a Webhook Service"
 msgstr "选择 Webhook 服务"
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr "选择作业类型"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr "选择模块"
 
@@ -1038,7 +1045,7 @@ msgstr "选择您想要作为用户提示的回答类型或格式。请参阅 An
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr "选择应用到所选资源的角色。请注意，所有选择的角色将应用到所有选择的资源。"
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr "选择将获得新角色的资源。您可以选择下一步中要应用的角色。请注意，此处选择的资源将接收下一步中选择的所有角色。"
 
@@ -1083,6 +1090,10 @@ msgstr "点击这个按钮使用所选凭证和指定的输入验证到 secret �
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
 msgstr "点击以创建到此节点的新链接。"
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
+msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
 msgid "Click to toggle default value"
@@ -1131,13 +1142,13 @@ msgstr "云"
 msgid "Collapse"
 msgstr "折叠"
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr "命令"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr "合规"
 
@@ -1145,7 +1156,7 @@ msgstr "合规"
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr "并发作业"
 
@@ -1176,11 +1187,11 @@ msgstr "确认取消作业"
 msgid "Confirm cancellation"
 msgstr "确认取消"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr "确认删除"
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr "确认解除关联"
 
@@ -1204,7 +1215,7 @@ msgstr "确认全部恢复"
 msgid "Confirm selection"
 msgstr "确认选择"
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr "容器组"
 
@@ -1239,7 +1250,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr "控制 ansible 在 playbook 执行时生成的输出级别。"
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1292,11 +1303,11 @@ msgstr "复制模板"
 msgid "Copy full revision to clipboard."
 msgstr "将完整修订复制到剪贴板。"
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr "版权"
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr "创建"
@@ -1409,14 +1420,14 @@ msgstr "创建新源"
 msgid "Create user token"
 msgstr "创建用户令牌"
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1426,7 +1437,7 @@ msgstr "创建用户令牌"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1435,58 +1446,58 @@ msgstr "创建用户令牌"
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr "已创建"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr "创建者（用户名）"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr "创建者（用户名）"
 
@@ -1516,7 +1527,7 @@ msgstr "凭证"
 msgid "Credential Input Sources"
 msgstr "凭证输入源"
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr "凭证名称"
 
@@ -1527,9 +1538,9 @@ msgid "Credential Type"
 msgstr "凭证类型"
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1555,24 +1566,24 @@ msgstr "使用受保护的容器 registry 进行身份验证的凭证。"
 msgid "Credential type not found."
 msgstr "未找到凭证类型。"
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr "凭证"
@@ -1623,7 +1634,7 @@ msgstr "已删除"
 msgid "Dashboard"
 msgstr "仪表板"
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr "仪表板（所有活动）"
 
@@ -1637,12 +1648,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr "天"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr "要保留数据的天数"
 
@@ -1650,7 +1661,7 @@ msgstr "要保留数据的天数"
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr "剩余的天数"
 
@@ -1667,12 +1678,20 @@ msgid "December"
 msgstr "12 月"
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr "默认"
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr "默认执行环境"
 
@@ -1682,7 +1701,7 @@ msgstr "默认执行环境"
 msgid "Default answer"
 msgstr "默认回答"
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr "定义系统级的特性和功能"
 
@@ -1696,8 +1715,8 @@ msgstr "定义系统级的特性和功能"
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1705,7 +1724,7 @@ msgstr "定义系统级的特性和功能"
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1713,15 +1732,15 @@ msgstr "定义系统级的特性和功能"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1750,7 +1769,7 @@ msgstr "删除主机"
 msgid "Delete Inventory"
 msgstr "删除清单"
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1764,7 +1783,7 @@ msgstr "删除作业模板"
 msgid "Delete Notification"
 msgstr "删除通知"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr "删除机构"
 
@@ -1772,15 +1791,15 @@ msgstr "删除机构"
 msgid "Delete Project"
 msgstr "删除项目"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr "删除问题"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr "删除调度"
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr "删除问卷调查"
 
@@ -1834,6 +1853,10 @@ msgstr "删除清单源"
 msgid "Delete smart inventory"
 msgstr "删除智能清单"
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1865,16 +1888,16 @@ msgstr "删除 {pluralizedItemName}?"
 msgid "Deleted"
 msgstr "已删除"
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr "删除错误"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr "删除错误"
 
@@ -1904,34 +1927,34 @@ msgid "Deprecated"
 msgstr "已弃用"
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1939,36 +1962,36 @@ msgstr "已弃用"
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr "描述"
 
@@ -2021,7 +2044,7 @@ msgstr "目标频道或用户"
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2107,39 +2130,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr "解除关联"
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr "从主机中解除关联组？"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr "从组中解除关联主机？"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr "从实例组中解除关联实例？"
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr "解除关联相关的组？"
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr "解除关联相关的团队？"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr "解除关联角色"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr "解除关联角色！"
 
@@ -2152,7 +2175,7 @@ msgstr "解除关联？"
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2217,8 +2240,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr "每次使用此项目运行作业时，请在启动该作业前更新项目的修订。"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2237,8 +2260,8 @@ msgstr "每次使用此项目运行作业时，请在启动该作业前更新项
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2260,7 +2283,7 @@ msgstr "每次使用此项目运行作业时，请在启动该作业前更新项
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2336,8 +2359,8 @@ msgstr "编辑执行环境"
 msgid "Edit Group"
 msgstr "编辑组"
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2366,6 +2389,10 @@ msgstr "编辑节点"
 msgid "Edit Notification Template"
 msgstr "编辑通知模板"
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2390,7 +2417,7 @@ msgstr "编辑调度"
 msgid "Edit Source"
 msgstr "编辑源"
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2478,8 +2505,8 @@ msgstr "过期的时间"
 msgid "Elapsed time that the job ran"
 msgstr "作业运行所经过的时间"
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2493,7 +2520,7 @@ msgstr "电子邮件选项"
 msgid "Enable Concurrent Jobs"
 msgstr "启用并发作业"
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr "启用事实缓存"
 
@@ -2501,8 +2528,8 @@ msgstr "启用事实缓存"
 msgid "Enable HTTPS certificate verification"
 msgstr "启用 HTTPS 证书验证"
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2520,8 +2547,8 @@ msgstr "启用外部日志记录"
 msgid "Enable log system tracking facts individually"
 msgstr "单独启用日志系统跟踪事实"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr "启用权限升级"
 
@@ -2529,15 +2556,15 @@ msgstr "启用权限升级"
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr "为此模板启用 Webhook。"
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr "启用"
@@ -2572,7 +2599,7 @@ msgstr "启用的变量"
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2580,7 +2607,7 @@ msgid ""
 "template"
 msgstr "允许创建部署回调 URL。使用此 URL，主机可访问 {brandName} 并使用此作业模板请求配置更新。"
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2602,7 +2629,7 @@ msgstr "结束"
 msgid "End User License Agreement"
 msgstr "最终用户许可证协议"
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr "结束与预期值不匹配"
 
@@ -2708,21 +2735,21 @@ msgstr "输入变量来配置清单源。有关如何配置此插件的详细描
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr "使用 JSON 或 YAML 语法输入变量。使用单选按钮在两者之间切换。"
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr "错误"
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2746,41 +2773,41 @@ msgstr "保存工作流时出错！"
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2788,21 +2815,21 @@ msgstr "保存工作流时出错！"
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2812,17 +2839,17 @@ msgstr "保存工作流时出错！"
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr "错误！"
 
@@ -2830,7 +2857,7 @@ msgstr "错误！"
 msgid "Error:"
 msgstr "错误："
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2848,15 +2875,19 @@ msgstr "事件详情 modal"
 msgid "Event summary not available"
 msgstr "事件摘要不可用"
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr "事件"
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr "完全匹配（如果没有指定，则默认查找）。"
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2892,15 +2923,15 @@ msgstr "当父节点出现故障状态时执行。"
 msgid "Execute when the parent node results in a successful state."
 msgstr "当父节点具有成功状态时执行。"
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr "执行环境"
 
@@ -2909,22 +2940,22 @@ msgstr "执行环境"
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr "执行环境"
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr "执行节点"
 
@@ -2958,24 +2989,24 @@ msgstr "展开输入"
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr "预期该文件中至少有一个 client_email、project_id 或 private_key 之一。"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr "过期"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr "过期于"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr "过期于 UTC"
 
@@ -2984,7 +3015,7 @@ msgstr "过期于 UTC"
 msgid "Expires on {0}"
 msgstr "过期于 {0}"
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr "解释"
@@ -2993,8 +3024,8 @@ msgstr "解释"
 msgid "External Secret Management System"
 msgstr "外部 Secret 管理系统"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr "额外变量"
 
@@ -3019,7 +3050,7 @@ msgstr ""
 msgid "Facts"
 msgstr "事实"
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3045,7 +3076,7 @@ msgstr "失败的主机"
 msgid "Failed jobs"
 msgstr "失败的作业"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr "批准一个或多个工作流批准失败。"
 
@@ -3053,21 +3084,21 @@ msgstr "批准一个或多个工作流批准失败。"
 msgid "Failed to approve workflow approval."
 msgstr "批准工作流批准失败。"
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr "正确分配角色失败"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr "关联角色失败"
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr "关联失败。"
 
@@ -3080,12 +3111,12 @@ msgstr "取消清单源同步失败"
 msgid "Failed to cancel Project Sync"
 msgstr "取消项目同步失败"
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr "取消一个或多个作业失败。"
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr "取消 {0} 失败"
@@ -3144,19 +3175,19 @@ msgstr "删除作业模板失败。"
 msgid "Failed to delete notification."
 msgstr "删除通知失败。"
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr "删除一个或多个应用程序失败。"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr "删除一个或多个凭证类型失败。"
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr "删除一个或多个凭证失败。"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr "删除一个或多个执行环境失败"
 
@@ -3164,16 +3195,16 @@ msgstr "删除一个或多个执行环境失败"
 msgid "Failed to delete one or more groups."
 msgstr "删除一个或多个组失败。"
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr "删除一个或多个主机失败。"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr "删除一个或多个实例组失败。"
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr "删除一个或多个清单失败。"
 
@@ -3181,55 +3212,55 @@ msgstr "删除一个或多个清单失败。"
 msgid "Failed to delete one or more inventory sources."
 msgstr "删除一个或多个清单源失败。"
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr "删除一个或多个作业模板失败。"
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr "删除一个或多个作业失败。"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr "删除一个或多个通知模板失败。"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr "删除一个或多个机构失败。"
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr "删除一个或多个项目失败。"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr "删除一个或多个调度失败。"
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr "删除一个或多个团队失败。"
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr "删除一个或多个模板失败。"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr "删除一个或多个令牌失败。"
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr "删除一个或多个用户令牌失败。"
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr "删除一个或多个用户失败。"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr "无法删除一个或多个工作流批准。"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr "删除机构失败。"
 
@@ -3237,16 +3268,16 @@ msgstr "删除机构失败。"
 msgid "Failed to delete project."
 msgstr "删除项目失败。"
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr "删除角色失败"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr "删除角色失败。"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr "删除调度失败。"
 
@@ -3275,7 +3306,7 @@ msgstr "删除工作流任务模板失败。"
 msgid "Failed to delete {name}."
 msgstr "删除 {name} 失败。"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr "拒绝一个或多个工作流批准失败。"
 
@@ -3283,21 +3314,21 @@ msgstr "拒绝一个或多个工作流批准失败。"
 msgid "Failed to deny workflow approval."
 msgstr "拒绝工作流批准失败。"
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr "解除关联一个或多个组关联。"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr "解除关联一个或多个主机失败。"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr "解除关联一个或多个实例失败。"
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr "解除关联一个或多个团队失败。"
 
@@ -3305,13 +3336,13 @@ msgstr "解除关联一个或多个团队失败。"
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr "获取自定义登录配置设置失败。系统默认设置会被显示。"
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr "启动作业失败。"
 
@@ -3351,7 +3382,7 @@ msgstr "切换主机失败。"
 msgid "Failed to toggle instance."
 msgstr "切换实例失败。"
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr "切换通知失败。"
 
@@ -3382,7 +3413,7 @@ msgstr "失败"
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr "false"
 
@@ -3390,11 +3421,11 @@ msgstr "false"
 msgid "February"
 msgstr "2 月"
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr "字段包含值。"
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr "字段以值结尾。"
 
@@ -3402,11 +3433,11 @@ msgstr "字段以值结尾。"
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr "用于传递自定义 Kubernetes 或 OpenShift Pod 规格的字段。"
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr "字段与给出的正则表达式匹配。"
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr "字段以值开头。"
 
@@ -3422,16 +3453,16 @@ msgstr "文件差异"
 msgid "File upload rejected. Please select a single .json file."
 msgstr "上传文件被拒绝。请选择单个 .json 文件。"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr "文件、目录或脚本"
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr "完成时间"
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr "完成"
@@ -3442,25 +3473,25 @@ msgstr "第一"
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr "名"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr "首次运行"
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr "名字"
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr "首先，选择一个密钥"
 
@@ -3476,7 +3507,7 @@ msgstr "浮点值"
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3495,11 +3526,11 @@ msgstr "对于作业模板，选择“运行”来执行 playbook。选择“检
 msgid "For more information, refer to the"
 msgstr "有关详情请参阅"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr "分叉"
 
@@ -3507,12 +3538,12 @@ msgstr "分叉"
 msgid "Fourth"
 msgstr "第六"
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr "频率详情"
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr "频率与预期值不匹配"
 
@@ -3525,11 +3556,11 @@ msgstr "周五"
 msgid "Friday"
 msgstr "周五"
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3554,11 +3585,11 @@ msgstr "获取订阅"
 msgid "Get subscriptions"
 msgstr "获取订阅"
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr "Git"
 
@@ -3597,7 +3628,7 @@ msgstr "GitHub Organization"
 msgid "GitHub Team"
 msgstr "GitHub Team"
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr "GitHub 设置"
 
@@ -3606,7 +3637,7 @@ msgstr "GitHub 设置"
 msgid "GitLab"
 msgstr "GitLab"
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr "全局默认执行环境"
 
@@ -3635,11 +3666,11 @@ msgstr "进入下一页"
 msgid "Go to previous page"
 msgstr "进入上一页"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr "Google Compute Engine"
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr "Google OAuth2 设置"
 
@@ -3647,8 +3678,8 @@ msgstr "Google OAuth2 设置"
 msgid "Google OAuth2"
 msgstr "Google OAuth2"
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr "Grafana"
 
@@ -3661,15 +3692,15 @@ msgstr "Grafana API 密钥"
 msgid "Grafana URL"
 msgstr "Grafana URL"
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr "大于比较。"
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr "大于或等于比较。"
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr "组"
 
@@ -3677,20 +3708,20 @@ msgstr "组"
 msgid "Group details"
 msgstr "组详情"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr "组类型"
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr "组"
@@ -3718,8 +3749,8 @@ msgstr "隐藏"
 msgid "Hide description"
 msgstr "隐藏描述"
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr "HipChat"
 
@@ -3738,7 +3769,7 @@ msgstr "主机异步正常"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr "主机配置键"
 
@@ -3809,20 +3840,20 @@ msgid "Host status information for this job is unavailable."
 msgstr "此作业的主机状态信息不可用。"
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3830,30 +3861,30 @@ msgstr "此作业的主机状态信息不可用。"
 msgid "Hosts"
 msgstr "主机"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr "可用主机"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr "剩余主机"
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr "小时"
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr "ID"
 
@@ -3873,8 +3904,8 @@ msgstr "仪表板 ID（可选）"
 msgid "ID of the panel (optional)"
 msgstr "面板 ID（可选）"
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr "IRC"
 
@@ -3931,7 +3962,7 @@ msgid ""
 "default group for the inventory."
 msgstr "如果选中，以前存在于外部源上的但现已被删除的任何主机和组都将从清单中删除。不由清单源管理的主机和组将提升到下一个手动创建的组，如果没有手动创建组来提升它们，则它们将保留在清单的“all”默认组中。"
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3944,18 +3975,18 @@ msgid ""
 "--diff mode."
 msgstr "如果启用，显示 Ansible 任务所做的更改（在支持的情况下）。这等同于 Ansible 的 --diff mode。"
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr "如果启用，显示 Ansible 任务所做的更改（在支持的情况下）。这等同于 Ansible 的 --diff 模式。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr "如果启用，显示 Ansible 任务所做的更改（在支持的情况下）。这等同于 Ansible 的 --diff 模式。"
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3965,7 +3996,7 @@ msgstr "如果启用，将允许同时运行此作业模板。"
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr "如果启用，将允许同时运行此工作流作业模板。"
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3976,7 +4007,7 @@ msgstr "如果启用，这将存储收集的事实，以便在主机一级查看
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr "如果您准备进行升级或续订，请点<0>联系我们。</0>"
 
@@ -3986,7 +4017,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr "如果您还没有订阅，请联系红帽来获得一个试用订阅。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr "如果您只想删除这个特定用户的访问，请将其从团队中删除。"
 
@@ -3998,13 +4029,13 @@ msgid ""
 msgstr "如果您希望清单源在启动和项目更新时更新，请点启动时更新，并进入"
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr "镜像"
@@ -4028,13 +4059,13 @@ msgstr "Info"
 msgid "Initiated By"
 msgstr "启动者"
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr "启动者"
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr "启动者（用户名）"
 
@@ -4061,7 +4092,7 @@ msgstr "Insights for Ansible Automation Platform"
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr "Insights for Ansible Automation Platform 仪表板"
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr "Insights 系统 ID"
 
@@ -4073,18 +4104,18 @@ msgstr "实例"
 msgid "Instance Filters"
 msgstr "实例过滤器"
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr "实例组"
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4093,7 +4124,7 @@ msgstr "实例组"
 msgid "Instance Groups"
 msgstr "实例组"
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr "实例 ID"
 
@@ -4115,11 +4146,11 @@ msgid "Instance groups"
 msgstr "实例组"
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr "实例"
 
@@ -4149,11 +4180,11 @@ msgstr "无效的用户名或密码。请重试。"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4164,41 +4195,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr "无法复制含有源的清单"
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr "清单"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr "清单（名称）"
 
@@ -4206,13 +4237,17 @@ msgstr "清单（名称）"
 msgid "Inventory File"
 msgstr "清单文件"
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr "清单 ID"
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
 msgstr "清单源"
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
+msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
 msgid "Inventory Source Sync"
@@ -4229,15 +4264,15 @@ msgstr "清单源同步错误"
 msgid "Inventory Sources"
 msgstr "清单源"
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr "清单同步"
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4282,7 +4317,7 @@ msgstr "项正常"
 msgid "Item Skipped"
 msgstr "项已跳过"
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr "项"
@@ -4314,20 +4349,20 @@ msgstr "JSON："
 msgid "January"
 msgstr "1 月"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr "作业"
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr "作业取消错误"
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4341,19 +4376,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr "作业分片"
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr "作业分片"
 
@@ -4365,20 +4400,20 @@ msgstr "作业状态"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr "作业标签"
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr "作业模板"
@@ -4403,15 +4438,15 @@ msgstr "在创建或编辑节点时无法选择缺失的清单或项目的作业
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr "在创建或编辑节点时无法选择具有提示密码凭证的作业模板"
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr "作业类型"
 
@@ -4424,15 +4459,15 @@ msgid "Job status graph tab"
 msgstr "作业状态图标签页"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr "作业模板"
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4447,7 +4482,7 @@ msgstr "作业模板"
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4455,7 +4490,7 @@ msgstr "作业模板"
 msgid "Jobs"
 msgstr "作业"
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr "作业设置"
 
@@ -4467,19 +4502,19 @@ msgstr "7 月"
 msgid "June"
 msgstr "6 月"
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr "密钥"
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr "键选择"
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr "键 typeahead"
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr "关键词"
 
@@ -4512,7 +4547,7 @@ msgstr "LDAP 5"
 msgid "LDAP Default"
 msgstr "LDAP 默认"
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr "LDAP 设置"
 
@@ -4536,18 +4571,18 @@ msgstr "LDAP4"
 msgid "LDAP5"
 msgstr "LDAP5"
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr "标签名称"
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr "标签"
@@ -4565,11 +4600,11 @@ msgid "Last Login"
 msgstr "最近登陆"
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4579,7 +4614,7 @@ msgstr "最近登陆"
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4593,25 +4628,25 @@ msgstr "最后修改"
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr "姓氏"
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr "最后运行"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr "最后运行"
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr "最后作业"
 
@@ -4622,7 +4657,7 @@ msgstr "最后作业"
 msgid "Last modified"
 msgstr "最后修改"
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr "姓氏"
@@ -4673,11 +4708,11 @@ msgstr "启动工作流"
 msgid "Launch | {0}"
 msgstr "启动 | {0}"
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr "启动者"
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr "启动者（用户名）"
 
@@ -4693,26 +4728,26 @@ msgstr "将此字段留空以使执行环境全局可用。"
 msgid "Legend"
 msgstr "图例"
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr "小于比较。"
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr "小于或等于比较。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr "限制"
@@ -4729,11 +4764,11 @@ msgstr "正在加载"
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr "本地时区"
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr "本地时区"
 
@@ -4745,7 +4780,7 @@ msgstr "登录"
 msgid "Logging"
 msgstr "日志记录"
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr "日志设置"
 
@@ -4755,20 +4790,20 @@ msgstr "日志设置"
 msgid "Logout"
 msgstr "退出"
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr "查找 modal"
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr "查找选择"
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr "查找类型"
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr "查找 typeahead"
 
@@ -4778,10 +4813,10 @@ msgstr "查找 typeahead"
 msgid "MOST RECENT SYNC"
 msgstr "最新同步"
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr "机器凭证"
 
@@ -4794,8 +4829,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr "受管的节点"
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4805,7 +4840,7 @@ msgid "Management Job"
 msgstr "管理作业"
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr "管理作业"
 
@@ -4826,15 +4861,15 @@ msgstr "未找到管理作业。"
 msgid "Management jobs"
 msgstr "管理作业"
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr "手动"
 
@@ -4842,8 +4877,8 @@ msgstr "手动"
 msgid "March"
 msgstr "3 月"
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr "Mattermost"
 
@@ -4864,7 +4899,7 @@ msgstr "最大长度"
 msgid "May"
 msgstr "5 月"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr "成员"
@@ -4881,7 +4916,7 @@ msgstr "指标"
 msgid "Metrics"
 msgstr "指标"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr "Microsoft Azure Resource Manager"
 
@@ -4905,7 +4940,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr "新实例上线时将自动分配给此组的所有实例的最小百分比。"
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr "分钟"
 
@@ -4913,7 +4948,7 @@ msgstr "分钟"
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4921,7 +4956,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr "杂项系统"
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr "杂项系统设置"
 
@@ -4936,70 +4971,70 @@ msgid "Missing resource"
 msgstr "缺少资源"
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr "修改"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr "修改者（用户名）"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr "修改者（用户名）"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr "模块"
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5012,7 +5047,7 @@ msgstr "周一"
 msgid "Monday"
 msgstr "周一"
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr "月"
 
@@ -5024,13 +5059,13 @@ msgstr "更多信息"
 msgid "More information for"
 msgstr "更多信息"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr "多选"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr "多选"
 
@@ -5046,57 +5081,57 @@ msgstr "多项选择（单选）"
 msgid "Multiple Choice Options"
 msgstr "多项选择选项"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5111,73 +5146,73 @@ msgstr "多项选择选项"
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5190,66 +5225,72 @@ msgstr "多项选择选项"
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr "名称"
@@ -5273,7 +5314,7 @@ msgstr "永不更新"
 msgid "Never expires"
 msgstr "永不过期"
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr "新"
@@ -5292,8 +5333,8 @@ msgstr "新"
 msgid "Next"
 msgstr "下一"
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5336,7 +5377,7 @@ msgstr "没有清单同步失败。"
 msgid "No items found."
 msgstr "没有找到项。"
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5344,10 +5385,10 @@ msgstr ""
 msgid "No result found"
 msgstr "未找到结果"
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr "没有找到结果"
 
@@ -5356,7 +5397,7 @@ msgstr "没有找到结果"
 msgid "No subscriptions found"
 msgstr "未找到订阅"
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr "没有找到问卷调查问题"
 
@@ -5371,7 +5412,7 @@ msgstr "没有找到 {pluralizedItemName}"
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5389,7 +5430,7 @@ msgstr "无"
 msgid "None (Run Once)"
 msgstr "无（运行一次）"
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr "无（运行一次）"
 
@@ -5412,15 +5453,15 @@ msgstr "没有配置"
 msgid "Not configured for inventory sync."
 msgstr "没有为清单同步配置。"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr "请注意，只有直接属于此组的主机才能解除关联。子组中的主机必须与其所属的子组级别直接解除关联。"
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5428,7 +5469,7 @@ msgid ""
 "with directly and indirectly."
 msgstr "请注意，如果主机也是组子对象的成员，在解除关联后，您可能仍然可以在列表中看到组。这个列表显示了主机与其直接及间接关联的所有组。"
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5459,9 +5500,9 @@ msgstr "通知颜色"
 msgid "Notification Template not found."
 msgstr "没有找到通知模板。"
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5476,20 +5517,20 @@ msgstr "通知类型"
 msgid "Notification color"
 msgstr "通知颜色"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr "发送通知成功"
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr "通知超时"
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr "通知类型"
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5524,39 +5565,37 @@ msgstr "发生次数"
 msgid "October"
 msgstr "10 月"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr "关"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr "于"
 
@@ -5586,7 +5625,7 @@ msgstr "于日"
 msgid "Only Group By"
 msgstr "唯一分组标准"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr "OpenStack"
 
@@ -5594,7 +5633,7 @@ msgstr "OpenStack"
 msgid "Option Details"
 msgstr "选项详情"
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5606,20 +5645,26 @@ msgstr "描述此作业模板的可选标签，如 'dev' 或 'test'。标签可�
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr "（可选）选择要用来向 Webhook 服务发回状态更新的凭证。"
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr "选项"
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5630,15 +5675,15 @@ msgstr "选项"
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5648,22 +5693,22 @@ msgstr "选项"
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr "机构"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr "机构（名称）"
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr "机构名称"
 
@@ -5673,9 +5718,9 @@ msgstr "未找到机构。"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5690,11 +5735,11 @@ msgstr "机构"
 msgid "Other prompts"
 msgstr "其他提示"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr "不合规"
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr "输出"
@@ -5725,8 +5770,8 @@ msgstr "POST"
 msgid "PUT"
 msgstr "PUT"
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr "Pagerduty"
 
@@ -5758,11 +5803,11 @@ msgstr "Pan 右"
 msgid "Pan Up"
 msgstr "Pan 上"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr "传递额外的命令行更改。有两个 ansible 命令行参数："
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5801,7 +5846,7 @@ msgstr "过去两周"
 msgid "Past week"
 msgstr "过去一周"
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5815,12 +5860,12 @@ msgstr "等待工作流批准"
 msgid "Pending delete"
 msgstr "等待删除"
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr "执行搜索以定义主机过滤器"
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5841,13 +5886,13 @@ msgid "Play Started"
 msgstr "Play 已启动"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr "Playbook"
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr "Playbook 检查"
@@ -5858,12 +5903,12 @@ msgstr "Playbook 完成"
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr "Playbook 目录"
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5873,10 +5918,10 @@ msgstr "Playbook 运行"
 msgid "Playbook Started"
 msgstr "Playbook 已启动"
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr "Playbook 名称"
 
@@ -5888,15 +5933,15 @@ msgstr "Playbook 运行"
 msgid "Plays"
 msgstr "Play"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr "请添加问卷调查问题"
 
@@ -5920,23 +5965,23 @@ msgstr "请输入一个值。"
 msgid "Please log in"
 msgstr "请登录"
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr "选择的日数字应介于 1 到 31 之间。"
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr "请选择一个清单或者选中“启动时提示”选项"
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr "请选择一个比开始日期/时间晚的结束日期/时间。"
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr "请在编辑主机过滤器前选择机构"
 
@@ -5944,7 +5989,7 @@ msgstr "请在编辑主机过滤器前选择机构"
 msgid "Pod spec override"
 msgstr "Pod 规格覆写"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5964,7 +6009,7 @@ msgstr "策略实例百分比"
 msgid "Populate field from an external secret management system"
 msgstr "从外部 secret 管理系统填充字段"
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6002,8 +6047,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr "预览"
 
@@ -6013,7 +6056,7 @@ msgstr "私钥密码"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr "权限升级"
 
@@ -6021,17 +6064,16 @@ msgstr "权限升级"
 msgid "Privilege escalation password"
 msgstr "权限升级密码"
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6039,7 +6081,7 @@ msgstr "项目"
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr "项目基本路径"
 
@@ -6067,10 +6109,10 @@ msgstr "项目同步失败"
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6083,8 +6125,8 @@ msgstr "项目"
 msgid "Promote Child Groups and Hosts"
 msgstr "提升子组和主机"
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr "提示"
 
@@ -6103,11 +6145,11 @@ msgid "Prompt | {0}"
 msgstr "提示 | {0}"
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr "提示的值"
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6128,7 +6170,7 @@ msgstr "提供主机模式以进一步限制受 playbook 管理或影响的主�
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr "为这个字段输入值或者选择「启动时提示」选项。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6150,18 +6192,18 @@ msgstr "提供您的 Red Hat 或 Red Hat Satellite 凭证，以便为 Ansible Au
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr "部署回调 URL"
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr "置备回调详情"
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr "置备回调"
 
@@ -6178,7 +6220,7 @@ msgstr "问题"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr "RADIUS 设置"
 
@@ -6208,7 +6250,7 @@ msgstr "最近模板列表标签页"
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6221,19 +6263,19 @@ msgstr "接收者列表"
 msgid "Recipient list"
 msgstr "接收者列表"
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr "Red Hat Insights"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr "Red Hat Satellite 6"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr "Red Hat Virtualization"
 
@@ -6241,7 +6283,7 @@ msgstr "Red Hat Virtualization"
 msgid "Red Hat subscription manifest"
 msgstr "Red Hat 订阅清单"
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr "Red Hat, Inc."
 
@@ -6265,7 +6307,7 @@ msgstr "重定向到订阅详情"
 msgid "Refer to the"
 msgstr "请参阅"
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6301,28 +6343,28 @@ msgstr "仅导入主机名与这个正则表达式匹配的主机。该过滤器
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr "相关组"
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr "重新启动"
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr "重新启动作业"
@@ -6340,16 +6382,16 @@ msgstr "重新启动失败的主机"
 msgid "Relaunch on"
 msgstr "重新启动于"
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr "使用主机参数重新启动"
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr "远程归档"
 
@@ -6376,7 +6418,7 @@ msgstr "删除节点"
 msgid "Remove any local modifications prior to performing an update."
 msgstr "在进行更新前删除任何本地修改。"
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr "删除 {0} 访问"
 
@@ -6392,7 +6434,7 @@ msgstr "删除此链接将会孤立分支的剩余部分，并导致它在启动
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr "重复频率"
 
@@ -6409,7 +6451,7 @@ msgstr "使用新值替换项"
 msgid "Request subscription"
 msgstr "请求订阅"
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr "必需"
@@ -6417,7 +6459,7 @@ msgstr "必需"
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr "资源名称"
 
@@ -6426,7 +6468,7 @@ msgid "Resource deleted"
 msgstr "资源已删除"
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr "资源"
 
@@ -6458,15 +6500,15 @@ msgstr "返回"
 msgid "Return to subscription management."
 msgstr "返回到订阅管理。"
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr "返回具有这个以外的值和其他过滤器的结果。"
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr "返回满足这个及其他过滤器的结果。如果没有进行选择，这是默认的集合类型。"
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr "返回满足这个或任何其他过滤器的结果。"
 
@@ -6497,8 +6539,8 @@ msgstr "恢复设置"
 msgid "Revert to factory default."
 msgstr "恢复到工厂默认值。"
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr "修订"
@@ -6507,25 +6549,25 @@ msgstr "修订"
 msgid "Revision #"
 msgstr "修订号"
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr "Rocket.Chat"
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr "角色"
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6539,7 +6581,7 @@ msgstr "角色"
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr "运行"
 
@@ -6563,7 +6605,7 @@ msgstr "运行命令"
 msgid "Run every"
 msgstr "运行每"
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr "运行频率"
 
@@ -6575,7 +6617,7 @@ msgstr "运行于"
 msgid "Run type"
 msgstr "运行类型"
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6586,8 +6628,8 @@ msgstr "运行中"
 msgid "Running Handlers"
 msgstr "正在运行的处理程序"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr "运行作业"
@@ -6600,7 +6642,7 @@ msgstr "运行作业"
 msgid "SAML"
 msgstr "SAML"
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr "SAML 设置"
 
@@ -6643,18 +6685,19 @@ msgid "Saturday"
 msgstr "周六"
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6692,7 +6735,7 @@ msgstr "调度处于活跃状态。"
 msgid "Schedule is inactive"
 msgstr "调度处于非活跃状态。"
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr "调度缺少规则"
 
@@ -6700,10 +6743,10 @@ msgstr "调度缺少规则"
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6717,11 +6760,11 @@ msgstr ""
 msgid "Schedules"
 msgstr "调度"
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6743,8 +6786,8 @@ msgstr "滚动到下一个"
 msgid "Scroll previous"
 msgstr "滚动到前一个"
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr "搜索"
 
@@ -6752,7 +6795,7 @@ msgstr "搜索"
 msgid "Search is disabled while the job is running"
 msgstr "作业运行时会禁用搜索"
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr "搜索提交按钮"
@@ -6776,9 +6819,9 @@ msgstr "秒"
 msgid "See errors on the left"
 msgstr "在左侧查看错误"
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6788,13 +6831,13 @@ msgstr "选择"
 msgid "Select Credential Type"
 msgstr "编辑凭证类型"
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr "选择组"
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr "选择主机"
 
@@ -6802,11 +6845,11 @@ msgstr "选择主机"
 msgid "Select Input"
 msgstr "选择输入"
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr "选择实例"
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr "选择项"
 
@@ -6822,7 +6865,7 @@ msgstr "选择标签"
 msgid "Select Roles to Apply"
 msgstr "选择要应用的角色"
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr "选择团队"
 
@@ -6838,7 +6881,7 @@ msgstr "选择节点类型"
 msgid "Select a Resource Type"
 msgstr "选择资源类型"
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6868,7 +6911,7 @@ msgstr "选择要取消的作业"
 msgid "Select a metric"
 msgstr "选择一个指标"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr "选择一个模块"
 
@@ -6877,16 +6920,20 @@ msgstr "选择一个模块"
 msgid "Select a playbook"
 msgstr "选择一个 playbook"
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
 msgstr "在编辑执行环境前选择一个项目。"
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
+msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
 msgid "Select a row to approve"
 msgstr "选择要批准的行"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr "选择要删除的行"
 
@@ -6907,8 +6954,8 @@ msgstr "导入一个订阅"
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6928,7 +6975,7 @@ msgstr "导入一个订阅"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6941,11 +6988,11 @@ msgid "Select a webhook service."
 msgstr "选择 Webhook 服务。"
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr "选择所有"
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr "选择一个活动类型"
 
@@ -6965,7 +7012,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr "在编辑默认执行环境前选择一个机构。"
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6974,7 +7021,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr "选择允许访问将运行此作业的节点的凭证。每种类型您只能选择一个凭证。对于机器凭证 (SSH)，如果选中了“启动时提示”但未选择凭证，您需要在运行时选择机器凭证。如果选择了凭证并选中了“启动时提示”，则所选凭证将变为默认设置，可以在运行时更新。"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7019,7 +7066,7 @@ msgstr "选择状态"
 msgid "Select tags"
 msgstr "选择标签"
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr "选择您希望这个命令在内运行的执行环境。"
 
@@ -7027,7 +7074,7 @@ msgstr "选择您希望这个命令在内运行的执行环境。"
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr "选择要运行此清单的实例组。"
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7047,16 +7094,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr "选择此令牌所属的应用程序。"
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr "选择要在访问远程主机时用来运行命令的凭证。选择包含 Ansbile 登录远程主机所需的用户名和 SSH 密钥或密码的凭证。"
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr "为此作业模板选择执行环境。"
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7074,11 +7121,11 @@ msgstr "选择要由此源同步的清单文件。您可以从下拉列表中选
 msgid "Select the inventory that this host will belong to."
 msgstr "选择此主机要属于的清单。"
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr "选择要由此作业执行的 playbook。"
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7088,7 +7135,7 @@ msgstr "选择包含此作业要执行的 playbook 的项目。"
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr "选择要使用的 Ansible Automation Platform 订阅。"
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr "选择 {0}"
 
@@ -7097,7 +7144,7 @@ msgstr "选择 {0}"
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7109,7 +7156,7 @@ msgstr "选择 {0}"
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7121,17 +7168,23 @@ msgstr "选择 {0}"
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr "已选择"
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
 msgstr "选择的类别"
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
+msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
 msgid "Sender Email"
@@ -7158,7 +7211,7 @@ msgstr "为这个字段设置值"
 msgid "Set how many days of data should be retained."
 msgstr "设置数据应保留的天数。"
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr "为数据收集、日志和登录设置偏好"
 
@@ -7174,19 +7227,19 @@ msgstr "设置实例在线或离线。如果离线，则不会将作业分配给
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr "根据客户端设备的安全情况，设置为公共或机密。"
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr "设置类型"
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr "设置类型选项"
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr "设置类型 typeahead"
 
@@ -7208,8 +7261,8 @@ msgstr "设置名称"
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr "设置"
@@ -7221,9 +7274,9 @@ msgstr "显示"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr "显示更改"
 
@@ -7231,8 +7284,8 @@ msgstr "显示更改"
 #~ msgid "Show all groups"
 #~ msgstr "显示所有组"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr "显示更改"
 
@@ -7245,7 +7298,7 @@ msgstr "显示描述"
 msgid "Show less"
 msgstr "显示更少"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr "只显示 root 组"
 
@@ -7298,14 +7351,14 @@ msgstr "简单键选择"
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr "跳过标签"
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7326,15 +7379,15 @@ msgstr "如果有一个大的 playbook，而您想要跳过某个 play 或任务
 msgid "Skipped"
 msgstr "跳过"
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr "Slack"
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr "智能清单"
@@ -7343,7 +7396,7 @@ msgstr "智能清单"
 msgid "Smart Inventory not found."
 msgstr "未找到智能清单"
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr "智能主机过滤器"
@@ -7375,13 +7428,15 @@ msgstr "排序"
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr "排序问题顺序"
+#~ msgid "Sort question order"
+#~ msgstr "排序问题顺序"
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr "源"
 
@@ -7390,12 +7445,12 @@ msgstr "源"
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr "源控制分支"
 
@@ -7428,19 +7483,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr "源控制类型"
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr "源控制 URL"
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7454,8 +7509,8 @@ msgstr "源电话号码"
 msgid "Source Variables"
 msgstr "源变量"
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr "源工作流作业"
 
@@ -7476,7 +7531,7 @@ msgstr "源电话号码"
 msgid "Source variables"
 msgstr "源变量"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr "来自项目的源"
 
@@ -7523,14 +7578,14 @@ msgstr "标准输出标签页"
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr "开始"
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr "开始时间"
 
@@ -7552,27 +7607,27 @@ msgstr "启动同步进程"
 msgid "Start sync source"
 msgstr "启动同步源"
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr "已开始"
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr "状态"
@@ -7597,14 +7652,14 @@ msgid ""
 "flag to git submodule update."
 msgstr "子模块将跟踪其 master 分支（或在 .gitmodules 中指定的其他分支）的最新提交。如果没有，子模块将会保留在主项目指定的修订版本中。这等同于在 git submodule update 命令中指定 --remote 标志。"
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr "订阅"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr "订阅详情"
 
@@ -7620,11 +7675,11 @@ msgstr "订阅清单"
 msgid "Subscription selection modal"
 msgstr "订阅选择模态"
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr "订阅设置"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr "订阅类型"
 
@@ -7632,11 +7687,11 @@ msgstr "订阅类型"
 msgid "Subscriptions table"
 msgstr "订阅表"
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr "Subversion"
 
@@ -7656,7 +7711,7 @@ msgstr "成功信息"
 msgid "Success message body"
 msgstr "成功消息正文"
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7688,25 +7743,37 @@ msgstr "周日"
 msgid "Survey"
 msgstr "问卷调查"
 
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
 #: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
-msgstr "问卷调查列表"
+#~ msgid "Survey List"
+#~ msgstr "问卷调查列表"
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
-msgstr "问卷调查预览"
+#~ msgid "Survey Preview"
+#~ msgstr "问卷调查预览"
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr "问卷调查切换"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr "问卷调查预览 modal"
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr "可选的问卷调查问题"
+#~ msgid "Survey questions"
+#~ msgstr "可选的问卷调查问题"
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7744,15 +7811,15 @@ msgstr "修订版本同步"
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr "系统"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr "系统管理员"
@@ -7767,8 +7834,8 @@ msgstr "系统审核员"
 msgid "System Warning"
 msgstr "系统警告"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr "系统管理员对所有资源的访问权限是不受限制的。"
 
@@ -7776,7 +7843,7 @@ msgstr "系统管理员对所有资源的访问权限是不受限制的。"
 msgid "TACACS+"
 msgstr "TACACS+"
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr "TACACS+ 设置"
 
@@ -7785,7 +7852,7 @@ msgstr "TACACS+ 设置"
 msgid "Tabs"
 msgstr "制表符"
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7840,7 +7907,7 @@ msgid "Team"
 msgstr "团队（team）"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr "团队角色"
 
@@ -7851,19 +7918,19 @@ msgstr "未找到团队"
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7874,12 +7941,12 @@ msgstr "团队"
 msgid "Template not found."
 msgstr "未找到模板"
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7908,12 +7975,12 @@ msgstr "测试通知"
 msgid "Test passed"
 msgstr "测试通过"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr "文本"
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr "文本区"
 
@@ -7948,7 +8015,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr "电子邮件通知停止尝试到达主机并超时之前所经过的时间（以秒为单位）。范围为 1 秒到 120 秒。"
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -7995,7 +8062,7 @@ msgid ""
 "documentation for more details."
 msgstr "允许由此机构管理的最大主机数。默认值为 0，表示无限制。请参阅 Ansible 文档以了解更多详情。"
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -8004,16 +8071,16 @@ msgid ""
 "with a change to"
 msgstr "执行 playbook 时使用的并行或同步进程数量。空值或小于 1 的值将使用 Ansible 默认值，通常为 5。要覆盖默认分叉数，可更改"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr "执行 playbook 时使用的并行或同步进程数量。如果不输入值，则将使用 %s 配置文件 %s 中的默认值。您可以找到更多信息"
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr "您请求的页面无法找到。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr "用于将字段保留为清单中的目标主机的模式。留空、所有和 * 将针对清单中的所有主机。您可以找到有关 Ansible 主机模式的更多信息"
 
@@ -8052,7 +8119,7 @@ msgstr "变量名称的建议格式为小写字母并用下划线分隔（例如
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8086,19 +8153,19 @@ msgstr "保存工作流时出错。"
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr "这些是支持的标准运行命令运行的详细程度。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr "这些参数与指定的模块一起使用。"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr "这些参数与指定的模块一起使用。点击可以找到有关 {0} 的信息。"
 
@@ -8106,21 +8173,21 @@ msgstr "这些参数与指定的模块一起使用。点击可以找到有关 {0
 msgid "Third"
 msgstr "第三"
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr "此项目需要被更新"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr "此操作将删除以下内容："
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr "此操作将从所选团队中解除该用户的所有角色。"
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr "此操作将从 {0} 中解除以下角色关联："
 
@@ -8216,7 +8283,7 @@ msgid "This field must be greater than 0"
 msgstr "此字段必须大于 0"
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8268,7 +8335,7 @@ msgstr "这是唯一显示令牌值和关联刷新令牌值的时间。"
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr "其他资源目前正在使用此任务模板。确定要删除它吗？"
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr "这个机构目前由其他资源使用。您确定要删除它吗？"
 
@@ -8280,11 +8347,11 @@ msgstr "其他资源目前正在使用这个项目。确定要删除它吗？"
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr "此项目当前处于同步状态，在同步过程完成前无法点击"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr "此调度缺少清单"
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr "此调度缺少所需的调查值"
 
@@ -8319,8 +8386,8 @@ msgstr "周四"
 msgid "Thursday"
 msgstr "周四"
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8354,7 +8421,7 @@ msgstr "超时"
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr "超时"
 
@@ -8365,6 +8432,10 @@ msgstr "超时分钟"
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
 msgstr "超时秒"
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
+msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
 msgid "Toggle Legend"
@@ -8432,11 +8503,11 @@ msgid "Token not found."
 msgstr "未找到令牌"
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr "令牌"
@@ -8449,8 +8520,8 @@ msgstr "工具"
 msgid "Top Pagination"
 msgstr "顶级分页"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr "作业总数"
@@ -8473,20 +8544,20 @@ msgstr "跟踪子模块"
 msgid "Track submodules latest commit on branch"
 msgstr "跟踪分支中的最新提交"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr "试用"
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr "True"
 
@@ -8499,55 +8570,57 @@ msgstr "周二"
 msgid "Tuesday"
 msgstr "周二"
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr "Twilio"
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr "类型"
@@ -8591,7 +8664,7 @@ msgstr "撤消"
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr "无限"
 
@@ -8608,7 +8681,7 @@ msgstr "无法访问的主机数"
 msgid "Unreachable Hosts"
 msgstr "无法访问的主机"
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr "未识别的日字符串"
 
@@ -8645,7 +8718,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8682,7 +8755,7 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr "当一个作业开始、成功或失败时使用的自定义消息来更改通知的内容。使用大括号来访问该作业的信息："
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8701,17 +8774,17 @@ msgstr "用户"
 msgid "User Details"
 msgstr "用户详情"
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr "用户界面"
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr "用户界面设置"
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr "用户角色"
 
@@ -8738,14 +8811,14 @@ msgstr "用户详情"
 msgid "User not found."
 msgstr "未找到用户。"
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr "用户令牌"
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8758,8 +8831,8 @@ msgstr "用户令牌"
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8772,16 +8845,16 @@ msgstr "用户名/密码"
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr "用户"
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr "VMware vCenter"
 
@@ -8792,7 +8865,7 @@ msgstr "VMware vCenter"
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8802,10 +8875,10 @@ msgstr "VMware vCenter"
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr "变量"
@@ -8826,21 +8899,21 @@ msgstr "Vault 密码 | {credId}"
 msgid "Verbose"
 msgstr "详细"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr "详细程度"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr "版本"
 
@@ -8887,7 +8960,7 @@ msgstr "查看清单主机详情"
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr "在 <0>www.json.org</0> 查看 JSON 示例"
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr "查看作业详情"
 
@@ -9000,7 +9073,7 @@ msgstr "查看所有清单主机。"
 msgid "View all Jobs"
 msgstr "查看所有作业"
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr "查看所有作业"
 
@@ -9063,7 +9136,7 @@ msgstr "查看所有设置"
 msgid "View all tokens."
 msgstr "查看所有令牌。"
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr "查看并编辑您的订阅信息"
 
@@ -9089,7 +9162,7 @@ msgid "View smart inventory host details"
 msgstr "查看智能清单主机详情"
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr "视图"
 
@@ -9099,11 +9172,11 @@ msgstr "视图"
 msgid "Visualizer"
 msgstr "Visualizer"
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr "警告："
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9127,8 +9200,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr "我们无法找到与这个帐户关联的许可证。"
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr "Webhook"
 
@@ -9168,7 +9241,7 @@ msgstr "Webhook 服务"
 msgid "Webhook URL"
 msgstr "Webhook URL"
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr "Webhook 详情"
@@ -9197,7 +9270,7 @@ msgstr "周三"
 msgid "Wednesday"
 msgstr "周三"
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr "周"
 
@@ -9246,26 +9319,26 @@ msgid "Workflow Approval not found."
 msgstr "未找到工作流批准。"
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr "工作流批准"
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr "工作流作业"
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9286,8 +9359,8 @@ msgstr "工作流作业模板"
 msgid "Workflow Link"
 msgstr "工作流链接"
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr "工作流模板"
 
@@ -9356,7 +9429,7 @@ msgstr "写入"
 msgid "YAML:"
 msgstr "YAML："
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr "年"
 
@@ -9372,11 +9445,11 @@ msgstr "您无法对以下工作流批准进行操作：{itemsUnableToApprove}"
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr "您无法对以下工作流批准进行操作： {itemsUnableToDeny}"
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr "您不能选择具有相同 vault ID 的多个 vault 凭证。这样做会自动取消选择具有相同的 vault ID 的另一个凭证。"
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr "您没有权限删除以下组： {itemsUnableToDelete}"
 
@@ -9410,19 +9483,19 @@ msgstr "放大"
 msgid "Zoom Out"
 msgstr "缩小"
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK 密钥"
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr "在保存时会生成一个新的 WEBHOOK url"
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr "操作"
+#~ msgid "actions"
+#~ msgstr "操作"
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9438,7 +9511,7 @@ msgid "brand logo"
 msgstr "品牌徽标"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr "取消删除"
 
@@ -9446,17 +9519,17 @@ msgstr "取消删除"
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr "命令"
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr "确认删除"
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr "确认解除关联"
 
@@ -9490,16 +9563,16 @@ msgstr "文档"
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr "编辑"
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr "加密"
 
@@ -9511,16 +9584,16 @@ msgstr "更多信息。"
 msgid "for more information."
 msgstr "更多信息"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr "此处"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr "此处。"
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr "主机"
 
@@ -9541,12 +9614,12 @@ msgid "min"
 msgstr "分钟"
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr "向下移动"
+#~ msgid "move down"
+#~ msgstr "向下移动"
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr "向上移动"
+#~ msgid "move up"
+#~ msgstr "向上移动"
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9557,7 +9630,7 @@ msgstr "新选择"
 msgid "of"
 msgstr "的"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr "选项"
 
@@ -9586,15 +9659,15 @@ msgstr "秒"
 msgid "seconds"
 msgstr "秒"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr "选择模块"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr "选择详细程度"
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9602,7 +9675,7 @@ msgstr ""
 msgid "social login"
 msgstr "社交登录"
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr "源控制分支"
@@ -9615,7 +9688,7 @@ msgstr "系统"
 msgid "timed out"
 msgstr "超时"
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr "切换更改"
 
@@ -9635,39 +9708,39 @@ msgstr "{0, plural, one {您确定要删除以下组吗？} other {您确定要�
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr "{0, plural, one {删除组?} other {删除组?}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr "{0, plural, one {清单会处于一个待处理状态，直到最终的删除被处理完成。} other {清单会处于一个待处理状态，直到最终的删除被处理完成。}}"
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr "{0, plural, one {选择的作业不能删除，因为没有足够的权限或处于作业运行状态} other {选择的作业不能删除，因为没有足够的权限或处于作业运行状}}"
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr "{0, plural, one {这个批准无法被删除，因为没有足够的权限或处于作业待处理状态} other {这个批准无法被删除，因为没有足够的权限或处于作业待处理状态}}"
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个凭证正被其他资源使用。您确定要删除它吗？} other {删除这些凭证可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个凭证类型正被其他凭证使用，无法删除。} other {正在被凭证使用的凭证类型不能被删除。您确定要删除吗？}}"
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr "{0, plural, one {这个执行环境正被其他资源使用。您确定要删除它吗？} other {这些凭证可能正在被依赖它的其他资源使用。您确定要删除吗？}}"
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个实例组正被其他资源使用。您确定要删除它吗？} other {删除这些实例组可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个清单正被一些模板使用。您确定要删除它吗？} other {删除这些清单可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
@@ -9675,15 +9748,15 @@ msgstr "{0, plural, one {这个清单正被一些模板使用。您确定要删�
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr "{0, plural, one {这个清单源正被依赖它的其他资源使用。您确定要删除它吗？} other {删除这些清单源可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个机构正被其他资源使用。您确定要删除它吗？} other {删除这些机构可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个项目正被其他资源使用。您确定要删除它吗？} other {删除这些项目可能会影响到其他依赖它的资源。您确定要删除吗？}}"
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr "{0, plural, one {这个模板正被一些工作流节点使用。您确定要删除它吗？} other {删除这些模板可能会影响到其他依赖它的工作流节点。您确定要删除吗？}}"
 
@@ -9772,8 +9845,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"

--- a/awx/ui/src/locales/zu/messages.po
+++ b/awx/ui/src/locales/zu/messages.po
@@ -38,7 +38,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:46
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:71
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:105
-#: screens/Template/shared/JobTemplateForm.js:212
+#: screens/Template/shared/JobTemplateForm.js:210
 msgid "0 (Normal)"
 msgstr ""
 
@@ -59,7 +59,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:47
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:72
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:106
-#: screens/Template/shared/JobTemplateForm.js:213
+#: screens/Template/shared/JobTemplateForm.js:211
 msgid "1 (Verbose)"
 msgstr ""
 
@@ -75,7 +75,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:48
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:73
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:107
-#: screens/Template/shared/JobTemplateForm.js:214
+#: screens/Template/shared/JobTemplateForm.js:212
 msgid "2 (More Verbose)"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:49
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:74
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:108
-#: screens/Template/shared/JobTemplateForm.js:215
+#: screens/Template/shared/JobTemplateForm.js:213
 msgid "3 (Debug)"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:50
 #: components/Schedule/ScheduleDetail/ScheduleDetail.js:75
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:109
-#: screens/Template/shared/JobTemplateForm.js:216
+#: screens/Template/shared/JobTemplateForm.js:214
 msgid "4 (Connection Debug)"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgid "About"
 msgstr ""
 
 #: routeConfig.js:90
-#: screens/ActivityStream/ActivityStream.js:170
+#: screens/ActivityStream/ActivityStream.js:169
 #: screens/Credential/Credential.js:72
 #: screens/Credential/Credentials.js:28
 #: screens/Inventory/Inventories.js:58
@@ -173,60 +173,63 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: components/JobList/JobList.js:221
-#: components/JobList/JobListItem.js:95
-#: components/Schedule/ScheduleList/ScheduleList.js:172
+#: components/JobList/JobList.js:242
+#: components/JobList/JobListItem.js:96
+#: components/Schedule/ScheduleList/ScheduleList.js:171
 #: components/Schedule/ScheduleList/ScheduleListItem.js:111
 #: components/SelectedList/DraggableSelectedList.js:101
-#: components/TemplateList/TemplateList.js:227
+#: components/TemplateList/TemplateList.js:226
 #: components/TemplateList/TemplateListItem.js:178
-#: screens/ActivityStream/ActivityStream.js:253
+#: screens/ActivityStream/ActivityStream.js:252
 #: screens/ActivityStream/ActivityStreamListItem.js:49
 #: screens/Application/ApplicationsList/ApplicationListItem.js:46
-#: screens/Application/ApplicationsList/ApplicationsList.js:161
-#: screens/Credential/CredentialList/CredentialList.js:148
+#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Credential/CredentialList/CredentialList.js:147
 #: screens/Credential/CredentialList/CredentialListItem.js:63
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:178
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:36
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:155
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:74
 #: screens/Host/HostGroups/HostGroupItem.js:34
-#: screens/Host/HostGroups/HostGroupsList.js:178
-#: screens/Host/HostList/HostList.js:160
-#: screens/Host/HostList/HostListItem.js:57
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:287
+#: screens/Host/HostGroups/HostGroupsList.js:177
+#: screens/Host/HostList/HostList.js:163
+#: screens/Host/HostList/HostListItem.js:64
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:75
-#: screens/InstanceGroup/Instances/InstanceList.js:213
+#: screens/InstanceGroup/Instances/InstanceList.js:212
 #: screens/InstanceGroup/Instances/InstanceListItem.js:152
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:216
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:48
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:39
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:144
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:38
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:188
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:38
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:140
-#: screens/Inventory/InventoryList/InventoryList.js:208
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
+#: screens/Inventory/InventoryList/InventoryList.js:207
 #: screens/Inventory/InventoryList/InventoryListItem.js:108
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:233
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
 #: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js:40
 #: screens/Inventory/InventorySources/InventorySourceList.js:198
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:92
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:100
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:72
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:122
-#: screens/Organization/OrganizationList/OrganizationList.js:147
+#: screens/Organization/OrganizationList/OrganizationList.js:146
 #: screens/Organization/OrganizationList/OrganizationListItem.js:68
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:87
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:17
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:160
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:79
-#: screens/Project/ProjectList/ProjectList.js:212
+#: screens/Project/ProjectList/ProjectList.js:211
 #: screens/Project/ProjectList/ProjectListItem.js:209
-#: screens/Team/TeamList/TeamList.js:145
+#: screens/Team/TeamList/TeamList.js:144
 #: screens/Team/TeamList/TeamListItem.js:47
-#: screens/User/UserList/UserList.js:161
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyList.js:115
+#: screens/Template/Survey/SurveyListItem.js:85
+#: screens/User/UserList/UserList.js:160
 #: screens/User/UserList/UserListItem.js:60
 msgid "Actions"
 msgstr ""
@@ -235,8 +238,8 @@ msgstr ""
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:61
 #: components/TemplateList/TemplateListItem.js:257
 #: screens/Host/HostDetail/HostDetail.js:71
-#: screens/Host/HostList/HostListItem.js:81
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:215
+#: screens/Host/HostList/HostListItem.js:89
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:45
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:77
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:100
@@ -246,12 +249,12 @@ msgid "Activity"
 msgstr ""
 
 #: routeConfig.js:47
-#: screens/ActivityStream/ActivityStream.js:112
+#: screens/ActivityStream/ActivityStream.js:111
 #: screens/Setting/Settings.js:43
 msgid "Activity Stream"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:115
+#: screens/ActivityStream/ActivityStream.js:114
 msgid "Activity Stream type selector"
 msgstr ""
 
@@ -297,35 +300,35 @@ msgstr ""
 msgid "Add a new node between these two nodes"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:186
 msgid "Add container group"
 msgstr ""
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:140
 msgid "Add existing group"
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:152
 msgid "Add existing host"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:188
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:187
 msgid "Add instance group"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:123
+#: screens/Inventory/InventoryList/InventoryList.js:122
 msgid "Add inventory"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:137
+#: components/TemplateList/TemplateList.js:136
 msgid "Add job template"
 msgstr ""
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:142
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:141
 msgid "Add new group"
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:154
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:153
 msgid "Add new host"
 msgstr ""
 
@@ -333,24 +336,24 @@ msgstr ""
 msgid "Add resource type"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:123
 msgid "Add smart inventory"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:203
+#: screens/Team/TeamRoles/TeamRolesList.js:202
 msgid "Add team permissions"
 msgstr ""
 
-#: screens/User/UserRoles/UserRolesList.js:199
+#: screens/User/UserRoles/UserRolesList.js:198
 msgid "Add user permissions"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:138
+#: components/TemplateList/TemplateList.js:137
 msgid "Add workflow template"
 msgstr ""
 
 #: routeConfig.js:111
-#: screens/ActivityStream/ActivityStream.js:181
+#: screens/ActivityStream/ActivityStream.js:180
 msgid "Administration"
 msgstr ""
 
@@ -359,11 +362,11 @@ msgstr ""
 msgid "Advanced"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:356
+#: components/Search/AdvancedSearch.js:219
 msgid "Advanced search documentation"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:338
+#: components/Search/AdvancedSearch.js:201
 msgid "Advanced search value input"
 msgstr ""
 
@@ -423,7 +426,7 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
 msgid "Amazon EC2"
 msgstr ""
 
@@ -435,7 +438,7 @@ msgstr ""
 msgid "An inventory must be selected"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:106
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
 msgid "Ansible Tower"
 msgstr ""
 
@@ -456,13 +459,13 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: components/Lookup/ApplicationLookup.js:84
+#: components/Lookup/ApplicationLookup.js:83
 #: screens/User/UserTokenDetail/UserTokenDetail.js:37
 #: screens/User/shared/UserTokenForm.js:47
 msgid "Application"
 msgstr ""
 
-#: screens/User/UserTokenList/UserTokenList.js:184
+#: screens/User/UserTokenList/UserTokenList.js:183
 msgid "Application Name"
 msgstr ""
 
@@ -471,8 +474,8 @@ msgstr ""
 msgid "Application information"
 msgstr ""
 
-#: screens/User/UserTokenList/UserTokenList.js:124
-#: screens/User/UserTokenList/UserTokenList.js:135
+#: screens/User/UserTokenList/UserTokenList.js:123
+#: screens/User/UserTokenList/UserTokenList.js:134
 msgid "Application name"
 msgstr ""
 
@@ -480,17 +483,17 @@ msgstr ""
 msgid "Application not found."
 msgstr ""
 
-#: components/Lookup/ApplicationLookup.js:96
+#: components/Lookup/ApplicationLookup.js:95
 #: routeConfig.js:135
 #: screens/Application/Applications.js:25
 #: screens/Application/Applications.js:34
-#: screens/Application/ApplicationsList/ApplicationsList.js:114
-#: screens/Application/ApplicationsList/ApplicationsList.js:149
+#: screens/Application/ApplicationsList/ApplicationsList.js:113
+#: screens/Application/ApplicationsList/ApplicationsList.js:148
 #: util/getRelatedResourceDeleteDetails.js:208
 msgid "Applications"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:198
+#: screens/ActivityStream/ActivityStream.js:197
 msgid "Applications & Tokens"
 msgstr ""
 
@@ -562,11 +565,11 @@ msgstr ""
 msgid "Are you sure you want to remove this node?"
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:43
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:42
 msgid "Are you sure you want to remove {0} access from {1}?  Doing so affects all members of the team."
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:50
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:49
 msgid "Are you sure you want to remove {0} access from {username}?"
 msgstr ""
 
@@ -574,26 +577,26 @@ msgstr ""
 msgid "Are you sure you want to submit the request to cancel this job?"
 msgstr ""
 
+#: components/AdHocCommands/AdHocDetailsStep.js:101
 #: components/AdHocCommands/AdHocDetailsStep.js:103
-#: components/AdHocCommands/AdHocDetailsStep.js:105
 msgid "Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:364
+#: screens/Job/JobDetail/JobDetail.js:440
 msgid "Artifacts"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:182
-#: screens/User/UserTeams/UserTeamList.js:209
+#: screens/InstanceGroup/Instances/InstanceList.js:181
+#: screens/User/UserTeams/UserTeamList.js:208
 msgid "Associate"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:245
-#: screens/User/UserRoles/UserRolesList.js:241
+#: screens/Team/TeamRoles/TeamRolesList.js:244
+#: screens/User/UserRoles/UserRolesList.js:240
 msgid "Associate role error"
 msgstr ""
 
-#: components/AssociateModal/AssociateModal.js:99
+#: components/AssociateModal/AssociateModal.js:98
 msgid "Association modal"
 msgstr ""
 
@@ -605,7 +608,7 @@ msgstr ""
 msgid "August"
 msgstr ""
 
-#: screens/Setting/SettingList.js:53
+#: screens/Setting/SettingList.js:52
 msgid "Authentication"
 msgstr ""
 
@@ -626,7 +629,7 @@ msgstr ""
 msgid "Azure AD"
 msgstr ""
 
-#: screens/Setting/SettingList.js:58
+#: screens/Setting/SettingList.js:57
 msgid "Azure AD settings"
 msgstr ""
 
@@ -660,12 +663,16 @@ msgstr ""
 msgid "Back to Hosts"
 msgstr ""
 
+#: screens/InstanceGroup/InstanceGroup.js:69
+msgid "Back to Instance Groups"
+msgstr ""
+
 #: screens/Inventory/Inventory.js:56
 #: screens/Inventory/SmartInventory.js:59
 msgid "Back to Inventories"
 msgstr ""
 
-#: screens/Job/Job.js:96
+#: screens/Job/Job.js:109
 msgid "Back to Jobs"
 msgstr ""
 
@@ -695,7 +702,7 @@ msgstr ""
 #: screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js:81
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:44
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:45
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:29
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:25
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:44
 #: screens/Setting/UI/UIDetail/UIDetail.js:59
 msgid "Back to Settings"
@@ -739,7 +746,6 @@ msgid "Back to execution environments"
 msgstr ""
 
 #: screens/InstanceGroup/ContainerGroup.js:68
-#: screens/InstanceGroup/InstanceGroup.js:69
 msgid "Back to instance groups"
 msgstr ""
 
@@ -747,7 +753,7 @@ msgstr ""
 msgid "Back to management jobs"
 msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:66
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:65
 msgid ""
 "Base path used for locating playbooks. Directories\n"
 "found inside this path will be listed in the playbook directory drop-down.\n"
@@ -767,7 +773,7 @@ msgid ""
 "provide a custom refspec."
 msgstr ""
 
-#: components/About/About.js:42
+#: components/About/About.js:45
 msgid "Brand Image"
 msgstr ""
 
@@ -805,8 +811,8 @@ msgstr ""
 
 #: components/AdHocCommands/AdHocCommandsWizard.js:53
 #: components/AddRole/AddResourceRole.js:287
-#: components/AssociateModal/AssociateModal.js:115
-#: components/AssociateModal/AssociateModal.js:120
+#: components/AssociateModal/AssociateModal.js:114
+#: components/AssociateModal/AssociateModal.js:119
 #: components/DeleteButton/DeleteButton.js:120
 #: components/DeleteButton/DeleteButton.js:123
 #: components/DisassociateButton/DisassociateButton.js:122
@@ -814,12 +820,12 @@ msgstr ""
 #: components/FormActionGroup/FormActionGroup.js:23
 #: components/FormActionGroup/FormActionGroup.js:28
 #: components/LaunchPrompt/LaunchPrompt.js:129
-#: components/Lookup/HostFilterLookup.js:357
-#: components/Lookup/Lookup.js:189
+#: components/Lookup/HostFilterLookup.js:359
+#: components/Lookup/Lookup.js:194
 #: components/PaginatedTable/ToolbarDeleteButton.js:282
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:37
-#: components/Schedule/shared/ScheduleForm.js:620
-#: components/Schedule/shared/ScheduleForm.js:625
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:36
+#: components/Schedule/shared/ScheduleForm.js:647
+#: components/Schedule/shared/ScheduleForm.js:652
 #: components/Schedule/shared/SchedulePromptableFields.js:133
 #: screens/Credential/shared/CredentialForm.js:342
 #: screens/Credential/shared/CredentialForm.js:347
@@ -837,17 +843,18 @@ msgstr ""
 #: screens/Setting/shared/SharedFields.js:132
 #: screens/Setting/shared/SharedFields.js:138
 #: screens/Setting/shared/SharedFields.js:316
-#: screens/Team/TeamRoles/TeamRolesList.js:229
-#: screens/Team/TeamRoles/TeamRolesList.js:232
-#: screens/Template/Survey/SurveyList.js:113
+#: screens/Team/TeamRoles/TeamRolesList.js:228
+#: screens/Team/TeamRoles/TeamRolesList.js:231
+#: screens/Template/Survey/SurveyList.js:88
+#: screens/Template/Survey/SurveyReorderModal.js:198
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/DeleteAllNodesModal.js:31
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkDeleteModal.js:39
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:45
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js:40
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:156
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:159
-#: screens/User/UserRoles/UserRolesList.js:225
-#: screens/User/UserRoles/UserRolesList.js:228
+#: screens/User/UserRoles/UserRolesList.js:224
+#: screens/User/UserRoles/UserRolesList.js:227
 msgid "Cancel"
 msgstr ""
 
@@ -883,7 +890,7 @@ msgstr ""
 msgid "Cancel link removal"
 msgstr ""
 
-#: components/Lookup/Lookup.js:187
+#: components/Lookup/Lookup.js:192
 msgid "Cancel lookup"
 msgstr ""
 
@@ -908,13 +915,13 @@ msgstr ""
 msgid "Cancel subscription edit"
 msgstr ""
 
-#: components/JobList/JobListItem.js:105
-#: screens/Job/JobDetail/JobDetail.js:403
+#: components/JobList/JobListItem.js:106
+#: screens/Job/JobDetail/JobDetail.js:479
 #: screens/Job/JobOutput/shared/OutputToolbar.js:135
 msgid "Cancel {0}"
 msgstr ""
 
-#: components/JobList/JobList.js:206
+#: components/JobList/JobList.js:227
 #: components/StatusLabel/StatusLabel.js:62
 #: components/Workflow/WorkflowNodeHelp.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:166
@@ -928,37 +935,37 @@ msgid ""
 "logging aggregator host and logging aggregator type."
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:286
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:74
 msgid "Capacity"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:211
+#: screens/InstanceGroup/Instances/InstanceList.js:210
 #: screens/InstanceGroup/Instances/InstanceListItem.js:124
 msgid "Capacity Adjustment"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:216
+#: components/Search/LookupTypeInput.js:59
 msgid "Case-insensitive version of contains"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:240
+#: components/Search/LookupTypeInput.js:87
 msgid "Case-insensitive version of endswith."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:203
+#: components/Search/LookupTypeInput.js:45
 msgid "Case-insensitive version of exact."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:252
+#: components/Search/LookupTypeInput.js:100
 msgid "Case-insensitive version of regex."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:228
+#: components/Search/LookupTypeInput.js:73
 msgid "Case-insensitive version of startswith."
 msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:72
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:71
 msgid ""
 "Change PROJECTS_ROOT when deploying\n"
 "{brandName} to change this location."
@@ -978,15 +985,15 @@ msgid "Channel"
 msgstr ""
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:102
-#: screens/Template/shared/JobTemplateForm.js:207
+#: screens/Template/shared/JobTemplateForm.js:205
 msgid "Check"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:282
+#: components/Search/LookupTypeInput.js:134
 msgid "Check whether the given field or related object is null; expects a boolean value."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:288
+#: components/Search/LookupTypeInput.js:140
 msgid "Check whether the given field's value is present in the list provided; expects a comma-separated list of items."
 msgstr ""
 
@@ -998,7 +1005,7 @@ msgstr ""
 msgid "Choose a Notification Type"
 msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:25
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:24
 msgid "Choose a Playbook Directory"
 msgstr ""
 
@@ -1011,11 +1018,11 @@ msgid "Choose a Webhook Service"
 msgstr ""
 
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:95
-#: screens/Template/shared/JobTemplateForm.js:200
+#: screens/Template/shared/JobTemplateForm.js:198
 msgid "Choose a job type"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:83
+#: components/AdHocCommands/AdHocDetailsStep.js:81
 msgid "Choose a module"
 msgstr ""
 
@@ -1038,7 +1045,7 @@ msgstr ""
 msgid "Choose roles to apply to the selected resources.  Note that all selected roles will be applied to all selected resources."
 msgstr ""
 
-#: components/AddRole/SelectResourceStep.js:79
+#: components/AddRole/SelectResourceStep.js:81
 msgid "Choose the resources that will be receiving new roles.  You'll be able to select the roles to apply in the next step.  Note that the resources chosen here will receive all roles chosen in the next step."
 msgstr ""
 
@@ -1082,6 +1089,10 @@ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:152
 msgid "Click to create a new link to this node."
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:62
+msgid "Click to rearrange the order of the survey questions"
 msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:117
@@ -1131,13 +1142,13 @@ msgstr ""
 msgid "Collapse"
 msgstr ""
 
-#: components/JobList/JobList.js:186
-#: components/JobList/JobListItem.js:38
+#: components/JobList/JobList.js:207
+#: components/JobList/JobListItem.js:39
 #: screens/Job/JobOutput/HostEventModal.js:133
 msgid "Command"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:55
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:49
 msgid "Compliant"
 msgstr ""
 
@@ -1145,7 +1156,7 @@ msgstr ""
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:36
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:137
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:57
-#: screens/Template/shared/JobTemplateForm.js:603
+#: screens/Template/shared/JobTemplateForm.js:601
 msgid "Concurrent Jobs"
 msgstr ""
 
@@ -1176,11 +1187,11 @@ msgstr ""
 msgid "Confirm cancellation"
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:26
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:25
 msgid "Confirm delete"
 msgstr ""
 
-#: screens/User/UserRoles/UserRolesList.js:216
+#: screens/User/UserRoles/UserRolesList.js:215
 msgid "Confirm disassociate"
 msgstr ""
 
@@ -1204,7 +1215,7 @@ msgstr ""
 msgid "Confirm selection"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:244
+#: screens/Job/JobDetail/JobDetail.js:297
 msgid "Container Group"
 msgstr ""
 
@@ -1239,7 +1250,7 @@ msgid ""
 "will produce as the playbook executes."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:466
+#: screens/Template/shared/JobTemplateForm.js:464
 msgid ""
 "Control the level of output ansible will\n"
 "produce as the playbook executes."
@@ -1292,11 +1303,11 @@ msgstr ""
 msgid "Copy full revision to clipboard."
 msgstr ""
 
-#: components/About/About.js:32
+#: components/About/About.js:35
 msgid "Copyright"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:407
+#: screens/Template/shared/JobTemplateForm.js:405
 #: screens/Template/shared/WorkflowJobTemplateForm.js:205
 msgid "Create"
 msgstr ""
@@ -1409,14 +1420,14 @@ msgstr ""
 msgid "Create user token"
 msgstr ""
 
-#: components/Lookup/ApplicationLookup.js:115
+#: components/Lookup/ApplicationLookup.js:114
 #: components/PromptDetail/PromptDetail.js:138
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:263
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:277
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:100
 #: screens/Credential/CredentialDetail/CredentialDetail.js:243
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:86
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:99
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:138
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:137
 #: screens/Host/HostDetail/HostDetail.js:85
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:66
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:90
@@ -1426,7 +1437,7 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:211
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:140
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:47
-#: screens/Job/JobDetail/JobDetail.js:340
+#: screens/Job/JobDetail/JobDetail.js:412
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:339
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:105
 #: screens/Project/ProjectDetail/ProjectDetail.js:231
@@ -1435,58 +1446,58 @@ msgstr ""
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:173
 #: screens/User/UserDetail/UserDetail.js:82
 #: screens/User/UserTokenDetail/UserTokenDetail.js:57
-#: screens/User/UserTokenList/UserTokenList.js:147
+#: screens/User/UserTokenList/UserTokenList.js:146
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:150
 msgid "Created"
 msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:123
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:113
+#: components/AdHocCommands/AdHocCredentialStep.js:122
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:112
 #: components/AddRole/AddResourceRole.js:56
-#: components/AssociateModal/AssociateModal.js:144
-#: components/LaunchPrompt/steps/CredentialsStep.js:173
-#: components/LaunchPrompt/steps/InventoryStep.js:89
-#: components/Lookup/CredentialLookup.js:194
-#: components/Lookup/InventoryLookup.js:159
-#: components/Lookup/InventoryLookup.js:215
-#: components/Lookup/MultiCredentialsLookup.js:193
-#: components/Lookup/OrganizationLookup.js:134
-#: components/Lookup/ProjectLookup.js:151
-#: components/NotificationList/NotificationList.js:204
-#: components/Schedule/ScheduleList/ScheduleList.js:198
-#: components/TemplateList/TemplateList.js:212
+#: components/AssociateModal/AssociateModal.js:143
+#: components/LaunchPrompt/steps/CredentialsStep.js:172
+#: components/LaunchPrompt/steps/InventoryStep.js:88
+#: components/Lookup/CredentialLookup.js:193
+#: components/Lookup/InventoryLookup.js:162
+#: components/Lookup/InventoryLookup.js:218
+#: components/Lookup/MultiCredentialsLookup.js:192
+#: components/Lookup/OrganizationLookup.js:133
+#: components/Lookup/ProjectLookup.js:150
+#: components/NotificationList/NotificationList.js:206
+#: components/Schedule/ScheduleList/ScheduleList.js:197
+#: components/TemplateList/TemplateList.js:211
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:27
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:58
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:104
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:127
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:173
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:196
-#: screens/Credential/CredentialList/CredentialList.js:136
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:97
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:133
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:104
-#: screens/Host/HostGroups/HostGroupsList.js:165
-#: screens/Host/HostList/HostList.js:146
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:198
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:131
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:175
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:129
-#: screens/Inventory/InventoryList/InventoryList.js:185
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:185
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:96
-#: screens/Organization/OrganizationList/OrganizationList.js:132
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:128
-#: screens/Project/ProjectList/ProjectList.js:200
-#: screens/Team/TeamList/TeamList.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:100
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:113
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:109
+#: screens/Credential/CredentialList/CredentialList.js:135
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:96
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:132
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:103
+#: screens/Host/HostGroups/HostGroupsList.js:164
+#: screens/Host/HostList/HostList.js:149
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:197
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:130
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:174
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:128
+#: screens/Inventory/InventoryList/InventoryList.js:184
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:184
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:95
+#: screens/Organization/OrganizationList/OrganizationList.js:131
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:127
+#: screens/Project/ProjectList/ProjectList.js:199
+#: screens/Team/TeamList/TeamList.js:130
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:99
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:112
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:108
 msgid "Created By (Username)"
 msgstr ""
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:74
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:163
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:74
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:162
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:73
 msgid "Created by (username)"
 msgstr ""
 
@@ -1516,7 +1527,7 @@ msgstr ""
 msgid "Credential Input Sources"
 msgstr ""
 
-#: components/Lookup/InstanceGroupsLookup.js:109
+#: components/Lookup/InstanceGroupsLookup.js:108
 msgid "Credential Name"
 msgstr ""
 
@@ -1527,9 +1538,9 @@ msgid "Credential Type"
 msgstr ""
 
 #: routeConfig.js:115
-#: screens/ActivityStream/ActivityStream.js:183
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:119
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:162
+#: screens/ActivityStream/ActivityStream.js:182
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:118
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:161
 #: screens/CredentialType/CredentialTypes.js:13
 #: screens/CredentialType/CredentialTypes.js:22
 msgid "Credential Types"
@@ -1555,24 +1566,24 @@ msgstr ""
 msgid "Credential type not found."
 msgstr ""
 
-#: components/JobList/JobListItem.js:224
-#: components/LaunchPrompt/steps/CredentialsStep.js:190
+#: components/JobList/JobListItem.js:235
+#: components/LaunchPrompt/steps/CredentialsStep.js:189
 #: components/LaunchPrompt/steps/useCredentialsStep.js:62
-#: components/Lookup/MultiCredentialsLookup.js:139
-#: components/Lookup/MultiCredentialsLookup.js:210
+#: components/Lookup/MultiCredentialsLookup.js:138
+#: components/Lookup/MultiCredentialsLookup.js:209
 #: components/PromptDetail/PromptDetail.js:176
 #: components/PromptDetail/PromptJobTemplateDetail.js:193
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:317
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:331
 #: components/TemplateList/TemplateListItem.js:315
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:77
 #: routeConfig.js:68
-#: screens/ActivityStream/ActivityStream.js:158
-#: screens/Credential/CredentialList/CredentialList.js:176
+#: screens/ActivityStream/ActivityStream.js:157
+#: screens/Credential/CredentialList/CredentialList.js:175
 #: screens/Credential/Credentials.js:13
 #: screens/Credential/Credentials.js:23
-#: screens/Job/JobDetail/JobDetail.js:276
+#: screens/Job/JobDetail/JobDetail.js:336
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:285
-#: screens/Template/shared/JobTemplateForm.js:375
+#: screens/Template/shared/JobTemplateForm.js:373
 #: util/getRelatedResourceDeleteDetails.js:90
 msgid "Credentials"
 msgstr ""
@@ -1623,7 +1634,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:138
+#: screens/ActivityStream/ActivityStream.js:137
 msgid "Dashboard (all activity)"
 msgstr ""
 
@@ -1637,12 +1648,12 @@ msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:337
 #: components/Schedule/shared/FrequencyDetailSubform.js:441
-#: components/Schedule/shared/ScheduleForm.js:145
+#: components/Schedule/shared/ScheduleForm.js:153
 msgid "Day"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
-#: components/Schedule/shared/ScheduleForm.js:156
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:273
+#: components/Schedule/shared/ScheduleForm.js:164
 msgid "Days of Data to Keep"
 msgstr ""
 
@@ -1650,7 +1661,7 @@ msgstr ""
 msgid "Days of data to be retained"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:110
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:105
 msgid "Days remaining"
 msgstr ""
 
@@ -1667,12 +1678,20 @@ msgid "December"
 msgstr ""
 
 #: screens/Setting/LDAP/LDAPDetail/LDAPDetail.js:102
-#: screens/Template/Survey/SurveyListItem.js:133
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyList.js:114
+#: screens/Template/Survey/SurveyListItem.js:63
 msgid "Default"
 msgstr ""
 
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:206
+#: screens/Template/Survey/SurveyReorderModal.js:227
+msgid "Default Answer(s)"
+msgstr ""
+
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:40
-#: components/Lookup/ExecutionEnvironmentLookup.js:210
+#: components/Lookup/ExecutionEnvironmentLookup.js:209
 msgid "Default Execution Environment"
 msgstr ""
 
@@ -1682,7 +1701,7 @@ msgstr ""
 msgid "Default answer"
 msgstr ""
 
-#: screens/Setting/SettingList.js:100
+#: screens/Setting/SettingList.js:99
 msgid "Define system-level features and functions"
 msgstr ""
 
@@ -1696,8 +1715,8 @@ msgstr ""
 #: components/PaginatedTable/ToolbarDeleteButton.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:250
 #: components/PaginatedTable/ToolbarDeleteButton.js:273
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:29
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:28
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:406
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:123
 #: screens/Credential/CredentialDetail/CredentialDetail.js:294
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:120
@@ -1705,7 +1724,7 @@ msgstr ""
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:113
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:125
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:131
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:102
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:101
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:240
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:165
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:64
@@ -1713,15 +1732,15 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:72
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:76
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:99
-#: screens/Job/JobDetail/JobDetail.js:415
+#: screens/Job/JobDetail/JobDetail.js:491
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:376
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:172
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:175
 #: screens/Project/ProjectDetail/ProjectDetail.js:279
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:75
 #: screens/Team/TeamDetail/TeamDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:409
-#: screens/Template/Survey/SurveyList.js:101
-#: screens/Template/Survey/SurveyToolbar.js:73
+#: screens/Template/Survey/SurveyList.js:76
+#: screens/Template/Survey/SurveyToolbar.js:91
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:247
 #: screens/User/UserDetail/UserDetail.js:107
 #: screens/User/UserTokenDetail/UserTokenDetail.js:76
@@ -1750,7 +1769,7 @@ msgstr ""
 msgid "Delete Inventory"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:411
+#: screens/Job/JobDetail/JobDetail.js:487
 #: screens/Job/JobOutput/shared/OutputToolbar.js:193
 #: screens/Job/JobOutput/shared/OutputToolbar.js:197
 msgid "Delete Job"
@@ -1764,7 +1783,7 @@ msgstr ""
 msgid "Delete Notification"
 msgstr ""
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:166
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:169
 msgid "Delete Organization"
 msgstr ""
 
@@ -1772,15 +1791,15 @@ msgstr ""
 msgid "Delete Project"
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Questions"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:388
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:402
 msgid "Delete Schedule"
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:87
+#: screens/Template/Survey/SurveyList.js:62
 msgid "Delete Survey"
 msgstr ""
 
@@ -1834,6 +1853,10 @@ msgstr ""
 msgid "Delete smart inventory"
 msgstr ""
 
+#: screens/Template/Survey/SurveyToolbar.js:81
+msgid "Delete survey question"
+msgstr ""
+
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:76
 msgid ""
 "Delete the local repository in its entirety prior to\n"
@@ -1865,16 +1888,16 @@ msgstr ""
 msgid "Deleted"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:275
-#: screens/Credential/CredentialList/CredentialList.js:192
-#: screens/Inventory/InventoryList/InventoryList.js:269
-#: screens/Project/ProjectList/ProjectList.js:275
+#: components/TemplateList/TemplateList.js:274
+#: screens/Credential/CredentialList/CredentialList.js:191
+#: screens/Inventory/InventoryList/InventoryList.js:268
+#: screens/Project/ProjectList/ProjectList.js:274
 msgid "Deletion Error"
 msgstr ""
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:203
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:213
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:306
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:202
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:212
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:305
 msgid "Deletion error"
 msgstr ""
 
@@ -1904,34 +1927,34 @@ msgid "Deprecated"
 msgstr ""
 
 #: components/HostForm/HostForm.js:104
-#: components/Lookup/ApplicationLookup.js:105
-#: components/Lookup/ApplicationLookup.js:123
-#: components/NotificationList/NotificationList.js:184
+#: components/Lookup/ApplicationLookup.js:104
+#: components/Lookup/ApplicationLookup.js:122
+#: components/NotificationList/NotificationList.js:186
 #: components/PromptDetail/PromptDetail.js:112
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:252
-#: components/Schedule/ScheduleList/ScheduleList.js:194
-#: components/Schedule/shared/ScheduleForm.js:104
-#: components/TemplateList/TemplateList.js:196
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:260
+#: components/Schedule/ScheduleList/ScheduleList.js:193
+#: components/Schedule/shared/ScheduleForm.js:112
+#: components/TemplateList/TemplateList.js:195
 #: components/TemplateList/TemplateListItem.js:251
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:63
-#: screens/Application/ApplicationsList/ApplicationsList.js:124
+#: screens/Application/ApplicationsList/ApplicationsList.js:123
 #: screens/Application/shared/ApplicationForm.js:60
 #: screens/Credential/CredentialDetail/CredentialDetail.js:208
-#: screens/Credential/CredentialList/CredentialList.js:132
+#: screens/Credential/CredentialList/CredentialList.js:131
 #: screens/Credential/shared/CredentialForm.js:168
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:72
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:129
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:128
 #: screens/CredentialType/shared/CredentialTypeForm.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:146
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:145
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:140
 #: screens/Host/HostDetail/HostDetail.js:73
-#: screens/Host/HostList/HostList.js:142
+#: screens/Host/HostList/HostList.js:145
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:71
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:35
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:81
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:125
-#: screens/Inventory/InventoryList/InventoryList.js:181
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:124
+#: screens/Inventory/InventoryList/InventoryList.js:180
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:151
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:104
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:37
@@ -1939,36 +1962,36 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupForm.js:40
 #: screens/Inventory/shared/InventorySourceForm.js:109
 #: screens/Inventory/shared/SmartInventoryForm.js:55
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:99
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:71
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:75
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:143
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:142
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:49
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:95
-#: screens/Organization/OrganizationList/OrganizationList.js:128
+#: screens/Organization/OrganizationList/OrganizationList.js:127
 #: screens/Organization/shared/OrganizationForm.js:64
 #: screens/Project/ProjectDetail/ProjectDetail.js:158
-#: screens/Project/ProjectList/ProjectList.js:177
+#: screens/Project/ProjectList/ProjectList.js:176
 #: screens/Project/ProjectList/ProjectListItem.js:268
 #: screens/Project/shared/ProjectForm.js:177
 #: screens/Team/TeamDetail/TeamDetail.js:38
-#: screens/Team/TeamList/TeamList.js:123
+#: screens/Team/TeamList/TeamList.js:122
 #: screens/Team/shared/TeamForm.js:37
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:181
 #: screens/Template/Survey/SurveyQuestionForm.js:165
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:111
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:174
-#: screens/Template/shared/JobTemplateForm.js:247
+#: screens/Template/shared/JobTemplateForm.js:245
 #: screens/Template/shared/WorkflowJobTemplateForm.js:111
 #: screens/User/UserOrganizations/UserOrganizationList.js:65
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:15
-#: screens/User/UserTeams/UserTeamList.js:183
+#: screens/User/UserTeams/UserTeamList.js:182
 #: screens/User/UserTeams/UserTeamListItem.js:32
 #: screens/User/UserTokenDetail/UserTokenDetail.js:42
-#: screens/User/UserTokenList/UserTokenList.js:129
+#: screens/User/UserTokenList/UserTokenList.js:128
 #: screens/User/shared/UserTokenForm.js:60
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:81
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:176
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:175
 msgid "Description"
 msgstr ""
 
@@ -2021,7 +2044,7 @@ msgstr ""
 #: screens/Inventory/InventorySource/InventorySource.js:83
 #: screens/Inventory/SmartInventory.js:65
 #: screens/Inventory/SmartInventoryHost/SmartInventoryHost.js:60
-#: screens/Job/Job.js:102
+#: screens/Job/Job.js:115
 #: screens/Job/JobOutput/HostEventModal.js:111
 #: screens/Job/Jobs.js:28
 #: screens/ManagementJob/ManagementJobs.js:27
@@ -2107,39 +2130,39 @@ msgstr ""
 #: components/DisassociateButton/DisassociateButton.js:92
 #: components/DisassociateButton/DisassociateButton.js:96
 #: components/DisassociateButton/DisassociateButton.js:116
-#: screens/Team/TeamRoles/TeamRolesList.js:223
-#: screens/User/UserRoles/UserRolesList.js:219
+#: screens/Team/TeamRoles/TeamRolesList.js:222
+#: screens/User/UserRoles/UserRolesList.js:218
 msgid "Disassociate"
 msgstr ""
 
-#: screens/Host/HostGroups/HostGroupsList.js:212
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
+#: screens/Host/HostGroups/HostGroupsList.js:211
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:229
 msgid "Disassociate group from host?"
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:244
 msgid "Disassociate host from group?"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:191
+#: screens/InstanceGroup/Instances/InstanceList.js:190
 msgid "Disassociate instance from instance group?"
 msgstr ""
 
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:225
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:224
 msgid "Disassociate related group(s)?"
 msgstr ""
 
-#: screens/User/UserTeams/UserTeamList.js:217
+#: screens/User/UserTeams/UserTeamList.js:216
 msgid "Disassociate related team(s)?"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:210
-#: screens/User/UserRoles/UserRolesList.js:206
+#: screens/Team/TeamRoles/TeamRolesList.js:209
+#: screens/User/UserRoles/UserRolesList.js:205
 msgid "Disassociate role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:213
-#: screens/User/UserRoles/UserRolesList.js:209
+#: screens/Team/TeamRoles/TeamRolesList.js:212
+#: screens/User/UserRoles/UserRolesList.js:208
 msgid "Disassociate role!"
 msgstr ""
 
@@ -2152,7 +2175,7 @@ msgstr ""
 msgid "Discard local changes before syncing"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:481
+#: screens/Template/shared/JobTemplateForm.js:479
 msgid ""
 "Divide the work done by this job template\n"
 "into the specified number of job slices, each running the\n"
@@ -2217,8 +2240,8 @@ msgid ""
 "revision of the project prior to starting the job."
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:378
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:382
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:392
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:396
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:110
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:112
 #: screens/Credential/CredentialDetail/CredentialDetail.js:281
@@ -2237,8 +2260,8 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:363
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:365
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:136
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:155
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:159
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:158
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:162
 #: screens/Project/ProjectDetail/ProjectDetail.js:252
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:85
 #: screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js:89
@@ -2260,7 +2283,7 @@ msgstr ""
 #: screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js:89
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:86
 #: screens/Setting/SAML/SAMLDetail/SAMLDetail.js:90
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:174
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:169
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:84
 #: screens/Setting/TACACS/TACACSDetail/TACACSDetail.js:89
 #: screens/Setting/UI/UIDetail/UIDetail.js:105
@@ -2336,8 +2359,8 @@ msgstr ""
 msgid "Edit Group"
 msgstr ""
 
-#: screens/Host/HostList/HostListItem.js:61
-#: screens/Host/HostList/HostListItem.js:65
+#: screens/Host/HostList/HostListItem.js:68
+#: screens/Host/HostList/HostListItem.js:72
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:56
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:59
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:62
@@ -2366,6 +2389,10 @@ msgstr ""
 msgid "Edit Notification Template"
 msgstr ""
 
+#: screens/Template/Survey/SurveyToolbar.js:71
+msgid "Edit Order"
+msgstr ""
+
 #: screens/Organization/OrganizationList/OrganizationListItem.js:71
 #: screens/Organization/OrganizationList/OrganizationListItem.js:75
 msgid "Edit Organization"
@@ -2390,7 +2417,7 @@ msgstr ""
 msgid "Edit Source"
 msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:160
+#: screens/Template/Survey/SurveyListItem.js:87
 msgid "Edit Survey"
 msgstr ""
 
@@ -2478,8 +2505,8 @@ msgstr ""
 msgid "Elapsed time that the job ran"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:191
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
+#: components/NotificationList/NotificationList.js:193
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:149
 #: screens/User/UserDetail/UserDetail.js:66
 #: screens/User/shared/UserForm.js:73
 msgid "Email"
@@ -2493,7 +2520,7 @@ msgstr ""
 msgid "Enable Concurrent Jobs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:610
+#: screens/Template/shared/JobTemplateForm.js:608
 msgid "Enable Fact Storage"
 msgstr ""
 
@@ -2501,8 +2528,8 @@ msgstr ""
 msgid "Enable HTTPS certificate verification"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:584
-#: screens/Template/shared/JobTemplateForm.js:587
+#: screens/Template/shared/JobTemplateForm.js:582
+#: screens/Template/shared/JobTemplateForm.js:585
 #: screens/Template/shared/WorkflowJobTemplateForm.js:221
 #: screens/Template/shared/WorkflowJobTemplateForm.js:224
 msgid "Enable Webhook"
@@ -2520,8 +2547,8 @@ msgstr ""
 msgid "Enable log system tracking facts individually"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:218
-#: components/AdHocCommands/AdHocDetailsStep.js:221
+#: components/AdHocCommands/AdHocDetailsStep.js:216
+#: components/AdHocCommands/AdHocDetailsStep.js:219
 msgid "Enable privilege escalation"
 msgstr ""
 
@@ -2529,15 +2556,15 @@ msgstr ""
 #~ msgid "Enable simplified login for your {0} applications"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:54
+#: screens/Setting/SettingList.js:53
 msgid "Enable simplified login for your {brandName} applications"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:590
+#: screens/Template/shared/JobTemplateForm.js:588
 msgid "Enable webhook for this template."
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:96
+#: components/Lookup/HostFilterLookup.js:100
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 msgid "Enabled"
 msgstr ""
@@ -2572,7 +2599,7 @@ msgstr ""
 #~ "template."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:226
+#: components/AdHocCommands/AdHocDetailsStep.js:224
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2580,7 +2607,7 @@ msgid ""
 "template"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:570
+#: screens/Template/shared/JobTemplateForm.js:568
 msgid ""
 "Enables creation of a provisioning\n"
 "callback URL. Using the URL a host can contact {brandName}\n"
@@ -2602,7 +2629,7 @@ msgstr ""
 msgid "End User License Agreement"
 msgstr ""
 
-#: components/Schedule/shared/buildRuleObj.js:99
+#: components/Schedule/shared/buildRuleObj.js:97
 msgid "End did not match an expected value"
 msgstr ""
 
@@ -2708,21 +2735,21 @@ msgstr ""
 msgid "Enter variables using either JSON or YAML syntax. Use the radio button to toggle between the two."
 msgstr ""
 
-#: components/JobList/JobList.js:205
+#: components/JobList/JobList.js:226
 #: components/StatusLabel/StatusLabel.js:57
 #: components/Workflow/WorkflowNodeHelp.js:108
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:129
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:206
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:205
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:141
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:216
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:215
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:121
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:133
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:309
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:308
 #: screens/Job/JobOutput/JobOutput.js:772
 msgid "Error"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectList.js:287
+#: screens/Project/ProjectList/ProjectList.js:286
 msgid "Error fetching updated project"
 msgstr ""
 
@@ -2746,41 +2773,41 @@ msgstr ""
 #: components/DeleteButton/DeleteButton.js:56
 #: components/HostToggle/HostToggle.js:75
 #: components/InstanceToggle/InstanceToggle.js:66
-#: components/JobList/JobList.js:283
-#: components/JobList/JobList.js:294
+#: components/JobList/JobList.js:305
+#: components/JobList/JobList.js:316
 #: components/LaunchButton/LaunchButton.js:161
 #: components/LaunchPrompt/LaunchPrompt.js:66
-#: components/NotificationList/NotificationList.js:244
+#: components/NotificationList/NotificationList.js:246
 #: components/PaginatedTable/ToolbarDeleteButton.js:205
-#: components/ResourceAccessList/ResourceAccessList.js:234
-#: components/ResourceAccessList/ResourceAccessList.js:246
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:400
-#: components/Schedule/ScheduleList/ScheduleList.js:239
+#: components/ResourceAccessList/ResourceAccessList.js:233
+#: components/ResourceAccessList/ResourceAccessList.js:245
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:414
+#: components/Schedule/ScheduleList/ScheduleList.js:238
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:72
 #: components/Schedule/shared/SchedulePromptableFields.js:70
-#: components/TemplateList/TemplateList.js:278
+#: components/TemplateList/TemplateList.js:277
 #: contexts/Config.js:94
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:131
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:156
-#: screens/Application/ApplicationsList/ApplicationsList.js:186
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:155
+#: screens/Application/ApplicationsList/ApplicationsList.js:185
 #: screens/Credential/CredentialDetail/CredentialDetail.js:302
-#: screens/Credential/CredentialList/CredentialList.js:195
+#: screens/Credential/CredentialList/CredentialList.js:194
 #: screens/Host/HostDetail/HostDetail.js:56
 #: screens/Host/HostDetail/HostDetail.js:125
-#: screens/Host/HostGroups/HostGroupsList.js:245
-#: screens/Host/HostList/HostList.js:215
-#: screens/InstanceGroup/Instances/InstanceList.js:244
+#: screens/Host/HostGroups/HostGroupsList.js:244
+#: screens/Host/HostList/HostList.js:222
+#: screens/InstanceGroup/Instances/InstanceList.js:243
 #: screens/InstanceGroup/Instances/InstanceListItem.js:167
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:140
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:77
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:283
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:294
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:282
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:293
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:56
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:118
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:262
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:201
-#: screens/Inventory/InventoryList/InventoryList.js:270
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:264
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:261
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:200
+#: screens/Inventory/InventoryList/InventoryList.js:269
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:263
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:247
 #: screens/Inventory/InventorySources/InventorySourceList.js:223
 #: screens/Inventory/InventorySources/InventorySourceList.js:236
@@ -2788,21 +2815,21 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupsDeleteModal.js:146
 #: screens/Inventory/shared/InventorySourceSyncButton.js:49
 #: screens/Login/Login.js:205
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:123
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:122
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:384
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:221
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:220
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:167
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:181
-#: screens/Organization/OrganizationList/OrganizationList.js:196
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationList/OrganizationList.js:195
 #: screens/Project/ProjectDetail/ProjectDetail.js:287
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:180
-#: screens/Project/ProjectList/ProjectList.js:276
-#: screens/Project/ProjectList/ProjectList.js:288
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:179
+#: screens/Project/ProjectList/ProjectList.js:275
+#: screens/Project/ProjectList/ProjectList.js:287
 #: screens/Project/shared/ProjectSyncButton.js:62
 #: screens/Team/TeamDetail/TeamDetail.js:78
-#: screens/Team/TeamList/TeamList.js:193
-#: screens/Team/TeamRoles/TeamRolesList.js:248
-#: screens/Team/TeamRoles/TeamRolesList.js:259
+#: screens/Team/TeamList/TeamList.js:192
+#: screens/Team/TeamRoles/TeamRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:258
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:418
 #: screens/Template/TemplateSurvey.js:130
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:255
@@ -2812,17 +2839,17 @@ msgstr ""
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:342
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js:353
 #: screens/User/UserDetail/UserDetail.js:115
-#: screens/User/UserList/UserList.js:186
-#: screens/User/UserRoles/UserRolesList.js:244
-#: screens/User/UserRoles/UserRolesList.js:255
-#: screens/User/UserTeams/UserTeamList.js:260
+#: screens/User/UserList/UserList.js:185
+#: screens/User/UserRoles/UserRolesList.js:243
+#: screens/User/UserRoles/UserRolesList.js:254
+#: screens/User/UserTeams/UserTeamList.js:259
 #: screens/User/UserTokenDetail/UserTokenDetail.js:83
-#: screens/User/UserTokenList/UserTokenList.js:210
+#: screens/User/UserTokenList/UserTokenList.js:209
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:216
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:227
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:238
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:247
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:258
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:246
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:257
 msgid "Error!"
 msgstr ""
 
@@ -2830,7 +2857,7 @@ msgstr ""
 msgid "Error:"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:252
+#: screens/ActivityStream/ActivityStream.js:251
 #: screens/ActivityStream/ActivityStreamListItem.js:46
 #: screens/Job/JobOutput/JobOutput.js:739
 msgid "Event"
@@ -2848,15 +2875,19 @@ msgstr ""
 msgid "Event summary not available"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:221
+#: screens/ActivityStream/ActivityStream.js:220
 msgid "Events"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:197
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:151
+msgid "Every minute for {0} times"
+msgstr ""
+
+#: components/Search/LookupTypeInput.js:39
 msgid "Exact match (default lookup if not specified)."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:164
+#: components/Search/RelatedLookupTypeInput.js:38
 msgid "Exact search on id field."
 msgstr ""
 
@@ -2892,15 +2923,15 @@ msgstr ""
 msgid "Execute when the parent node results in a successful state."
 msgstr ""
 
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:90
 #: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:91
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:92
 #: components/AdHocCommands/AdHocPreviewStep.jsx:55
 #: components/AdHocCommands/useAdHocExecutionEnvironmentStep.jsx:15
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:41
 #: components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js:104
-#: components/Lookup/ExecutionEnvironmentLookup.js:159
-#: components/Lookup/ExecutionEnvironmentLookup.js:190
-#: components/Lookup/ExecutionEnvironmentLookup.js:212
+#: components/Lookup/ExecutionEnvironmentLookup.js:158
+#: components/Lookup/ExecutionEnvironmentLookup.js:189
+#: components/Lookup/ExecutionEnvironmentLookup.js:211
 msgid "Execution Environment"
 msgstr ""
 
@@ -2909,22 +2940,22 @@ msgstr ""
 msgid "Execution Environment Missing"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:104
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:103
 #: routeConfig.js:140
-#: screens/ActivityStream/ActivityStream.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:116
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:178
+#: screens/ActivityStream/ActivityStream.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:115
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:177
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:13
 #: screens/ExecutionEnvironment/ExecutionEnvironments.js:22
 #: screens/Organization/Organization.js:126
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:80
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:79
 #: screens/Organization/Organizations.js:34
 #: util/getRelatedResourceDeleteDetails.js:80
 #: util/getRelatedResourceDeleteDetails.js:187
 msgid "Execution Environments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:235
+#: screens/Job/JobDetail/JobDetail.js:284
 msgid "Execution Node"
 msgstr ""
 
@@ -2958,24 +2989,24 @@ msgstr ""
 msgid "Expected at least one of client_email, project_id or private_key to be present in the file."
 msgstr ""
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:138
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:32
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:149
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:170
 #: screens/User/UserTokenDetail/UserTokenDetail.js:52
-#: screens/User/UserTokenList/UserTokenList.js:143
-#: screens/User/UserTokenList/UserTokenList.js:186
+#: screens/User/UserTokenList/UserTokenList.js:142
+#: screens/User/UserTokenList/UserTokenList.js:185
 #: screens/User/UserTokenList/UserTokenListItem.js:32
 #: screens/User/UserTokens/UserTokens.js:89
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:87
 msgid "Expires"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:90
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:84
 msgid "Expires on"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:100
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:94
 msgid "Expires on UTC"
 msgstr ""
 
@@ -2984,7 +3015,7 @@ msgstr ""
 msgid "Expires on {0}"
 msgstr ""
 
-#: components/JobList/JobListItem.js:252
+#: components/JobList/JobListItem.js:263
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:119
 msgid "Explanation"
 msgstr ""
@@ -2993,8 +3024,8 @@ msgstr ""
 msgid "External Secret Management System"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:288
-#: components/AdHocCommands/AdHocDetailsStep.js:289
+#: components/AdHocCommands/AdHocDetailsStep.js:286
+#: components/AdHocCommands/AdHocDetailsStep.js:287
 msgid "Extra variables"
 msgstr ""
 
@@ -3019,7 +3050,7 @@ msgstr ""
 msgid "Facts"
 msgstr ""
 
-#: components/JobList/JobList.js:204
+#: components/JobList/JobList.js:225
 #: components/StatusLabel/StatusLabel.js:56
 #: components/Workflow/WorkflowNodeHelp.js:105
 #: screens/Dashboard/shared/ChartTooltip.js:66
@@ -3045,7 +3076,7 @@ msgstr ""
 msgid "Failed jobs"
 msgstr ""
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:261
 msgid "Failed to approve one or more workflow approval."
 msgstr ""
 
@@ -3053,21 +3084,21 @@ msgstr ""
 msgid "Failed to approve workflow approval."
 msgstr ""
 
-#: components/ResourceAccessList/ResourceAccessList.js:238
+#: components/ResourceAccessList/ResourceAccessList.js:237
 msgid "Failed to assign roles properly"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:251
-#: screens/User/UserRoles/UserRolesList.js:247
+#: screens/Team/TeamRoles/TeamRolesList.js:250
+#: screens/User/UserRoles/UserRolesList.js:246
 msgid "Failed to associate role"
 msgstr ""
 
-#: screens/Host/HostGroups/HostGroupsList.js:249
-#: screens/InstanceGroup/Instances/InstanceList.js:248
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:286
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
-#: screens/User/UserTeams/UserTeamList.js:264
+#: screens/Host/HostGroups/HostGroupsList.js:248
+#: screens/InstanceGroup/Instances/InstanceList.js:247
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:285
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:265
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:267
+#: screens/User/UserTeams/UserTeamList.js:263
 msgid "Failed to associate."
 msgstr ""
 
@@ -3080,12 +3111,12 @@ msgstr ""
 msgid "Failed to cancel Project Sync"
 msgstr ""
 
-#: components/JobList/JobList.js:297
+#: components/JobList/JobList.js:319
 msgid "Failed to cancel one or more jobs."
 msgstr ""
 
-#: components/JobList/JobListItem.js:106
-#: screens/Job/JobDetail/JobDetail.js:404
+#: components/JobList/JobListItem.js:107
+#: screens/Job/JobDetail/JobDetail.js:480
 #: screens/Job/JobOutput/shared/OutputToolbar.js:136
 msgid "Failed to cancel {0}"
 msgstr ""
@@ -3144,19 +3175,19 @@ msgstr ""
 msgid "Failed to delete notification."
 msgstr ""
 
-#: screens/Application/ApplicationsList/ApplicationsList.js:189
+#: screens/Application/ApplicationsList/ApplicationsList.js:188
 msgid "Failed to delete one or more applications."
 msgstr ""
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:209
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:208
 msgid "Failed to delete one or more credential types."
 msgstr ""
 
-#: screens/Credential/CredentialList/CredentialList.js:198
+#: screens/Credential/CredentialList/CredentialList.js:197
 msgid "Failed to delete one or more credentials."
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:219
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:218
 msgid "Failed to delete one or more execution environments"
 msgstr ""
 
@@ -3164,16 +3195,16 @@ msgstr ""
 msgid "Failed to delete one or more groups."
 msgstr ""
 
-#: screens/Host/HostList/HostList.js:218
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:204
+#: screens/Host/HostList/HostList.js:225
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:203
 msgid "Failed to delete one or more hosts."
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:312
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:311
 msgid "Failed to delete one or more instance groups."
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:273
+#: screens/Inventory/InventoryList/InventoryList.js:272
 msgid "Failed to delete one or more inventories."
 msgstr ""
 
@@ -3181,55 +3212,55 @@ msgstr ""
 msgid "Failed to delete one or more inventory sources."
 msgstr ""
 
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:183
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:182
 msgid "Failed to delete one or more job templates."
 msgstr ""
 
-#: components/JobList/JobList.js:286
+#: components/JobList/JobList.js:308
 msgid "Failed to delete one or more jobs."
 msgstr ""
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:224
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:223
 msgid "Failed to delete one or more notification template."
 msgstr ""
 
-#: screens/Organization/OrganizationList/OrganizationList.js:199
+#: screens/Organization/OrganizationList/OrganizationList.js:198
 msgid "Failed to delete one or more organizations."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectList.js:279
+#: screens/Project/ProjectList/ProjectList.js:278
 msgid "Failed to delete one or more projects."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:242
+#: components/Schedule/ScheduleList/ScheduleList.js:241
 msgid "Failed to delete one or more schedules."
 msgstr ""
 
-#: screens/Team/TeamList/TeamList.js:196
+#: screens/Team/TeamList/TeamList.js:195
 msgid "Failed to delete one or more teams."
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:281
+#: components/TemplateList/TemplateList.js:280
 msgid "Failed to delete one or more templates."
 msgstr ""
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:159
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:158
 msgid "Failed to delete one or more tokens."
 msgstr ""
 
-#: screens/User/UserTokenList/UserTokenList.js:213
+#: screens/User/UserTokenList/UserTokenList.js:212
 msgid "Failed to delete one or more user tokens."
 msgstr ""
 
-#: screens/User/UserList/UserList.js:189
+#: screens/User/UserList/UserList.js:188
 msgid "Failed to delete one or more users."
 msgstr ""
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:250
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:249
 msgid "Failed to delete one or more workflow approval."
 msgstr ""
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:184
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:187
 msgid "Failed to delete organization."
 msgstr ""
 
@@ -3237,16 +3268,16 @@ msgstr ""
 msgid "Failed to delete project."
 msgstr ""
 
-#: components/ResourceAccessList/ResourceAccessList.js:249
+#: components/ResourceAccessList/ResourceAccessList.js:248
 msgid "Failed to delete role"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:262
-#: screens/User/UserRoles/UserRolesList.js:258
+#: screens/Team/TeamRoles/TeamRolesList.js:261
+#: screens/User/UserRoles/UserRolesList.js:257
 msgid "Failed to delete role."
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:403
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:417
 msgid "Failed to delete schedule."
 msgstr ""
 
@@ -3275,7 +3306,7 @@ msgstr ""
 msgid "Failed to delete {name}."
 msgstr ""
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:263
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:262
 msgid "Failed to deny one or more workflow approval."
 msgstr ""
 
@@ -3283,21 +3314,21 @@ msgstr ""
 msgid "Failed to deny workflow approval."
 msgstr ""
 
-#: screens/Host/HostGroups/HostGroupsList.js:250
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:267
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:269
+#: screens/Host/HostGroups/HostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:266
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:268
 msgid "Failed to disassociate one or more groups."
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:297
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:296
 msgid "Failed to disassociate one or more hosts."
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:249
+#: screens/InstanceGroup/Instances/InstanceList.js:248
 msgid "Failed to disassociate one or more instances."
 msgstr ""
 
-#: screens/User/UserTeams/UserTeamList.js:265
+#: screens/User/UserTeams/UserTeamList.js:264
 msgid "Failed to disassociate one or more teams."
 msgstr ""
 
@@ -3305,13 +3336,13 @@ msgstr ""
 msgid "Failed to fetch custom login configuration settings.  System defaults will be shown instead."
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectList.js:291
+#: screens/Project/ProjectList/ProjectList.js:290
 msgid "Failed to fetch the updated project data."
 msgstr ""
 
 #: components/AdHocCommands/AdHocCommands.js:110
 #: components/LaunchButton/LaunchButton.js:164
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:126
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:125
 msgid "Failed to launch job."
 msgstr ""
 
@@ -3351,7 +3382,7 @@ msgstr ""
 msgid "Failed to toggle instance."
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:248
+#: components/NotificationList/NotificationList.js:250
 msgid "Failed to toggle notification."
 msgstr ""
 
@@ -3382,7 +3413,7 @@ msgstr ""
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "False"
 msgstr ""
 
@@ -3390,11 +3421,11 @@ msgstr ""
 msgid "February"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:210
+#: components/Search/LookupTypeInput.js:52
 msgid "Field contains value."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:234
+#: components/Search/LookupTypeInput.js:80
 msgid "Field ends with value."
 msgstr ""
 
@@ -3402,11 +3433,11 @@ msgstr ""
 msgid "Field for passing a custom Kubernetes or OpenShift Pod specification."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:246
+#: components/Search/LookupTypeInput.js:94
 msgid "Field matches the given regular expression."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:222
+#: components/Search/LookupTypeInput.js:66
 msgid "Field starts with value."
 msgstr ""
 
@@ -3422,16 +3453,16 @@ msgstr ""
 msgid "File upload rejected. Please select a single .json file."
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:96
 msgid "File, directory or script"
 msgstr ""
 
-#: components/JobList/JobList.js:220
-#: components/JobList/JobListItem.js:92
+#: components/JobList/JobList.js:241
+#: components/JobList/JobListItem.js:93
 msgid "Finish Time"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:137
+#: screens/Job/JobDetail/JobDetail.js:144
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:161
 msgid "Finished"
 msgstr ""
@@ -3442,25 +3473,25 @@ msgstr ""
 
 #: components/AddRole/AddResourceRole.js:27
 #: components/AddRole/AddResourceRole.js:41
-#: components/ResourceAccessList/ResourceAccessList.js:135
+#: components/ResourceAccessList/ResourceAccessList.js:134
 #: screens/User/UserDetail/UserDetail.js:64
-#: screens/User/UserList/UserList.js:121
-#: screens/User/UserList/UserList.js:158
+#: screens/User/UserList/UserList.js:120
+#: screens/User/UserList/UserList.js:157
 #: screens/User/UserList/UserListItem.js:53
 #: screens/User/shared/UserForm.js:63
 msgid "First Name"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:253
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:262
 msgid "First Run"
 msgstr ""
 
-#: components/ResourceAccessList/ResourceAccessList.js:184
+#: components/ResourceAccessList/ResourceAccessList.js:183
 #: components/ResourceAccessList/ResourceAccessListItem.js:64
 msgid "First name"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:340
+#: components/Search/AdvancedSearch.js:203
 msgid "First, select a key"
 msgstr ""
 
@@ -3476,7 +3507,7 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:255
+#: screens/Template/shared/JobTemplateForm.js:253
 msgid ""
 "For job templates, select run to execute\n"
 "the playbook. Select check to only check playbook syntax,\n"
@@ -3495,11 +3526,11 @@ msgstr ""
 msgid "For more information, refer to the"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:178
-#: components/AdHocCommands/AdHocDetailsStep.js:179
+#: components/AdHocCommands/AdHocDetailsStep.js:176
+#: components/AdHocCommands/AdHocDetailsStep.js:177
 #: components/PromptDetail/PromptJobTemplateDetail.js:154
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:229
-#: screens/Template/shared/JobTemplateForm.js:426
+#: screens/Template/shared/JobTemplateForm.js:424
 msgid "Forks"
 msgstr ""
 
@@ -3507,12 +3538,12 @@ msgstr ""
 msgid "Fourth"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:166
+#: components/Schedule/shared/ScheduleForm.js:174
 msgid "Frequency Details"
 msgstr ""
 
 #: components/Schedule/shared/FrequencyDetailSubform.js:196
-#: components/Schedule/shared/buildRuleObj.js:73
+#: components/Schedule/shared/buildRuleObj.js:71
 msgid "Frequency did not match an expected value"
 msgstr ""
 
@@ -3525,11 +3556,11 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:171
+#: components/Search/RelatedLookupTypeInput.js:45
 msgid "Fuzzy search on id, name or description fields."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:158
+#: components/Search/RelatedLookupTypeInput.js:32
 msgid "Fuzzy search on name field."
 msgstr ""
 
@@ -3554,11 +3585,11 @@ msgstr ""
 msgid "Get subscriptions"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:136
+#: components/Lookup/ProjectLookup.js:135
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:89
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:158
-#: screens/Project/ProjectList/ProjectList.js:185
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
+#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
 msgid "Git"
 msgstr ""
 
@@ -3597,7 +3628,7 @@ msgstr ""
 msgid "GitHub Team"
 msgstr ""
 
-#: screens/Setting/SettingList.js:62
+#: screens/Setting/SettingList.js:61
 msgid "GitHub settings"
 msgstr ""
 
@@ -3606,7 +3637,7 @@ msgstr ""
 msgid "GitLab"
 msgstr ""
 
-#: components/Lookup/ExecutionEnvironmentLookup.js:207
+#: components/Lookup/ExecutionEnvironmentLookup.js:206
 msgid "Global Default Execution Environment"
 msgstr ""
 
@@ -3635,11 +3666,11 @@ msgstr ""
 msgid "Go to previous page"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:99
 msgid "Google Compute Engine"
 msgstr ""
 
-#: screens/Setting/SettingList.js:66
+#: screens/Setting/SettingList.js:65
 msgid "Google OAuth 2 settings"
 msgstr ""
 
@@ -3647,8 +3678,8 @@ msgstr ""
 msgid "Google OAuth2"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:192
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
+#: components/NotificationList/NotificationList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:150
 msgid "Grafana"
 msgstr ""
 
@@ -3661,15 +3692,15 @@ msgstr ""
 msgid "Grafana URL"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:258
+#: components/Search/LookupTypeInput.js:106
 msgid "Greater than comparison."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:264
+#: components/Search/LookupTypeInput.js:113
 msgid "Greater than or equal to comparison."
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:88
+#: components/Lookup/HostFilterLookup.js:92
 msgid "Group"
 msgstr ""
 
@@ -3677,20 +3708,20 @@ msgstr ""
 msgid "Group details"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:126
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:125
 msgid "Group type"
 msgstr ""
 
 #: screens/Host/Host.js:67
-#: screens/Host/HostGroups/HostGroupsList.js:232
+#: screens/Host/HostGroups/HostGroupsList.js:231
 #: screens/Host/Hosts.js:30
 #: screens/Inventory/Inventories.js:70
 #: screens/Inventory/Inventories.js:72
 #: screens/Inventory/Inventory.js:64
 #: screens/Inventory/InventoryHost/InventoryHost.js:83
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:249
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:248
 #: screens/Inventory/InventoryList/InventoryListItem.js:104
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:251
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:250
 #: util/getRelatedResourceDeleteDetails.js:118
 msgid "Groups"
 msgstr ""
@@ -3718,8 +3749,8 @@ msgstr ""
 msgid "Hide description"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:193
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
+#: components/NotificationList/NotificationList.js:195
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:151
 msgid "Hipchat"
 msgstr ""
 
@@ -3738,7 +3769,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:161
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:237
-#: screens/Template/shared/JobTemplateForm.js:643
+#: screens/Template/shared/JobTemplateForm.js:641
 msgid "Host Config Key"
 msgstr ""
 
@@ -3809,20 +3840,20 @@ msgid "Host status information for this job is unavailable."
 msgstr ""
 
 #: routeConfig.js:83
-#: screens/ActivityStream/ActivityStream.js:167
+#: screens/ActivityStream/ActivityStream.js:166
 #: screens/Dashboard/Dashboard.js:81
-#: screens/Host/HostList/HostList.js:132
-#: screens/Host/HostList/HostList.js:177
+#: screens/Host/HostList/HostList.js:135
+#: screens/Host/HostList/HostList.js:182
 #: screens/Host/Hosts.js:15
 #: screens/Host/Hosts.js:24
 #: screens/Inventory/Inventories.js:63
 #: screens/Inventory/Inventories.js:77
 #: screens/Inventory/Inventory.js:65
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:67
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:188
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:270
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:113
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:172
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:187
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:269
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:112
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:171
 #: screens/Inventory/SmartInventory.js:67
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:64
 #: screens/Job/JobOutput/shared/OutputToolbar.js:95
@@ -3830,30 +3861,30 @@ msgstr ""
 msgid "Hosts"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:137
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
 msgid "Hosts automated"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:119
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:126
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:114
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:121
 msgid "Hosts available"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:132
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
 msgid "Hosts imported"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:145
 msgid "Hosts remaining"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:144
+#: components/Schedule/shared/ScheduleForm.js:152
 msgid "Hour"
 msgstr ""
 
-#: components/JobList/JobList.js:172
-#: components/Lookup/HostFilterLookup.js:84
-#: screens/Team/TeamRoles/TeamRolesList.js:156
+#: components/JobList/JobList.js:193
+#: components/Lookup/HostFilterLookup.js:88
+#: screens/Team/TeamRoles/TeamRolesList.js:155
 msgid "ID"
 msgstr ""
 
@@ -3873,8 +3904,8 @@ msgstr ""
 msgid "ID of the panel (optional)"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:194
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
+#: components/NotificationList/NotificationList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:152
 msgid "IRC"
 msgstr ""
 
@@ -3931,7 +3962,7 @@ msgid ""
 "default group for the inventory."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:560
+#: screens/Template/shared/JobTemplateForm.js:558
 msgid ""
 "If enabled, run this playbook as an\n"
 "administrator."
@@ -3944,18 +3975,18 @@ msgid ""
 "--diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:500
+#: screens/Template/shared/JobTemplateForm.js:498
 msgid ""
 "If enabled, show the changes made by\n"
 "Ansible tasks, where supported. This is equivalent\n"
 "to Ansible's --diff mode."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:199
+#: components/AdHocCommands/AdHocDetailsStep.js:197
 msgid "If enabled, show the changes made by Ansible tasks, where supported. This is equivalent to Ansible’s --diff mode."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:604
+#: screens/Template/shared/JobTemplateForm.js:602
 msgid ""
 "If enabled, simultaneous runs of this job\n"
 "template will be allowed."
@@ -3965,7 +3996,7 @@ msgstr ""
 msgid "If enabled, simultaneous runs of this workflow job template will be allowed."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:611
+#: screens/Template/shared/JobTemplateForm.js:609
 msgid ""
 "If enabled, this will store gathered facts so they can\n"
 "be viewed at the host level. Facts are persisted and\n"
@@ -3976,7 +4007,7 @@ msgstr ""
 msgid "If specified, this field will be shown on the node instead of the resource name when viewing the workflow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:155
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:150
 msgid "If you are ready to upgrade or renew, please <0>contact us.</0>"
 msgstr ""
 
@@ -3986,7 +4017,7 @@ msgid ""
 "Red Hat to obtain a trial subscription."
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:46
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:45
 msgid "If you only want to remove access for this particular user, please remove them from the team."
 msgstr ""
 
@@ -3998,13 +4029,13 @@ msgid ""
 msgstr ""
 
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:52
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:128
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:134
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:127
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:133
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:62
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:96
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:110
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:90
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:16
 msgid "Image"
 msgstr ""
@@ -4028,13 +4059,13 @@ msgstr ""
 msgid "Initiated By"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:240
-#: screens/ActivityStream/ActivityStream.js:250
+#: screens/ActivityStream/ActivityStream.js:239
+#: screens/ActivityStream/ActivityStream.js:249
 #: screens/ActivityStream/ActivityStreamDetailButton.js:44
 msgid "Initiated by"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:230
+#: screens/ActivityStream/ActivityStream.js:229
 msgid "Initiated by (username)"
 msgstr ""
 
@@ -4061,7 +4092,7 @@ msgstr ""
 msgid "Insights for Ansible Automation Platform dashboard"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:109
+#: components/Lookup/HostFilterLookup.js:113
 msgid "Insights system ID"
 msgstr ""
 
@@ -4073,18 +4104,18 @@ msgstr ""
 msgid "Instance Filters"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:238
+#: screens/Job/JobDetail/JobDetail.js:290
 msgid "Instance Group"
 msgstr ""
 
-#: components/Lookup/InstanceGroupsLookup.js:70
-#: components/Lookup/InstanceGroupsLookup.js:76
-#: components/Lookup/InstanceGroupsLookup.js:122
+#: components/Lookup/InstanceGroupsLookup.js:69
+#: components/Lookup/InstanceGroupsLookup.js:75
+#: components/Lookup/InstanceGroupsLookup.js:121
 #: components/PromptDetail/PromptJobTemplateDetail.js:227
 #: routeConfig.js:130
-#: screens/ActivityStream/ActivityStream.js:192
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:170
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:265
+#: screens/ActivityStream/ActivityStream.js:191
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:169
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:264
 #: screens/InstanceGroup/InstanceGroups.js:36
 #: screens/InstanceGroup/InstanceGroups.js:46
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:84
@@ -4093,7 +4124,7 @@ msgstr ""
 msgid "Instance Groups"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:101
+#: components/Lookup/HostFilterLookup.js:105
 msgid "Instance ID"
 msgstr ""
 
@@ -4115,11 +4146,11 @@ msgid "Instance groups"
 msgstr ""
 
 #: screens/InstanceGroup/InstanceGroup.js:81
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:285
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:73
 #: screens/InstanceGroup/InstanceGroups.js:51
-#: screens/InstanceGroup/Instances/InstanceList.js:152
-#: screens/InstanceGroup/Instances/InstanceList.js:230
+#: screens/InstanceGroup/Instances/InstanceList.js:151
+#: screens/InstanceGroup/Instances/InstanceList.js:229
 msgid "Instances"
 msgstr ""
 
@@ -4149,11 +4180,11 @@ msgstr ""
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:119
 #: routeConfig.js:78
-#: screens/ActivityStream/ActivityStream.js:164
+#: screens/ActivityStream/ActivityStream.js:163
 #: screens/Dashboard/Dashboard.js:92
 #: screens/Inventory/Inventories.js:16
-#: screens/Inventory/InventoryList/InventoryList.js:160
-#: screens/Inventory/InventoryList/InventoryList.js:223
+#: screens/Inventory/InventoryList/InventoryList.js:159
+#: screens/Inventory/InventoryList/InventoryList.js:222
 #: util/getRelatedResourceDeleteDetails.js:201
 #: util/getRelatedResourceDeleteDetails.js:269
 msgid "Inventories"
@@ -4164,41 +4195,41 @@ msgid "Inventories with sources cannot be copied"
 msgstr ""
 
 #: components/HostForm/HostForm.js:48
-#: components/JobList/JobListItem.js:189
-#: components/LaunchPrompt/steps/InventoryStep.js:105
+#: components/JobList/JobListItem.js:200
+#: components/LaunchPrompt/steps/InventoryStep.js:104
 #: components/LaunchPrompt/steps/useInventoryStep.js:48
-#: components/Lookup/HostFilterLookup.js:372
+#: components/Lookup/HostFilterLookup.js:374
 #: components/Lookup/HostListItem.js:9
-#: components/Lookup/InventoryLookup.js:127
-#: components/Lookup/InventoryLookup.js:136
-#: components/Lookup/InventoryLookup.js:176
-#: components/Lookup/InventoryLookup.js:192
-#: components/Lookup/InventoryLookup.js:232
+#: components/Lookup/InventoryLookup.js:130
+#: components/Lookup/InventoryLookup.js:139
+#: components/Lookup/InventoryLookup.js:179
+#: components/Lookup/InventoryLookup.js:195
+#: components/Lookup/InventoryLookup.js:235
 #: components/PromptDetail/PromptDetail.js:196
 #: components/PromptDetail/PromptInventorySourceDetail.js:94
 #: components/PromptDetail/PromptJobTemplateDetail.js:124
 #: components/PromptDetail/PromptJobTemplateDetail.js:134
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:77
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:283
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:297
 #: components/TemplateList/TemplateListItem.js:277
 #: components/TemplateList/TemplateListItem.js:287
 #: screens/Host/HostDetail/HostDetail.js:75
-#: screens/Host/HostList/HostList.js:159
-#: screens/Host/HostList/HostListItem.js:48
+#: screens/Host/HostList/HostList.js:162
+#: screens/Host/HostList/HostListItem.js:55
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:172
+#: screens/Inventory/InventoryList/InventoryList.js:171
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:39
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:105
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:39
-#: screens/Job/JobDetail/JobDetail.js:174
+#: screens/Job/JobDetail/JobDetail.js:191
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:199
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:206
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:140
 msgid "Inventory"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:104
 msgid "Inventory (Name)"
 msgstr ""
 
@@ -4206,12 +4237,16 @@ msgstr ""
 msgid "Inventory File"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:92
+#: components/Lookup/HostFilterLookup.js:96
 msgid "Inventory ID"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:190
+#: screens/Job/JobDetail/JobDetail.js:209
 msgid "Inventory Source"
+msgstr ""
+
+#: screens/Job/JobDetail/JobDetail.js:232
+msgid "Inventory Source Project"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:87
@@ -4229,15 +4264,15 @@ msgstr ""
 msgid "Inventory Sources"
 msgstr ""
 
-#: components/JobList/JobList.js:184
-#: components/JobList/JobListItem.js:36
+#: components/JobList/JobList.js:205
+#: components/JobList/JobListItem.js:37
 #: components/Schedule/ScheduleList/ScheduleListItem.js:36
 #: components/Workflow/WorkflowLegend.js:100
 #: screens/Job/JobDetail/JobDetail.js:77
 msgid "Inventory Sync"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:169
+#: screens/Inventory/InventoryList/InventoryList.js:168
 msgid "Inventory Type"
 msgstr ""
 
@@ -4282,7 +4317,7 @@ msgstr ""
 msgid "Item Skipped"
 msgstr ""
 
-#: components/AssociateModal/AssociateModal.js:19
+#: components/AssociateModal/AssociateModal.js:20
 #: components/PaginatedTable/PaginatedTable.js:42
 msgid "Items"
 msgstr ""
@@ -4314,20 +4349,20 @@ msgstr ""
 msgid "January"
 msgstr ""
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:66
 msgid "Job"
 msgstr ""
 
-#: components/JobList/JobListItem.js:104
-#: screens/Job/JobDetail/JobDetail.js:402
+#: components/JobList/JobListItem.js:105
+#: screens/Job/JobDetail/JobDetail.js:478
 #: screens/Job/JobOutput/JobOutput.js:939
 #: screens/Job/JobOutput/JobOutput.js:940
 #: screens/Job/JobOutput/shared/OutputToolbar.js:134
 msgid "Job Cancel Error"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:424
+#: screens/Job/JobDetail/JobDetail.js:500
 #: screens/Job/JobOutput/JobOutput.js:928
 #: screens/Job/JobOutput/JobOutput.js:929
 msgid "Job Delete Error"
@@ -4341,19 +4376,19 @@ msgstr ""
 msgid "Job Runs"
 msgstr ""
 
-#: components/JobList/JobListItem.js:259
-#: screens/Job/JobDetail/JobDetail.js:251
+#: components/JobList/JobListItem.js:270
+#: screens/Job/JobDetail/JobDetail.js:305
 msgid "Job Slice"
 msgstr ""
 
-#: components/JobList/JobListItem.js:264
-#: screens/Job/JobDetail/JobDetail.js:256
+#: components/JobList/JobListItem.js:275
+#: screens/Job/JobDetail/JobDetail.js:312
 msgid "Job Slice Parent"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:160
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:234
-#: screens/Template/shared/JobTemplateForm.js:480
+#: screens/Template/shared/JobTemplateForm.js:478
 msgid "Job Slicing"
 msgstr ""
 
@@ -4365,20 +4400,20 @@ msgstr ""
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:57
 #: components/PromptDetail/PromptDetail.js:219
 #: components/PromptDetail/PromptJobTemplateDetail.js:242
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:330
-#: screens/Job/JobDetail/JobDetail.js:304
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:366
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:336
-#: screens/Template/shared/JobTemplateForm.js:521
+#: screens/Template/shared/JobTemplateForm.js:519
 msgid "Job Tags"
 msgstr ""
 
-#: components/JobList/JobListItem.js:157
-#: components/TemplateList/TemplateList.js:203
+#: components/JobList/JobListItem.js:168
+#: components/TemplateList/TemplateList.js:202
 #: components/Workflow/WorkflowLegend.js:92
 #: components/Workflow/WorkflowNodeHelp.js:59
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:98
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:14
-#: screens/Job/JobDetail/JobDetail.js:140
+#: screens/Job/JobDetail/JobDetail.js:150
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:93
 msgid "Job Template"
 msgstr ""
@@ -4403,15 +4438,15 @@ msgstr ""
 msgid "Job Templates with credentials that prompt for passwords cannot be selected when creating or editing nodes"
 msgstr ""
 
-#: components/JobList/JobList.js:180
+#: components/JobList/JobList.js:201
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:110
 #: components/PromptDetail/PromptDetail.js:169
 #: components/PromptDetail/PromptJobTemplateDetail.js:107
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:279
-#: screens/Job/JobDetail/JobDetail.js:170
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:293
+#: screens/Job/JobDetail/JobDetail.js:184
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:182
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:137
-#: screens/Template/shared/JobTemplateForm.js:252
+#: screens/Template/shared/JobTemplateForm.js:250
 msgid "Job Type"
 msgstr ""
 
@@ -4424,15 +4459,15 @@ msgid "Job status graph tab"
 msgstr ""
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:15
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:118
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:150
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:117
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:149
 msgid "Job templates"
 msgstr ""
 
-#: components/JobList/JobList.js:163
-#: components/JobList/JobList.js:243
+#: components/JobList/JobList.js:184
+#: components/JobList/JobList.js:264
 #: routeConfig.js:37
-#: screens/ActivityStream/ActivityStream.js:141
+#: screens/ActivityStream/ActivityStream.js:140
 #: screens/Dashboard/shared/LineChart.js:64
 #: screens/Host/Host.js:72
 #: screens/Host/Hosts.js:31
@@ -4447,7 +4482,7 @@ msgstr ""
 #: screens/Inventory/SmartInventory.js:69
 #: screens/Job/Jobs.js:15
 #: screens/Job/Jobs.js:25
-#: screens/Setting/SettingList.js:88
+#: screens/Setting/SettingList.js:87
 #: screens/Setting/Settings.js:71
 #: screens/Template/Template.js:154
 #: screens/Template/Templates.js:46
@@ -4455,7 +4490,7 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: screens/Setting/SettingList.js:93
+#: screens/Setting/SettingList.js:92
 msgid "Jobs settings"
 msgstr ""
 
@@ -4467,19 +4502,19 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:315
+#: components/Search/AdvancedSearch.js:166
 msgid "Key"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:306
+#: components/Search/AdvancedSearch.js:157
 msgid "Key select"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:309
+#: components/Search/AdvancedSearch.js:160
 msgid "Key typeahead"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:225
+#: screens/ActivityStream/ActivityStream.js:224
 msgid "Keyword"
 msgstr ""
 
@@ -4512,7 +4547,7 @@ msgstr ""
 msgid "LDAP Default"
 msgstr ""
 
-#: screens/Setting/SettingList.js:70
+#: screens/Setting/SettingList.js:69
 msgid "LDAP settings"
 msgstr ""
 
@@ -4536,18 +4571,18 @@ msgstr ""
 msgid "LDAP5"
 msgstr ""
 
-#: components/JobList/JobList.js:176
+#: components/JobList/JobList.js:197
 msgid "Label Name"
 msgstr ""
 
-#: components/JobList/JobListItem.js:237
+#: components/JobList/JobListItem.js:248
 #: components/PromptDetail/PromptJobTemplateDetail.js:209
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:114
 #: components/TemplateList/TemplateListItem.js:332
-#: screens/Job/JobDetail/JobDetail.js:289
+#: screens/Job/JobDetail/JobDetail.js:350
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:303
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:188
-#: screens/Template/shared/JobTemplateForm.js:393
+#: screens/Template/shared/JobTemplateForm.js:391
 #: screens/Template/shared/WorkflowJobTemplateForm.js:191
 msgid "Labels"
 msgstr ""
@@ -4565,11 +4600,11 @@ msgid "Last Login"
 msgstr ""
 
 #: components/PromptDetail/PromptDetail.js:145
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:268
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:282
 #: components/TemplateList/TemplateListItem.js:308
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:101
 #: screens/Application/ApplicationsList/ApplicationListItem.js:43
-#: screens/Application/ApplicationsList/ApplicationsList.js:160
+#: screens/Application/ApplicationsList/ApplicationsList.js:159
 #: screens/Credential/CredentialDetail/CredentialDetail.js:250
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:91
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:105
@@ -4579,7 +4614,7 @@ msgstr ""
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:108
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:44
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:85
-#: screens/Job/JobDetail/JobDetail.js:344
+#: screens/Job/JobDetail/JobDetail.js:418
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:344
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:110
 #: screens/Project/ProjectDetail/ProjectDetail.js:236
@@ -4593,25 +4628,25 @@ msgstr ""
 
 #: components/AddRole/AddResourceRole.js:31
 #: components/AddRole/AddResourceRole.js:45
-#: components/ResourceAccessList/ResourceAccessList.js:139
+#: components/ResourceAccessList/ResourceAccessList.js:138
 #: screens/User/UserDetail/UserDetail.js:65
-#: screens/User/UserList/UserList.js:125
-#: screens/User/UserList/UserList.js:159
+#: screens/User/UserList/UserList.js:124
+#: screens/User/UserList/UserList.js:158
 #: screens/User/UserList/UserListItem.js:56
 #: screens/User/shared/UserForm.js:69
 msgid "Last Name"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:226
+#: components/TemplateList/TemplateList.js:225
 #: components/TemplateList/TemplateListItem.js:177
 msgid "Last Ran"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:255
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:269
 msgid "Last Run"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:105
+#: components/Lookup/HostFilterLookup.js:109
 msgid "Last job"
 msgstr ""
 
@@ -4622,7 +4657,7 @@ msgstr ""
 msgid "Last modified"
 msgstr ""
 
-#: components/ResourceAccessList/ResourceAccessList.js:185
+#: components/ResourceAccessList/ResourceAccessList.js:184
 #: components/ResourceAccessList/ResourceAccessListItem.js:65
 msgid "Last name"
 msgstr ""
@@ -4673,11 +4708,11 @@ msgstr ""
 msgid "Launch | {0}"
 msgstr ""
 
-#: components/DetailList/LaunchedByDetail.js:82
+#: components/DetailList/LaunchedByDetail.js:83
 msgid "Launched By"
 msgstr ""
 
-#: components/JobList/JobList.js:192
+#: components/JobList/JobList.js:213
 msgid "Launched By (Username)"
 msgstr ""
 
@@ -4693,26 +4728,26 @@ msgstr ""
 msgid "Legend"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:270
+#: components/Search/LookupTypeInput.js:120
 msgid "Less than comparison."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:276
+#: components/Search/LookupTypeInput.js:127
 msgid "Less than or equal to comparison."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:158
-#: components/AdHocCommands/AdHocDetailsStep.js:159
-#: components/JobList/JobList.js:210
+#: components/AdHocCommands/AdHocDetailsStep.js:156
+#: components/AdHocCommands/AdHocDetailsStep.js:157
+#: components/JobList/JobList.js:231
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:35
 #: components/PromptDetail/PromptDetail.js:207
 #: components/PromptDetail/PromptJobTemplateDetail.js:155
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:88
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:307
-#: screens/Job/JobDetail/JobDetail.js:227
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:321
+#: screens/Job/JobDetail/JobDetail.js:269
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:230
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:147
-#: screens/Template/shared/JobTemplateForm.js:442
+#: screens/Template/shared/JobTemplateForm.js:440
 #: screens/Template/shared/WorkflowJobTemplateForm.js:152
 msgid "Limit"
 msgstr ""
@@ -4729,11 +4764,11 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:256
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:270
 msgid "Local Time Zone"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:121
+#: components/Schedule/shared/ScheduleForm.js:129
 msgid "Local time zone"
 msgstr ""
 
@@ -4745,7 +4780,7 @@ msgstr ""
 msgid "Logging"
 msgstr ""
 
-#: screens/Setting/SettingList.js:112
+#: screens/Setting/SettingList.js:111
 msgid "Logging settings"
 msgstr ""
 
@@ -4755,20 +4790,20 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:336
-#: components/Lookup/Lookup.js:168
+#: components/Lookup/HostFilterLookup.js:338
+#: components/Lookup/Lookup.js:173
 msgid "Lookup modal"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:180
+#: components/Search/LookupTypeInput.js:22
 msgid "Lookup select"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:189
+#: components/Search/LookupTypeInput.js:31
 msgid "Lookup type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:183
+#: components/Search/LookupTypeInput.js:25
 msgid "Lookup typeahead"
 msgstr ""
 
@@ -4778,10 +4813,10 @@ msgstr ""
 msgid "MOST RECENT SYNC"
 msgstr ""
 
+#: components/AdHocCommands/AdHocCredentialStep.js:97
 #: components/AdHocCommands/AdHocCredentialStep.js:98
-#: components/AdHocCommands/AdHocCredentialStep.js:99
-#: components/AdHocCommands/AdHocCredentialStep.js:113
-#: screens/Job/JobDetail/JobDetail.js:261
+#: components/AdHocCommands/AdHocCredentialStep.js:112
+#: screens/Job/JobDetail/JobDetail.js:320
 msgid "Machine Credential"
 msgstr ""
 
@@ -4794,8 +4829,8 @@ msgstr ""
 msgid "Managed nodes"
 msgstr ""
 
-#: components/JobList/JobList.js:187
-#: components/JobList/JobListItem.js:39
+#: components/JobList/JobList.js:208
+#: components/JobList/JobListItem.js:40
 #: components/Schedule/ScheduleList/ScheduleListItem.js:39
 #: components/Workflow/WorkflowLegend.js:108
 #: components/Workflow/WorkflowNodeHelp.js:79
@@ -4805,7 +4840,7 @@ msgid "Management Job"
 msgstr ""
 
 #: routeConfig.js:125
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:82
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:81
 msgid "Management Jobs"
 msgstr ""
 
@@ -4826,15 +4861,15 @@ msgstr ""
 msgid "Management jobs"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:135
+#: components/Lookup/ProjectLookup.js:134
 #: components/PromptDetail/PromptProjectDetail.js:95
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:88
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:157
 #: screens/InstanceGroup/Instances/InstanceListItem.js:120
 #: screens/Project/ProjectDetail/ProjectDetail.js:173
-#: screens/Project/ProjectList/ProjectList.js:184
+#: screens/Project/ProjectList/ProjectList.js:183
 #: screens/Project/ProjectList/ProjectListItem.js:206
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:97
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:96
 msgid "Manual"
 msgstr ""
 
@@ -4842,8 +4877,8 @@ msgstr ""
 msgid "March"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:195
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
+#: components/NotificationList/NotificationList.js:197
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:153
 msgid "Mattermost"
 msgstr ""
 
@@ -4864,7 +4899,7 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: screens/Organization/OrganizationList/OrganizationList.js:145
+#: screens/Organization/OrganizationList/OrganizationList.js:144
 #: screens/Organization/OrganizationList/OrganizationListItem.js:62
 msgid "Members"
 msgstr ""
@@ -4881,7 +4916,7 @@ msgstr ""
 msgid "Metrics"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:100
 msgid "Microsoft Azure Resource Manager"
 msgstr ""
 
@@ -4905,7 +4940,7 @@ msgid ""
 "assigned to this group when new instances come online."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:143
+#: components/Schedule/shared/ScheduleForm.js:151
 msgid "Minute"
 msgstr ""
 
@@ -4913,7 +4948,7 @@ msgstr ""
 msgid "Miscellaneous Authentication"
 msgstr ""
 
-#: screens/Setting/SettingList.js:108
+#: screens/Setting/SettingList.js:107
 msgid "Miscellaneous Authentication settings"
 msgstr ""
 
@@ -4921,7 +4956,7 @@ msgstr ""
 msgid "Miscellaneous System"
 msgstr ""
 
-#: screens/Setting/SettingList.js:104
+#: screens/Setting/SettingList.js:103
 msgid "Miscellaneous System settings"
 msgstr ""
 
@@ -4936,70 +4971,70 @@ msgid "Missing resource"
 msgstr ""
 
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:178
-#: screens/User/UserTokenList/UserTokenList.js:151
+#: screens/User/UserTokenList/UserTokenList.js:150
 msgid "Modified"
 msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:127
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:126
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:116
 #: components/AddRole/AddResourceRole.js:60
-#: components/AssociateModal/AssociateModal.js:148
-#: components/LaunchPrompt/steps/CredentialsStep.js:177
-#: components/LaunchPrompt/steps/InventoryStep.js:93
-#: components/Lookup/CredentialLookup.js:198
-#: components/Lookup/InventoryLookup.js:163
-#: components/Lookup/InventoryLookup.js:219
-#: components/Lookup/MultiCredentialsLookup.js:197
-#: components/Lookup/OrganizationLookup.js:138
-#: components/Lookup/ProjectLookup.js:147
-#: components/NotificationList/NotificationList.js:208
-#: components/Schedule/ScheduleList/ScheduleList.js:202
-#: components/TemplateList/TemplateList.js:216
+#: components/AssociateModal/AssociateModal.js:147
+#: components/LaunchPrompt/steps/CredentialsStep.js:176
+#: components/LaunchPrompt/steps/InventoryStep.js:92
+#: components/Lookup/CredentialLookup.js:197
+#: components/Lookup/InventoryLookup.js:166
+#: components/Lookup/InventoryLookup.js:222
+#: components/Lookup/MultiCredentialsLookup.js:196
+#: components/Lookup/OrganizationLookup.js:137
+#: components/Lookup/ProjectLookup.js:146
+#: components/NotificationList/NotificationList.js:210
+#: components/Schedule/ScheduleList/ScheduleList.js:201
+#: components/TemplateList/TemplateList.js:215
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:31
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:62
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:100
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:131
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:169
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:200
-#: screens/Credential/CredentialList/CredentialList.js:140
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:101
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:137
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:108
-#: screens/Host/HostGroups/HostGroupsList.js:169
-#: screens/Host/HostList/HostList.js:150
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:202
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:135
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:179
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:133
-#: screens/Inventory/InventoryList/InventoryList.js:189
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:189
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:100
-#: screens/Organization/OrganizationList/OrganizationList.js:136
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:132
-#: screens/Project/ProjectList/ProjectList.js:196
-#: screens/Team/TeamList/TeamList.js:135
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:104
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:109
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:113
+#: screens/Credential/CredentialList/CredentialList.js:139
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:100
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:136
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:107
+#: screens/Host/HostGroups/HostGroupsList.js:168
+#: screens/Host/HostList/HostList.js:153
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:201
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:134
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:178
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:132
+#: screens/Inventory/InventoryList/InventoryList.js:188
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:188
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:99
+#: screens/Organization/OrganizationList/OrganizationList.js:135
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:131
+#: screens/Project/ProjectList/ProjectList.js:195
+#: screens/Team/TeamList/TeamList.js:134
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:108
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:112
 msgid "Modified By (Username)"
 msgstr ""
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:78
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:167
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:78
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:166
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:77
 msgid "Modified by (username)"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:60
+#: components/AdHocCommands/AdHocDetailsStep.js:58
 #: screens/Job/JobOutput/HostEventModal.js:129
 msgid "Module"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:338
+#: screens/Job/JobDetail/JobDetail.js:407
 msgid "Module Arguments"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:337
+#: screens/Job/JobDetail/JobDetail.js:402
 msgid "Module Name"
 msgstr ""
 
@@ -5012,7 +5047,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:147
+#: components/Schedule/shared/ScheduleForm.js:155
 msgid "Month"
 msgstr ""
 
@@ -5024,13 +5059,13 @@ msgstr ""
 msgid "More information for"
 msgstr ""
 
-#: screens/Template/Survey/SurveyPreviewModal.js:111
-#: screens/Template/Survey/SurveyPreviewModal.js:112
+#: screens/Template/Survey/SurveyReorderModal.js:151
+#: screens/Template/Survey/SurveyReorderModal.js:152
 msgid "Multi-Select"
 msgstr ""
 
-#: screens/Template/Survey/SurveyPreviewModal.js:89
-#: screens/Template/Survey/SurveyPreviewModal.js:90
+#: screens/Template/Survey/SurveyReorderModal.js:135
+#: screens/Template/Survey/SurveyReorderModal.js:136
 msgid "Multiple Choice"
 msgstr ""
 
@@ -5046,57 +5081,57 @@ msgstr ""
 msgid "Multiple Choice Options"
 msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:118
-#: components/AdHocCommands/AdHocCredentialStep.js:133
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:108
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:123
+#: components/AdHocCommands/AdHocCredentialStep.js:117
+#: components/AdHocCommands/AdHocCredentialStep.js:132
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:107
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:122
 #: components/AddRole/AddResourceRole.js:51
 #: components/AddRole/AddResourceRole.js:67
-#: components/AssociateModal/AssociateModal.js:139
-#: components/AssociateModal/AssociateModal.js:154
+#: components/AssociateModal/AssociateModal.js:138
+#: components/AssociateModal/AssociateModal.js:153
 #: components/HostForm/HostForm.js:96
-#: components/JobList/JobList.js:167
-#: components/JobList/JobList.js:216
-#: components/JobList/JobListItem.js:78
-#: components/LaunchPrompt/steps/CredentialsStep.js:168
-#: components/LaunchPrompt/steps/CredentialsStep.js:183
-#: components/LaunchPrompt/steps/InventoryStep.js:84
-#: components/LaunchPrompt/steps/InventoryStep.js:99
-#: components/Lookup/ApplicationLookup.js:100
-#: components/Lookup/ApplicationLookup.js:111
-#: components/Lookup/CredentialLookup.js:189
-#: components/Lookup/CredentialLookup.js:204
-#: components/Lookup/ExecutionEnvironmentLookup.js:176
-#: components/Lookup/ExecutionEnvironmentLookup.js:183
-#: components/Lookup/HostFilterLookup.js:79
-#: components/Lookup/HostFilterLookup.js:371
+#: components/JobList/JobList.js:188
+#: components/JobList/JobList.js:237
+#: components/JobList/JobListItem.js:79
+#: components/LaunchPrompt/steps/CredentialsStep.js:167
+#: components/LaunchPrompt/steps/CredentialsStep.js:182
+#: components/LaunchPrompt/steps/InventoryStep.js:83
+#: components/LaunchPrompt/steps/InventoryStep.js:98
+#: components/Lookup/ApplicationLookup.js:99
+#: components/Lookup/ApplicationLookup.js:110
+#: components/Lookup/CredentialLookup.js:188
+#: components/Lookup/CredentialLookup.js:203
+#: components/Lookup/ExecutionEnvironmentLookup.js:175
+#: components/Lookup/ExecutionEnvironmentLookup.js:182
+#: components/Lookup/HostFilterLookup.js:83
+#: components/Lookup/HostFilterLookup.js:373
 #: components/Lookup/HostListItem.js:8
-#: components/Lookup/InstanceGroupsLookup.js:104
-#: components/Lookup/InstanceGroupsLookup.js:115
-#: components/Lookup/InventoryLookup.js:154
-#: components/Lookup/InventoryLookup.js:169
-#: components/Lookup/InventoryLookup.js:210
-#: components/Lookup/InventoryLookup.js:225
-#: components/Lookup/MultiCredentialsLookup.js:188
-#: components/Lookup/MultiCredentialsLookup.js:203
-#: components/Lookup/OrganizationLookup.js:129
-#: components/Lookup/OrganizationLookup.js:144
-#: components/Lookup/ProjectLookup.js:127
-#: components/Lookup/ProjectLookup.js:157
-#: components/NotificationList/NotificationList.js:179
-#: components/NotificationList/NotificationList.js:216
+#: components/Lookup/InstanceGroupsLookup.js:103
+#: components/Lookup/InstanceGroupsLookup.js:114
+#: components/Lookup/InventoryLookup.js:157
+#: components/Lookup/InventoryLookup.js:172
+#: components/Lookup/InventoryLookup.js:213
+#: components/Lookup/InventoryLookup.js:228
+#: components/Lookup/MultiCredentialsLookup.js:187
+#: components/Lookup/MultiCredentialsLookup.js:202
+#: components/Lookup/OrganizationLookup.js:128
+#: components/Lookup/OrganizationLookup.js:143
+#: components/Lookup/ProjectLookup.js:126
+#: components/Lookup/ProjectLookup.js:156
+#: components/NotificationList/NotificationList.js:181
+#: components/NotificationList/NotificationList.js:218
 #: components/NotificationList/NotificationListItem.js:25
 #: components/OptionsList/OptionsList.js:87
 #: components/PaginatedTable/PaginatedTable.js:72
 #: components/PromptDetail/PromptDetail.js:111
 #: components/ResourceAccessList/ResourceAccessListItem.js:55
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:251
-#: components/Schedule/ScheduleList/ScheduleList.js:169
-#: components/Schedule/ScheduleList/ScheduleList.js:189
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:259
+#: components/Schedule/ScheduleList/ScheduleList.js:168
+#: components/Schedule/ScheduleList/ScheduleList.js:188
 #: components/Schedule/ScheduleList/ScheduleListItem.js:77
-#: components/Schedule/shared/ScheduleForm.js:96
-#: components/TemplateList/TemplateList.js:191
-#: components/TemplateList/TemplateList.js:224
+#: components/Schedule/shared/ScheduleForm.js:104
+#: components/TemplateList/TemplateList.js:190
+#: components/TemplateList/TemplateList.js:223
 #: components/TemplateList/TemplateListItem.js:134
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:18
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:37
@@ -5111,73 +5146,73 @@ msgstr ""
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:191
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:206
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:58
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:110
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:109
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:135
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:28
 #: screens/Application/Applications.js:78
 #: screens/Application/ApplicationsList/ApplicationListItem.js:31
-#: screens/Application/ApplicationsList/ApplicationsList.js:119
-#: screens/Application/ApplicationsList/ApplicationsList.js:156
+#: screens/Application/ApplicationsList/ApplicationsList.js:118
+#: screens/Application/ApplicationsList/ApplicationsList.js:155
 #: screens/Application/shared/ApplicationForm.js:52
 #: screens/Credential/CredentialDetail/CredentialDetail.js:202
-#: screens/Credential/CredentialList/CredentialList.js:127
-#: screens/Credential/CredentialList/CredentialList.js:146
+#: screens/Credential/CredentialList/CredentialList.js:126
+#: screens/Credential/CredentialList/CredentialList.js:145
 #: screens/Credential/CredentialList/CredentialListItem.js:55
 #: screens/Credential/shared/CredentialForm.js:160
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:72
-#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:92
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:71
+#: screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js:91
 #: screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js:68
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:124
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:177
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:123
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:176
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:31
 #: screens/CredentialType/shared/CredentialTypeForm.js:21
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:47
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:123
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:152
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:122
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:151
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:57
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:91
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:90
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:116
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:9
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:87
 #: screens/Host/HostDetail/HostDetail.js:69
 #: screens/Host/HostGroups/HostGroupItem.js:28
-#: screens/Host/HostGroups/HostGroupsList.js:160
-#: screens/Host/HostGroups/HostGroupsList.js:177
-#: screens/Host/HostList/HostList.js:137
-#: screens/Host/HostList/HostList.js:158
-#: screens/Host/HostList/HostListItem.js:43
+#: screens/Host/HostGroups/HostGroupsList.js:159
+#: screens/Host/HostGroups/HostGroupsList.js:176
+#: screens/Host/HostList/HostList.js:140
+#: screens/Host/HostList/HostList.js:161
+#: screens/Host/HostList/HostListItem.js:50
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:41
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:50
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:280
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:61
-#: screens/InstanceGroup/Instances/InstanceList.js:159
-#: screens/InstanceGroup/Instances/InstanceList.js:166
-#: screens/InstanceGroup/Instances/InstanceList.js:206
+#: screens/InstanceGroup/Instances/InstanceList.js:158
+#: screens/InstanceGroup/Instances/InstanceList.js:165
+#: screens/InstanceGroup/Instances/InstanceList.js:205
 #: screens/InstanceGroup/Instances/InstanceListItem.js:115
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:46
 #: screens/InstanceGroup/shared/InstanceGroupForm.js:21
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:67
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:31
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:193
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:208
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:214
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:192
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:207
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:213
 #: screens/Inventory/InventoryGroups/InventoryGroupItem.js:34
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:121
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:143
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:120
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:142
 #: screens/Inventory/InventoryHostDetail/InventoryHostDetail.js:74
 #: screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js:33
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:170
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:187
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:169
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:186
 #: screens/Inventory/InventoryHosts/InventoryHostItem.js:33
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:120
-#: screens/Inventory/InventoryHosts/InventoryHostList.js:139
-#: screens/Inventory/InventoryList/InventoryList.js:164
-#: screens/Inventory/InventoryList/InventoryList.js:195
-#: screens/Inventory/InventoryList/InventoryList.js:204
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:119
+#: screens/Inventory/InventoryHosts/InventoryHostList.js:138
+#: screens/Inventory/InventoryList/InventoryList.js:163
+#: screens/Inventory/InventoryList/InventoryList.js:194
+#: screens/Inventory/InventoryList/InventoryList.js:203
 #: screens/Inventory/InventoryList/InventoryListItem.js:79
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:180
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:195
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:232
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:179
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:194
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:231
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:150
 #: screens/Inventory/InventorySources/InventorySourceList.js:195
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:62
@@ -5190,66 +5225,72 @@ msgstr ""
 #: screens/Inventory/shared/InventoryGroupForm.js:32
 #: screens/Inventory/shared/InventorySourceForm.js:101
 #: screens/Inventory/shared/SmartInventoryForm.js:47
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:88
-#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:98
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:87
+#: screens/ManagementJob/ManagementJobList/ManagementJobList.js:97
 #: screens/ManagementJob/ManagementJobList/ManagementJobListItem.js:66
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:73
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:138
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:137
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:193
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:110
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:41
 #: screens/Organization/OrganizationDetail/OrganizationDetail.js:91
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:86
-#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:109
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:85
+#: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js:108
 #: screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js:13
-#: screens/Organization/OrganizationList/OrganizationList.js:123
-#: screens/Organization/OrganizationList/OrganizationList.js:144
+#: screens/Organization/OrganizationList/OrganizationList.js:122
+#: screens/Organization/OrganizationList/OrganizationList.js:143
 #: screens/Organization/OrganizationList/OrganizationListItem.js:44
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:69
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:86
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:68
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:85
 #: screens/Organization/OrganizationTeams/OrganizationTeamListItem.js:14
 #: screens/Organization/shared/OrganizationForm.js:56
 #: screens/Project/ProjectDetail/ProjectDetail.js:157
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:123
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:122
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:156
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:53
-#: screens/Project/ProjectList/ProjectList.js:172
-#: screens/Project/ProjectList/ProjectList.js:208
+#: screens/Project/ProjectList/ProjectList.js:171
+#: screens/Project/ProjectList/ProjectList.js:207
 #: screens/Project/ProjectList/ProjectListItem.js:174
 #: screens/Project/shared/ProjectForm.js:169
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:147
 #: screens/Team/TeamDetail/TeamDetail.js:37
-#: screens/Team/TeamList/TeamList.js:118
-#: screens/Team/TeamList/TeamList.js:143
+#: screens/Team/TeamList/TeamList.js:117
+#: screens/Team/TeamList/TeamList.js:142
 #: screens/Team/TeamList/TeamListItem.js:33
 #: screens/Team/shared/TeamForm.js:29
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:180
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyList.js:112
+#: screens/Template/Survey/SurveyListItem.js:39
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:205
+#: screens/Template/Survey/SurveyReorderModal.js:224
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:110
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:70
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:71
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:91
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:69
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:70
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:90
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:169
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:69
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:89
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:75
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:95
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:76
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:96
-#: screens/Template/shared/JobTemplateForm.js:239
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:68
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:88
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:74
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.jsx:94
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:75
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:95
+#: screens/Template/shared/JobTemplateForm.js:237
 #: screens/Template/shared/WorkflowJobTemplateForm.js:103
 #: screens/User/UserOrganizations/UserOrganizationList.js:60
 #: screens/User/UserOrganizations/UserOrganizationList.js:64
 #: screens/User/UserOrganizations/UserOrganizationListItem.js:10
-#: screens/User/UserRoles/UserRolesList.js:156
+#: screens/User/UserRoles/UserRolesList.js:155
 #: screens/User/UserRoles/UserRolesListItem.js:12
-#: screens/User/UserTeams/UserTeamList.js:181
-#: screens/User/UserTeams/UserTeamList.js:233
+#: screens/User/UserTeams/UserTeamList.js:180
+#: screens/User/UserTeams/UserTeamList.js:232
 #: screens/User/UserTeams/UserTeamListItem.js:18
 #: screens/User/UserTokenList/UserTokenListItem.js:22
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:76
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:171
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:221
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:170
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:220
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:59
 msgid "Name"
 msgstr ""
@@ -5273,7 +5314,7 @@ msgstr ""
 msgid "Never expires"
 msgstr ""
 
-#: components/JobList/JobList.js:199
+#: components/JobList/JobList.js:220
 #: components/Workflow/WorkflowNodeHelp.js:90
 msgid "New"
 msgstr ""
@@ -5292,8 +5333,8 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:254
-#: components/Schedule/ScheduleList/ScheduleList.js:171
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:266
+#: components/Schedule/ScheduleList/ScheduleList.js:170
 #: components/Schedule/ScheduleList/ScheduleListItem.js:101
 #: components/Schedule/ScheduleList/ScheduleListItem.js:105
 msgid "Next Run"
@@ -5336,7 +5377,7 @@ msgstr ""
 msgid "No items found."
 msgstr ""
 
-#: screens/Host/HostList/HostListItem.js:86
+#: screens/Host/HostList/HostListItem.js:94
 msgid "No job data available"
 msgstr ""
 
@@ -5344,10 +5385,10 @@ msgstr ""
 msgid "No result found"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:113
-#: components/Search/AdvancedSearch.js:152
-#: components/Search/AdvancedSearch.js:191
-#: components/Search/AdvancedSearch.js:319
+#: components/Search/AdvancedSearch.js:118
+#: components/Search/AdvancedSearch.js:170
+#: components/Search/LookupTypeInput.js:33
+#: components/Search/RelatedLookupTypeInput.js:26
 msgid "No results found"
 msgstr ""
 
@@ -5356,7 +5397,7 @@ msgstr ""
 msgid "No subscriptions found"
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:170
+#: screens/Template/Survey/SurveyList.js:156
 msgid "No survey questions found."
 msgstr ""
 
@@ -5371,7 +5412,7 @@ msgstr ""
 msgid "Node Alias"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:207
+#: screens/InstanceGroup/Instances/InstanceList.js:206
 #: screens/InstanceGroup/Instances/InstanceListItem.js:118
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:72
 msgid "Node Type"
@@ -5389,7 +5430,7 @@ msgstr ""
 msgid "None (Run Once)"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:142
+#: components/Schedule/shared/ScheduleForm.js:150
 msgid "None (run once)"
 msgstr ""
 
@@ -5412,15 +5453,15 @@ msgstr ""
 msgid "Not configured for inventory sync."
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:246
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:245
 msgid ""
 "Note that only hosts directly in this group can\n"
 "be disassociated. Hosts in sub-groups must be disassociated\n"
 "directly from the sub-group level that they belong."
 msgstr ""
 
-#: screens/Host/HostGroups/HostGroupsList.js:213
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:231
+#: screens/Host/HostGroups/HostGroupsList.js:212
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:230
 msgid ""
 "Note that you may still see the group in the list after\n"
 "disassociating if the host is also a member of that group’s\n"
@@ -5428,7 +5469,7 @@ msgid ""
 "with directly and indirectly."
 msgstr ""
 
-#: components/Lookup/InstanceGroupsLookup.js:91
+#: components/Lookup/InstanceGroupsLookup.js:90
 msgid "Note: The order in which these are selected sets the execution precedence. Select more than one to enable drag."
 msgstr ""
 
@@ -5459,9 +5500,9 @@ msgstr ""
 msgid "Notification Template not found."
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:189
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:133
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:187
+#: screens/ActivityStream/ActivityStream.js:188
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:132
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:186
 #: screens/NotificationTemplate/NotificationTemplates.js:13
 #: screens/NotificationTemplate/NotificationTemplates.js:20
 #: util/getRelatedResourceDeleteDetails.js:180
@@ -5476,20 +5517,20 @@ msgstr ""
 msgid "Notification color"
 msgstr ""
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:246
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:245
 msgid "Notification sent successfully"
 msgstr ""
 
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:250
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:249
 msgid "Notification timed out"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:188
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:147
+#: components/NotificationList/NotificationList.js:190
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:146
 msgid "Notification type"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:175
+#: components/NotificationList/NotificationList.js:177
 #: routeConfig.js:120
 #: screens/Inventory/Inventories.js:91
 #: screens/Inventory/InventorySource/InventorySource.js:99
@@ -5524,39 +5565,37 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:207
+#: components/AdHocCommands/AdHocDetailsStep.js:205
 #: components/HostToggle/HostToggle.js:61
 #: components/InstanceToggle/InstanceToggle.js:56
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:186
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:58
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:149
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:53
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "Off"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:206
+#: components/AdHocCommands/AdHocDetailsStep.js:204
 #: components/HostToggle/HostToggle.js:60
 #: components/InstanceToggle/InstanceToggle.js:55
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:183
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:185
 #: components/PromptDetail/PromptDetail.js:265
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:311
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:325
 #: components/Schedule/ScheduleToggle/ScheduleToggle.js:57
 #: screens/Inventory/SmartInventoryHostDetail/SmartInventoryHostDetail.js:46
 #: screens/Setting/shared/SettingDetail.js:85
 #: screens/Setting/shared/SharedFields.js:148
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/Survey/SurveyToolbar.js:52
-#: screens/Template/shared/JobTemplateForm.js:506
+#: screens/Template/shared/JobTemplateForm.js:504
 msgid "On"
 msgstr ""
 
@@ -5586,7 +5625,7 @@ msgstr ""
 msgid "Only Group By"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
 msgid "OpenStack"
 msgstr ""
 
@@ -5594,7 +5633,7 @@ msgstr ""
 msgid "Option Details"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:396
+#: screens/Template/shared/JobTemplateForm.js:394
 #: screens/Template/shared/WorkflowJobTemplateForm.js:194
 msgid ""
 "Optional labels that describe this job template,\n"
@@ -5606,20 +5645,26 @@ msgstr ""
 msgid "Optionally select the credential to use to send status updates back to the webhook service."
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:218
+#: components/NotificationList/NotificationList.js:220
 #: components/NotificationList/NotificationListItem.js:31
 #: screens/Credential/shared/TypeInputsSubForm.js:47
 #: screens/InstanceGroup/shared/ContainerGroupForm.js:64
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:64
-#: screens/Template/shared/JobTemplateForm.js:553
+#: screens/Template/shared/JobTemplateForm.js:551
 #: screens/Template/shared/WorkflowJobTemplateForm.js:218
 msgid "Options"
 msgstr ""
 
-#: components/Lookup/ApplicationLookup.js:119
-#: components/Lookup/OrganizationLookup.js:102
-#: components/Lookup/OrganizationLookup.js:108
-#: components/Lookup/OrganizationLookup.js:124
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:204
+#: screens/Template/Survey/SurveyReorderModal.js:219
+msgid "Order"
+msgstr ""
+
+#: components/Lookup/ApplicationLookup.js:118
+#: components/Lookup/OrganizationLookup.js:101
+#: components/Lookup/OrganizationLookup.js:107
+#: components/Lookup/OrganizationLookup.js:123
 #: components/PromptDetail/PromptInventorySourceDetail.js:80
 #: components/PromptDetail/PromptInventorySourceDetail.js:90
 #: components/PromptDetail/PromptJobTemplateDetail.js:110
@@ -5630,15 +5675,15 @@ msgstr ""
 #: components/TemplateList/TemplateListItem.js:264
 #: screens/Application/ApplicationDetails/ApplicationDetails.js:68
 #: screens/Application/ApplicationsList/ApplicationListItem.js:36
-#: screens/Application/ApplicationsList/ApplicationsList.js:158
+#: screens/Application/ApplicationsList/ApplicationsList.js:157
 #: screens/Credential/CredentialDetail/CredentialDetail.js:215
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:67
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:142
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:154
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:141
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:153
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:63
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:74
-#: screens/Inventory/InventoryList/InventoryList.js:177
-#: screens/Inventory/InventoryList/InventoryList.js:207
+#: screens/Inventory/InventoryList/InventoryList.js:176
+#: screens/Inventory/InventoryList/InventoryList.js:206
 #: screens/Inventory/InventoryList/InventoryListItem.js:96
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:155
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:107
@@ -5648,22 +5693,22 @@ msgstr ""
 #: screens/Project/ProjectList/ProjectListItem.js:274
 #: screens/Project/ProjectList/ProjectListItem.js:285
 #: screens/Team/TeamDetail/TeamDetail.js:40
-#: screens/Team/TeamList/TeamList.js:144
+#: screens/Team/TeamList/TeamList.js:143
 #: screens/Team/TeamList/TeamListItem.js:38
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:185
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:195
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:120
-#: screens/User/UserTeams/UserTeamList.js:182
-#: screens/User/UserTeams/UserTeamList.js:238
+#: screens/User/UserTeams/UserTeamList.js:181
+#: screens/User/UserTeams/UserTeamList.js:237
 #: screens/User/UserTeams/UserTeamListItem.js:23
 msgid "Organization"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:101
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js:100
 msgid "Organization (Name)"
 msgstr ""
 
-#: screens/Team/TeamList/TeamList.js:127
+#: screens/Team/TeamList/TeamList.js:126
 msgid "Organization Name"
 msgstr ""
 
@@ -5673,9 +5718,9 @@ msgstr ""
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:188
 #: routeConfig.js:94
-#: screens/ActivityStream/ActivityStream.js:172
-#: screens/Organization/OrganizationList/OrganizationList.js:118
-#: screens/Organization/OrganizationList/OrganizationList.js:164
+#: screens/ActivityStream/ActivityStream.js:171
+#: screens/Organization/OrganizationList/OrganizationList.js:117
+#: screens/Organization/OrganizationList/OrganizationList.js:163
 #: screens/Organization/Organizations.js:16
 #: screens/Organization/Organizations.js:26
 #: screens/User/User.js:65
@@ -5690,11 +5735,11 @@ msgstr ""
 msgid "Other prompts"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:63
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:57
 msgid "Out of compliance"
 msgstr ""
 
-#: screens/Job/Job.js:103
+#: screens/Job/Job.js:116
 #: screens/Job/Jobs.js:27
 msgid "Output"
 msgstr ""
@@ -5725,8 +5770,8 @@ msgstr ""
 msgid "PUT"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:196
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
+#: components/NotificationList/NotificationList.js:198
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:154
 msgid "Pagerduty"
 msgstr ""
 
@@ -5758,11 +5803,11 @@ msgstr ""
 msgid "Pan Up"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:259
+#: components/AdHocCommands/AdHocDetailsStep.js:257
 msgid "Pass extra command line changes. There are two ansible command line parameters:"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:415
+#: screens/Template/shared/JobTemplateForm.js:413
 msgid ""
 "Pass extra command line variables to the playbook. This is the\n"
 "-e or --extra-vars command line parameter for ansible-playbook.\n"
@@ -5799,7 +5844,7 @@ msgstr ""
 msgid "Past week"
 msgstr ""
 
-#: components/JobList/JobList.js:200
+#: components/JobList/JobList.js:221
 #: components/StatusLabel/StatusLabel.js:59
 #: components/Workflow/WorkflowNodeHelp.js:93
 msgid "Pending"
@@ -5813,12 +5858,12 @@ msgstr ""
 msgid "Pending delete"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:339
+#: components/Lookup/HostFilterLookup.js:341
 msgid "Perform a search to define a host filter"
 msgstr ""
 
 #: screens/User/UserTokenDetail/UserTokenDetail.js:71
-#: screens/User/UserTokenList/UserTokenList.js:106
+#: screens/User/UserTokenList/UserTokenList.js:105
 msgid "Personal Access Token"
 msgstr ""
 
@@ -5839,13 +5884,13 @@ msgid "Play Started"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:153
-#: screens/Job/JobDetail/JobDetail.js:226
+#: screens/Job/JobDetail/JobDetail.js:266
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:228
-#: screens/Template/shared/JobTemplateForm.js:356
+#: screens/Template/shared/JobTemplateForm.js:354
 msgid "Playbook"
 msgstr ""
 
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Check"
 msgstr ""
@@ -5856,12 +5901,12 @@ msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.js:122
 #: screens/Project/ProjectDetail/ProjectDetail.js:229
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:82
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:81
 msgid "Playbook Directory"
 msgstr ""
 
-#: components/JobList/JobList.js:185
-#: components/JobList/JobListItem.js:37
+#: components/JobList/JobList.js:206
+#: components/JobList/JobListItem.js:38
 #: components/Schedule/ScheduleList/ScheduleListItem.js:37
 #: screens/Job/JobDetail/JobDetail.js:78
 msgid "Playbook Run"
@@ -5871,10 +5916,10 @@ msgstr ""
 msgid "Playbook Started"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:208
+#: components/TemplateList/TemplateList.js:207
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:23
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:54
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:96
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js:95
 msgid "Playbook name"
 msgstr ""
 
@@ -5886,15 +5931,15 @@ msgstr ""
 msgid "Plays"
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:150
+#: components/Schedule/ScheduleList/ScheduleList.js:149
 msgid "Please add a Schedule to populate this list."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:153
+#: components/Schedule/ScheduleList/ScheduleList.js:152
 msgid "Please add a Schedule to populate this list.  Schedules can be added to a Template, Project, or Inventory Source."
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:172
+#: screens/Template/Survey/SurveyList.js:158
 msgid "Please add survey questions."
 msgstr ""
 
@@ -5918,23 +5963,23 @@ msgstr ""
 msgid "Please log in"
 msgstr ""
 
-#: components/JobList/JobList.js:162
+#: components/JobList/JobList.js:183
 msgid "Please run a job to populate this list."
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:562
+#: components/Schedule/shared/ScheduleForm.js:590
 msgid "Please select a day number between 1 and 31."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:171
+#: screens/Template/shared/JobTemplateForm.js:169
 msgid "Please select an Inventory or check the Prompt on Launch option"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:554
+#: components/Schedule/shared/ScheduleForm.js:582
 msgid "Please select an end date/time that comes after the start date/time."
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:328
+#: components/Lookup/HostFilterLookup.js:330
 msgid "Please select an organization before editing the host filter"
 msgstr ""
 
@@ -5942,7 +5987,7 @@ msgstr ""
 msgid "Pod spec override"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:208
+#: screens/InstanceGroup/Instances/InstanceList.js:207
 #: screens/InstanceGroup/Instances/InstanceListItem.js:119
 msgid "Policy Type"
 msgstr ""
@@ -5962,7 +6007,7 @@ msgstr ""
 msgid "Populate field from an external secret management system"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:318
+#: components/Lookup/HostFilterLookup.js:320
 msgid ""
 "Populate the hosts for this inventory by using a search\n"
 "filter. Example: ansible_facts.ansible_distribution:\"RedHat\".\n"
@@ -6000,8 +6045,6 @@ msgstr ""
 
 #: components/AdHocCommands/useAdHocPreviewStep.jsx:17
 #: components/LaunchPrompt/steps/usePreviewStep.js:23
-#: screens/Template/Survey/SurveyList.js:157
-#: screens/Template/Survey/SurveyList.js:159
 msgid "Preview"
 msgstr ""
 
@@ -6011,7 +6054,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:65
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:127
-#: screens/Template/shared/JobTemplateForm.js:559
+#: screens/Template/shared/JobTemplateForm.js:557
 msgid "Privilege Escalation"
 msgstr ""
 
@@ -6019,17 +6062,16 @@ msgstr ""
 msgid "Privilege escalation password"
 msgstr ""
 
-#: components/JobList/JobListItem.js:205
-#: components/Lookup/ProjectLookup.js:105
-#: components/Lookup/ProjectLookup.js:110
-#: components/Lookup/ProjectLookup.js:166
+#: components/JobList/JobListItem.js:216
+#: components/Lookup/ProjectLookup.js:104
+#: components/Lookup/ProjectLookup.js:109
+#: components/Lookup/ProjectLookup.js:165
 #: components/PromptDetail/PromptInventorySourceDetail.js:105
 #: components/PromptDetail/PromptJobTemplateDetail.js:138
 #: components/PromptDetail/PromptJobTemplateDetail.js:146
 #: components/TemplateList/TemplateListItem.js:292
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:169
-#: screens/Job/JobDetail/JobDetail.js:202
-#: screens/Job/JobDetail/JobDetail.js:216
+#: screens/Job/JobDetail/JobDetail.js:248
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:210
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:218
 msgid "Project"
@@ -6037,7 +6079,7 @@ msgstr ""
 
 #: components/PromptDetail/PromptProjectDetail.js:119
 #: screens/Project/ProjectDetail/ProjectDetail.js:226
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:60
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:59
 msgid "Project Base Path"
 msgstr ""
 
@@ -6065,10 +6107,10 @@ msgstr ""
 
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:146
 #: routeConfig.js:73
-#: screens/ActivityStream/ActivityStream.js:161
+#: screens/ActivityStream/ActivityStream.js:160
 #: screens/Dashboard/Dashboard.js:103
-#: screens/Project/ProjectList/ProjectList.js:167
-#: screens/Project/ProjectList/ProjectList.js:236
+#: screens/Project/ProjectList/ProjectList.js:166
+#: screens/Project/ProjectList/ProjectList.js:235
 #: screens/Project/Projects.js:14
 #: screens/Project/Projects.js:24
 #: util/getRelatedResourceDeleteDetails.js:59
@@ -6081,8 +6123,8 @@ msgstr ""
 msgid "Promote Child Groups and Hosts"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:612
-#: components/Schedule/shared/ScheduleForm.js:615
+#: components/Schedule/shared/ScheduleForm.js:639
+#: components/Schedule/shared/ScheduleForm.js:642
 msgid "Prompt"
 msgstr ""
 
@@ -6101,11 +6143,11 @@ msgid "Prompt | {0}"
 msgstr ""
 
 #: components/PromptDetail/PromptDetail.js:164
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:275
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:289
 msgid "Prompted Values"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:445
+#: screens/Template/shared/JobTemplateForm.js:443
 #: screens/Template/shared/WorkflowJobTemplateForm.js:155
 msgid ""
 "Provide a host pattern to further constrain\n"
@@ -6126,7 +6168,7 @@ msgstr ""
 msgid "Provide a value for this field or select the Prompt on launch option."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:263
+#: components/AdHocCommands/AdHocDetailsStep.js:261
 msgid ""
 "Provide key/value pairs using either\n"
 "YAML or JSON."
@@ -6146,18 +6188,18 @@ msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:164
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:239
-#: screens/Template/shared/JobTemplateForm.js:630
+#: screens/Template/shared/JobTemplateForm.js:628
 msgid "Provisioning Callback URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:625
+#: screens/Template/shared/JobTemplateForm.js:623
 msgid "Provisioning Callback details"
 msgstr ""
 
 #: components/PromptDetail/PromptJobTemplateDetail.js:70
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:132
-#: screens/Template/shared/JobTemplateForm.js:564
-#: screens/Template/shared/JobTemplateForm.js:567
+#: screens/Template/shared/JobTemplateForm.js:562
+#: screens/Template/shared/JobTemplateForm.js:565
 msgid "Provisioning Callbacks"
 msgstr ""
 
@@ -6174,7 +6216,7 @@ msgstr ""
 msgid "RADIUS"
 msgstr ""
 
-#: screens/Setting/SettingList.js:74
+#: screens/Setting/SettingList.js:73
 msgid "RADIUS settings"
 msgstr ""
 
@@ -6204,7 +6246,7 @@ msgstr ""
 
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js:104
 #: screens/Inventory/SmartInventoryHosts/SmartInventoryHostListItem.js:36
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:159
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:76
 msgid "Recent jobs"
 msgstr ""
@@ -6217,19 +6259,19 @@ msgstr ""
 msgid "Recipient list"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:139
+#: components/Lookup/ProjectLookup.js:138
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:92
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:161
-#: screens/Project/ProjectList/ProjectList.js:188
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:101
+#: screens/Project/ProjectList/ProjectList.js:187
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
 msgid "Red Hat Insights"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:103
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
 msgid "Red Hat Satellite 6"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:104
 msgid "Red Hat Virtualization"
 msgstr ""
 
@@ -6237,7 +6279,7 @@ msgstr ""
 msgid "Red Hat subscription manifest"
 msgstr ""
 
-#: components/About/About.js:33
+#: components/About/About.js:36
 msgid "Red Hat, Inc."
 msgstr ""
 
@@ -6261,7 +6303,7 @@ msgstr ""
 msgid "Refer to the"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:435
+#: screens/Template/shared/JobTemplateForm.js:433
 msgid ""
 "Refer to the Ansible documentation for details\n"
 "about the configuration file."
@@ -6297,28 +6339,28 @@ msgstr ""
 
 #: screens/Inventory/Inventories.js:79
 #: screens/Inventory/InventoryGroup/InventoryGroup.js:62
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:175
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:174
 msgid "Related Groups"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:142
-#: components/Search/AdvancedSearch.js:150
+#: components/Search/RelatedLookupTypeInput.js:16
+#: components/Search/RelatedLookupTypeInput.js:24
 msgid "Related search type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:145
+#: components/Search/RelatedLookupTypeInput.js:19
 msgid "Related search type typeahead"
 msgstr ""
 
-#: components/JobList/JobListItem.js:138
+#: components/JobList/JobListItem.js:139
 #: components/LaunchButton/ReLaunchDropDown.js:81
-#: screens/Job/JobDetail/JobDetail.js:383
-#: screens/Job/JobDetail/JobDetail.js:391
+#: screens/Job/JobDetail/JobDetail.js:459
+#: screens/Job/JobDetail/JobDetail.js:467
 #: screens/Job/JobOutput/shared/OutputToolbar.js:165
 msgid "Relaunch"
 msgstr ""
 
-#: components/JobList/JobListItem.js:118
+#: components/JobList/JobListItem.js:119
 #: screens/Job/JobOutput/shared/OutputToolbar.js:145
 msgid "Relaunch Job"
 msgstr ""
@@ -6336,16 +6378,16 @@ msgstr ""
 msgid "Relaunch on"
 msgstr ""
 
-#: components/JobList/JobListItem.js:117
+#: components/JobList/JobListItem.js:118
 #: screens/Job/JobOutput/shared/OutputToolbar.js:144
 msgid "Relaunch using host parameters"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:138
+#: components/Lookup/ProjectLookup.js:137
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:91
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:160
-#: screens/Project/ProjectList/ProjectList.js:187
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:100
+#: screens/Project/ProjectList/ProjectList.js:186
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
 msgid "Remote Archive"
 msgstr ""
 
@@ -6372,7 +6414,7 @@ msgstr ""
 msgid "Remove any local modifications prior to performing an update."
 msgstr ""
 
-#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:14
+#: components/ResourceAccessList/DeleteRoleConfirmationModal.js:13
 msgid "Remove {0} Access"
 msgstr ""
 
@@ -6388,7 +6430,7 @@ msgstr ""
 msgid "Reorder"
 msgstr ""
 
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:257
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:271
 msgid "Repeat Frequency"
 msgstr ""
 
@@ -6405,7 +6447,7 @@ msgstr ""
 msgid "Request subscription"
 msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:119
+#: screens/Template/Survey/SurveyListItem.js:51
 #: screens/Template/Survey/SurveyQuestionForm.js:182
 msgid "Required"
 msgstr ""
@@ -6413,7 +6455,7 @@ msgstr ""
 #: components/Workflow/WorkflowNodeHelp.js:156
 #: components/Workflow/WorkflowNodeHelp.js:190
 #: screens/Team/TeamRoles/TeamRoleListItem.js:12
-#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Team/TeamRoles/TeamRolesList.js:180
 msgid "Resource Name"
 msgstr ""
 
@@ -6422,7 +6464,7 @@ msgid "Resource deleted"
 msgstr ""
 
 #: routeConfig.js:59
-#: screens/ActivityStream/ActivityStream.js:150
+#: screens/ActivityStream/ActivityStream.js:149
 msgid "Resources"
 msgstr ""
 
@@ -6454,15 +6496,15 @@ msgstr ""
 msgid "Return to subscription management."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:133
+#: components/Search/AdvancedSearch.js:138
 msgid "Returns results that have values other than this one as well as other filters."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:120
+#: components/Search/AdvancedSearch.js:125
 msgid "Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:126
+#: components/Search/AdvancedSearch.js:131
 msgid "Returns results that satisfy this one or any other filters."
 msgstr ""
 
@@ -6493,8 +6535,8 @@ msgstr ""
 msgid "Revert to factory default."
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:225
-#: screens/Project/ProjectList/ProjectList.js:211
+#: screens/Job/JobDetail/JobDetail.js:261
+#: screens/Project/ProjectList/ProjectList.js:210
 #: screens/Project/ProjectList/ProjectListItem.js:208
 msgid "Revision"
 msgstr ""
@@ -6503,25 +6545,25 @@ msgstr ""
 msgid "Revision #"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:197
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
+#: components/NotificationList/NotificationList.js:199
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:155
 msgid "Rocket.Chat"
 msgstr ""
 
 #: screens/Team/TeamRoles/TeamRoleListItem.js:20
-#: screens/Team/TeamRoles/TeamRolesList.js:149
-#: screens/Team/TeamRoles/TeamRolesList.js:183
-#: screens/User/UserList/UserList.js:160
+#: screens/Team/TeamRoles/TeamRolesList.js:148
+#: screens/Team/TeamRoles/TeamRolesList.js:182
+#: screens/User/UserList/UserList.js:159
 #: screens/User/UserList/UserListItem.js:59
-#: screens/User/UserRoles/UserRolesList.js:147
-#: screens/User/UserRoles/UserRolesList.js:158
+#: screens/User/UserRoles/UserRolesList.js:146
+#: screens/User/UserRoles/UserRolesList.js:157
 #: screens/User/UserRoles/UserRolesListItem.js:26
 msgid "Role"
 msgstr ""
 
-#: components/ResourceAccessList/ResourceAccessList.js:146
-#: components/ResourceAccessList/ResourceAccessList.js:159
-#: components/ResourceAccessList/ResourceAccessList.js:186
+#: components/ResourceAccessList/ResourceAccessList.js:145
+#: components/ResourceAccessList/ResourceAccessList.js:158
+#: components/ResourceAccessList/ResourceAccessList.js:185
 #: components/ResourceAccessList/ResourceAccessListItem.js:66
 #: screens/Team/Team.js:57
 #: screens/Team/Teams.js:31
@@ -6535,7 +6577,7 @@ msgstr ""
 #: screens/Credential/shared/ExternalTestModal.js:89
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:49
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/RunStep.js:24
-#: screens/Template/shared/JobTemplateForm.js:203
+#: screens/Template/shared/JobTemplateForm.js:201
 msgid "Run"
 msgstr ""
 
@@ -6559,7 +6601,7 @@ msgstr ""
 msgid "Run every"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:137
+#: components/Schedule/shared/ScheduleForm.js:145
 msgid "Run frequency"
 msgstr ""
 
@@ -6571,7 +6613,7 @@ msgstr ""
 msgid "Run type"
 msgstr ""
 
-#: components/JobList/JobList.js:202
+#: components/JobList/JobList.js:223
 #: components/StatusLabel/StatusLabel.js:58
 #: components/TemplateList/TemplateListItem.js:113
 #: components/Workflow/WorkflowNodeHelp.js:99
@@ -6582,8 +6624,8 @@ msgstr ""
 msgid "Running Handlers"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
-#: screens/InstanceGroup/Instances/InstanceList.js:209
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/Instances/InstanceList.js:208
 #: screens/InstanceGroup/Instances/InstanceListItem.js:122
 msgid "Running Jobs"
 msgstr ""
@@ -6596,7 +6638,7 @@ msgstr ""
 msgid "SAML"
 msgstr ""
 
-#: screens/Setting/SettingList.js:78
+#: screens/Setting/SettingList.js:77
 msgid "SAML settings"
 msgstr ""
 
@@ -6639,18 +6681,19 @@ msgid "Saturday"
 msgstr ""
 
 #: components/AddRole/AddResourceRole.js:266
-#: components/AssociateModal/AssociateModal.js:105
-#: components/AssociateModal/AssociateModal.js:111
+#: components/AssociateModal/AssociateModal.js:104
+#: components/AssociateModal/AssociateModal.js:110
 #: components/FormActionGroup/FormActionGroup.js:13
 #: components/FormActionGroup/FormActionGroup.js:19
-#: components/Schedule/shared/ScheduleForm.js:598
-#: components/Schedule/shared/ScheduleForm.js:604
+#: components/Schedule/shared/ScheduleForm.js:625
+#: components/Schedule/shared/ScheduleForm.js:631
 #: components/Schedule/shared/useSchedulePromptSteps.js:45
 #: components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js:113
 #: screens/Credential/shared/CredentialForm.js:317
 #: screens/Credential/shared/CredentialForm.js:322
 #: screens/Setting/shared/RevertFormActionGroup.js:12
 #: screens/Setting/shared/RevertFormActionGroup.js:18
+#: screens/Template/Survey/SurveyReorderModal.js:192
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/LinkModals/LinkModal.js:35
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js:124
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js:158
@@ -6688,7 +6731,7 @@ msgstr ""
 msgid "Schedule is inactive"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:522
+#: components/Schedule/shared/ScheduleForm.js:534
 msgid "Schedule is missing rrule"
 msgstr ""
 
@@ -6696,10 +6739,10 @@ msgstr ""
 msgid "Schedule not found."
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:164
-#: components/Schedule/ScheduleList/ScheduleList.js:229
+#: components/Schedule/ScheduleList/ScheduleList.js:163
+#: components/Schedule/ScheduleList/ScheduleList.js:228
 #: routeConfig.js:42
-#: screens/ActivityStream/ActivityStream.js:144
+#: screens/ActivityStream/ActivityStream.js:143
 #: screens/Inventory/Inventories.js:87
 #: screens/Inventory/InventorySource/InventorySource.js:88
 #: screens/ManagementJob/ManagementJob.js:107
@@ -6713,11 +6756,11 @@ msgstr ""
 msgid "Schedules"
 msgstr ""
 
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:137
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:136
 #: screens/Application/ApplicationTokens/ApplicationTokenListItem.js:31
 #: screens/User/UserTokenDetail/UserTokenDetail.js:47
-#: screens/User/UserTokenList/UserTokenList.js:139
-#: screens/User/UserTokenList/UserTokenList.js:185
+#: screens/User/UserTokenList/UserTokenList.js:138
+#: screens/User/UserTokenList/UserTokenList.js:184
 #: screens/User/UserTokenList/UserTokenListItem.js:29
 #: screens/User/shared/UserTokenForm.js:69
 msgid "Scope"
@@ -6739,8 +6782,8 @@ msgstr ""
 msgid "Scroll previous"
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:261
-#: components/Lookup/Lookup.js:130
+#: components/Lookup/HostFilterLookup.js:263
+#: components/Lookup/Lookup.js:135
 msgid "Search"
 msgstr ""
 
@@ -6748,7 +6791,7 @@ msgstr ""
 msgid "Search is disabled while the job is running"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:349
+#: components/Search/AdvancedSearch.js:212
 #: components/Search/Search.js:235
 msgid "Search submit button"
 msgstr ""
@@ -6772,9 +6815,9 @@ msgstr ""
 msgid "See errors on the left"
 msgstr ""
 
-#: components/JobList/JobListItem.js:76
-#: components/Lookup/HostFilterLookup.js:349
-#: components/Lookup/Lookup.js:180
+#: components/JobList/JobListItem.js:77
+#: components/Lookup/HostFilterLookup.js:351
+#: components/Lookup/Lookup.js:185
 #: components/Pagination/Pagination.js:33
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:97
 msgid "Select"
@@ -6784,13 +6827,13 @@ msgstr ""
 msgid "Select Credential Type"
 msgstr ""
 
-#: screens/Host/HostGroups/HostGroupsList.js:238
-#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:255
-#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:257
+#: screens/Host/HostGroups/HostGroupsList.js:237
+#: screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js:254
+#: screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js:256
 msgid "Select Groups"
 msgstr ""
 
-#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:276
+#: screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js:275
 msgid "Select Hosts"
 msgstr ""
 
@@ -6798,11 +6841,11 @@ msgstr ""
 msgid "Select Input"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:235
+#: screens/InstanceGroup/Instances/InstanceList.js:234
 msgid "Select Instances"
 msgstr ""
 
-#: components/AssociateModal/AssociateModal.js:20
+#: components/AssociateModal/AssociateModal.js:21
 msgid "Select Items"
 msgstr ""
 
@@ -6818,7 +6861,7 @@ msgstr ""
 msgid "Select Roles to Apply"
 msgstr ""
 
-#: screens/User/UserTeams/UserTeamList.js:252
+#: screens/User/UserTeams/UserTeamList.js:251
 msgid "Select Teams"
 msgstr ""
 
@@ -6834,7 +6877,7 @@ msgstr ""
 msgid "Select a Resource Type"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:336
+#: screens/Template/shared/JobTemplateForm.js:334
 msgid ""
 "Select a branch for the job template. This branch is applied to\n"
 "all job template nodes that prompt for a branch."
@@ -6864,7 +6907,7 @@ msgstr ""
 msgid "Select a metric"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:76
+#: components/AdHocCommands/AdHocDetailsStep.js:74
 msgid "Select a module"
 msgstr ""
 
@@ -6873,8 +6916,12 @@ msgstr ""
 msgid "Select a playbook"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:324
+#: screens/Template/shared/JobTemplateForm.js:322
 msgid "Select a project before editing the execution environment."
+msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:80
+msgid "Select a question to delete"
 msgstr ""
 
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js:18
@@ -6882,7 +6929,7 @@ msgid "Select a row to approve"
 msgstr ""
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:160
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:104
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:103
 msgid "Select a row to delete"
 msgstr ""
 
@@ -6903,8 +6950,8 @@ msgstr ""
 #: components/Schedule/shared/FrequencyDetailSubform.js:82
 #: components/Schedule/shared/FrequencyDetailSubform.js:86
 #: components/Schedule/shared/FrequencyDetailSubform.js:94
-#: components/Schedule/shared/ScheduleForm.js:85
-#: components/Schedule/shared/ScheduleForm.js:89
+#: components/Schedule/shared/ScheduleForm.js:93
+#: components/Schedule/shared/ScheduleForm.js:97
 #: screens/Credential/shared/CredentialForm.js:44
 #: screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js:77
 #: screens/Inventory/shared/InventoryForm.js:54
@@ -6924,7 +6971,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:431
 #: screens/Project/shared/ProjectForm.js:189
 #: screens/Project/shared/ProjectSubForms/InsightsSubForm.js:39
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:37
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:36
 #: screens/Team/shared/TeamForm.js:49
 #: screens/Template/Survey/SurveyQuestionForm.js:30
 #: screens/Template/shared/WorkflowJobTemplateForm.js:124
@@ -6937,11 +6984,11 @@ msgid "Select a webhook service."
 msgstr ""
 
 #: components/DataListToolbar/DataListToolbar.js:113
-#: screens/Template/Survey/SurveyToolbar.js:44
+#: screens/Template/Survey/SurveyToolbar.js:48
 msgid "Select all"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:122
+#: screens/ActivityStream/ActivityStream.js:121
 msgid "Select an activity type"
 msgstr ""
 
@@ -6961,7 +7008,7 @@ msgstr ""
 msgid "Select an organization before editing the default execution environment."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:378
+#: screens/Template/shared/JobTemplateForm.js:376
 msgid ""
 "Select credentials for accessing the nodes this job will be ran\n"
 "against. You can only select one credential of each type. For machine credentials (SSH),\n"
@@ -6970,7 +7017,7 @@ msgid ""
 "credential(s) become the defaults that can be updated at run time."
 msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:85
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:84
 msgid ""
 "Select from the list of directories found in\n"
 "the Project Base Path. Together the base path and the playbook\n"
@@ -7015,7 +7062,7 @@ msgstr ""
 msgid "Select tags"
 msgstr ""
 
-#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:95
+#: components/AdHocCommands/AdHocExecutionEnvironmentStep.js:94
 msgid "Select the Execution Environment you want this command to run inside."
 msgstr ""
 
@@ -7023,7 +7070,7 @@ msgstr ""
 msgid "Select the Instance Groups for this Inventory to run on."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:515
+#: screens/Template/shared/JobTemplateForm.js:513
 msgid ""
 "Select the Instance Groups for this Organization\n"
 "to run on."
@@ -7041,16 +7088,16 @@ msgstr ""
 #~ msgid "Select the application that this token will belong to."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocCredentialStep.js:105
+#: components/AdHocCommands/AdHocCredentialStep.js:104
 msgid "Select the credential you want to use when accessing the remote hosts to run the command. Choose the credential containing the username and SSH key or password that Ansible will need to log into the remote hosts."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:323
+#: screens/Template/shared/JobTemplateForm.js:321
 msgid "Select the execution environment for this job template."
 msgstr ""
 
-#: components/Lookup/InventoryLookup.js:131
-#: screens/Template/shared/JobTemplateForm.js:287
+#: components/Lookup/InventoryLookup.js:134
+#: screens/Template/shared/JobTemplateForm.js:285
 msgid ""
 "Select the inventory containing the hosts\n"
 "you want this job to manage."
@@ -7068,11 +7115,11 @@ msgstr ""
 msgid "Select the inventory that this host will belong to."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:359
+#: screens/Template/shared/JobTemplateForm.js:357
 msgid "Select the playbook to be executed by this job."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:302
+#: screens/Template/shared/JobTemplateForm.js:300
 msgid ""
 "Select the project containing the playbook\n"
 "you want this job to execute."
@@ -7082,7 +7129,7 @@ msgstr ""
 msgid "Select your Ansible Automation Platform subscription to use."
 msgstr ""
 
-#: components/Lookup/Lookup.js:167
+#: components/Lookup/Lookup.js:172
 msgid "Select {0}"
 msgstr ""
 
@@ -7091,7 +7138,7 @@ msgstr ""
 #: components/AddRole/AddResourceRole.js:261
 #: components/AddRole/SelectRoleStep.js:27
 #: components/CheckboxListItem/CheckboxListItem.js:42
-#: components/Lookup/InstanceGroupsLookup.js:88
+#: components/Lookup/InstanceGroupsLookup.js:87
 #: components/OptionsList/OptionsList.js:60
 #: components/Schedule/ScheduleList/ScheduleListItem.js:75
 #: components/TemplateList/TemplateListItem.js:132
@@ -7103,7 +7150,7 @@ msgstr ""
 #: screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js:29
 #: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js:55
 #: screens/Host/HostGroups/HostGroupItem.js:26
-#: screens/Host/HostList/HostListItem.js:41
+#: screens/Host/HostList/HostListItem.js:48
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:59
 #: screens/InstanceGroup/Instances/InstanceListItem.js:113
 #: screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js:38
@@ -7115,16 +7162,22 @@ msgstr ""
 #: screens/Project/ProjectList/ProjectListItem.js:172
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:244
 #: screens/Team/TeamList/TeamListItem.js:31
+#: screens/Template/Survey/SurveyListItem.js:34
 #: screens/User/UserTokenList/UserTokenListItem.js:19
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:57
 msgid "Selected"
 msgstr ""
 
-#: components/LaunchPrompt/steps/CredentialsStep.js:142
-#: components/LaunchPrompt/steps/CredentialsStep.js:147
-#: components/Lookup/MultiCredentialsLookup.js:161
-#: components/Lookup/MultiCredentialsLookup.js:166
+#: components/LaunchPrompt/steps/CredentialsStep.js:141
+#: components/LaunchPrompt/steps/CredentialsStep.js:146
+#: components/Lookup/MultiCredentialsLookup.js:160
+#: components/Lookup/MultiCredentialsLookup.js:165
 msgid "Selected Category"
+msgstr ""
+
+#: components/Schedule/shared/ScheduleForm.js:573
+#: components/Schedule/shared/ScheduleForm.js:574
+msgid "Selected date range must have at least 1 schedule occurrence."
 msgstr ""
 
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:119
@@ -7152,7 +7205,7 @@ msgstr ""
 msgid "Set how many days of data should be retained."
 msgstr ""
 
-#: screens/Setting/SettingList.js:119
+#: screens/Setting/SettingList.js:118
 msgid "Set preferences for data collection, logos, and logins"
 msgstr ""
 
@@ -7168,19 +7221,19 @@ msgstr ""
 msgid "Set to Public or Confidential depending on how secure the client device is."
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:111
+#: components/Search/AdvancedSearch.js:116
 msgid "Set type"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:297
+#: components/Search/AdvancedSearch.js:148
 msgid "Set type disabled for related search field fuzzy searches"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:102
+#: components/Search/AdvancedSearch.js:107
 msgid "Set type select"
 msgstr ""
 
-#: components/Search/AdvancedSearch.js:105
+#: components/Search/AdvancedSearch.js:110
 msgid "Set type typeahead"
 msgstr ""
 
@@ -7202,8 +7255,8 @@ msgstr ""
 
 #: routeConfig.js:147
 #: routeConfig.js:151
-#: screens/ActivityStream/ActivityStream.js:207
-#: screens/ActivityStream/ActivityStream.js:209
+#: screens/ActivityStream/ActivityStream.js:206
+#: screens/ActivityStream/ActivityStream.js:208
 #: screens/Setting/Settings.js:42
 msgid "Settings"
 msgstr ""
@@ -7215,9 +7268,9 @@ msgstr ""
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:173
 #: components/PromptDetail/PromptDetail.js:264
 #: components/PromptDetail/PromptJobTemplateDetail.js:158
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:310
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:324
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:233
-#: screens/Template/shared/JobTemplateForm.js:497
+#: screens/Template/shared/JobTemplateForm.js:495
 msgid "Show Changes"
 msgstr ""
 
@@ -7225,8 +7278,8 @@ msgstr ""
 #~ msgid "Show all groups"
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:195
-#: components/AdHocCommands/AdHocDetailsStep.js:196
+#: components/AdHocCommands/AdHocDetailsStep.js:193
+#: components/AdHocCommands/AdHocDetailsStep.js:194
 msgid "Show changes"
 msgstr ""
 
@@ -7239,7 +7292,7 @@ msgstr ""
 msgid "Show less"
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:128
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:127
 msgid "Show only root groups"
 msgstr ""
 
@@ -7292,14 +7345,14 @@ msgstr ""
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:69
 #: components/PromptDetail/PromptDetail.js:242
 #: components/PromptDetail/PromptJobTemplateDetail.js:257
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:348
-#: screens/Job/JobDetail/JobDetail.js:322
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:362
+#: screens/Job/JobDetail/JobDetail.js:385
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:351
-#: screens/Template/shared/JobTemplateForm.js:537
+#: screens/Template/shared/JobTemplateForm.js:535
 msgid "Skip Tags"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:540
+#: screens/Template/shared/JobTemplateForm.js:538
 msgid ""
 "Skip tags are useful when you have a\n"
 "large playbook, and you want to skip specific parts of a\n"
@@ -7320,15 +7373,15 @@ msgstr ""
 msgid "Skipped"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:198
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
+#: components/NotificationList/NotificationList.js:200
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:156
 msgid "Slack"
 msgstr ""
 
 #: screens/Host/HostList/SmartInventoryButton.js:30
 #: screens/Host/HostList/SmartInventoryButton.js:39
 #: screens/Host/HostList/SmartInventoryButton.js:43
-#: screens/Inventory/InventoryList/InventoryList.js:173
+#: screens/Inventory/InventoryList/InventoryList.js:172
 #: screens/Inventory/InventoryList/InventoryListItem.js:94
 msgid "Smart Inventory"
 msgstr ""
@@ -7337,7 +7390,7 @@ msgstr ""
 msgid "Smart Inventory not found."
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:314
+#: components/Lookup/HostFilterLookup.js:316
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:116
 msgid "Smart host filter"
 msgstr ""
@@ -7369,13 +7422,15 @@ msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:72
 #: screens/Template/Survey/SurveyListItem.js:73
-msgid "Sort question order"
-msgstr ""
+#~ msgid "Sort question order"
+#~ msgstr ""
 
+#: components/JobList/JobListItem.js:159
 #: components/PromptDetail/PromptInventorySourceDetail.js:102
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:152
 #: screens/Inventory/shared/InventorySourceForm.js:131
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:94
+#: screens/Job/JobDetail/JobDetail.js:221
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:93
 msgid "Source"
 msgstr ""
 
@@ -7384,12 +7439,12 @@ msgstr ""
 #: components/PromptDetail/PromptJobTemplateDetail.js:152
 #: components/PromptDetail/PromptProjectDetail.js:98
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:87
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:305
-#: screens/Job/JobDetail/JobDetail.js:221
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:319
+#: screens/Job/JobDetail/JobDetail.js:255
 #: screens/Project/ProjectDetail/ProjectDetail.js:201
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:227
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:133
-#: screens/Template/shared/JobTemplateForm.js:333
+#: screens/Template/shared/JobTemplateForm.js:331
 msgid "Source Control Branch"
 msgstr ""
 
@@ -7422,19 +7477,19 @@ msgstr ""
 msgid "Source Control Type"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:143
+#: components/Lookup/ProjectLookup.js:142
 #: components/PromptDetail/PromptProjectDetail.js:97
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:96
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:165
 #: screens/Project/ProjectDetail/ProjectDetail.js:200
-#: screens/Project/ProjectList/ProjectList.js:192
+#: screens/Project/ProjectList/ProjectList.js:191
 #: screens/Project/shared/ProjectSubForms/SharedFields.js:15
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:105
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:104
 msgid "Source Control URL"
 msgstr ""
 
-#: components/JobList/JobList.js:183
-#: components/JobList/JobListItem.js:35
+#: components/JobList/JobList.js:204
+#: components/JobList/JobListItem.js:36
 #: components/Schedule/ScheduleList/ScheduleListItem.js:38
 #: screens/Job/JobDetail/JobDetail.js:76
 msgid "Source Control Update"
@@ -7448,8 +7503,8 @@ msgstr ""
 msgid "Source Variables"
 msgstr ""
 
-#: components/JobList/JobListItem.js:179
-#: screens/Job/JobDetail/JobDetail.js:162
+#: components/JobList/JobListItem.js:190
+#: screens/Job/JobDetail/JobDetail.js:174
 msgid "Source Workflow Job"
 msgstr ""
 
@@ -7470,7 +7525,7 @@ msgstr ""
 msgid "Source variables"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:98
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:97
 msgid "Sourced from a project"
 msgstr ""
 
@@ -7517,14 +7572,14 @@ msgstr ""
 
 #: components/NotificationList/NotificationListItem.js:52
 #: components/NotificationList/NotificationListItem.js:53
-#: components/Schedule/shared/ScheduleForm.js:111
+#: components/Schedule/shared/ScheduleForm.js:119
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:47
 #: screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js:53
 msgid "Start"
 msgstr ""
 
-#: components/JobList/JobList.js:219
-#: components/JobList/JobListItem.js:91
+#: components/JobList/JobList.js:240
+#: components/JobList/JobListItem.js:92
 msgid "Start Time"
 msgstr ""
 
@@ -7546,27 +7601,27 @@ msgstr ""
 msgid "Start sync source"
 msgstr ""
 
-#: screens/Job/JobDetail/JobDetail.js:136
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
+#: screens/Job/JobDetail/JobDetail.js:139
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:222
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:76
 msgid "Started"
 msgstr ""
 
-#: components/JobList/JobList.js:196
 #: components/JobList/JobList.js:217
-#: components/JobList/JobListItem.js:87
-#: screens/Inventory/InventoryList/InventoryList.js:205
+#: components/JobList/JobList.js:238
+#: components/JobList/JobListItem.js:88
+#: screens/Inventory/InventoryList/InventoryList.js:204
 #: screens/Inventory/InventoryList/InventoryListItem.js:88
 #: screens/Inventory/InventorySources/InventorySourceList.js:196
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:78
-#: screens/Job/JobDetail/JobDetail.js:126
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
+#: screens/Job/JobDetail/JobDetail.js:127
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:194
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:115
-#: screens/Project/ProjectList/ProjectList.js:209
+#: screens/Project/ProjectList/ProjectList.js:208
 #: screens/Project/ProjectList/ProjectListItem.js:192
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:51
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:45
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:98
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:224
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:223
 #: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js:79
 msgid "Status"
 msgstr ""
@@ -7591,14 +7646,14 @@ msgid ""
 "flag to git submodule update."
 msgstr ""
 
-#: screens/Setting/SettingList.js:129
+#: screens/Setting/SettingList.js:128
 #: screens/Setting/Settings.js:108
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:74
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js:195
 msgid "Subscription"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:36
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:32
 msgid "Subscription Details"
 msgstr ""
 
@@ -7614,11 +7669,11 @@ msgstr ""
 msgid "Subscription selection modal"
 msgstr ""
 
-#: screens/Setting/SettingList.js:134
+#: screens/Setting/SettingList.js:133
 msgid "Subscription settings"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:75
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:69
 msgid "Subscription type"
 msgstr ""
 
@@ -7626,11 +7681,11 @@ msgstr ""
 msgid "Subscriptions table"
 msgstr ""
 
-#: components/Lookup/ProjectLookup.js:137
+#: components/Lookup/ProjectLookup.js:136
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:90
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:159
-#: screens/Project/ProjectList/ProjectList.js:186
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:99
+#: screens/Project/ProjectList/ProjectList.js:185
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:98
 msgid "Subversion"
 msgstr ""
 
@@ -7650,7 +7705,7 @@ msgstr ""
 msgid "Success message body"
 msgstr ""
 
-#: components/JobList/JobList.js:203
+#: components/JobList/JobList.js:224
 #: components/StatusLabel/StatusLabel.js:55
 #: components/Workflow/WorkflowNodeHelp.js:102
 #: screens/Dashboard/shared/ChartTooltip.js:59
@@ -7682,25 +7737,37 @@ msgstr ""
 msgid "Survey"
 msgstr ""
 
-#: screens/Template/Survey/SurveyList.js:132
-msgid "Survey List"
+#: screens/Template/Survey/SurveyToolbar.js:102
+msgid "Survey Disabled"
 msgstr ""
+
+#: screens/Template/Survey/SurveyToolbar.js:101
+msgid "Survey Enabled"
+msgstr ""
+
+#: screens/Template/Survey/SurveyList.js:132
+#~ msgid "Survey List"
+#~ msgstr ""
 
 #: screens/Template/Survey/SurveyPreviewModal.js:31
-msgid "Survey Preview"
+#~ msgid "Survey Preview"
+#~ msgstr ""
+
+#: screens/Template/Survey/SurveyReorderModal.js:178
+msgid "Survey Question Order"
 msgstr ""
 
-#: screens/Template/Survey/SurveyToolbar.js:50
+#: screens/Template/Survey/SurveyToolbar.js:99
 msgid "Survey Toggle"
 msgstr ""
 
-#: screens/Template/Survey/SurveyPreviewModal.js:32
+#: screens/Template/Survey/SurveyReorderModal.js:179
 msgid "Survey preview modal"
 msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:66
-msgid "Survey questions"
-msgstr ""
+#~ msgid "Survey questions"
+#~ msgstr ""
 
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:111
 #: screens/Inventory/shared/InventorySourceSyncButton.js:41
@@ -7738,15 +7805,15 @@ msgstr ""
 msgid "Syncing"
 msgstr ""
 
-#: screens/Setting/SettingList.js:99
+#: screens/Setting/SettingList.js:98
 #: screens/User/UserRoles/UserRolesListItem.js:18
 msgid "System"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:129
+#: screens/Team/TeamRoles/TeamRolesList.js:128
 #: screens/User/UserDetail/UserDetail.js:47
 #: screens/User/UserList/UserListItem.js:19
-#: screens/User/UserRoles/UserRolesList.js:128
+#: screens/User/UserRoles/UserRolesList.js:127
 #: screens/User/shared/UserForm.js:41
 msgid "System Administrator"
 msgstr ""
@@ -7761,8 +7828,8 @@ msgstr ""
 msgid "System Warning"
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:132
-#: screens/User/UserRoles/UserRolesList.js:131
+#: screens/Team/TeamRoles/TeamRolesList.js:131
+#: screens/User/UserRoles/UserRolesList.js:130
 msgid "System administrators have unrestricted access to all resources."
 msgstr ""
 
@@ -7770,7 +7837,7 @@ msgstr ""
 msgid "TACACS+"
 msgstr ""
 
-#: screens/Setting/SettingList.js:82
+#: screens/Setting/SettingList.js:81
 msgid "TACACS+ settings"
 msgstr ""
 
@@ -7779,7 +7846,7 @@ msgstr ""
 msgid "Tabs"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:524
+#: screens/Template/shared/JobTemplateForm.js:522
 msgid ""
 "Tags are useful when you have a large\n"
 "playbook, and you want to run a specific part of a\n"
@@ -7834,7 +7901,7 @@ msgid "Team"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:80
-#: screens/Team/TeamRoles/TeamRolesList.js:145
+#: screens/Team/TeamRoles/TeamRolesList.js:144
 msgid "Team Roles"
 msgstr ""
 
@@ -7845,19 +7912,19 @@ msgstr ""
 #: components/AddRole/AddResourceRole.js:207
 #: components/AddRole/AddResourceRole.js:208
 #: routeConfig.js:104
-#: screens/ActivityStream/ActivityStream.js:178
+#: screens/ActivityStream/ActivityStream.js:177
 #: screens/Organization/Organization.js:124
-#: screens/Organization/OrganizationList/OrganizationList.js:146
+#: screens/Organization/OrganizationList/OrganizationList.js:145
 #: screens/Organization/OrganizationList/OrganizationListItem.js:65
-#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:65
+#: screens/Organization/OrganizationTeams/OrganizationTeamList.js:64
 #: screens/Organization/Organizations.js:32
-#: screens/Team/TeamList/TeamList.js:113
-#: screens/Team/TeamList/TeamList.js:167
+#: screens/Team/TeamList/TeamList.js:112
+#: screens/Team/TeamList/TeamList.js:166
 #: screens/Team/Teams.js:14
 #: screens/Team/Teams.js:24
 #: screens/User/User.js:69
-#: screens/User/UserTeams/UserTeamList.js:176
-#: screens/User/UserTeams/UserTeamList.js:247
+#: screens/User/UserTeams/UserTeamList.js:175
+#: screens/User/UserTeams/UserTeamList.js:246
 #: screens/User/Users.js:32
 #: util/getRelatedResourceDeleteDetails.js:173
 msgid "Teams"
@@ -7868,12 +7935,12 @@ msgstr ""
 msgid "Template not found."
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:186
-#: components/TemplateList/TemplateList.js:244
+#: components/TemplateList/TemplateList.js:185
+#: components/TemplateList/TemplateList.js:243
 #: routeConfig.js:63
-#: screens/ActivityStream/ActivityStream.js:155
+#: screens/ActivityStream/ActivityStream.js:154
 #: screens/ExecutionEnvironment/ExecutionEnvironment.js:69
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:85
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:84
 #: screens/Template/Templates.js:16
 #: util/getRelatedResourceDeleteDetails.js:217
 #: util/getRelatedResourceDeleteDetails.js:274
@@ -7902,12 +7969,12 @@ msgstr ""
 msgid "Test passed"
 msgstr ""
 
-#: screens/Template/Survey/SurveyPreviewModal.js:52
 #: screens/Template/Survey/SurveyQuestionForm.js:80
+#: screens/Template/Survey/SurveyReorderModal.js:168
 msgid "Text"
 msgstr ""
 
-#: screens/Template/Survey/SurveyPreviewModal.js:66
+#: screens/Template/Survey/SurveyReorderModal.js:125
 msgid "Text Area"
 msgstr ""
 
@@ -7942,7 +8009,7 @@ msgid ""
 "from 1 to 120 seconds."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:491
+#: screens/Template/shared/JobTemplateForm.js:489
 msgid ""
 "The amount of time (in seconds) to run\n"
 "before the job is canceled. Defaults to 0 for no job\n"
@@ -7989,7 +8056,7 @@ msgid ""
 "documentation for more details."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:429
+#: screens/Template/shared/JobTemplateForm.js:427
 msgid ""
 "The number of parallel or simultaneous\n"
 "processes to use while executing the playbook. An empty value,\n"
@@ -7998,16 +8065,16 @@ msgid ""
 "with a change to"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:182
+#: components/AdHocCommands/AdHocDetailsStep.js:180
 msgid "The number of parallel or simultaneous processes to use while executing the playbook. Inputting no value will use the default value from the ansible configuration file.  You can find more information"
 msgstr ""
 
 #: components/ContentError/ContentError.js:40
-#: screens/Job/Job.js:123
+#: screens/Job/Job.js:136
 msgid "The page you requested could not be found."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:162
+#: components/AdHocCommands/AdHocDetailsStep.js:160
 msgid "The pattern used to target hosts in the inventory. Leaving the field blank, all, and * will all target all hosts in the inventory. You can find more information about Ansible's host patterns"
 msgstr ""
 
@@ -8046,7 +8113,7 @@ msgstr ""
 #~ "source control using the Source Control Type option above."
 #~ msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:49
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:48
 msgid ""
 "There are no available playbook directories in {project_base_dir}.\n"
 "Either that directory is empty, or all of the contents are already\n"
@@ -8080,19 +8147,19 @@ msgstr ""
 #~ msgid "These are the modules that {0} supports running commands against."
 #~ msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:70
+#: components/AdHocCommands/AdHocDetailsStep.js:68
 msgid "These are the modules that {brandName} supports running commands against."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:140
+#: components/AdHocCommands/AdHocDetailsStep.js:138
 msgid "These are the verbosity levels for standard out of the command run that are supported."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:123
+#: components/AdHocCommands/AdHocDetailsStep.js:121
 msgid "These arguments are used with the specified module."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:112
+#: components/AdHocCommands/AdHocDetailsStep.js:110
 msgid "These arguments are used with the specified module. You can find information about {0} by clicking"
 msgstr ""
 
@@ -8100,21 +8167,21 @@ msgstr ""
 msgid "Third"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:154
+#: screens/Template/shared/JobTemplateForm.js:152
 msgid "This Project needs to be updated"
 msgstr ""
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:286
-#: screens/Template/Survey/SurveyList.js:117
+#: screens/Template/Survey/SurveyList.js:92
 msgid "This action will delete the following:"
 msgstr ""
 
-#: screens/User/UserTeams/UserTeamList.js:218
+#: screens/User/UserTeams/UserTeamList.js:217
 msgid "This action will disassociate all roles for this user from the selected teams."
 msgstr ""
 
-#: screens/Team/TeamRoles/TeamRolesList.js:237
-#: screens/User/UserRoles/UserRolesList.js:233
+#: screens/Team/TeamRoles/TeamRolesList.js:236
+#: screens/User/UserRoles/UserRolesList.js:232
 msgid "This action will disassociate the following role from {0}:"
 msgstr ""
 
@@ -8210,7 +8277,7 @@ msgid "This field must be greater than 0"
 msgstr ""
 
 #: components/LaunchPrompt/steps/useSurveyStep.js:111
-#: screens/Template/shared/JobTemplateForm.js:151
+#: screens/Template/shared/JobTemplateForm.js:149
 #: screens/User/shared/UserForm.js:92
 #: screens/User/shared/UserForm.js:103
 #: util/validators.js:5
@@ -8262,7 +8329,7 @@ msgstr ""
 msgid "This job template is currently being used by other resources. Are you sure you want to delete it?"
 msgstr ""
 
-#: screens/Organization/OrganizationDetail/OrganizationDetail.js:170
+#: screens/Organization/OrganizationDetail/OrganizationDetail.js:173
 msgid "This organization is currently being by other resources. Are you sure you want to delete it?"
 msgstr ""
 
@@ -8274,11 +8341,11 @@ msgstr ""
 msgid "This project is currently on sync and cannot be clicked until sync process completed"
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:123
+#: components/Schedule/ScheduleList/ScheduleList.js:122
 msgid "This schedule is missing an Inventory"
 msgstr ""
 
-#: components/Schedule/ScheduleList/ScheduleList.js:148
+#: components/Schedule/ScheduleList/ScheduleList.js:147
 msgid "This schedule is missing required survey values"
 msgstr ""
 
@@ -8313,8 +8380,8 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
-#: screens/ActivityStream/ActivityStream.js:236
-#: screens/ActivityStream/ActivityStream.js:248
+#: screens/ActivityStream/ActivityStream.js:235
+#: screens/ActivityStream/ActivityStream.js:247
 #: screens/ActivityStream/ActivityStreamDetailButton.js:41
 #: screens/ActivityStream/ActivityStreamListItem.js:42
 msgid "Time"
@@ -8348,7 +8415,7 @@ msgstr ""
 #: screens/NotificationTemplate/shared/TypeInputsSubForm.js:112
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:232
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:177
-#: screens/Template/shared/JobTemplateForm.js:490
+#: screens/Template/shared/JobTemplateForm.js:488
 msgid "Timeout"
 msgstr ""
 
@@ -8358,6 +8425,10 @@ msgstr ""
 
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:198
 msgid "Timeout seconds"
+msgstr ""
+
+#: screens/Template/Survey/SurveyReorderModal.js:181
+msgid "To reoder the survey questions drag and drop them in the desired location."
 msgstr ""
 
 #: screens/Job/WorkflowOutput/WorkflowOutputToolbar.js:93
@@ -8426,11 +8497,11 @@ msgid "Token not found."
 msgstr ""
 
 #: screens/Application/Application/Application.js:79
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:106
-#: screens/Application/ApplicationTokens/ApplicationTokenList.js:129
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:105
+#: screens/Application/ApplicationTokens/ApplicationTokenList.js:128
 #: screens/Application/Applications.js:39
 #: screens/User/User.js:75
-#: screens/User/UserTokenList/UserTokenList.js:119
+#: screens/User/UserTokenList/UserTokenList.js:118
 #: screens/User/Users.js:34
 msgid "Tokens"
 msgstr ""
@@ -8443,8 +8514,8 @@ msgstr ""
 msgid "Top Pagination"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:284
-#: screens/InstanceGroup/Instances/InstanceList.js:210
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:283
+#: screens/InstanceGroup/Instances/InstanceList.js:209
 #: screens/InstanceGroup/Instances/InstanceListItem.js:123
 msgid "Total Jobs"
 msgstr ""
@@ -8467,20 +8538,20 @@ msgstr ""
 msgid "Track submodules latest commit on branch"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:85
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:79
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionModal.js:166
 msgid "Trial"
 msgstr ""
 
-#: components/JobList/JobListItem.js:264
+#: components/JobList/JobListItem.js:275
 #: screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js:63
-#: screens/Job/JobDetail/JobDetail.js:256
+#: screens/Job/JobDetail/JobDetail.js:313
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:162
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:191
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:221
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:266
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:320
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:86
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:80
 msgid "True"
 msgstr ""
 
@@ -8493,55 +8564,57 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
-#: components/NotificationList/NotificationList.js:199
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
+#: components/NotificationList/NotificationList.js:201
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:157
 msgid "Twilio"
 msgstr ""
 
-#: components/JobList/JobList.js:218
-#: components/JobList/JobListItem.js:90
-#: components/Lookup/ProjectLookup.js:132
-#: components/NotificationList/NotificationList.js:217
+#: components/JobList/JobList.js:239
+#: components/JobList/JobListItem.js:91
+#: components/Lookup/ProjectLookup.js:131
+#: components/NotificationList/NotificationList.js:219
 #: components/NotificationList/NotificationListItem.js:30
 #: components/PromptDetail/PromptDetail.js:114
-#: components/Schedule/ScheduleList/ScheduleList.js:170
+#: components/Schedule/ScheduleList/ScheduleList.js:169
 #: components/Schedule/ScheduleList/ScheduleListItem.js:94
-#: components/TemplateList/TemplateList.js:200
-#: components/TemplateList/TemplateList.js:225
+#: components/TemplateList/TemplateList.js:199
+#: components/TemplateList/TemplateList.js:224
 #: components/TemplateList/TemplateListItem.js:176
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:85
 #: components/UserAndTeamAccessAdd/getResourceAccessConfig.js:154
 #: components/Workflow/WorkflowNodeHelp.js:160
 #: components/Workflow/WorkflowNodeHelp.js:194
-#: screens/Credential/CredentialList/CredentialList.js:147
+#: screens/Credential/CredentialList/CredentialList.js:146
 #: screens/Credential/CredentialList/CredentialListItem.js:60
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:96
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:118
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:95
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:117
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:12
 #: screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js:46
 #: screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js:55
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:282
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:281
 #: screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js:66
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:72
-#: screens/Inventory/InventoryList/InventoryList.js:206
+#: screens/Inventory/InventoryList/InventoryList.js:205
 #: screens/Inventory/InventoryList/InventoryListItem.js:93
 #: screens/Inventory/InventorySources/InventorySourceList.js:197
 #: screens/Inventory/InventorySources/InventorySourceListItem.js:91
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:105
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:196
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:195
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js:118
 #: screens/NotificationTemplate/shared/NotificationTemplateForm.js:68
-#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:158
+#: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesList.js:157
 #: screens/Project/ProjectJobTemplatesList/ProjectJobTemplatesListItem.js:75
-#: screens/Project/ProjectList/ProjectList.js:181
-#: screens/Project/ProjectList/ProjectList.js:210
+#: screens/Project/ProjectList/ProjectList.js:180
+#: screens/Project/ProjectList/ProjectList.js:209
 #: screens/Project/ProjectList/ProjectListItem.js:205
 #: screens/Team/TeamRoles/TeamRoleListItem.js:17
-#: screens/Team/TeamRoles/TeamRolesList.js:182
-#: screens/Template/Survey/SurveyListItem.js:129
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:94
+#: screens/Team/TeamRoles/TeamRolesList.js:181
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyList.js:113
+#: screens/Template/Survey/SurveyListItem.js:60
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js:93
 #: screens/User/UserDetail/UserDetail.js:75
-#: screens/User/UserRoles/UserRolesList.js:157
+#: screens/User/UserRoles/UserRolesList.js:156
 #: screens/User/UserRoles/UserRolesListItem.js:21
 msgid "Type"
 msgstr ""
@@ -8585,7 +8658,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:127
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:122
 msgid "Unlimited"
 msgstr ""
 
@@ -8602,7 +8675,7 @@ msgstr ""
 msgid "Unreachable Hosts"
 msgstr ""
 
-#: util/dates.js:93
+#: util/dates.js:74
 msgid "Unrecognized day string"
 msgstr ""
 
@@ -8639,7 +8712,7 @@ msgstr ""
 #~ msgid "Update settings pertaining to Jobs within {0}"
 #~ msgstr ""
 
-#: screens/Setting/SettingList.js:89
+#: screens/Setting/SettingList.js:88
 msgid "Update settings pertaining to Jobs within {brandName}"
 msgstr ""
 
@@ -8676,7 +8749,7 @@ msgid ""
 "curly braces to access information about the job:"
 msgstr ""
 
-#: screens/InstanceGroup/Instances/InstanceList.js:212
+#: screens/InstanceGroup/Instances/InstanceList.js:211
 msgid "Used Capacity"
 msgstr ""
 
@@ -8695,17 +8768,17 @@ msgstr ""
 msgid "User Details"
 msgstr ""
 
-#: screens/Setting/SettingList.js:118
+#: screens/Setting/SettingList.js:117
 #: screens/Setting/Settings.js:114
 msgid "User Interface"
 msgstr ""
 
-#: screens/Setting/SettingList.js:123
+#: screens/Setting/SettingList.js:122
 msgid "User Interface settings"
 msgstr ""
 
 #: components/ResourceAccessList/ResourceAccessListItem.js:70
-#: screens/User/UserRoles/UserRolesList.js:143
+#: screens/User/UserRoles/UserRolesList.js:142
 msgid "User Roles"
 msgstr ""
 
@@ -8732,14 +8805,14 @@ msgstr ""
 msgid "User not found."
 msgstr ""
 
-#: screens/User/UserTokenList/UserTokenList.js:177
+#: screens/User/UserTokenList/UserTokenList.js:176
 msgid "User tokens"
 msgstr ""
 
 #: components/AddRole/AddResourceRole.js:22
 #: components/AddRole/AddResourceRole.js:37
-#: components/ResourceAccessList/ResourceAccessList.js:130
-#: components/ResourceAccessList/ResourceAccessList.js:183
+#: components/ResourceAccessList/ResourceAccessList.js:129
+#: components/ResourceAccessList/ResourceAccessList.js:182
 #: screens/Login/Login.js:196
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:104
 #: screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js:204
@@ -8752,8 +8825,8 @@ msgstr ""
 #: screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js:92
 #: screens/Setting/Subscription/SubscriptionEdit/SubscriptionStep.js:206
 #: screens/User/UserDetail/UserDetail.js:68
-#: screens/User/UserList/UserList.js:116
-#: screens/User/UserList/UserList.js:157
+#: screens/User/UserList/UserList.js:115
+#: screens/User/UserList/UserList.js:156
 #: screens/User/UserList/UserListItem.js:38
 #: screens/User/shared/UserForm.js:76
 msgid "Username"
@@ -8766,16 +8839,16 @@ msgstr ""
 #: components/AddRole/AddResourceRole.js:197
 #: components/AddRole/AddResourceRole.js:198
 #: routeConfig.js:99
-#: screens/ActivityStream/ActivityStream.js:175
+#: screens/ActivityStream/ActivityStream.js:174
 #: screens/Team/Teams.js:29
-#: screens/User/UserList/UserList.js:111
-#: screens/User/UserList/UserList.js:150
+#: screens/User/UserList/UserList.js:110
+#: screens/User/UserList/UserList.js:149
 #: screens/User/Users.js:15
 #: screens/User/Users.js:26
 msgid "Users"
 msgstr ""
 
-#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:102
+#: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js:101
 msgid "VMware vCenter"
 msgstr ""
 
@@ -8786,7 +8859,7 @@ msgstr ""
 #: components/PromptDetail/PromptDetail.js:271
 #: components/PromptDetail/PromptJobTemplateDetail.js:271
 #: components/PromptDetail/PromptWFJobTemplateDetail.js:131
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:367
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:381
 #: screens/Host/HostDetail/HostDetail.js:96
 #: screens/Inventory/InventoryDetail/InventoryDetail.js:97
 #: screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js:37
@@ -8796,10 +8869,10 @@ msgstr ""
 #: screens/Inventory/shared/InventoryForm.js:68
 #: screens/Inventory/shared/InventoryGroupForm.js:46
 #: screens/Inventory/shared/SmartInventoryForm.js:93
-#: screens/Job/JobDetail/JobDetail.js:353
+#: screens/Job/JobDetail/JobDetail.js:429
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:366
 #: screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js:204
-#: screens/Template/shared/JobTemplateForm.js:413
+#: screens/Template/shared/JobTemplateForm.js:411
 #: screens/Template/shared/WorkflowJobTemplateForm.js:213
 msgid "Variables"
 msgstr ""
@@ -8820,21 +8893,21 @@ msgstr ""
 msgid "Verbose"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:130
+#: components/AdHocCommands/AdHocDetailsStep.js:128
 #: components/LaunchPrompt/steps/OtherPromptsStep.js:147
 #: components/PromptDetail/PromptDetail.js:212
 #: components/PromptDetail/PromptInventorySourceDetail.js:118
 #: components/PromptDetail/PromptJobTemplateDetail.js:156
-#: components/Schedule/ScheduleDetail/ScheduleDetail.js:302
+#: components/Schedule/ScheduleDetail/ScheduleDetail.js:316
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:183
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:87
-#: screens/Job/JobDetail/JobDetail.js:228
+#: screens/Job/JobDetail/JobDetail.js:272
 #: screens/Template/JobTemplateDetail/JobTemplateDetail.js:231
-#: screens/Template/shared/JobTemplateForm.js:463
+#: screens/Template/shared/JobTemplateForm.js:461
 msgid "Verbosity"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:70
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:64
 msgid "Version"
 msgstr ""
 
@@ -8881,7 +8954,7 @@ msgstr ""
 msgid "View JSON examples at <0>www.json.org</0>"
 msgstr ""
 
-#: screens/Job/Job.js:164
+#: screens/Job/Job.js:180
 msgid "View Job Details"
 msgstr ""
 
@@ -8994,7 +9067,7 @@ msgstr ""
 msgid "View all Jobs"
 msgstr ""
 
-#: screens/Job/Job.js:124
+#: screens/Job/Job.js:137
 msgid "View all Jobs."
 msgstr ""
 
@@ -9057,7 +9130,7 @@ msgstr ""
 msgid "View all tokens."
 msgstr ""
 
-#: screens/Setting/SettingList.js:130
+#: screens/Setting/SettingList.js:129
 msgid "View and edit your subscription information"
 msgstr ""
 
@@ -9083,7 +9156,7 @@ msgid "View smart inventory host details"
 msgstr ""
 
 #: routeConfig.js:28
-#: screens/ActivityStream/ActivityStream.js:136
+#: screens/ActivityStream/ActivityStream.js:135
 msgid "Views"
 msgstr ""
 
@@ -9093,11 +9166,11 @@ msgstr ""
 msgid "Visualizer"
 msgstr ""
 
-#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:44
+#: screens/Project/shared/ProjectSubForms/ManualSubForm.js:43
 msgid "WARNING:"
 msgstr ""
 
-#: components/JobList/JobList.js:201
+#: components/JobList/JobList.js:222
 #: components/StatusLabel/StatusLabel.js:60
 #: components/Workflow/WorkflowNodeHelp.js:96
 msgid "Waiting"
@@ -9121,8 +9194,8 @@ msgid "We were unable to locate subscriptions associated with this account."
 msgstr ""
 
 #: components/DetailList/LaunchedByDetail.js:53
-#: components/NotificationList/NotificationList.js:200
-#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:159
+#: components/NotificationList/NotificationList.js:202
+#: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:158
 msgid "Webhook"
 msgstr ""
 
@@ -9162,7 +9235,7 @@ msgstr ""
 msgid "Webhook URL"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:656
+#: screens/Template/shared/JobTemplateForm.js:654
 #: screens/Template/shared/WorkflowJobTemplateForm.js:249
 msgid "Webhook details"
 msgstr ""
@@ -9191,7 +9264,7 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:146
+#: components/Schedule/shared/ScheduleForm.js:154
 msgid "Week"
 msgstr ""
 
@@ -9240,26 +9313,26 @@ msgid "Workflow Approval not found."
 msgstr ""
 
 #: routeConfig.js:52
-#: screens/ActivityStream/ActivityStream.js:147
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:166
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:203
+#: screens/ActivityStream/ActivityStream.js:146
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:165
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:202
 #: screens/WorkflowApproval/WorkflowApprovals.js:12
 #: screens/WorkflowApproval/WorkflowApprovals.js:21
 msgid "Workflow Approvals"
 msgstr ""
 
-#: components/JobList/JobList.js:188
-#: components/JobList/JobListItem.js:40
+#: components/JobList/JobList.js:209
+#: components/JobList/JobListItem.js:41
 #: components/Schedule/ScheduleList/ScheduleListItem.js:40
 #: screens/Job/JobDetail/JobDetail.js:81
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:124
 msgid "Workflow Job"
 msgstr ""
 
-#: components/JobList/JobListItem.js:167
+#: components/JobList/JobListItem.js:178
 #: components/Workflow/WorkflowNodeHelp.js:63
 #: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js:15
-#: screens/Job/JobDetail/JobDetail.js:150
+#: screens/Job/JobDetail/JobDetail.js:161
 #: screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js:111
 #: screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js:137
 #: util/getRelatedResourceDeleteDetails.js:104
@@ -9280,8 +9353,8 @@ msgstr ""
 msgid "Workflow Link"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:204
-#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:100
+#: components/TemplateList/TemplateList.js:203
+#: screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js:99
 msgid "Workflow Template"
 msgstr ""
 
@@ -9350,7 +9423,7 @@ msgstr ""
 msgid "YAML:"
 msgstr ""
 
-#: components/Schedule/shared/ScheduleForm.js:148
+#: components/Schedule/shared/ScheduleForm.js:156
 msgid "Year"
 msgstr ""
 
@@ -9366,11 +9439,11 @@ msgstr ""
 msgid "You are unable to act on the following workflow approvals: {itemsUnableToDeny}"
 msgstr ""
 
-#: components/Lookup/MultiCredentialsLookup.js:155
+#: components/Lookup/MultiCredentialsLookup.js:154
 msgid "You cannot select multiple vault credentials with the same vault ID. Doing so will automatically deselect the other with the same vault ID."
 msgstr ""
 
-#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:97
+#: screens/Inventory/InventoryGroups/InventoryGroupsList.js:96
 msgid "You do not have permission to delete the following Groups: {itemsUnableToDelete}"
 msgstr ""
 
@@ -9404,19 +9477,19 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:754
+#: screens/Template/shared/JobTemplateForm.js:752
 #: screens/Template/shared/WebhookSubForm.js:148
 msgid "a new webhook key will be generated on save."
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:751
+#: screens/Template/shared/JobTemplateForm.js:749
 #: screens/Template/shared/WebhookSubForm.js:138
 msgid "a new webhook url will be generated on save."
 msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:157
-msgid "actions"
-msgstr ""
+#~ msgid "actions"
+#~ msgstr ""
 
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:181
 #: screens/Inventory/shared/InventorySourceSubForms/SharedFields.js:210
@@ -9432,7 +9505,7 @@ msgid "brand logo"
 msgstr ""
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:279
-#: screens/Template/Survey/SurveyList.js:107
+#: screens/Template/Survey/SurveyList.js:82
 msgid "cancel delete"
 msgstr ""
 
@@ -9440,17 +9513,17 @@ msgstr ""
 msgid "cancel edit login redirect"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:234
+#: components/AdHocCommands/AdHocDetailsStep.js:232
 msgid "command"
 msgstr ""
 
 #: components/PaginatedTable/ToolbarDeleteButton.js:267
-#: screens/Template/Survey/SurveyList.js:98
+#: screens/Template/Survey/SurveyList.js:73
 msgid "confirm delete"
 msgstr ""
 
 #: components/DisassociateButton/DisassociateButton.js:113
-#: screens/Team/TeamRoles/TeamRolesList.js:220
+#: screens/Team/TeamRoles/TeamRolesList.js:219
 msgid "confirm disassociate"
 msgstr ""
 
@@ -9484,16 +9557,16 @@ msgstr ""
 #: screens/Inventory/InventorySourceDetail/InventorySourceDetail.js:223
 #: screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js:152
 #: screens/Project/ProjectDetail/ProjectDetail.js:248
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:170
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:165
 #: screens/User/UserDetail/UserDetail.js:92
 msgid "edit"
 msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:163
-msgid "edit survey"
-msgstr ""
+#~ msgid "edit survey"
+#~ msgstr ""
 
-#: screens/Template/Survey/SurveyListItem.js:135
+#: screens/Template/Survey/SurveyListItem.js:65
 msgid "encrypted"
 msgstr ""
 
@@ -9505,16 +9578,16 @@ msgstr ""
 msgid "for more information."
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:168
+#: components/AdHocCommands/AdHocDetailsStep.js:166
 msgid "here"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:119
-#: components/AdHocCommands/AdHocDetailsStep.js:188
+#: components/AdHocCommands/AdHocDetailsStep.js:117
+#: components/AdHocCommands/AdHocDetailsStep.js:186
 msgid "here."
 msgstr ""
 
-#: components/Lookup/HostFilterLookup.js:367
+#: components/Lookup/HostFilterLookup.js:369
 msgid "hosts"
 msgstr ""
 
@@ -9535,12 +9608,12 @@ msgid "min"
 msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:91
-msgid "move down"
-msgstr ""
+#~ msgid "move down"
+#~ msgstr ""
 
 #: screens/Template/Survey/SurveyListItem.js:80
-msgid "move up"
-msgstr ""
+#~ msgid "move up"
+#~ msgstr ""
 
 #: screens/Template/Survey/MultipleChoiceField.js:76
 msgid "new choice"
@@ -9551,7 +9624,7 @@ msgstr ""
 msgid "of"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:232
+#: components/AdHocCommands/AdHocDetailsStep.js:230
 msgid "option to the"
 msgstr ""
 
@@ -9580,15 +9653,15 @@ msgstr ""
 msgid "seconds"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:59
+#: components/AdHocCommands/AdHocDetailsStep.js:57
 msgid "select module"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:129
+#: components/AdHocCommands/AdHocDetailsStep.js:127
 msgid "select verbosity"
 msgstr ""
 
-#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:140
+#: screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js:135
 msgid "since"
 msgstr ""
 
@@ -9596,7 +9669,7 @@ msgstr ""
 msgid "social login"
 msgstr ""
 
-#: screens/Template/shared/JobTemplateForm.js:345
+#: screens/Template/shared/JobTemplateForm.js:343
 #: screens/Template/shared/WorkflowJobTemplateForm.js:185
 msgid "source control branch"
 msgstr ""
@@ -9609,7 +9682,7 @@ msgstr ""
 msgid "timed out"
 msgstr ""
 
-#: components/AdHocCommands/AdHocDetailsStep.js:212
+#: components/AdHocCommands/AdHocDetailsStep.js:210
 msgid "toggle changes"
 msgstr ""
 
@@ -9629,39 +9702,39 @@ msgstr ""
 msgid "{0, plural, one {Delete Group?} other {Delete Groups?}}"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:179
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:178
 msgid "{0, plural, one {The following Instance Group cannot be deleted} other {The following Instance Groups cannot be deleted}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:233
+#: screens/Inventory/InventoryList/InventoryList.js:232
 msgid "{0, plural, one {The inventory will be in a pending status until the final delete is processed.} other {The inventories will be in a pending status until the final delete is processed.}}"
 msgstr ""
 
-#: components/JobList/JobList.js:249
+#: components/JobList/JobList.js:270
 msgid "{0, plural, one {The selected job cannot be deleted due to insufficient permission or a running job status} other {The selected jobs cannot be deleted due to insufficient permissions or a running job status}}"
 msgstr ""
 
-#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:209
+#: screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js:208
 msgid "{0, plural, one {This approval cannot be deleted due to insufficient permissions or a pending job status} other {These approvals cannot be deleted due to insufficient permissions or a pending job status}}"
 msgstr ""
 
-#: screens/Credential/CredentialList/CredentialList.js:179
+#: screens/Credential/CredentialList/CredentialList.js:178
 msgid "{0, plural, one {This credential is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these credentials could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:165
+#: screens/CredentialType/CredentialTypeList/CredentialTypeList.js:164
 msgid "{0, plural, one {This credential type is currently being used by some credentials and cannot be deleted.} other {Credential types that are being used by credentials cannot be deleted. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:181
+#: screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js:180
 msgid "{0, plural, one {This execution environment is currently being used by other resources. Are you sure you want to delete it?} other {These execution environments could be in use by other resources that rely on them. Are you sure you want to delete them anyway?}}"
 msgstr ""
 
-#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:269
+#: screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js:268
 msgid "{0, plural, one {This instance group is currently being by other resources. Are you sure you want to delete it?} other {Deleting these instance groups could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Inventory/InventoryList/InventoryList.js:226
+#: screens/Inventory/InventoryList/InventoryList.js:225
 msgid "{0, plural, one {This inventory is currently being used by some templates. Are you sure you want to delete it?} other {Deleting these inventories could impact some templates that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
@@ -9669,15 +9742,15 @@ msgstr ""
 msgid "{0, plural, one {This inventory source is currently being used by other resources that rely on it. Are you sure you want to delete it?} other {Deleting these inventory sources could impact other resources that rely on them. Are you sure you want to delete anyway}}"
 msgstr ""
 
-#: screens/Organization/OrganizationList/OrganizationList.js:167
+#: screens/Organization/OrganizationList/OrganizationList.js:166
 msgid "{0, plural, one {This organization is currently being by other resources. Are you sure you want to delete it?} other {Deleting these organizations could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: screens/Project/ProjectList/ProjectList.js:239
+#: screens/Project/ProjectList/ProjectList.js:238
 msgid "{0, plural, one {This project is currently being used by other resources. Are you sure you want to delete it?} other {Deleting these projects could impact other resources that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
-#: components/TemplateList/TemplateList.js:247
+#: components/TemplateList/TemplateList.js:246
 msgid "{0, plural, one {This template is currently being used by some workflow nodes. Are you sure you want to delete it?} other {Deleting these templates could impact some workflow nodes that rely on them. Are you sure you want to delete anyway?}}"
 msgstr ""
 
@@ -9766,8 +9839,12 @@ msgid "{numJobsToCancel, plural, one {{0}} other {{1}}}"
 msgstr ""
 
 #: components/DetailList/NumberSinceDetail.js:19
-msgid "{number} since {dateStr}"
-msgstr ""
+#~ msgid "{number} since {dateStr}"
+#~ msgstr ""
+
+#: components/DetailList/NumberSinceDetail.js:13
+#~ msgid "{number} since {date}"
+#~ msgstr ""
 
 #: components/PaginatedTable/PaginatedTable.js:79
 msgid "{pluralizedItemName} List"


### PR DESCRIPTION
##### SUMMARY

See: https://github.com/ansible/awx/issues/10947

Rrule had a problem that caused the word `minute` to always be pluralized regardless of whether it was referring to 1 or more than 1 minutes.  Their latest version has a fix for it, however, that same version has caused some warning to appear.  This PR offers a work around for that problem.  There is also documentation in the code.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
##### ADDITIONAL INFORMATION

![Screen Shot 2021-08-26 at 3 41 56 PM](https://user-images.githubusercontent.com/39280967/131025692-858b53e9-0735-44d9-9ccd-6dfe0f58a956.png)
