### PR TITLE
Remove deprecated lingui add-locale cmd

### DIFF
--- a/awx/ui/CONTRIBUTING.md
+++ b/awx/ui/CONTRIBUTING.md
@@ -350,7 +350,7 @@ You can learn more about the ways lingui and its React helpers at [this link](ht
 
 ### Setting up .po files to give to translation team
 
-1. `npm run add-locale` to add the language that you want to translate to (we should only have to do this once and the commit to repo afaik). Example: `npm run add-locale en es fr` # Add English, Spanish and French locale
+1. Make sure that the languages you intend to translate are set correctly in the `.linguirc` configuration file.
 2. `npm run extract-strings` to create .po files for each language specified. The .po files will be placed in src/locales. When updating strings that are used by `<Plural>` or `plural()` you will need to run this command to get the strings to render properly. This command will create `.po` files for each of the supported languages that will need to be committed with your PR.
 3. Open up the .po file for the language you want to test and add some translations. In production we would pass this .po file off to the translation team.
 4. Once you've edited your .po file (or we've gotten a .po file back from the translation team) run `npm run compile-strings`. This command takes the .po files and turns them into a minified JSON object and can be seen in the `messages.js` file in each locale directory. These files get loaded at the App root level (see: App.js).

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -72,7 +72,6 @@
     "test-watch": "TZ='UTC' react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js --ext .jsx .",
-    "add-locale": "lingui add-locale",
     "extract-strings": "lingui extract",
     "extract-template": "lingui extract-template",
     "compile-strings": "lingui compile",


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
The lingui add-locale command is now deprecated.  To add a new language, specify it in the `.linguirc` config file.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Spring cleaning
 - Docs Pull Request

##### COMPONENT NAME

 - UI
