### PR TITLE
prevent duplicate UUIDs from being created and allow users to update hostnames based on uuid

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -129,24 +129,25 @@ class InstanceManager(models.Manager):
                         other_inst.save(update_fields=['ip_address'])
                         logger.warning("IP address {0} conflict detected, ip address unset for host {1}.".format(ip_address, other_hostname))
 
-            # get the instance based on the hostname
-            instance = self.filter(hostname=hostname)
-
-            # Check or update the existing uuid
-            if uuid is not None and uuid != UUID_DEFAULT:
-                if self.filter(uuid=uuid).exists():
-                    instance = self.filter(uuid=uuid)
+            # Return existing instance that matches hostname or UUID (default to UUID)
+            if uuid is not None and uuid != UUID_DEFAULT and self.filter(uuid=uuid).exists():
+                instance = self.filter(uuid=uuid)
+            else:
+                # if instance was not retrieved by uuid and hostname was, use the hostname
+                instance = self.filter(hostname=hostname)
 
             # Return existing instance
             if instance.exists():
-                instance = instance.get()
+                instance = instance.first()  # in the unusual occasion that there is more than one, only get one
                 update_fields = []
+                # if instance was retrieved by uuid and hostname has changed, update hostname
                 if instance.hostname != hostname:
+                    logger.warning("passed in hostname {0} is different from the original hostname {1}, updating to {0}".format(hostname, instance.hostname))
                     instance.hostname = hostname
                     update_fields.append('hostname')
+                # if any other fields are to be updated
                 if instance.ip_address != ip_address:
                     instance.ip_address = ip_address
-                    update_fields.append('ip_address')
                 if instance.node_type != node_type:
                     instance.node_type = node_type
                     update_fields.append('node_type')

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -18,7 +18,7 @@ from solo.models import SingletonModel
 
 from awx import __version__ as awx_application_version
 from awx.api.versioning import reverse
-from awx.main.managers import InstanceManager, InstanceGroupManager
+from awx.main.managers import InstanceManager, InstanceGroupManager, UUID_DEFAULT
 from awx.main.fields import JSONField
 from awx.main.models.base import BaseModel, HasEditsMixin, prevent_search
 from awx.main.models.unified_jobs import UnifiedJob
@@ -59,7 +59,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
     objects = InstanceManager()
 
     # Fields set in instance registration
-    uuid = models.CharField(max_length=40, default='00000000-0000-0000-0000-000000000000')
+    uuid = models.CharField(max_length=40, default=UUID_DEFAULT)
     hostname = models.CharField(max_length=250, unique=True)
     ip_address = models.CharField(
         blank=True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
if the user provides a uuid and it exists, allow that to tie to the instance, which allows the user to update the instance based on the UUID (includeding updating the hostname) should they choose to do so.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx-manage provision_instance
```
##### TODO
---
- [ ] Modify the installer to make the `system_uuid` consistent (see discussion below)
