### PR TITLE
Fix bug that would run --worker-info health checks on control or hybrid nodes

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -438,6 +438,9 @@ def execution_node_health_check(node):
         logger.warn(f'Instance record for {node} missing, could not check capacity.')
         return
 
+    if instance.node_type != 'execution':
+        raise RuntimeError(f'Execution node health check ran against {instance.node_type} node {instance.hostname}')
+
     data = worker_info(node, work_type='ansible-runner' if instance.node_type == 'execution' else 'local')
 
     prior_capacity = instance.capacity

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3023,7 +3023,7 @@ class AWXReceptorJob:
             if self.unit_id is not None and settings.RECEPTOR_RELEASE_WORK:
                 receptor_ctl.simple_command(f"work release {self.unit_id}")
             # If an error occured without the job itself failing, it could be a broken instance
-            if self.work_type == 'ansible-runner' and res is None or getattr(res, 'rc', None) is None:
+            if self.work_type == 'ansible-runner' and ((res is None) or (getattr(res, 'rc', None) is None)):
                 execution_node_health_check(self.task.instance.execution_node)
 
     def _run_internal(self, receptor_ctl):


### PR DESCRIPTION
##### SUMMARY
I discovered that project updates could sometimes trigger a health check via `--worker-info` on control or hybrid nodes. This should never happen.

For a time, I tried to make that work, but it's just too complicated. Running `ansible-runner worker --worker-info` gives the _runner_ version, and these instances report the _AWX_ version, so that's just never going to work as we need.

This is intended to fix the bug and make it even more clear that this should never be ran on execution nodes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
It looks like the actual bug can be expressed as

```python
False and object() is None or None is None  # feturns True
```

The intent was:

```python
False and ((object() is None) or (None is None))  # returns False
```

But python actually parsed it as

```python
(False and object() is None) or (None is None)  # returns True
```



