### PR TITLE
Fix survey update with job_template module

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -909,7 +909,7 @@ class ControllerAPIModule(ControllerModule):
                 if response['status_code'] == 200:
                     # compare apples-to-apples, old API data to new API data
                     # but do so considering the fields given in parameters
-                    self.json_output['changed'] = self.objects_could_be_different(existing_item, response['json'], field_set=new_item.keys(), warning=True)
+                    self.json_output['changed'] |= self.objects_could_be_different(existing_item, response['json'], field_set=new_item.keys(), warning=True)
                 elif 'json' in response and '__all__' in response['json']:
                     self.fail_json(msg=response['json']['__all__'])
                 else:


### PR DESCRIPTION
job_template module sets self.json_output['changed'] to true before calling create_or_update_if_needed.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "fix job_template module to update survey specs"
-->

##### SUMMARY
related #11229

the job_template module set json_output['changed'] to true and adds an on_update callback to ControllerModule.create_or_update_if_needed()
this callback will only be called if json_output['changed'] is true.
Without the fix json_output['changed'] can be changed back to false by ControllerModule.objects_could_be_different()

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx_collection
