### PR TITLE
Grafana notifications: Fix panel/dashboardId type

### DIFF
--- a/awx/main/notifications/grafana_backend.py
+++ b/awx/main/notifications/grafana_backend.py
@@ -54,8 +54,8 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
     ):
         super(GrafanaBackend, self).__init__(fail_silently=fail_silently)
         self.grafana_key = grafana_key
-        self.dashboardId = int(dashboardId) if dashboardId else None
-        self.panelId = int(panelId) if panelId else None
+        self.dashboardId = int(dashboardId) if dashboardId is not None else None
+        self.panelId = int(panelId) if panelId is not None else None
         self.annotation_tags = annotation_tags if annotation_tags is not None else []
         self.grafana_no_verify_ssl = grafana_no_verify_ssl
         self.isRegion = isRegion
@@ -87,9 +87,9 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
                         raise Exception(smart_str(_("Error converting time {} and/or timeEnd {} to int.").format(m.body['started'], m.body['finished'])))
             grafana_data['isRegion'] = self.isRegion
             if self.dashboardId is not None:
-               grafana_data['dashboardId'] = self.dashboardId
+                grafana_data['dashboardId'] = self.dashboardId
             if self.panelId is not None:
-               grafana_data['panelId'] = self.panelId
+                grafana_data['panelId'] = self.panelId
             if self.annotation_tags:
                 grafana_data['tags'] = self.annotation_tags
             grafana_data['text'] = m.subject

--- a/awx/main/notifications/grafana_backend.py
+++ b/awx/main/notifications/grafana_backend.py
@@ -54,8 +54,8 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
     ):
         super(GrafanaBackend, self).__init__(fail_silently=fail_silently)
         self.grafana_key = grafana_key
-        self.dashboardId = dashboardId
-        self.panelId = panelId
+        self.dashboardId = int(dashboardId) if dashboardId else None
+        self.panelId = int(panelId) if panelId else None
         self.annotation_tags = annotation_tags if annotation_tags is not None else []
         self.grafana_no_verify_ssl = grafana_no_verify_ssl
         self.isRegion = isRegion
@@ -86,8 +86,10 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
                     if not self.fail_silently:
                         raise Exception(smart_str(_("Error converting time {} and/or timeEnd {} to int.").format(m.body['started'], m.body['finished'])))
             grafana_data['isRegion'] = self.isRegion
-            grafana_data['dashboardId'] = self.dashboardId
-            grafana_data['panelId'] = self.panelId
+            if self.dashboardId is not None:
+               grafana_data['dashboardId'] = self.dashboardId
+            if self.panelId is not None:
+               grafana_data['panelId'] = self.panelId
             if self.annotation_tags:
                 grafana_data['tags'] = self.annotation_tags
             grafana_data['text'] = m.subject


### PR DESCRIPTION

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Ensure grafana IDs are integers in notifications "
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Latest grafana fails with
  Error sending notification grafana: 400
  [{"classification":"DeserializationError",
    "message":"json: cannot unmarshal string into Go struct
        field PostAnnotationsCmd.dashboardId of type int64"}]

So ensure the IDs are really inst and not strings.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Try sending notifcations to grafana v8.1.3 to reproduce this bug.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
