### PR TITLE
Do not display EE if a job was canceled

### DIFF
--- a/awx/ui/src/components/JobList/JobListItem.js
+++ b/awx/ui/src/components/JobList/JobListItem.js
@@ -222,13 +222,15 @@ function JobListItem({
                   dataCy={`job-${job.id}-project`}
                 />
               )}
-              {job.type !== 'workflow_job' && !isJobRunning(job.status) && (
-                <ExecutionEnvironmentDetail
-                  executionEnvironment={execution_environment}
-                  verifyMissingVirtualEnv={false}
-                  dataCy={`execution-environment-detail-${job.id}`}
-                />
-              )}
+              {job.type !== 'workflow_job' &&
+                !isJobRunning(job.status) &&
+                job.status !== 'canceled' && (
+                  <ExecutionEnvironmentDetail
+                    executionEnvironment={execution_environment}
+                    verifyMissingVirtualEnv={false}
+                    dataCy={`execution-environment-detail-${job.id}`}
+                  />
+                )}
               {credentials && credentials.length > 0 && (
                 <Detail
                   fullWidth

--- a/awx/ui/src/components/JobList/JobListItem.test.js
+++ b/awx/ui/src/components/JobList/JobListItem.test.js
@@ -24,6 +24,7 @@ const mockJob = {
   status: 'successful',
   job_slice_number: 1,
   job_slice_count: 3,
+  execution_environment: 1,
 };
 
 describe('<JobListItem />', () => {
@@ -61,7 +62,7 @@ describe('<JobListItem />', () => {
     expect(wrapper.find('LaunchButton').length).toBe(1);
   });
 
-  test('should render souce data in expanded view', () => {
+  test('should render source data in expanded view', () => {
     wrapper = mountWithContexts(
       <table>
         <tbody>
@@ -126,6 +127,49 @@ describe('<JobListItem />', () => {
       </table>
     );
     expect(wrapper.find('Td[dataLabel="Type"]').length).toBe(1);
+  });
+
+  test('should not display EE for canceled jobs', () => {
+    wrapper = mountWithContexts(
+      <table>
+        <tbody>
+          <JobListItem
+            job={{
+              ...mockJob,
+              status: 'canceled',
+              execution_environment: null,
+            }}
+            showTypeColumn
+            isSelected
+            onSelect={() => {}}
+          />
+        </tbody>
+      </table>
+    );
+    expect(wrapper.find('Detail[label="Execution Environment"]').length).toBe(
+      0
+    );
+  });
+
+  test('should display missing resource for completed jobs and missing EE', () => {
+    wrapper = mountWithContexts(
+      <table>
+        <tbody>
+          <JobListItem
+            job={mockJob}
+            showTypeColumn
+            isSelected
+            onSelect={() => {}}
+          />
+        </tbody>
+      </table>
+    );
+    expect(wrapper.find('Detail[label="Execution Environment"]').length).toBe(
+      1
+    );
+    expect(
+      wrapper.find('Detail[label="Execution Environment"] dd').text()
+    ).toBe('Missing resource');
   });
 });
 


### PR DESCRIPTION
Do not display EE if a job was canceled. Since the API is returning null
for the value of the EE for this particular scenario.

See: https://github.com/ansible/awx/issues/11127
