### PR TITLE
Assure consistent ordering with default IG first

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1438,7 +1438,7 @@ class UnifiedJob(
         default_instance_groups = list(InstanceGroup.objects.filter(name__in=default_instance_group_names))
 
         # assure deterministic precedence by making sure the default group is first
-        if default_instance_groups[0].name != settings.DEFAULT_EXECUTION_QUEUE_NAME:
+        if (not settings.IS_K8S) and default_instance_groups and default_instance_groups[0].name != settings.DEFAULT_EXECUTION_QUEUE_NAME:
             default_instance_groups.reverse()
 
         return default_instance_groups

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1435,9 +1435,13 @@ class UnifiedJob(
         if not settings.IS_K8S:
             default_instance_group_names.append(settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME)
 
-        default_instance_groups = InstanceGroup.objects.filter(name__in=default_instance_group_names)
+        default_instance_groups = list(InstanceGroup.objects.filter(name__in=default_instance_group_names))
 
-        return list(default_instance_groups)
+        # assure deterministic precedence by making sure the default group is first
+        if default_instance_groups[0].name != settings.DEFAULT_EXECUTION_QUEUE_NAME:
+            default_instance_groups.reverse()
+
+        return default_instance_groups
 
     def awx_meta_vars(self):
         """

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -302,6 +302,12 @@ def test_inherited_instance_group_membership(instance_group_factory, default_ins
 
 
 @pytest.mark.django_db
+def test_global_instance_groups_as_defaults(controlplane_instance_group, default_instance_group, job_factory):
+    j = job_factory()
+    assert j.preferred_instance_groups == [default_instance_group, controlplane_instance_group]
+
+
+@pytest.mark.django_db
 def test_mixed_group_membership(instance_factory, instance_group_factory):
     for i in range(5):
         instance_factory("i{}".format(i))


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Assure that default instance group is preferred over controlplane for jobs"
-->

##### SUMMARY
I have been hitting a mismatch between expectation  / outcome

 - expectation: jobs run on "default" instance group by default
 - outcome: jobs run on "controlplane" instance group by default

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
For traditional installs, we only recently started creating the default instance group to begin with.

In many cases, the "default" and "controlplane" will have the same instance groups.

I cannot tell what the InstanceGroup default ordering should be by looking at this code @jbradberry do you know?
