### PR TITLE
Set python to ansible_playbook_python on hosts

### DIFF
--- a/awxkit/awxkit/api/pages/inventory.py
+++ b/awxkit/awxkit/api/pages/inventory.py
@@ -249,7 +249,7 @@ class Host(HasCreate, HasVariables, base.Base):
         variables = kwargs.get('variables', not_provided)
 
         if variables is None:
-            variables = dict(ansible_host='127.0.0.1', ansible_connection='local')
+            variables = dict(ansible_host='localhost', ansible_connection='local')
 
         if variables != not_provided:
             if isinstance(variables, dict):

--- a/awxkit/awxkit/api/pages/inventory.py
+++ b/awxkit/awxkit/api/pages/inventory.py
@@ -249,7 +249,7 @@ class Host(HasCreate, HasVariables, base.Base):
         variables = kwargs.get('variables', not_provided)
 
         if variables is None:
-            variables = dict(ansible_host='localhost', ansible_connection='local')
+            variables = dict(ansible_host='localhost', ansible_connection='local', ansible_python_interpreter='{{ ansible_playbook_python }}')
 
         if variables != not_provided:
             if isinstance(variables, dict):


### PR DESCRIPTION
see 9d000a7

This change works around the fact that the presumed correct python3 for rhel8 (which the EE is based on)
is not the python3 that ansible-playbook is using, and is not where the python dependencies are installed.