### PR TITLE
Check dynamic_input fields also with has_input() 

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -299,10 +299,7 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
 
     def has_inputs(self, field_names=()):
         for name in field_names:
-            if name in self.inputs:
-                if self.inputs[name] in ('', None):
-                    return False
-            else:
+            if not self.has_input(name):
                 raise ValueError('{} is not an input field'.format(name))
         return True
 


### PR DESCRIPTION
Signed-off-by: quasd <qquasd@gmail.com>

##### SUMMARY
has_inputs doesn't check dynamic input fields leading to credential plugins not working with pulling execution environment that uses credential plugin for registry credential. 

```
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 1410, in run
    receptor_job = AWXReceptorJob(self, params)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 2935, in __init__
    execution_environment_params = self.task.build_execution_environment_params(self.task.instance, runner_params['private_data_dir'])
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 828, in build_execution_environment_params
    if cred.has_inputs(field_names=('host', 'username', 'password')):
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/models/credential/__init__.py", line 306, in has_inputs
    raise ValueError('{} is not an input field'.format(name))
ValueError: username is not an input field
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Credential module

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
 _____________________________________ 
<  Ansible Automation Platform 4.0.0  >
 ------------------------------------- 
          \
          \   ^__^
              (oo)\_______
              (__)      A )\
                  ||----w |
                  ||     ||
```


##### ADDITIONAL INFORMATION
Change the code to use has_input since that already properly checks the dynamic_input_fields. 
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->