### PR TITLE
Delete images by id instead of tag in docker-refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,7 +537,7 @@ docker-compose-build:
 
 docker-clean:
 	$(foreach container_id,$(shell docker ps -f name=tools_awx -aq),docker stop $(container_id); docker rm -f $(container_id);)
-	docker images | grep "awx_devel" | awk '{print $$1 ":" $$2}' | xargs docker rmi
+	docker images | grep "awx_devel" | awk '{print $$3}' | xargs docker rmi
 
 docker-clean-volumes: docker-compose-clean docker-compose-container-group-clean
 	docker volume rm tools_awx_db


### PR DESCRIPTION
When you do `make docker-refresh`, it will delete existing images from the "awx_devel"

Before, it would do this by combining the name:tag, like `docker rmi quay.io/awx/awx_devel:devel`, but I've found that it's pretty easy to get in a situation where these will be left without tags, so it'll fail on `docker rmi quay.io/awx/awx_devel:<none>`.

So this is intended to make it more durable by doing `docker rmi a8ebcdeede11` instead