### PR TITLE
Capture /etc/receptor in sos report

### DIFF
--- a/tools/sosreport/controller.py
+++ b/tools/sosreport/controller.py
@@ -27,6 +27,7 @@ SOSREPORT_CONTROLLER_COMMANDS = [
 
 SOSREPORT_CONTROLLER_DIRS = [
     "/etc/tower/",
+    "/etc/receptor/",
     "/etc/supervisord.d/",
     "/etc/nginx/",
     "/var/log/tower",


### PR DESCRIPTION
this will help with debugging so we can know what receptor's configuration was
at the time the sos report was collected