### PR TITLE
Add awx-operator CI check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 awx/ui/node_modules
 Dockerfile
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,41 @@ jobs:
         run: |
           docker run -u $(id -u) --rm -v ${{ github.workspace}}:/awx_devel/:Z \
             --workdir=/awx_devel ghcr.io/${{ github.repository_owner }}/awx_devel:${{ env.BRANCH }} make ui-test
+  awx-operator:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout awx
+        uses: actions/checkout@v2
+        with:
+          path: awx
+
+      - name: Checkout awx-operator
+        uses: actions/checkout@v2
+        with:
+          repository: ansible/awx-operator
+          path: awx-operator
+
+      - name: Install playbook dependencies
+        run: |
+          python3 -m pip install docker
+
+      - name: Build AWX image
+        working-directory: awx
+        run: |
+          ansible-playbook -v tools/ansible/build.yml \
+            -e headless=yes \
+            -e awx_image=awx \
+            -e awx_image_tag=ci \
+            -e ansible_python_interpreter=$(which python3)
+
+      - name: Run test deployment with awx-operator
+        working-directory: awx-operator
+        run: |
+          python3 -m pip install -r molecule/requirements.txt
+          ansible-galaxy collection install -r molecule/requirements.yml
+          sudo rm -f $(which kustomize)
+          make kustomize
+          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule test -s kind
+        env:
+          AWX_TEST_IMAGE: awx
+          AWX_TEST_VERSION: ci

--- a/.yamllint
+++ b/.yamllint
@@ -6,6 +6,8 @@ ignore: |
   # vault files
   awx/main/tests/data/ansible_utils/playbooks/valid/vault.yml
   awx/ui/test/e2e/tests/smoke-vars.yml
+  awx/ui/node_modules
+  tools/docker-compose/_sources
 
 extends: default
 

--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,4 @@ extends: default
 
 rules:
   line-length: disable
+  truthy: disable

--- a/docs/build_awx_image.md
+++ b/docs/build_awx_image.md
@@ -5,7 +5,10 @@
 To build a custom awx image to use with the awx-operator, use the `build_image` role:
 
 ```
-$ ansible-playbook tools/ansible/build.yml -v -e awx_image=registry.example.com/awx -e awx_version=test
+$ ansible-playbook tools/ansible/build.yml \
+    -e registry=registry.example.com \
+    -e awx_image=ansible/awx \
+    -e awx_version=test -v
 ```
 
 > Note: The development image (`make docker-compose-build`) will not work with the awx-operator, the UI is not built in that image, among other things (see Dockerfile.j2 for more info).
