### PR TITLE
Fix Makefile conditional used for docker-refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,8 +493,8 @@ docker-compose-build:
 
 docker-clean:
 	$(foreach container_id,$(shell docker ps -f name=tools_awx -aq && docker ps -f name=tools_receptor -aq),docker stop $(container_id); docker rm -f $(container_id);)
-	if [ $(shell docker images | grep "awx_devel") ]; then \
-	  docker images | grep "awx_devel" | awk '{print $$3}' | xargs docker rmi --force; \
+	if [ "$(shell docker images | grep awx_devel)" ]; then \
+	  docker images | grep awx_devel | awk '{print $$3}' | xargs docker rmi --force; \
 	fi
 
 docker-clean-volumes: docker-compose-clean docker-compose-container-group-clean


### PR DESCRIPTION
This was giving errors like:

```
if [ quay.io/awx/awx_devel               devel     017543585c6a   5 days ago     1.92GB quay.io/awx/awx_devel               latest    ba08c326792c   5 weeks ago    2.17GB ]; then \
  docker images | grep "awx_devel" | awk '{print $3}' | xargs docker rmi --force; \
fi
/bin/sh: line 1: [: too many arguments
```

But then it would just continue on with the docker-compose logic. It appears that the `if` just needed a string, and this was my fault.