### PR TITLE
fix: Internationalization causes the project to be unable to choose manual option

### DIFF
--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -224,7 +224,7 @@ function ProjectFormFields({
               isDisabled: true,
             },
             ...scmTypeOptions.map(([value, label]) => {
-              if (label === 'Manual') {
+              if (value === '') {
                 value = 'manual';
               }
               return {


### PR DESCRIPTION
…anual select

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 Bug, Docs Fix or other nominal change
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

1. Create new project
2. Choose a Source Control Type
3. I can't select the manual option

I use Chinese page, In the `scmTypeOptions`, the `manual` labe is 手动(Manual), not `Manual` word, So Cannot be selected due to the `manual` option's value that is empty string
```
After I modified it, as shown in the figure

![image](https://user-images.githubusercontent.com/2959046/133277484-901d5aba-33c3-49b9-92ab-9e164f73e412.png)
