### PR TITLE
update to allow use of id for unified job template

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -482,20 +482,17 @@ def create_schema_nodes(module, response, schema, workflow_id):
 
         # Lookup Job Template ID
         if workflow_node['unified_job_template']['name']:
-            search_fields = {'name': workflow_node['unified_job_template']['name']}
             if workflow_node['unified_job_template']['type'] is None:
                 module.fail_json(msg='Could not find unified job template type in schema {1}'.format(workflow_node))
             if workflow_node['unified_job_template']['type'] == 'inventory_source':
-                # workflow_node['unified_job_template']['inventory']:
                 organization_id = module.resolve_name_to_id('organizations', workflow_node['unified_job_template']['inventory']['organization']['name'])
                 search_fields['organization'] = organization_id
             elif workflow_node['unified_job_template']['type'] == 'workflow_approval':
                 pass
             else:
-                # workflow_node['unified_job_template']['organization']:
                 organization_id = module.resolve_name_to_id('organizations', workflow_node['unified_job_template']['organization']['name'])
                 search_fields['organization'] = organization_id
-            unified_job_template = module.get_one('unified_job_templates', **{'data': search_fields})
+            unified_job_template = module.get_one('unified_job_templates', name_or_id=workflow_node['unified_job_template']['name'], **{'data': search_fields})
             if unified_job_template:
                 workflow_node_fields['unified_job_template'] = unified_job_template['id']
             else:

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -310,9 +310,7 @@ def main():
 
     unified_job_template = module.params.get('unified_job_template')
     if unified_job_template:
-        search_fields['name'] = unified_job_template
-        new_fields['unified_job_template'] = module.get_one('unified_job_templates', **{'data': search_fields})['id']
-
+        new_fields['unified_job_template'] = module.get_one('unified_job_templates', name_or_id=unified_job_template, **{'data': search_fields})['id']
     inventory = module.params.get('inventory')
     if inventory:
         new_fields['inventory'] = module.resolve_name_to_id('inventories', inventory)

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -117,11 +117,11 @@
     source_path: "/inventories/inventory.ini"
     overwrite: true
     source: scm
-  register: result
+  register: project_inv_source_result
 
 - assert:
     that:
-      - "result is changed"
+      - "project_inv_source_result is changed"
 
 - name: Create a Job Template
   job_template:
@@ -159,11 +159,11 @@
     playbook: hello_world.yml
     job_type: run
     state: present
-  register: result
+  register: jt2_name_result
 
 - assert:
     that:
-      - "result is changed"
+      - "jt2_name_result is changed"
 
 - name: Add a Survey to second Job Template
   job_template:
@@ -536,7 +536,7 @@
     schema:
       - identifier: node101
         unified_job_template:
-          name: "{{ project_inv_source }}"
+          name: "{{ project_inv_source_result.id }}"
           inventory:
             organization:
               name: Default


### PR DESCRIPTION
<!--- changelog-entry
---
msg: "update workflow_node and workflow schema modules to allow use of id for unified job template"
-->

##### SUMMARY
Update to allow user to supply a unified job template ID when creating a workflow node. Either through the workflow node module or the workflow module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - awx collection


##### AWX VERSION
```
19.4.0
```
