### PR TITLE
Enable Jobs to Run on Execution-Only Nodes Via EEs from Protected Registries

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -949,7 +949,8 @@ class BaseTask(object):
                 host = cred.get_input('host')
                 username = cred.get_input('username')
                 password = cred.get_input('password')
-                params['container_auth_data'] = {'host': host, 'username': username, 'password': password}
+                verify_ssl = cred.get_input('verify_ssl')
+                params['container_auth_data'] = {'host': host, 'username': username, 'password': password, 'verify_ssl': verify_ssl}
             else:
                 raise RuntimeError('Please recheck that your host, username, and password fields are all filled.')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Connecting issue https://github.com/ansible/awx/issues/10944

This PR updates the way auth info is passed to Ansible Runner when pulling Execution Environments from protected registries.
Related Ansible Runner PR: https://github.com/ansible/ansible-runner/pull/817

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.0
```