### PR TITLE
Fix the hostname of execution nodes in dev environment

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -112,7 +112,7 @@ services:
     image: quay.io/awx/awx_devel:devel
     user: "{{ ansible_user_uid }}"
     container_name: tools_receptor_{{ loop.index }}
-    hostname: receptor-1
+    hostname: receptor-{{ loop.index }}
     command: 'receptor --config /etc/receptor/receptor.conf'
     links:
       - receptor-hop


### PR DESCRIPTION
before

```
(env) [alancoding@alan-red-hat awx]$ docker exec -it tools_awx_1 /bin/bash
bash-4.4$ hostname
awx_1
bash-4.4$ exit
exit
(env) [alancoding@alan-red-hat awx]$ docker exec -it tools_receptor_1 /bin/bash
bash-4.4$ hostname
receptor-1
bash-4.4$ exit
exit
(env) [alancoding@alan-red-hat awx]$ docker exec -it tools_receptor_2 /bin/bash
bash-4.4$ hostname
receptor-1
```

after

```
(env) [alancoding@alan-red-hat awx]$ docker exec -it tools_receptor_2 hostname
receptor-2
(env) [alancoding@alan-red-hat awx]$ docker exec -it tools_receptor_1 hostname
receptor-1
```

I don't think this was breaking usage, but it was clearly not right. Maybe because the connection was inbound, I don't know.