### PR TITLE
Collection version change

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -263,9 +263,9 @@ class ControllerAPIModule(ControllerModule):
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
             if not controller_version:
                 self.warn(
-                  "You are using the {0} version of this collection but connecting to a controller that did not return a version".format(
-                    self._COLLECTION_VERSION
-                  )
+                    "You are using the {0} version of this collection but connecting to a controller that did not return a version".format(
+                        self._COLLECTION_VERSION
+                    )
                 )
             else:
                 parsed_controller_version = Version(controller_version).version

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -262,7 +262,7 @@ class ControllerAPIModule(ControllerModule):
 
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
             if(not controller_version):
-                self.warn("You are using the {0} version of this collection but connecting to a controller that did not return a version".format(self._COLLECTION_TYPE))
+                self.warn("You are using the {0} version of this collection but connecting to a controller that did not return a version".format(self._COLLECTION_VERSION))
             else:
                 parsed_controller_version = Version(controller_version).version
                 if controller_type == 'AWX':

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -261,7 +261,7 @@ class ControllerAPIModule(ControllerModule):
                 controller_version = response.info().getheader('X-API-Product-Version', None)
 
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
-            if(not controller_version):
+            if not controller_version:
                 self.warn("You are using the {0} version of this collection but connecting to a controller that did not return a version".format(self._COLLECTION_VERSION))
             else:
                 parsed_controller_version = Version(controller_version).version

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -261,22 +261,25 @@ class ControllerAPIModule(ControllerModule):
                 controller_version = response.info().getheader('X-API-Product-Version', None)
 
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
-            parsed_controller_version = Version(controller_version).version
-            if controller_type == 'AWX':
-                collection_compare_ver = parsed_collection_version[0]
-                controller_compare_ver = parsed_controller_version[0]
+            if(not controller_version):
+                self.warn("You are using the {0} version of this collection but connecting to a controller that did not return a version".format(self._COLLECTION_TYPE))
             else:
-                collection_compare_ver = "{0}.{1}".format(parsed_collection_version[0], parsed_collection_version[1])
-                controller_compare_ver = '{0}.{1}'.format(parsed_controller_version[0], parsed_controller_version[1])
+                parsed_controller_version = Version(controller_version).version
+                if controller_type == 'AWX':
+                    collection_compare_ver = parsed_collection_version[0]
+                    controller_compare_ver = parsed_controller_version[0]
+                else:
+                    collection_compare_ver = "{0}.{1}".format(parsed_collection_version[0], parsed_collection_version[1])
+                    controller_compare_ver = '{0}.{1}'.format(parsed_controller_version[0], parsed_controller_version[1])
 
-            if self._COLLECTION_TYPE not in self.collection_to_version or self.collection_to_version[self._COLLECTION_TYPE] != controller_type:
-                self.warn("You are using the {0} version of this collection but connecting to {1}".format(self._COLLECTION_TYPE, controller_type))
-            elif collection_compare_ver != controller_compare_ver:
-                self.warn(
-                    "You are running collection version {0} but connecting to {2} version {1}".format(
-                        self._COLLECTION_VERSION, controller_version, controller_type
+                if self._COLLECTION_TYPE not in self.collection_to_version or self.collection_to_version[self._COLLECTION_TYPE] != controller_type:
+                    self.warn("You are using the {0} version of this collection but connecting to {1}".format(self._COLLECTION_TYPE, controller_type))
+                elif collection_compare_ver != controller_compare_ver:
+                    self.warn(
+                        "You are running collection version {0} but connecting to {2} version {1}".format(
+                            self._COLLECTION_VERSION, controller_version, controller_type
+                        )
                     )
-                )
 
             self.version_checked = True
 

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -262,7 +262,11 @@ class ControllerAPIModule(ControllerModule):
 
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
             if not controller_version:
-                self.warn("You are using the {0} version of this collection but connecting to a controller that did not return a version".format(self._COLLECTION_VERSION))
+                self.warn(
+                  "You are using the {0} version of this collection but connecting to a controller that did not return a version".format(
+                    self._COLLECTION_VERSION
+                  )
+                )
             else:
                 parsed_controller_version = Version(controller_version).version
                 if controller_type == 'AWX':


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Collection will not error out if controller does not return the proper header"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When pointing the collection to older versions of AWX an error can occur if the version header is not present:
```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'awx.awx.controller_api'. Error was a <class 'AttributeError'>, original message: 'LooseVersion' object has no attribute 'version'"}
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before Change:
```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'awx.awx.controller_api'. Error was a <class 'AttributeError'>, original message: 'LooseVersion' object has no attribute 'version'"}
```

After Change:
```
[WARNING]: You are using the 19.2.2 version of this collection but connecting to a controller that did not return a version
```
