### PR TITLE
Use ansible-runner imports for cpu and memory calculation

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -22,8 +22,11 @@ from awx.main.managers import InstanceManager, InstanceGroupManager
 from awx.main.fields import JSONField
 from awx.main.models.base import BaseModel, HasEditsMixin, prevent_search
 from awx.main.models.unified_jobs import UnifiedJob
-from awx.main.utils.common import measure_cpu, get_corrected_cpu, get_cpu_effective_capacity, measure_memory, get_corrected_memory, get_mem_effective_capacity
+from awx.main.utils.common import get_corrected_cpu, get_cpu_effective_capacity, get_corrected_memory, get_mem_effective_capacity
 from awx.main.models.mixins import RelatedJobsMixin
+
+# ansible-runner
+from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes
 
 __all__ = ('Instance', 'InstanceGroup', 'TowerScheduleState')
 
@@ -222,7 +225,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         except redis.ConnectionError:
             has_error = True
 
-        self.save_health_data(awx_application_version, measure_cpu(), measure_memory(), last_seen=now(), has_error=has_error)
+        self.save_health_data(awx_application_version, get_cpu_count(), get_mem_in_bytes(), last_seen=now(), has_error=has_error)
 
 
 class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -710,6 +710,14 @@ def parse_yaml_or_json(vars_str, silent_failure=True):
 def get_cpu_effective_capacity(cpu_count):
     from django.conf import settings
 
+    settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
+    env_abscpu = os.getenv('SYSTEM_TASK_ABS_CPU', None)
+
+    if env_abscpu is not None:
+        return int(env_abscpu)
+    elif settings_abscpu is not None:
+        return int(settings_abscpu)
+
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
     env_forkcpu = os.getenv('SYSTEM_TASK_FORKS_CPU', None)
 
@@ -732,16 +740,22 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
     env_abscpu = os.getenv('SYSTEM_TASK_ABS_CPU', None)
 
-    if env_abscpu is not None:
-        return 0, int(env_abscpu)
-    elif settings_abscpu is not None:
-        return 0, int(settings_abscpu)
+    if env_abscpu is not None or settings_abscpu is not None:
+        return 0
 
     return cpu_count  # no correction
 
 
 def get_mem_effective_capacity(mem_mb):
     from django.conf import settings
+
+    settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
+    env_absmem = os.getenv('SYSTEM_TASK_ABS_MEM', None)
+
+    if env_absmem is not None:
+        return int(env_absmem)
+    elif settings_absmem is not None:
+        return int(settings_absmem)
 
     settings_forkmem = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_forkmem = os.getenv('SYSTEM_TASK_FORKS_MEM', None)
@@ -762,10 +776,8 @@ def get_corrected_memory(memory):
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
     env_absmem = os.getenv('SYSTEM_TASK_ABS_MEM', None)
 
-    if env_absmem is not None:
-        return 0, int(env_absmem)
-    elif settings_absmem is not None:
-        return 0, int(settings_absmem)
+    if env_absmem is not None or settings_absmem is not None:
+        return 0
 
     return memory
 

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -15,7 +15,6 @@ import urllib.parse
 import threading
 import contextlib
 import tempfile
-import psutil
 from functools import reduce, wraps
 
 # Django
@@ -724,10 +723,6 @@ def get_cpu_effective_capacity(cpu_count):
     return cpu_count * forkcpu
 
 
-def measure_cpu():  # TODO: replace with import from ansible-runner
-    return psutil.cpu_count()
-
-
 def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     """Some environments will do a correction to the reported CPU number
     because the given OpenShift value is a lie
@@ -759,10 +754,6 @@ def get_mem_effective_capacity(mem_mb):
         forkmem = 100
 
     return max(1, ((mem_mb // 1024 // 1024) - 2048) // forkmem)
-
-
-def measure_memory():  # TODO: replace with import from ansible-runner
-    return psutil.virtual_memory().total
 
 
 def get_corrected_memory(memory):


### PR DESCRIPTION
We delayed this to make sure the images were updated, but now it seems there are no blockers for doing it.