@@ -21,7 +24,7 @@ $ docker push registry.example.com/awx:test
 ## Using this image with the awx-operator
 
 In the spec section of the `my-awx.yml` file described in the [install docs](./../INSTALL.md#deploy-awx),
-specify the new custom image.  
+specify the new custom image.
 
 ```
 spec:

--- a/tools/ansible/build.yml
+++ b/tools/ansible/build.yml
@@ -2,7 +2,24 @@
 - name: Build AWX Docker Images
   hosts: localhost
   gather_facts: true
-  roles:
-    - {role: dockerfile}
-    - {role: image_build}
-    - {role: image_push, when: "docker_registry is defined"}
+  tasks:
+    - name: Get version from SCM if not explicitly provided
+      shell: |
+        python setup.py --version | cut -d + -f -1
+      args:
+        chdir: '../../'
+      register: setup_py_version
+      when: awx_version is not defined
+
+    - name: Set awx_version
+      set_fact:
+        awx_version: "{{ setup_py_version.stdout }}"
+      when: awx_version is not defined
+
+    - include_role:
+        name: dockerfile
+    - include_role:
+        name: image_build
+    - include_role:
+        name: image_push
+      when: push | default(false) | bool

--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 build_dev: false
 kube_dev: false
+headless: no
 dockerfile_dest: '../..'
 dockerfile_name: 'Dockerfile'
 template_dest: '_build'

--- a/tools/ansible/roles/dockerfile/files/launch_awx.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx.sh
@@ -17,6 +17,4 @@ set -e
 
 wait-for-migrations
 
-awx-manage collectstatic --noinput --clear
-
 supervisord -c /etc/supervisord.conf

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -54,6 +54,9 @@ ADD requirements/requirements.txt \
 
 RUN cd /tmp && make requirements_awx
 
+ARG VERSION
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+
 {% if (build_dev|bool) or (kube_dev|bool) %}
 ADD requirements/requirements_dev.txt /tmp/requirements
 RUN cd /tmp && make requirements_awx_dev

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -11,6 +11,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+
 USER root
 
 # Install build dependencies
@@ -27,7 +28,9 @@ RUN dnf -y update && \
     libffi-devel \
     libtool-ltdl-devel \
     make \
+{% if not headless|bool %}
     nodejs \
+{% endif %}
     nss \
     openldap-devel \
     patch \
@@ -44,6 +47,7 @@ RUN dnf -y update && \
 
 RUN python3.8 -m ensurepip && pip3 install "virtualenv < 20"
 
+
 # Install & build requirements
 ADD Makefile /tmp/Makefile
 RUN mkdir /tmp/requirements
@@ -56,19 +60,27 @@ RUN cd /tmp && make requirements_awx
 
 ARG VERSION
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ARG HEADLESS
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
 ADD requirements/requirements_dev.txt /tmp/requirements
 RUN cd /tmp && make requirements_awx_dev
 {% else %}
 # Use the distro provided npm to bootstrap our required version of node
-RUN npm install -g n && n 14.15.1 && dnf remove -y nodejs
+
+{% if not headless|bool %}
+RUN npm install -g n && n 14.15.1
+{% endif %}
 
 # Copy source into builder, build sdist, install it into awx venv
 COPY . /tmp/src/
 WORKDIR /tmp/src/
-RUN make sdist && \
-    /var/lib/awx/venv/awx/bin/pip install dist/awx-$(cat VERSION).tar.gz
+RUN make sdist && /var/lib/awx/venv/awx/bin/pip install dist/awx.tar.gz
+
+{% if not headless|bool %}
+RUN /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
+{% endif %}
+
 {% endif %}
 
 # Final container(s)

--- a/tools/ansible/roles/image_build/defaults/main.yml
+++ b/tools/ansible/roles/image_build/defaults/main.yml
@@ -2,4 +2,4 @@
 awx_image: ansible/awx
 awx_image_tag: "{{ awx_version }}"
 dockerfile_name: 'Dockerfile'
-
+headless: no

--- a/tools/ansible/roles/image_build/tasks/main.yml
+++ b/tools/ansible/roles/image_build/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Set global version if not provided
-  set_fact:
-    awx_version: "{{ lookup('file', playbook_dir + '/../../VERSION') }}"
-  when: awx_version is not defined
-
 - name: Verify awx-logos directory exists for official install
   stat:
     path: "../../../awx-logos"
@@ -17,11 +12,19 @@
     dest: "../../awx/ui/public/static/media/"
   when: awx_official|default(false)|bool
 
+- set_fact:
+    command_to_run: |
+      docker build -t {{ awx_image }}:{{ awx_image_tag }} \
+        -f {{ dockerfile_name }} \
+        --build-arg VERSION={{ awx_version }} \
+        --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{ awx_version }} \
+        --build-arg HEADLESS={{ headless }} \
+        .
+
 # Calling Docker directly because docker-py doesnt support BuildKit
 - name: Build AWX image
-  command: docker build -t {{ awx_image }}:{{ awx_version }} -f ../../{{ dockerfile_name }} ../..
-
-- name: Tag awx images as latest
-  command: "docker tag {{ item }}:{{ awx_version }} {{ item }}:latest"
-  with_items:
-    - "{{ awx_image }}"
+  shell: "{{ command_to_run }}"
+  environment:
+    DOCKER_BUILDKIT: 1
+  args:
+    chdir: "{{ playbook_dir }}/../../"

--- a/tools/ansible/roles/image_push/defaults/main.yml
+++ b/tools/ansible/roles/image_push/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
+registry: quay.io
 awx_image: ansible/awx
 awx_image_tag: "{{ awx_version }}"
-dockerfile_name: 'Dockerfile'
-

--- a/tools/ansible/roles/image_push/tasks/main.yml
+++ b/tools/ansible/roles/image_push/tasks/main.yml
@@ -1,33 +1,22 @@
 ---
 - name: Authenticate with Docker registry if registry password given
   docker_login:
-    registry: "{{ docker_registry }}"
-    username: "{{ docker_registry_username }}"
-    password: "{{ docker_registry_password }}"
+    registry: "{{ registry }}"
+    username: "{{ registry_username }}"
+    password: "{{ registry_password }}"
     reauthorize: true
-  when: docker_registry is defined and docker_registry_password is defined
-
-- name: Remove local images to ensure proper push behavior
-  block:
-    - name: Remove awx image
-      docker_image:
-        name: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}"
-        tag: "{{ awx_version }}"
-        state: absent
+  when:
+    - registry is defined
+    - registry_username is defined
+    - registry_password is defined
 
 - name: Tag and Push Container Images
-  block:
-    - name: Tag and push awx image to registry
-      docker_image:
-        name: "{{ awx_image }}"
-        repository: "{{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}"
-        tag: "{{ item }}"
-        push: true
-      with_items:
-        - "latest"
-        - "{{ awx_version }}"
-
-- name: Set full image path for Registry
-  set_fact:
-    awx_docker_actual_image: >-
-      {{ docker_registry }}/{{ docker_registry_repository }}/{{ awx_image }}:{{ awx_version }}
+  docker_image:
+    name: "{{ awx_image }}:{{ awx_version }}"
+    repository: "{{ registry }}/{{ awx_image }}:{{ item }}"
+    force_tag: yes
+    push: true
+    source: local
+  with_items:
+    - "latest"
+    - "{{ awx_version }}"


### PR DESCRIPTION
I was in the process of rewriting the automation around our release process and this fell out as a separate thing that would be nice to have.

My goal was to have this run faster than our current slowest CI check. It takes about ~15 minutes:

<img width="229" alt="image" src="https://user-images.githubusercontent.com/773186/137040457-642e841b-445e-4f12-8e8d-90f951e18b87.png">
