### PR TITLE
Disable autodiscovery except for docker-compose

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -263,6 +263,10 @@ CSRF_COOKIE_SECURE = True
 # Limit CSRF cookies to browser sessions
 CSRF_COOKIE_AGE = None
 
+# Auto-discover new instances that appear on receptor mesh
+# used for docker-compose environment, unsupported
+MESH_AUTODISCOVERY_ENABLED = False
+
 TEMPLATES = [
     {
         'NAME': 'default',

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -69,6 +69,9 @@ AWX_ROLES_ENABLED = True
 PENDO_TRACKING_STATE = "off"
 INSIGHTS_TRACKING_STATE = False
 
+# auto-discover receptor-* execution nodes
+MESH_AUTODISCOVERY_ENABLED = True
+
 # debug toolbar and swagger assume that requirements/requirements_dev.txt are installed
 
 INSTALLED_APPS += ['rest_framework_swagger', 'debug_toolbar']  # NOQA


### PR DESCRIPTION
##### SUMMARY
With this, we will no longer register new nodes `Instance.register` because of seeing them on the receptor mesh, with the exception of the docker-compose development environment.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Also removed logic to add those instances to the "default" instance group, because that is no longer need with recent changes - it will get added by the policy rules and we don't need to worry about it anymore.
