### PR TITLE
fix workflow_job_template related field type specification

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -277,42 +277,46 @@ options:
                 - Nodes that will run after this node completes.
                 - List of node identifiers.
               type: list
+              elements: dict
               suboptions:
                 identifier:
                   description:
                     - Identifier of Node that will run after this node completes given this option.
-                  elements: str
+                  type: str
             success_nodes:
               description:
                 - Nodes that will run after this node on success.
                 - List of node identifiers.
               type: list
+              elements: dict
               suboptions:
                 identifier:
                   description:
                     - Identifier of Node that will run after this node completes given this option.
-                  elements: str
+                  type: str
             failure_nodes:
               description:
                 - Nodes that will run after this node on failure.
                 - List of node identifiers.
               type: list
+              elements: dict
               suboptions:
                 identifier:
                   description:
                     - Identifier of Node that will run after this node completes given this option.
-                  elements: str
+                  type: str
             credentials:
               description:
                 - Credentials to be applied to job as launch-time prompts.
                 - List of credential names.
                 - Uniqueness is not handled rigorously.
               type: list
+              elements: dict
               suboptions:
                 name:
                   description:
                     - Name Credentials to be applied to job as launch-time prompts.
-                  elements: str
+                  type: str
     destroy_current_schema:
       description:
         - Set in order to destroy current schema on the workflow.


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix type documentation for workflow_job_template 'related' fields"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The documentation currently states that the workflow_job_template schema `related` field should be a dict which contains 4 possible keys (success_nodes/failure_nodes/credentials/always_nodes) with values that are arrays of strings, despite the example on the same page being an array of dicts:

![image](https://user-images.githubusercontent.com/28678245/133113317-8290a085-a83b-4adb-9f24-7261273d70b4.png)

This is further validated by looking at the logic in the module itself: https://github.com/ansible/awx/blob/devel/awx_collection/plugins/modules/workflow_job_template.py#L616 and seeing that it does indeed check for a key in the value instead of reading the value directly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
