### PR TITLE
Introduce the control-service TLS support on receptor

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3049,7 +3049,7 @@ class AWXReceptorJob:
         _kw = {}
         if self.work_type == 'ansible-runner':
             _kw['node'] = self.task.instance.execution_node
-            use_stream_tls = True if get_conn_type(_kw['node'], receptor_ctl) == 2 else False
+            use_stream_tls = get_conn_type(_kw['node'], receptor_ctl).name == "STREAMTLS"
             _kw['tlsclient'] = get_tls_client(use_stream_tls)
 
         result = receptor_ctl.submit_work(worktype=self.work_type, payload=sockout.makefile('rb'), params=self.receptor_params, **_kw)

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -7,10 +7,11 @@ from receptorctl.socket_interface import ReceptorControl
 
 logger = logging.getLogger('awx.main.utils.receptor')
 
+__RECEPTOR_CONF = '/etc/receptor/receptor.conf'
+
 
 def get_receptor_sockfile():
-    receptor_conf = '/etc/receptor/receptor.conf'
-    with open(receptor_conf, 'r') as f:
+    with open(__RECEPTOR_CONF, 'r') as f:
         data = yaml.safe_load(f)
     for section in data:
         for entry_name, entry_data in section.items():
@@ -18,23 +19,54 @@ def get_receptor_sockfile():
                 if 'filename' in entry_data:
                     return entry_data['filename']
                 else:
-                    raise RuntimeError(f'Receptor conf {receptor_conf} control-service entry does not have a filename parameter')
+                    raise RuntimeError(f'Receptor conf {__RECEPTOR_CONF} control-service entry does not have a filename parameter')
     else:
-        raise RuntimeError(f'Receptor conf {receptor_conf} does not have control-service entry needed to get sockfile')
+        raise RuntimeError(f'Receptor conf {__RECEPTOR_CONF} does not have control-service entry needed to get sockfile')
+
+
+def get_tls_client(use_stream_tls=None):
+    if not use_stream_tls:
+        return None
+
+    with open(__RECEPTOR_CONF, 'r') as f:
+        data = yaml.safe_load(f)
+    for section in data:
+        for entry_name, entry_data in section.items():
+            if entry_name == 'tls-client':
+                if 'name' in entry_data:
+                    return entry_data['name']
+    return None
 
 
 def get_receptor_ctl():
     receptor_sockfile = get_receptor_sockfile()
-    return ReceptorControl(receptor_sockfile)
+    try:
+        return ReceptorControl(receptor_sockfile, config=__RECEPTOR_CONF, tlsclient=get_tls_client(True))
+    except RuntimeError:
+        return ReceptorControl(receptor_sockfile)
+
+
+def get_conn_type(node_name, receptor_ctl):
+    """
+    ConnType 0: Datagram
+    ConnType 1: Stream
+    ConnType 2: StreamTLS
+    """
+    all_nodes = receptor_ctl.simple_command("status").get('Advertisements', None)
+    for node in all_nodes:
+        if node.get('NodeID') == node_name:
+            return node.get('ConnType')
 
 
 def worker_info(node_name, work_type='ansible-runner'):
     receptor_ctl = get_receptor_ctl()
+    use_stream_tls = True if get_conn_type(node_name, receptor_ctl) == 2 else False
     transmit_start = time.time()
     error_list = []
     data = {'errors': error_list, 'transmit_timing': 0.0}
 
     kwargs = {}
+    kwargs['tlsclient'] = get_tls_client(use_stream_tls)
     if work_type != 'local':
         kwargs['ttl'] = '20s'
     result = receptor_ctl.submit_work(worktype=work_type, payload='', params={"params": f"--worker-info"}, node=node_name, **kwargs)


