### PR TITLE
Fixed logic to avoid tracebacks when node_name is invalid

### DIFF
--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -63,7 +63,7 @@ def get_conn_type(node_name, receptor_ctl):
 
 def worker_info(node_name, work_type='ansible-runner'):
     receptor_ctl = get_receptor_ctl()
-    use_stream_tls = get_conn_type(node_name, receptor_ctl).name == "STREAMTLS"
+    use_stream_tls = getattr(get_conn_type(node_name, receptor_ctl), 'name', None) == "STREAMTLS"
     transmit_start = time.time()
     error_list = []
     data = {'errors': error_list, 'transmit_timing': 0.0}


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

**cc**: @fosterseth @ffirg @chrismeyersfsu 

##### SUMMARY
Whenever an invalid `node_name` is reported in the `mesh` network, the `get_conn_type()` could traceback for not having the `.name` attribute. 

Fixes: https://github.com/ansible/awx/issues/11141

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
##### Before:
```python
>>> from receptorctl.socket_interface import ReceptorControl
>>> from awx.main.utils.receptor import get_receptor_ctl
>>> from awx.main.utils.receptor import get_receptor_ctl, get_conn_type, worker_info
>>> receptor_ctl = get_receptor_ctl()

# node without TLS
>>> node_name = '192.168.111.126' <-- node exists without TLS
>>> get_conn_type(node_name, receptor_ctl).name == "STREAMTLS"
False

# node with TLS
>>> node_name = '192.168.111.115'
>>> get_conn_type(node_name, receptor_ctl).name == "STREAMTLS"
True

# invalid node
>>> node_name = 'not_valid'
>>> get_conn_type(node_name, receptor_ctl).name == "STREAMTLS"
Traceback (most recent call last):
  File "<console>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'name'
```

##### After:
```python
>>> from receptorctl.socket_interface import ReceptorControl
>>> from awx.main.utils.receptor import get_receptor_ctl
>>> from awx.main.utils.receptor import get_receptor_ctl, get_conn_type, worker_info
>>> receptor_ctl = get_receptor_ctl()

# node without TLS
>>> node_name = '192.168.111.126'
>>> getattr(get_conn_type(node_name, receptor_ctl), 'name', None) == "STREAMTLS"
False

# node with TLS
>>> node_name = '192.168.111.115'
>>> getattr(get_conn_type(node_name, receptor_ctl), 'name', None) == "STREAMTLS"
True

# invalid node
>>> node_name = 'node_invalid'
>>> getattr(get_conn_type(node_name, receptor_ctl), 'name', None) == "STREAMTLS"
False
```
