### PR TITLE
Sufrace ALLOW_JINJA_IN_EXTRA_VARS on the job settings page

### DIFF
--- a/awx/ui/src/screens/Setting/Jobs/JobsDetail/JobsDetail.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsDetail/JobsDetail.js
@@ -30,7 +30,6 @@ function JobsDetail() {
       const { data } = await SettingsAPI.readCategory('jobs');
 
       const {
-        ALLOW_JINJA_IN_EXTRA_VARS,
         STDOUT_MAX_BYTES_DISPLAY,
         EVENT_STDOUT_MAX_BYTES_DISPLAY,
         ...jobsData

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
+import { t } from '@lingui/macro';
 import { useHistory } from 'react-router-dom';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
@@ -18,6 +19,7 @@ import {
   ObjectField,
   RevertAllAlert,
   RevertFormActionGroup,
+  ChoiceField,
 } from '../../shared';
 
 function JobsEdit() {
@@ -34,7 +36,6 @@ function JobsEdit() {
     useCallback(async () => {
       const { data } = await SettingsAPI.readCategory('jobs');
       const {
-        ALLOW_JINJA_IN_EXTRA_VARS,
         EVENT_STDOUT_MAX_BYTES_DISPLAY,
         STDOUT_MAX_BYTES_DISPLAY,
         ...jobsData
@@ -112,6 +113,23 @@ function JobsEdit() {
       return acc;
     }, {});
 
+  // We have to rebuild the ALLOW_JINJA_IN_EXTRA_VARS object because the default value
+  // is 'template' but its label that comes from the api is 'Only On Job Template
+  // Definitions'.  The problem is that this label does not match whats in the help
+  // text, or what is rendered on the screen in the details, 'template' is what is
+  // rendered in those locations. For consistency sake I have changed that label
+  // value below.
+
+  const jinja = {
+    default: 'template',
+    help_text: jobs?.ALLOW_JINJA_IN_EXTRA_VARS?.help_text,
+    label: jobs?.ALLOW_JINJA_IN_EXTRA_VARS?.label,
+  };
+  jinja.choices = jobs?.ALLOW_JINJA_IN_EXTRA_VARS?.choices.map(
+    ([value, label]) =>
+      value === 'template' ? [value, t`Template`] : [value, label]
+  );
+
   return (
     <CardBody>
       {isLoading && <ContentLoading />}
@@ -157,6 +175,7 @@ function JobsEdit() {
                   config={jobs.MAX_FORKS}
                   type="number"
                 />
+                <ChoiceField name="ALLOW_JINJA_IN_EXTRA_VARS" config={jinja} />
                 <BooleanField
                   name="PROJECT_UPDATE_VVV"
                   config={jobs.PROJECT_UPDATE_VVV}

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.test.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.test.js
@@ -77,7 +77,6 @@ describe('<JobsEdit />', () => {
     });
     expect(SettingsAPI.updateAll).toHaveBeenCalledTimes(1);
     const {
-      ALLOW_JINJA_IN_EXTRA_VARS,
       EVENT_STDOUT_MAX_BYTES_DISPLAY,
       STDOUT_MAX_BYTES_DISPLAY,
       ...jobRequest


### PR DESCRIPTION


##### SUMMARY
This addresses #11103.  It surfaces the ALLOW_JINJA_IN_EXTRA_VARS on the job settings page.  

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

##### AWX VERSION

##### ADDITIONAL INFORMATION
![Screen Shot 2021-09-29 at 12 23 13 PM](https://user-images.githubusercontent.com/39280967/135309519-88ca00b9-839c-490c-96fc-75769cf62bd4.png)
![Screen Shot 2021-09-29 at 12 22 55 PM](https://user-images.githubusercontent.com/39280967/135309522-ee5dddde-336c-41f8-9283-16b657c60d06.png)

