### PR TITLE
Always set project sync execution_node to current host

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -2625,7 +2625,7 @@ class RunInventoryUpdate(BaseTask):
                     job_type='run',
                     job_tags=','.join(sync_needs),
                     status='running',
-                    execution_node=inventory_update.execution_node,
+                    execution_node=Instance.objects.me().hostname,
                     instance_group=inventory_update.instance_group,
                     celery_task_id=inventory_update.celery_task_id,
                 )


### PR DESCRIPTION
@tchellomello made this exact change in commit 6d4b4cac3721e459ca77fdd2bb05038197ac91a5, but that was only for project syncs running before a job starts. We do the same thing for inventory updates, and this updates that other point in code with the same diff.