### PR TITLE
Adds support for pre-filling EE add form name, description, and image from query params

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -100,7 +100,7 @@ const AuthorizedRoutes = ({ routeConfig }) => {
 
 const ProtectedRoute = ({ children, ...rest }) => {
   const { authRedirectTo, setAuthRedirectTo } = useSession();
-  const { pathname } = useLocation();
+  const location = useLocation();
 
   useEffect(() => {
     setAuthRedirectTo(authRedirectTo === '/logout' ? '/' : pathname);
@@ -115,6 +115,12 @@ const ProtectedRoute = ({ children, ...rest }) => {
       </Route>
     );
   }
+
+  setAuthRedirectTo(
+    authRedirectTo === '/logout'
+      ? '/'
+      : `${location.pathname}${location.search}`
+  );
 
   return <Redirect to="/login" />;
 };

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -103,7 +103,11 @@ const ProtectedRoute = ({ children, ...rest }) => {
   const location = useLocation();
 
   useEffect(() => {
-    setAuthRedirectTo(authRedirectTo === '/logout' ? '/' : pathname);
+    setAuthRedirectTo(
+      authRedirectTo === '/logout'
+        ? '/'
+        : `${location.pathname}${location.search}`
+    );
   });
 
   if (isAuthenticated(document.cookie)) {
@@ -115,12 +119,6 @@ const ProtectedRoute = ({ children, ...rest }) => {
       </Route>
     );
   }
-
-  setAuthRedirectTo(
-    authRedirectTo === '/logout'
-      ? '/'
-      : `${location.pathname}${location.search}`
-  );
 
   return <Redirect to="/login" />;
 };

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
@@ -27,6 +27,21 @@ function ExecutionEnvironmentAdd() {
   const handleCancel = () => {
     history.push(`/execution_environments`);
   };
+
+  const hubParams = {
+    image: '',
+    credential: null // reverse lookup?
+  };
+  history.location.search.replace(/^\?/, '')
+    .split('&')
+    .map((s) => s.split('='))
+    .forEach(([key, val]) => {
+      if (!(key in hubParams)) {
+        return;
+      }
+      hubParams[key] = decodeURIComponent(val);
+    });
+
   return (
     <PageSection>
       <Card>
@@ -38,6 +53,7 @@ function ExecutionEnvironmentAdd() {
                 submitError={submitError}
                 onCancel={handleCancel}
                 me={me || {}}
+                executionEnvironment={hubParams}
               />
             )}
           </Config>

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
@@ -30,9 +30,10 @@ function ExecutionEnvironmentAdd() {
 
   const hubParams = {
     image: '',
-    credential: null // reverse lookup?
   };
-  history.location.search.replace(/^\?/, '')
+
+  history.location.search
+    .replace(/^\?/, '')
     .split('&')
     .map((s) => s.split('='))
     .forEach(([key, val]) => {

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
@@ -29,7 +29,9 @@ function ExecutionEnvironmentAdd() {
   };
 
   const hubParams = {
+    description: '',
     image: '',
+    name: '',
   };
 
   history.location.search

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
@@ -86,6 +86,8 @@ describe('<ExecutionEnvironmentAdd/>', () => {
         context: { router: { history } },
       });
     });
+
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
 
   afterEach(() => {
@@ -108,8 +110,6 @@ describe('<ExecutionEnvironmentAdd/>', () => {
   });
 
   test('handleCancel should return the user back to the execution environments list', async () => {
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-
     wrapper.find('Button[aria-label="Cancel"]').simulate('click');
     expect(history.location.pathname).toEqual('/execution_environments');
   });
@@ -130,5 +130,24 @@ describe('<ExecutionEnvironmentAdd/>', () => {
     });
     wrapper.update();
     expect(wrapper.find('FormSubmitError').length).toBe(1);
+  });
+
+  test('should parse and prefill select form fields from query params', async () => {
+    history = createMemoryHistory({
+      initialEntries: [
+        '/execution_environments/add?image=https://myhub.io/repo:2.0',
+      ],
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(<ExecutionEnvironmentAdd me={mockMe} />, {
+        context: { router: { history } },
+      });
+    });
+
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+
+    expect(
+      wrapper.find('input#execution-environment-image').prop('value')
+    ).toEqual('https://myhub.io/repo:2.0');
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.js
@@ -212,6 +212,7 @@ function ExecutionEnvironmentForm({
   };
   return (
     <Formik
+      enableReinitialize
       initialValues={initialValues}
       onSubmit={(values) => onSubmit(values)}
     >


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Adds UI support for pre-filling EE add form name, description, and image from query params"
-->

##### SUMMARY
These changes allow links to be built that will take a navigating user straight to the EE add form with query params that will pre-fill some EE add form values:

<img width="1675" alt="Screen Shot 2021-09-29 at 5 23 49 PM" src="https://user-images.githubusercontent.com/9889020/135350653-d160a42a-4319-4bcc-9674-cfcd9bcf2bec.png">

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
