### PR TITLE
Adds deprecation banner

### DIFF
--- a/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js
@@ -2,8 +2,9 @@ import React, { useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { t } from '@lingui/macro';
-import { Button } from '@patternfly/react-core';
+import { Button, Alert as PFAlert } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
+import styled from 'styled-components';
 import { CardBody, CardActionsRow } from 'components/Card';
 import ContentLoading from 'components/ContentLoading';
 import ContentError from 'components/ContentError';
@@ -14,6 +15,10 @@ import { DetailList } from 'components/DetailList';
 import { useConfig } from 'contexts/Config';
 import { useSettings } from 'contexts/Settings';
 import { SettingDetail } from '../../shared';
+
+const Alert = styled(PFAlert)`
+  margin-bottom: 20px;
+`;
 
 function RADIUSDetail() {
   const { me } = useConfig();
@@ -61,22 +66,30 @@ function RADIUSDetail() {
         {isLoading && <ContentLoading />}
         {!isLoading && error && <ContentError error={error} />}
         {!isLoading && radius && (
-          <DetailList>
-            {Object.keys(radius).map((key) => {
-              const record = options?.[key];
-              return (
-                <SettingDetail
-                  key={key}
-                  id={key}
-                  helpText={record?.help_text}
-                  label={record?.label}
-                  type={record?.type}
-                  unit={record?.unit}
-                  value={radius?.[key]}
-                />
-              );
-            })}
-          </DetailList>
+          <>
+            <Alert
+              variant="info"
+              isInline
+              data-cy="RADIUS-deprecation-warning"
+              title={t`This feature is deprecated and will be removed in a future release.`}
+            />
+            <DetailList>
+              {Object.keys(radius).map((key) => {
+                const record = options?.[key];
+                return (
+                  <SettingDetail
+                    key={key}
+                    id={key}
+                    helpText={record?.help_text}
+                    label={record?.label}
+                    type={record?.type}
+                    unit={record?.unit}
+                    value={radius?.[key]}
+                  />
+                );
+              })}
+            </DetailList>
+          </>
         )}
         {me?.is_superuser && (
           <CardActionsRow>

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.test.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.test.js
@@ -52,6 +52,9 @@ describe('<RADIUSDetail />', () => {
   });
 
   test('should render expected details', () => {
+    expect(wrapper.find('Alert').prop('title')).toBe(
+      'This feature is deprecated and will be removed in a future release.'
+    );
     assertDetail(wrapper, 'RADIUS Server', 'example.org');
     assertDetail(wrapper, 'RADIUS Port', '1812');
     assertDetail(wrapper, 'RADIUS Secret', 'Encrypted');

--- a/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.js
@@ -2,8 +2,9 @@ import React, { useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { t } from '@lingui/macro';
-import { Button } from '@patternfly/react-core';
+import { Button, Alert as PFAlert } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
+import styled from 'styled-components';
 import { CardBody, CardActionsRow } from 'components/Card';
 import ContentLoading from 'components/ContentLoading';
 import ContentError from 'components/ContentError';
@@ -14,6 +15,10 @@ import { DetailList } from 'components/DetailList';
 import { useConfig } from 'contexts/Config';
 import { useSettings } from 'contexts/Settings';
 import { SettingDetail } from '../../shared';
+
+const Alert = styled(PFAlert)`
+  margin-bottom: 20px;
+`;
 
 function TACACSDetail() {
   const { me } = useConfig();
@@ -53,7 +58,12 @@ function TACACSDetail() {
       id: 0,
     },
   ];
-
+  if (isLoading) {
+    return <ContentLoading />;
+  }
+  if (!isLoading && error) {
+    return <ContentError error={error} />;
+  }
   return (
     <>
       <RoutedTabs tabsArray={tabsArray} />
@@ -61,22 +71,30 @@ function TACACSDetail() {
         {isLoading && <ContentLoading />}
         {!isLoading && error && <ContentError error={error} />}
         {!isLoading && tacacs && (
-          <DetailList>
-            {Object.keys(tacacs).map((key) => {
-              const record = options?.[key];
-              return (
-                <SettingDetail
-                  key={key}
-                  id={key}
-                  helpText={record?.help_text}
-                  label={record?.label}
-                  type={record?.type}
-                  unit={record?.unit}
-                  value={tacacs?.[key]}
-                />
-              );
-            })}
-          </DetailList>
+          <>
+            <Alert
+              variant="info"
+              isInline
+              data-cy="TACACS-deprecation-warning"
+              title={t`This feature is deprecated and will be removed in a future release.`}
+            />
+            <DetailList>
+              {Object.keys(tacacs).map((key) => {
+                const record = options?.[key];
+                return (
+                  <SettingDetail
+                    key={key}
+                    id={key}
+                    helpText={record?.help_text}
+                    label={record?.label}
+                    type={record?.type}
+                    unit={record?.unit}
+                    value={tacacs?.[key]}
+                  />
+                );
+              })}
+            </DetailList>
+          </>
         )}
         {me?.is_superuser && (
           <CardActionsRow>

--- a/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.test.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.test.js
@@ -54,6 +54,9 @@ describe('<TACACSDetail />', () => {
   });
 
   test('should render expected details', () => {
+    expect(wrapper.find('Alert').prop('title')).toBe(
+      'This feature is deprecated and will be removed in a future release.'
+    );
     assertDetail(wrapper, 'TACACS+ Server', 'mockhost');
     assertDetail(wrapper, 'TACACS+ Port', '49');
     assertDetail(wrapper, 'TACACS+ Secret', 'Encrypted');


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "This introduces a info banner on RADUS and TACASC+ settings that those features will be deprecated in a future release"
-->

##### SUMMARY
This adds a warning on the details view for RADIUS and TACACS+ settings.  Those features will be deprecated in a future releasse

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
##### ADDITIONAL INFORMATION

![Screen Shot 2021-09-01 at 1 23 39 PM](https://user-images.githubusercontent.com/39280967/131716785-83722604-cd92-4ce5-9a6a-844d6d4aab88.png)
![Screen Shot 2021-09-01 at 1 23 31 PM](https://user-images.githubusercontent.com/39280967/131716788-6ae4f339-d1c0-4758-a052-cda3bd0f433c.png)
