### PR TITLE
Fixed Org mapping behavior with SAML when Ansible Galaxy cred does not exist

### DIFF
--- a/awx/main/models/organization.py
+++ b/awx/main/models/organization.py
@@ -118,7 +118,7 @@ class Organization(CommonModel, NotificationFieldsModel, ResourceMixin, CustomVi
         from awx.main.models import Credential
 
         public_galaxy_credential = Credential.objects.filter(managed=True, name='Ansible Galaxy').first()
-        if public_galaxy_credential not in self.galaxy_credentials.all():
+        if public_galaxy_credential is not None and public_galaxy_credential not in self.galaxy_credentials.all():
             self.galaxy_credentials.add(public_galaxy_credential)
 
 


### PR DESCRIPTION
##### SUMMARY

Fixed Orginzation mapping behavior with SAML when Ansible Galaxy credential does not exist to address the following issues:

- Fixes #10879
- Fixes ansible/tower#5061

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
devel
```

##### ADDITIONAL INFORMATION
If the installation process did not run `awx-manage create_preload_data`, users may not have default Ansible Galaxy credentials.