### PR TITLE
Associates ldap_dn on a first User() login

### DIFF
--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -395,10 +395,17 @@ def on_populate_user(sender, **kwargs):
         remove = bool(team_opts.get('remove', True))
         _update_m2m_from_groups(user, ldap_user, team.member_role.members, users_opts, remove)
 
+    # Check if user.profile is available, otherwise force user.save()
+    try:
+        _ = user.profile
+    except ValueError:
+        force_user_update = True
+    finally:
+        if force_user_update:
+            user.save()
+
     # Update user profile to store LDAP DN.
-    if force_user_update:
-        user.save()
-        profile = user.profile
-        if profile.ldap_dn != ldap_user.dn:
-            profile.ldap_dn = ldap_user.dn
-            profile.save()
+    profile = user.profile
+    if profile.ldap_dn != ldap_user.dn:
+        profile.ldap_dn = ldap_user.dn
+        profile.save()


### PR DESCRIPTION
##### SUMMARY
Related: https://github.com/ansible/awx/issues/10883
Fixes: https://github.com/ansible/awx-operator/issues/507

Related: https://github.com/ansible/awx/pull/9703

Fix the missing ldap_dn attribute for new LDAP users.

To avoid calling the user.save() on every single login (PR#9703)
we can check if the user.profile is available. For new users,
accessing the user.profile throws an ValueError exception which
is capture on this fix.

* Example:
```
>>> _ = user.profile
*** ValueError: save() prohibited to prevent data loss due to unsaved related object 'user'.
>>> User.objects.filter(username=user.username).count()
0
```

This way, the user.save() gets called for brand users and will get the
ldap_dn associated as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.3.0
```


##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/809840/131267068-685f6102-9cff-4407-8a64-603932bb7cf3.png)