### PR TITLE
dev environment - change location of receptor socket and sync awx and receptor nodes function

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -210,7 +210,7 @@ RUN for dir in \
       /var/log/nginx \
       /var/lib/postgresql \
       /var/run/supervisor \
-      /var/run/receptor \
+      /var/run/awx-receptor \
       /var/lib/nginx ; \
     do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp root $dir ; done && \
     for file in \

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -7,3 +7,4 @@ pg_username: 'awx'
 pg_database: 'awx'
 control_plane_node_count: 1
 minikube_container_group: false
+receptor_socket_file: /var/run/awx-receptor/receptor.sock

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -18,7 +18,7 @@ services:
       SDB_PORT: {{ awx_sdb_port_start }}
       AWX_GROUP_QUEUES: tower
       MAIN_NODE_TYPE: "${MAIN_NODE_TYPE:-hybrid}"
-      RECEPTORCTL_SOCKET: /var/run/awx-receptor/receptor.sock
+      RECEPTORCTL_SOCKET: {{ receptor_socket_file }}
 {% if loop.index == 1 %}
       RUN_MIGRATIONS: 1
 {% endif %}
@@ -114,6 +114,8 @@ services:
     container_name: tools_receptor_{{ loop.index }}
     hostname: receptor-{{ loop.index }}
     command: 'receptor --config /etc/receptor/receptor.conf'
+    environment:
+      RECEPTORCTL_SOCKET: {{ receptor_socket_file }}
     links:
       - receptor-hop
     volumes:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -18,7 +18,7 @@ services:
       SDB_PORT: {{ awx_sdb_port_start }}
       AWX_GROUP_QUEUES: tower
       MAIN_NODE_TYPE: "${MAIN_NODE_TYPE:-hybrid}"
-      RECEPTORCTL_SOCKET: /var/run/receptor/receptor.sock
+      RECEPTORCTL_SOCKET: /var/run/awx-receptor/receptor.sock
 {% if loop.index == 1 %}
       RUN_MIGRATIONS: 1
 {% endif %}

--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
@@ -22,7 +22,7 @@
 
 - control-service:
     service: control
-    filename: /var/run/receptor/receptor.sock
+    filename: /var/run/awx-receptor/receptor.sock
 
 - work-command:
     worktype: local

--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
@@ -22,7 +22,7 @@
 
 - control-service:
     service: control
-    filename: /var/run/awx-receptor/receptor.sock
+    filename: {{ receptor_socket_file }}
 
 - work-command:
     worktype: local

--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
@@ -16,3 +16,4 @@
 
 - control-service:
     service: control
+    filename: {{ receptor_socket_file }}


### PR DESCRIPTION
I tested this by doing `COMPOSE_TAG=devel make docker-compose-build` and then running it.

Everything seems to be working fine.

This is basically just continuing from https://github.com/ansible/awx/pull/10980

But it also makes it work to do:

```
docker exec -it tools_receptor_1 receptorctl status
```

which is a win in my book.