### PR TITLE
Add additional validation against hard-coded ansible-runner version

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -423,6 +423,10 @@ DEVSERVER_DEFAULT_PORT = '8013'
 # Set default ports for live server tests.
 os.environ.setdefault('DJANGO_LIVE_TEST_SERVER_ADDRESS', 'localhost:9013-9199')
 
+# Fail health checks if remote nodes do not have at least this version ansible-runner
+# of if they do not match both the x and y of x.y.z type versions
+MINIMUM_ALLOWED_ANSIBLE_RUNNER_VERSION = '2.0.0'
+
 # heartbeat period can factor into some forms of logic, so it is maintained as a setting here
 CLUSTER_NODE_HEARTBEAT_PERIOD = 60
 RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD = 60  # https://github.com/ansible/receptor/blob/aa1d589e154d8a0cb99a220aff8f98faf2273be6/pkg/netceptor/netceptor.go#L34


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/11114

With this, we will _always_ write a warning to the log if an execution node's runner version differs from the node doing the health check.

The idea here is that users should be able to bump runner versions as needed, but if they do, a log warning should be a comforting validation of the customization they have, themselves, configured.

Second thing here - we hard-code an ansible-runner version in the settings to be a strict requirement. If the execution node does not match the major/minor numbers we fail, and we also require at z-stream or above, because there might be CVEs or bug fixes that we care absolutely need to have in the future.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

