### PR TITLE
Mark execution node error strings for translation, avoid unnecessary mark_lost

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -452,7 +452,8 @@ class InstanceHealthCheck(GenericAPIView):
                     else:
                         time.sleep(1.0)
                 else:
-                    obj.mark_offline(errors=_('Health check initiated by user determined this instance to be unresponsive'))
+                    if obj.capacity > 0:
+                        obj.mark_offline(errors=_('Health check initiated by user determined this instance to be unresponsive'))
             obj.refresh_from_db()
             data = self.get_serializer(data=request.data).to_representation(obj)
 


### PR DESCRIPTION
This is a random thing on my TODO list from prior discussions with @AlexSCorey 

The `Instance.errors` field may be surfaced in the UI for errored nodes. Because of that, it is expected that it will be translated for the errors that we control. Projects of receptor & ansible-runner do not have translated versions, so errors from those cannot reasonably be translated. They'll just be put in as-is.