### PR TITLE
Fix rpm 'offline' build (add pbr to venv and change receptorctl wheel file name)

### DIFF
--- a/awx/main/tests/functional/test_licenses.py
+++ b/awx/main/tests/functional/test_licenses.py
@@ -48,6 +48,7 @@ def test_python_and_js_licenses():
 
     def read_api_requirements(path):
         ret = {}
+        skip_pbr_license_check = False
         for req_file in ['requirements.txt', 'requirements_git.txt']:
             fname = '%s/%s' % (path, req_file)
 
@@ -65,7 +66,11 @@ def test_python_and_js_licenses():
                         name = name[:-4]
                     if name == 'receptor':
                         name = 'receptorctl'
+                    if name == 'ansible-runner':
+                        skip_pbr_license_check = True
                 ret[name] = {'name': name, 'version': version}
+        if 'pbr' in ret and skip_pbr_license_check:
+            del ret['pbr']
         return ret
 
     def read_ui_requirements(path):

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -59,3 +59,7 @@ uwsgitop
 wheel
 pip==19.3.1  # see UPGRADE BLOCKERs
 setuptools==41.6.0  # see UPGRADE BLOCKERs
+
+# Temporarily added to use ansible-runner from git branch, to be removed
+# when ansible-runner moves from requirements_git.txt to here
+pbr

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -224,6 +224,8 @@ oauthlib==3.1.0
     #   social-auth-core
 openshift==0.11.0
     # via -r /awx_devel/requirements/requirements.in
+pbr==5.6.0
+    # via -r /awx_devel/requirements/requirements.in
 pexpect==4.7.0
     # via
     #   -r /awx_devel/requirements/requirements.in

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,4 +1,4 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
-https://receptor-nightlies.s3.amazonaws.com/receptorctl/receptorctl-latest-py3-none-any.whl
+https://receptor-nightlies.s3.amazonaws.com/receptorctl/receptorctl-0.0.0-py3-none-any.whl

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,3 +1,4 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
+# Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 https://receptor-nightlies.s3.amazonaws.com/receptorctl/receptorctl-latest-py3-none-any.whl


### PR DESCRIPTION
Requires: https://github.com/ansible/receptor/pull/427

There are currently 2 issues with rpm 'offline' build:

- The build fails tying to get version info from ansible-runner due to missing `pbr`. Since ansible-runner requires pbr to get version info when it comes from git branch, adding pbr to venv for now.  When we move ansible-runner from requirements_git.txt to requirements.in, pbr should be removed as well.

- receptorctl nightly wheel file name `receptorctl-latest-py3-none-any.whl` was considered invalid and needed to change the version identifier to numeric.