### PR TITLE
Project updates must run on controller nodes

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1865,7 +1865,7 @@ class RunJob(BaseTask):
 
         if sync_needs:
             pu_ig = job.instance_group
-            pu_en = job.execution_node
+            pu_en = Instance.objects.me().hostname
 
             sync_metafields = dict(
                 launch_type="sync",


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related: https://github.com/ansible/awx/issues/11116

For project updates jobs triggered due a job template run,
we must ensure that project_update job to run on at the same
controller which dispatched the original job template, otherwise
the job might fail for being unable to find the playbook YAML file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
When submitting a job to an `execution_node`, the playbook will fail if the `controller_node` which dispatched the job does not have yet a `project` cached at `/var/lib/awx/projects` directory. 

The error will be:

```
Using /etc/ansible/ansible.cfg as config file
ERROR! the playbook: hello_world.yml could not be found
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
