### PR TITLE
Consolidate cleanup actions under new `ansible-runner worker cleanup` command

### DIFF
--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -81,3 +81,6 @@ LOGGER_BLOCKLIST = (
 # Reported version for node seen in receptor mesh but for which capacity check
 # failed or is in progress
 RECEPTOR_PENDING = 'ansible-runner-???'
+
+# Naming pattern for AWX jobs in /tmp folder, like /tmp/awx_42_xiwm
+JOB_FOLDER_PREFIX = 'awx_%s_'

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -165,7 +165,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         vargs = dict(file_pattern='/tmp/{}*'.format(JOB_FOLDER_PREFIX % '*'))
         vargs.update(kwargs)
         if 'exclude_strings' not in vargs and vargs.get('file_pattern'):
-            active_pks = list(UnifiedJob.objects.filter(execution_node=self.hostname, status_in=('running', 'waiting')).values_list('pk', flat=True))
+            active_pks = list(UnifiedJob.objects.filter(execution_node=self.hostname, status__in=('running', 'waiting')).values_list('pk', flat=True))
             if active_pks:
                 vargs['exclude_strings'] = [JOB_FOLDER_PREFIX % job_id for job_id in active_pks]
         if 'remove_images' in vargs or 'image_prune' in vargs:

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -162,12 +162,14 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         returns a dict that is passed to the python interface for the runner method corresponding to that command
         any kwargs will override that key=value combination in the returned dict
         """
-        vargs = dict(process_isolation_executable='podman', file_pattern='/tmp/{}*'.format(JOB_FOLDER_PREFIX % '*'), exclude_strings=None)
+        vargs = dict(file_pattern='/tmp/{}*'.format(JOB_FOLDER_PREFIX % '*'))
         vargs.update(kwargs)
-        if 'exclude_strings' not in vargs:
+        if 'exclude_strings' not in vargs and vargs.get('file_pattern'):
             active_pks = list(UnifiedJob.objects.filter(execution_node=self.hostname, status_in=('running', 'waiting')).values_list('pk', flat=True))
             if active_pks:
                 vargs['exclude_strings'] = [JOB_FOLDER_PREFIX % job_id for job_id in active_pks]
+        if 'remove_images' in vargs or 'image_prune' in vargs:
+            vargs.setdefault('process_isolation_executable', 'podman')
         return vargs
 
     def is_lost(self, ref_time=None):

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -58,7 +58,7 @@ from awx.main.models import (
 from awx.main.constants import CENSOR_VALUE
 from awx.main.utils import model_instance_diff, model_to_dict, camelcase_to_underscore, get_current_apps
 from awx.main.utils import ignore_inventory_computed_fields, ignore_inventory_group_removal, _inventory_updates
-from awx.main.tasks import update_inventory_computed_fields, handle_removed_image, cleanup_images_and_files_execution_nodes
+from awx.main.tasks import update_inventory_computed_fields, handle_removed_image
 from awx.main.fields import (
     is_implicit_parent,
     update_role_parentage_for_instance,
@@ -628,7 +628,6 @@ def _handle_image_cleanup(removed_image, pk):
     if (not removed_image) or ExecutionEnvironment.objects.filter(image=removed_image).exclude(pk=pk).exists():
         return  # if other EE objects reference the tag, then do not purge it
     handle_removed_image.delay(remove_images=removed_image)
-    cleanup_images_and_files_execution_nodes.delay(remove_images=removed_image)
 
 
 @receiver(pre_delete, sender=ExecutionEnvironment)

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -627,7 +627,7 @@ def deny_orphaned_approvals(sender, instance, **kwargs):
 def _handle_image_cleanup(removed_image, pk):
     if (not removed_image) or ExecutionEnvironment.objects.filter(image=removed_image).exclude(pk=pk).exists():
         return  # if other EE objects reference the tag, then do not purge it
-    handle_removed_image.delay(remove_images=removed_image)
+    handle_removed_image.delay(remove_images=[removed_image])
 
 
 @receiver(pre_delete, sender=ExecutionEnvironment)

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -390,8 +390,7 @@ def purge_old_stdout_files():
             logger.debug("Removing {}".format(os.path.join(settings.JOBOUTPUT_ROOT, f)))
 
 
-@task(queue=get_local_queuename)
-def cleanup_images_and_files(remove_images=None):
+def _cleanup_images_and_files(remove_images=None):
     if settings.IS_K8S:
         return
     this_inst = Instance.objects.me()
@@ -399,16 +398,9 @@ def cleanup_images_and_files(remove_images=None):
     runner_cleanup_kwargs['remove_images'] = remove_images
     ansible_runner.cleanup.run_cleanup(runner_cleanup_kwargs)
 
-
-@task(queue='tower_broadcast_all')
-def handle_removed_image(remove_images=None):
-    """Special broadcast invocation of this method to handle case of deleted EE"""
-    cleanup_images_and_files(remove_images=remove_images)
-
-
-@task(queue=get_local_queuename)
-def cleanup_images_and_files_execution_nodes(remove_images=None):
-    with advisory_lock('clean_execution_nodes_lock', wait=False):
+    # if we are the first instance alphabetically, then run cleanup on execution nodes
+    checker_instance = Instance.objects.filter(node_type__in=['hybrid', 'control'], enabled=True, capacity__gt=0).order_by('-hostname').first()
+    if checker_instance and this_inst.hostname == checker_instance.hostname:
         for inst in Instance.objects.filter(node_type='execution', enabled=True, capacity__gt=0):
             runner_cleanup_kwargs = inst.get_cleanup_task_kwargs()
             runner_cleanup_kwargs['remove_images'] = remove_images
@@ -416,6 +408,17 @@ def cleanup_images_and_files_execution_nodes(remove_images=None):
                 worker_cleanup(inst.hostname, runner_cleanup_kwargs)
             except RuntimeError:
                 logger.exception(f'Error running cleanup on execution node {inst.hostname}')
+
+
+@task(queue='tower_broadcast_all')
+def handle_removed_image(remove_images=None):
+    """Special broadcast invocation of this method to handle case of deleted EE"""
+    _cleanup_images_and_files(remove_images=remove_images)
+
+
+@task(queue=get_local_queuename)
+def cleanup_images_and_files():
+    _cleanup_images_and_files()
 
 
 @task(queue=get_local_queuename)

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -422,7 +422,7 @@ def _cleanup_images_and_files(**kwargs):
 @task(queue='tower_broadcast_all')
 def handle_removed_image(remove_images=None):
     """Special broadcast invocation of this method to handle case of deleted EE"""
-    _cleanup_images_and_files(remove_images=remove_images, file_pattern='', exclude_strings='')
+    _cleanup_images_and_files(remove_images=remove_images, file_pattern='')
 
 
 @task(queue=get_local_queuename)

--- a/awx/main/tests/functional/models/test_execution_environment.py
+++ b/awx/main/tests/functional/models/test_execution_environment.py
@@ -1,9 +1,29 @@
 import pytest
 
+from awx.main.models.execution_environments import ExecutionEnvironment
 
-def test_image_unchanged_no_delete_task(execution_environment, mocker):
+
+@pytest.mark.django_db
+def test_image_unchanged_no_delete_task(mocker):
     """When an irrelevant EE field is changed, we do not run the image cleanup task"""
+    execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.description = 'foobar'
-    with mocker.patch() as p:
-        execution_environment.save()
-        p.assert_not_called()
+    with mocker.patch('awx.main.signals.handle_removed_image') as p1:
+        with mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes') as p2:
+            execution_environment.save()
+            p1.assert_not_called()
+            p2.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_image_unchanged_no_delete_task(mocker):
+    """When an irrelevant EE field is changed, we do not run the image cleanup task"""
+    execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
+    execution_environment.image = 'quay.io/new/image'
+    with mocker.patch('awx.main.signals.handle_removed_image'):
+        with mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes'):
+            execution_environment.save()
+            from awx.main.signals import handle_removed_image, cleanup_images_and_files_execution_nodes
+
+            handle_removed_image.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+            cleanup_images_and_files_execution_nodes.delay.assert_called_once_with(remove_images='quay.io/foo/bar')

--- a/awx/main/tests/functional/models/test_execution_environment.py
+++ b/awx/main/tests/functional/models/test_execution_environment.py
@@ -15,7 +15,7 @@ def test_image_unchanged_no_delete_task(cleanup_patch):
     execution_environment.description = 'foobar'
     execution_environment.save()
 
-    cleanup_patch.patch.assert_not_called()
+    cleanup_patch.delay.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -24,7 +24,7 @@ def test_image_changed_creates_delete_task(cleanup_patch):
     execution_environment.image = 'quay.io/new/image'
     execution_environment.save()
 
-    cleanup_patch.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patch.delay.assert_called_once_with(remove_images=['quay.io/foo/bar'])
 
 
 @pytest.mark.django_db
@@ -35,7 +35,7 @@ def test_image_still_in_use(cleanup_patch):
     execution_environment.image = 'quay.io/new/image'
     execution_environment.save()
 
-    cleanup_patch.patch.assert_not_called()
+    cleanup_patch.delay.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -43,4 +43,4 @@ def test_image_deletion_creates_delete_task(cleanup_patch):
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.delete()
 
-    cleanup_patch.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patch.delay.assert_called_once_with(remove_images=['quay.io/foo/bar'])

--- a/awx/main/tests/functional/models/test_execution_environment.py
+++ b/awx/main/tests/functional/models/test_execution_environment.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_image_unchanged_no_delete_task(execution_environment, mocker):
+    """When an irrelevant EE field is changed, we do not run the image cleanup task"""
+    execution_environment.description = 'foobar'
+    with mocker.patch() as p:
+        execution_environment.save()
+        p.assert_not_called()

--- a/awx/main/tests/functional/models/test_execution_environment.py
+++ b/awx/main/tests/functional/models/test_execution_environment.py
@@ -4,49 +4,43 @@ from awx.main.models.execution_environments import ExecutionEnvironment
 
 
 @pytest.fixture
-def cleanup_patches(mocker):
-    p1 = mocker.patch('awx.main.signals.handle_removed_image')
-    p2 = mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes')
-    return (p1, p2)
+def cleanup_patch(mocker):
+    return mocker.patch('awx.main.signals.handle_removed_image')
 
 
 @pytest.mark.django_db
-def test_image_unchanged_no_delete_task(cleanup_patches):
+def test_image_unchanged_no_delete_task(cleanup_patch):
     """When an irrelevant EE field is changed, we do not run the image cleanup task"""
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.description = 'foobar'
     execution_environment.save()
 
-    cleanup_patches[0].patch.assert_not_called()
-    cleanup_patches[1].patch.assert_not_called()
+    cleanup_patch.patch.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_image_changed_creates_delete_task(cleanup_patches):
+def test_image_changed_creates_delete_task(cleanup_patch):
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.image = 'quay.io/new/image'
     execution_environment.save()
 
-    cleanup_patches[0].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
-    cleanup_patches[1].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patch.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
 
 
 @pytest.mark.django_db
-def test_image_still_in_use(cleanup_patches):
+def test_image_still_in_use(cleanup_patch):
     """When an image is still in use by another EE, we do not clean it up"""
     ExecutionEnvironment.objects.create(name='unrelated-ee', image='quay.io/foo/bar')
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.image = 'quay.io/new/image'
     execution_environment.save()
 
-    cleanup_patches[0].patch.assert_not_called()
-    cleanup_patches[1].patch.assert_not_called()
+    cleanup_patch.patch.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_image_deletion_creates_delete_task(cleanup_patches):
+def test_image_deletion_creates_delete_task(cleanup_patch):
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.delete()
 
-    cleanup_patches[0].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
-    cleanup_patches[1].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patch.delay.assert_called_once_with(remove_images='quay.io/foo/bar')

--- a/awx/main/tests/functional/models/test_execution_environment.py
+++ b/awx/main/tests/functional/models/test_execution_environment.py
@@ -3,27 +3,50 @@ import pytest
 from awx.main.models.execution_environments import ExecutionEnvironment
 
 
+@pytest.fixture
+def cleanup_patches(mocker):
+    p1 = mocker.patch('awx.main.signals.handle_removed_image')
+    p2 = mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes')
+    return (p1, p2)
+
+
 @pytest.mark.django_db
-def test_image_unchanged_no_delete_task(mocker):
+def test_image_unchanged_no_delete_task(cleanup_patches):
     """When an irrelevant EE field is changed, we do not run the image cleanup task"""
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.description = 'foobar'
-    with mocker.patch('awx.main.signals.handle_removed_image') as p1:
-        with mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes') as p2:
-            execution_environment.save()
-            p1.assert_not_called()
-            p2.assert_not_called()
+    execution_environment.save()
+
+    cleanup_patches[0].patch.assert_not_called()
+    cleanup_patches[1].patch.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_image_unchanged_no_delete_task(mocker):
-    """When an irrelevant EE field is changed, we do not run the image cleanup task"""
+def test_image_changed_creates_delete_task(cleanup_patches):
     execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
     execution_environment.image = 'quay.io/new/image'
-    with mocker.patch('awx.main.signals.handle_removed_image'):
-        with mocker.patch('awx.main.signals.cleanup_images_and_files_execution_nodes'):
-            execution_environment.save()
-            from awx.main.signals import handle_removed_image, cleanup_images_and_files_execution_nodes
+    execution_environment.save()
 
-            handle_removed_image.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
-            cleanup_images_and_files_execution_nodes.delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patches[0].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patches[1].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+
+
+@pytest.mark.django_db
+def test_image_still_in_use(cleanup_patches):
+    """When an image is still in use by another EE, we do not clean it up"""
+    ExecutionEnvironment.objects.create(name='unrelated-ee', image='quay.io/foo/bar')
+    execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
+    execution_environment.image = 'quay.io/new/image'
+    execution_environment.save()
+
+    cleanup_patches[0].patch.assert_not_called()
+    cleanup_patches[1].patch.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_image_deletion_creates_delete_task(cleanup_patches):
+    execution_environment = ExecutionEnvironment.objects.create(name='test-ee', image='quay.io/foo/bar')
+    execution_environment.delete()
+
+    cleanup_patches[0].delay.assert_called_once_with(remove_images='quay.io/foo/bar')
+    cleanup_patches[1].delay.assert_called_once_with(remove_images='quay.io/foo/bar')

--- a/awx/main/tests/unit/models/test_ha.py
+++ b/awx/main/tests/unit/models/test_ha.py
@@ -89,3 +89,19 @@ class TestInstanceGroup(object):
             assert ig.find_largest_idle_instance(instances_online_only) is None, reason
         else:
             assert ig.find_largest_idle_instance(instances_online_only) == instances[instance_fit_index], reason
+
+
+def test_cleanup_params_defaults():
+    inst = Instance(hostname='foobar')
+    assert inst.get_cleanup_task_kwargs(exclude_strings=['awx_423_']) == {'exclude_strings': ['awx_423_'], 'file_pattern': '/tmp/awx_*_*'}
+
+
+def test_cleanup_params_for_image_cleanup():
+    inst = Instance(hostname='foobar')
+    # see CLI conversion in awx.main.tests.unit.utils.test_receptor
+    assert inst.get_cleanup_task_kwargs(file_pattern='', remove_images=['quay.invalid/foo/bar'], image_prune=True) == {
+        'file_pattern': '',
+        'process_isolation_executable': 'podman',
+        'remove_images': ['quay.invalid/foo/bar'],
+        'image_prune': True,
+    }

--- a/awx/main/tests/unit/utils/test_receptor.py
+++ b/awx/main/tests/unit/utils/test_receptor.py
@@ -1,0 +1,22 @@
+from awx.main.utils.receptor import _convert_args_to_cli
+
+
+def test_file_cleanup_scenario():
+    args = _convert_args_to_cli({'exclude_strings': ['awx_423_', 'awx_582_'], 'file_pattern': '/tmp/awx_*_*'})
+    assert ' '.join(args) == 'cleanup --exclude-strings=awx_423_ awx_582_ --file-pattern=/tmp/awx_*_*'
+
+
+def test_image_cleanup_scenario():
+    # See input dict in awx.main.tests.unit.models.test_ha
+    args = _convert_args_to_cli(
+        {
+            'file_pattern': '',
+            'process_isolation_executable': 'podman',
+            'remove_images': ['quay.invalid/foo/bar:latest', 'quay.invalid/foo/bar:devel'],
+            'image_prune': True,
+        }
+    )
+    assert (
+        ' '.join(args)
+        == 'cleanup --remove-images=quay.invalid/foo/bar:latest quay.invalid/foo/bar:devel --image-prune --image-prune=True --process-isolation-executable=podman'
+    )

--- a/awx/main/tests/unit/utils/test_receptor.py
+++ b/awx/main/tests/unit/utils/test_receptor.py
@@ -17,6 +17,5 @@ def test_image_cleanup_scenario():
         }
     )
     assert (
-        ' '.join(args)
-        == 'cleanup --remove-images=quay.invalid/foo/bar:latest quay.invalid/foo/bar:devel --image-prune --image-prune=True --process-isolation-executable=podman'
+        ' '.join(args) == 'cleanup --remove-images=quay.invalid/foo/bar:latest quay.invalid/foo/bar:devel --image-prune --process-isolation-executable=podman'
     )

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -144,7 +144,10 @@ def worker_cleanup(node_name, vargs, timeout=300.0):
 
     # convert python args into CLI args
     args = ['cleanup']
-    for option in ('file_pattern', 'exclude_strings', 'remove_images', 'image_prune', 'process_isolation_executable'):
+    for option in ('exclude_strings', 'remove_images'):
+        if vargs.get(option):
+            args.append('--{} '.format(option.replace('_', '-'), ' '.join(vargs.get(option))))
+    for option in ('file_pattern', 'image_prune', 'process_isolation_executable'):
         if vargs.get(option) is True:
             args.append('--{}'.format(option.replace('_', '-')))
         if vargs.get(option):

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -175,7 +175,7 @@ def _convert_args_to_cli(vargs):
     for option in ('file_pattern', 'image_prune', 'process_isolation_executable', 'grace_period'):
         if vargs.get(option) is True:
             args.append('--{}'.format(option.replace('_', '-')))
-        if vargs.get(option) not in (None, ''):
+        elif vargs.get(option) not in (None, ''):
             args.append('--{}={}'.format(option.replace('_', '-'), vargs.get(option)))
     return args
 

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -61,40 +61,48 @@ def get_conn_type(node_name, receptor_ctl):
             return ReceptorConnectionType(node.get('ConnType'))
 
 
-def worker_info(node_name, work_type='ansible-runner'):
-    receptor_ctl = get_receptor_ctl()
-    use_stream_tls = getattr(get_conn_type(node_name, receptor_ctl), 'name', None) == "STREAMTLS"
-    transmit_start = time.time()
-    error_list = []
-    data = {'errors': error_list, 'transmit_timing': 0.0}
+class RemoteJobError(RuntimeError):
+    pass
 
-    kwargs = {}
-    kwargs['tlsclient'] = get_tls_client(use_stream_tls)
-    kwargs['signwork'] = True
-    if work_type != 'local':
-        kwargs['ttl'] = '20s'
-    result = receptor_ctl.submit_work(worktype=work_type, payload='', params={"params": "--worker-info"}, node=node_name, **kwargs)
+
+def run_until_complete(node, timing_data=None, **kwargs):
+    """
+    Runs an ansible-runner work_type on remote node, waits until it completes, then returns stdout.
+    """
+    receptor_ctl = get_receptor_ctl()
+
+    use_stream_tls = getattr(get_conn_type(node, receptor_ctl), 'name', None) == "STREAMTLS"
+    kwargs.setdefault('tlsclient', get_tls_client(use_stream_tls))
+    kwargs.setdefault('signwork', True)
+    kwargs.setdefault('ttl', '20s')
+    kwargs.setdefault('payload', '')
+
+    transmit_start = time.time()
+    result = receptor_ctl.submit_work(worktype='ansible-runner', node=node, **kwargs)
 
     unit_id = result['unitid']
     run_start = time.time()
-    data['transmit_timing'] = run_start - transmit_start
-    data['run_timing'] = 0.0
+    if timing_data:
+        timing_data['transmit_timing'] = run_start - transmit_start
+    run_timing = 0.0
+    stdout = ''
 
     try:
 
         resultfile = receptor_ctl.get_work_results(unit_id)
 
-        stdout = ''
-
-        while data['run_timing'] < 20.0:
+        while run_timing < 20.0:
             status = receptor_ctl.simple_command(f'work status {unit_id}')
             state_name = status.get('StateName')
             if state_name not in ('Pending', 'Running'):
                 break
-            data['run_timing'] = time.time() - run_start
+            run_timing = time.time() - run_start
             time.sleep(0.5)
         else:
-            error_list.append(f'Timeout getting worker info on {node_name}, state remains in {state_name}')
+            raise RemoteJobError(f'Receptor job timeout on {node} after {run_timing} seconds, state remains in {state_name}')
+
+        if timing_data:
+            timing_data['run_timing'] = run_timing
 
         stdout = resultfile.read()
         stdout = str(stdout, encoding='utf-8')
@@ -103,19 +111,27 @@ def worker_info(node_name, work_type='ansible-runner'):
 
         res = receptor_ctl.simple_command(f"work release {unit_id}")
         if res != {'released': unit_id}:
-            logger.warn(f'Could not confirm release of receptor work unit id {unit_id} from {node_name}, data: {res}')
+            logger.warn(f'Could not confirm release of receptor work unit id {unit_id} from {node}, data: {res}')
 
         receptor_ctl.close()
 
     if state_name.lower() == 'failed':
         work_detail = status.get('Detail', '')
-        if not work_detail.startswith('exit status'):
-            error_list.append(f'Receptor error getting worker info from {node_name}, detail:\n{work_detail}')
-        elif 'unrecognized arguments: --worker-info' in stdout:
-            error_list.append(f'Old version (2.0.1 or earlier) of ansible-runner on node {node_name} without --worker-info')
+        if work_detail:
+            raise RemoteJobError(f'Receptor error from {node}, detail:\n{work_detail}')
         else:
-            error_list.append(f'Unknown ansible-runner error on node {node_name}, stdout:\n{stdout}')
-    else:
+            raise RemoteJobError(f'Unknown ansible-runner error on node {node}, stdout:\n{stdout}')
+
+    return stdout
+
+
+def worker_info(node_name, work_type='ansible-runner'):
+    error_list = []
+    data = {'errors': error_list, 'transmit_timing': 0.0}
+
+    try:
+        stdout = run_until_complete(node=node_name, timing_data=data, params={"params": "--worker-info"})
+
         yaml_stdout = stdout.strip()
         remote_data = {}
         try:
@@ -129,6 +145,13 @@ def worker_info(node_name, work_type='ansible-runner'):
             error_list.extend(remote_data.pop('errors', []))  # merge both error lists
             data.update(remote_data)
 
+    except RemoteJobError as exc:
+        details = exc.args[0]
+        if 'unrecognized arguments: --worker-info' in details:
+            error_list.append(f'Old version (2.0.1 or earlier) of ansible-runner on node {node_name} without --worker-info')
+        else:
+            error_list.append(details)
+
     # If we have a connection error, missing keys would be trivial consequence of that
     if not data['errors']:
         # see tasks.py usage of keys
@@ -140,8 +163,6 @@ def worker_info(node_name, work_type='ansible-runner'):
 
 
 def worker_cleanup(node_name, vargs, timeout=300.0):
-    receptor_ctl = get_receptor_ctl()
-
     # convert python args into CLI args
     args = ['cleanup']
     for option in ('exclude_strings', 'remove_images'):
@@ -156,39 +177,6 @@ def worker_cleanup(node_name, vargs, timeout=300.0):
     remote_command = ' '.join(args)
     logger.debug(f'Running command over receptor mesh on {node_name}: ansible-runner worker {remote_command}')
 
-    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": remote_command}, node=node_name, ttl='20s')
-
-    unit_id = result['unitid']
-    run_start = time.time()
-
-    try:
-
-        resultfile = receptor_ctl.get_work_results(unit_id)
-
-        stdout = ''
-
-        while time.time() - run_start < timeout:
-            status = receptor_ctl.simple_command(f'work status {unit_id}')
-            state_name = status.get('StateName')
-            if state_name not in ('Pending', 'Running'):
-                break
-            time.sleep(0.5)
-        else:
-            raise RuntimeError(f'Timeout running worker cleanup, state in {state_name}')
-
-        stdout = resultfile.read()
-        stdout = str(stdout, encoding='utf-8')
-
-    finally:
-
-        res = receptor_ctl.simple_command(f"work release {unit_id}")
-        if res != {'released': unit_id}:
-            logger.warn(f'Could not confirm release of receptor work unit id {unit_id} from {node_name}, data: {res}')
-
-        receptor_ctl.close()
-
-    if state_name.lower() == 'failed':
-        work_detail = status.get('Detail', '')
-        raise RuntimeError(f'Worker cleanup receptor failure, stdout:\n{stdout}\nwork detail:{work_detail}')
+    stdout = run_until_complete(node=node_name, params={"params": remote_command})
 
     return stdout

--- a/awx/main/utils/receptor.py
+++ b/awx/main/utils/receptor.py
@@ -147,13 +147,16 @@ def worker_cleanup(node_name, vargs, timeout=300.0):
     for option in ('exclude_strings', 'remove_images'):
         if vargs.get(option):
             args.append('--{} '.format(option.replace('_', '-'), ' '.join(vargs.get(option))))
-    for option in ('file_pattern', 'image_prune', 'process_isolation_executable'):
+    for option in ('file_pattern', 'image_prune', 'process_isolation_executable', 'grace_period'):
         if vargs.get(option) is True:
             args.append('--{}'.format(option.replace('_', '-')))
-        if vargs.get(option):
+        if vargs.get(option) is not None:
             args.append('--{}={}'.format(option.replace('_', '-'), vargs.get(option)))
 
-    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": ' '.join(args)}, node=node_name, ttl='20s')
+    remote_command = ' '.join(args)
+    logger.debug(f'Running command over receptor mesh on {node_name}: ansible-runner worker {remote_command}')
+
+    result = receptor_ctl.submit_work(worktype='ansible-runner', payload='', params={"params": remote_command}, node=node_name, ttl='20s')
 
     unit_id = result['unitid']
     run_start = time.time()

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -441,7 +441,7 @@ CELERYBEAT_SCHEDULE = {
     'k8s_reaper': {'task': 'awx.main.tasks.awx_k8s_reaper', 'schedule': timedelta(seconds=60), 'options': {'expires': 50}},
     'receptor_reaper': {'task': 'awx.main.tasks.awx_receptor_workunit_reaper', 'schedule': timedelta(seconds=60)},
     'send_subsystem_metrics': {'task': 'awx.main.analytics.analytics_tasks.send_subsystem_metrics', 'schedule': timedelta(seconds=20)},
-    'cleanup_images': {'task': 'awx.main.tasks.cleanup_execution_environment_images', 'schedule': timedelta(hours=3)},
+    'cleanup_images': {'task': 'awx.main.tasks.cleanup_images_and_files', 'schedule': timedelta(hours=3)},
 }
 
 # Django Caching Configuration


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Use ansible-runner worker cleanup for file and image cleanup on main cluster and remote nodes"
-->

##### SUMMARY
This is the corresponding AWX change for the ansible-runner PR https://github.com/ansible/ansible-runner/pull/846

These issues I link here should be fully closed when this is merged and tested:

Connect https://github.com/ansible/awx/issues/10948
Connect https://github.com/ansible/awx/issues/10701
Connect https://github.com/ansible/awx/issues/10702

This is a little bit of an aggressive refactor that grew to envelop several issues, because this involves designing a new interface, and I don't want to introduce that sort of thing unless it is thought-out and works for all the cases we planned.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
19.3.3
```


##### ADDITIONAL INFORMATION
This might help people to grok what's going on here:

```
$ ansible-runner worker cleanup --help
usage: ansible-runner worker cleanup [-h] [--file-pattern FILE_PATTERN] [--exclude-strings [EXCLUDE_STRINGS ...]]
                                     [--remove-images [REMOVE_IMAGES ...]] [--grace-period GRACE_PERIOD] [--image-prune]
                                     [--process-isolation-executable PROCESS_ISOLATION_EXECUTABLE]

optional arguments:
  -h, --help            show this help message and exit
  --file-pattern FILE_PATTERN
                        A file glob pattern to find private_data_dir folders to remove. Example: --file-
                        pattern=/tmp/.ansible-runner-*
  --exclude-strings [EXCLUDE_STRINGS ...]
                        A comma separated list of keywords in directory name or path to avoid deleting.
  --remove-images [REMOVE_IMAGES ...]
                        A comma separated list of podman or docker tags to delete. This may not remove the corresponding
                        layers, use the image-prune option to assure full deletion. Example: --remove-
                        images=quay.io/user/image:devel quay.io/user/builder:latest
  --grace-period GRACE_PERIOD
                        Time (in minutes) after last modification to exclude a folder from deletion for. This is to avoid
                        deleting folders that were recently created, or folders not started via the start command. Value of
                        0 indicates that no folders will be excluded based on modified time.
  --image-prune         If specified, will run docker / podman image prune --force. This will only run after untagging.
  --process-isolation-executable PROCESS_ISOLATION_EXECUTABLE
                        The container image to clean up images for (default=podman)
```

Everything here is glue to use this. For the control / hybrid nodes, we import it and just directly call it. For execution nodes, we build the CLI args and run those over receptor in the same way as we do for the `--worker-info` health checks.

There's still a lot of tests and docs to write, but this has developed enough that I don't expect any additional major code revisions.