### PR TITLE
Revert removing the old isolated groups

### DIFF
--- a/awx/main/migrations/0139_isolated_removal.py
+++ b/awx/main/migrations/0139_isolated_removal.py
@@ -9,12 +9,6 @@ def remove_iso_instances(apps, schema_editor):
         Instance.objects.filter(rampart_groups__controller__isnull=False).delete()
 
 
-def remove_iso_groups(apps, schema_editor):
-    InstanceGroup = apps.get_model('main', 'InstanceGroup')
-    with transaction.atomic():
-        InstanceGroup.objects.filter(controller__isnull=False).delete()
-
-
 class Migration(migrations.Migration):
     atomic = False
 
@@ -24,7 +18,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(remove_iso_instances),
-        migrations.RunPython(remove_iso_groups),
         migrations.RemoveField(
             model_name='instance',
             name='last_isolated_check',


### PR DESCRIPTION
In 4.1+ / AAP 2.1+, isolated groups should be converted into plain
instance groups, and it's desirable for the old ones to stick around
since they'll likely be tied to a bunch of job templates.  We do not
want to make the users have to reconstruct those relationships.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```