### PR TITLE
Removes receptor instances from select option on metrics screen

### DIFF
--- a/awx/ui/src/screens/Metrics/Metrics.js
+++ b/awx/ui/src/screens/Metrics/Metrics.js
@@ -70,9 +70,16 @@ function Metrics() {
       ]);
 
       const metricOptions = Object.keys(mets);
+      const instanceNames = [];
+      results.forEach((result) => {
+        if (result.node_type !== 'execution') {
+          instanceNames.push(result.hostname);
+        }
+      });
 
       return {
-        instances: [...results.map((result) => result.hostname), t`All`],
+        instances:
+          instanceNames.length > 1 ? [...instanceNames, t`All`] : instanceNames,
         metrics: metricOptions,
       };
     }, []),

--- a/awx/ui/src/screens/Metrics/Metrics.test.js
+++ b/awx/ui/src/screens/Metrics/Metrics.test.js
@@ -13,7 +13,11 @@ describe('<Metrics/>', () => {
   beforeEach(async () => {
     InstancesAPI.read.mockResolvedValue({
       data: {
-        results: [{ hostname: 'instance 1' }, { hostname: 'instance 2' }],
+        results: [
+          { hostname: 'instance 1', node_type: 'control' },
+          { hostname: 'instance 2', node_type: 'hybrid' },
+          { hostname: 'receptor', node_type: 'execution' },
+        ],
       },
     });
     MetricsAPI.read.mockResolvedValue({
@@ -69,5 +73,16 @@ describe('<Metrics/>', () => {
       metric: 'metric1',
       node: 'instance 1',
     });
+  });
+
+  test('should not include receptor instances', async () => {
+    await act(async () => {
+      wrapper.find('Select[ouiaId="Instance-select"]').prop('onToggle')(true);
+    });
+    wrapper.update();
+    expect(wrapper.find('SelectOption[value="receptor"]')).toHaveLength(0);
+    expect(
+      wrapper.find('Select[ouiaId="Instance-select"]').find('SelectOption')
+    ).toHaveLength(3);
   });
 });


### PR DESCRIPTION
##### SUMMARY
This addresses #11028.  It removes receptor instances from the Instances drop down.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION

##### ADDITIONAL INFORMATION

![Screen Shot 2021-09-23 at 12 37 30 PM](https://user-images.githubusercontent.com/39280967/134548366-41cc47c1-d514-45d9-b71c-84c4375bee69.png)