### PR DESCRIPTION
TODO:
-- 
- [x] Need some love for non-TLS stanzas as job is failing as shown below (https://github.com/ansible/awx/issues/11116)

Related: https://github.com/ansible/tower-packaging/issues/1452

Installer PR: https://github.com/ansible/automation-platform-collection/pull/163 (dependent this to be test)
 
##### SUMMARY
Support StreamTLS when submitting work to remote receptor nodes
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description, but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
This PR works in addition to the  https://github.com/ansible/automation-platform-collection/pull/163 which enables connecting to the `receptor` instances with TLS. 

For example:


```
[root@126-addr ~]# receptorctl  --socket /var/run/awx-receptor/receptor.sock status
Node ID: 192.168.111.126
Version: 
System CPU Count: 1
System Memory MiB: 2273

Connection      Cost
192.168.111.110 1
192.168.111.121 1
192.168.111.115 1
192.168.111.108 1

[... SNIP..]

Node            Service   Type       Last Seen             Tags
192.168.111.126 control   StreamTLS  2021-09-14 00:20:36   {'type': 'Control Service'}
192.168.111.110 control   StreamTLS  2021-09-14 00:19:27   {'type': 'Control Service'}
192.168.111.121 control   StreamTLS  2021-09-14 00:19:10   {'type': 'Control Service'}
192.168.111.115 control   StreamTLS  2021-09-14 00:19:18   {'type': 'Control Service'}
192.168.111.108 control   Stream     2021-09-14 00:19:22   {'type': 'Control Service'}
192.168.111.100 control   StreamTLS  2021-09-14 00:20:42   {'type': 'Control Service'}

Node            Work Types
192.168.111.126 local, kubernetes-runtime-auth, kubernetes-incluster-auth
192.168.111.110 ansible-runner
192.168.111.121 local, kubernetes-runtime-auth, kubernetes-incluster-auth
192.168.111.115 local, kubernetes-runtime-auth, kubernetes-incluster-auth
192.168.111.108 ansible-runner
```
As we can see the node `192.169.111.108`  does not have TLS while the others do. So running a quick test, we can see it working as expected:


```python
>>> from awx.main.utils.receptor import get_receptor_ctl, worker_info, get_tls_client, get_conn_type
>>> ctl = get_receptor_ctl()
>>> worker_info('192.168.111.110')
{'errors': [], 'transmit_timing': 0.06040644645690918, 'run_timing': 1.002300500869751, 'cpu_count': 1, 'mem_in_bytes': 2383781888, 'runner_version': '2.1.0', 'uuid': 'e82814c6df6e4db6a93beb6c041f76a5'}
>>> worker_info('192.168.111.108')
{'errors': [], 'transmit_timing': 0.03332328796386719, 'run_timing': 1.0026488304138184, 'cpu_count': 1, 'mem_in_bytes': 2383781888, 'runner_version': '2.1.0', 'uuid': '5ffbd38ae5734483882edbb68ee1a43a'}
>>> worker_info('192.168.111.126', 'local')
{'errors': [], 'transmit_timing': 0.015320539474487305, 'run_timing': 0.017684221267700195, 'cpu_count': 1, 'mem_in_bytes': 2383781888, 'runner_version': '2.1.0', 'uuid': 'a1003832d3974afd93f53b13c305f398'}
```

I was able to dispatch jobs to instances with or without TLS:

* With TLS
```json
{
    "id": 92,
    "type": "job",
    "url": "/api/v2/jobs/92/",
    "playbook": "hello_world.yml",
    "execution_node": "192.168.111.110",
    "controller_node": "192.168.111.126",
    "result_traceback": "",
    "event_processing_finished": true,
    "work_unit_id": "qvVR6hzG",
    "failed": false,
    "started": "2021-09-14T03:15:57.552424Z",
    "finished": "2021-09-14T03:16:07.302501Z",
}
```

* WithoutTLS I'm hitting this error
```json
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible-playbook [core 2.12.0.dev0]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.8/site-packages/ansible
  ansible collection location = /runner/requirements_collections:/home/runner/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible-playbook
  python version = 3.8.6 (default, Jan 22 2021, 11:41:28) [GCC 8.4.1 20200928 (Red Hat 8.4.1-1)]
  jinja version = 2.10.3
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
ERROR! the playbook: hello_world.yml could not be found
```

```json
{
    "id": 94,
    "type": "job",
    "url": "/api/v2/jobs/94/",
    "playbook": "hello_world.yml",
    "failed": true,
    "elapsed": 17.882,
    "job_args": "[\"podman\", \"run\", \"--rm\", \"--tty\", \"--interactive\", \"--workdir\", \"/runner/project\", \"-v\", \"/tmp/awx_94_prz4ec0_/:/runner/:Z\", \"--authfile=/tmp/ansible_runner_registry_94_5fd9x3rj/auth.json\", \"--env-file\", \"/tmp/awx_94_prz4ec0_/artifacts/94/env.list\", \"--quiet\", \"--name\", \"ansible_runner_94\", \"--user=root\", \"brew.registry.redhat.io/rh-osbs/ansible-automation-platform-21-ee-supported-rhel8:latest\", \"ansible-playbook\", \"-u\", \"admin\", \"-vv\", \"-i\", \"/runner/inventory/hosts\", \"-e\", \"@/runner/env/extravars\", \"hello_world.yml\"]",
    "job_cwd": "/runner/project",
    "job_env": {
        "LAUNCHED_BY_RUNNER": "1",
        "ANSIBLE_UNSAFE_WRITES": "1",
        "AWX_ISOLATED_DATA_DIR": "/runner/artifacts/94",
        "ANSIBLE_FORCE_COLOR": "True",
        "ANSIBLE_HOST_KEY_CHECKING": "False",
        "ANSIBLE_INVENTORY_UNPARSED_FAILED": "True",
        "ANSIBLE_PARAMIKO_RECORD_HOST_KEYS": "False",
        "AWX_PRIVATE_DATA_DIR": "/tmp/awx_94_prz4ec0_",
        "JOB_ID": "94",
        "INVENTORY_ID": "1",
        "PROJECT_REVISION": "347e44fea036c94d5f60e544de006453ee5c71ad",
        "ANSIBLE_RETRY_FILES_ENABLED": "False",
        "MAX_EVENT_RES": "700000",
        "AWX_HOST": "https://towerhost",
        "ANSIBLE_SSH_CONTROL_PATH_DIR": "/runner/cp",
        "ANSIBLE_COLLECTIONS_PATHS": "/runner/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
        "ANSIBLE_ROLES_PATH": "/runner/requirements_roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles",
        "ANSIBLE_STDOUT_CALLBACK": "awx_display",
        "RUNNER_OMIT_EVENTS": "False",
        "RUNNER_ONLY_FAILED_EVENTS": "False"
    },
    "job_explanation": "",
    "execution_node": "192.168.111.108",
    "controller_node": "192.168.111.121",
    "work_unit_id": "adtRQpew",
} 
```