### PR TITLE
Wrap `setAuthRedirectTo` in useEffect.

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -102,6 +102,10 @@ const ProtectedRoute = ({ children, ...rest }) => {
   const { authRedirectTo, setAuthRedirectTo } = useSession();
   const { pathname } = useLocation();
 
+  useEffect(() => {
+    setAuthRedirectTo(authRedirectTo === '/logout' ? '/' : pathname);
+  });
+
   if (isAuthenticated(document.cookie)) {
     return (
       <Route {...rest}>
@@ -111,8 +115,6 @@ const ProtectedRoute = ({ children, ...rest }) => {
       </Route>
     );
   }
-
-  setAuthRedirectTo(authRedirectTo === '/logout' ? '/' : pathname);
 
   return <Redirect to="/login" />;
 };


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #10822

[Introduced in React v16.3.0](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#warnings-for-some-updates-during-render), this warning fires if `setState` is called from within a different component than the one being rendered. As documented, the fix is to wrap the `setState` call in a `useEffect` hook.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.3.0
```
