### PR TITLE
Include "node_type" in "awx-manage list_instances" output

### DIFF
--- a/awx/main/management/commands/list_instances.py
+++ b/awx/main/management/commands/list_instances.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                     color = '\033[90m[DISABLED] '
                 if no_color:
                     color = ''
-                fmt = '\t' + color + '{0.hostname} capacity={0.capacity} version={1}'
+                fmt = '\t' + color + '{0.hostname} capacity={0.capacity} node_type={0.node_type} version={1}'
                 if x.capacity:
                     fmt += ' heartbeat="{0.modified:%Y-%m-%d %H:%M:%S}"'
                 print((fmt + '\033[0m').format(x, x.version or '?'))


### PR DESCRIPTION
##### SUMMARY
Include "node_type" in "awx-manage list_instances" output


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
[root@117-addr limits.d]# awx-manage  list_instances
[controlplane capacity=8 policy=100%]
	192.168.111.113 capacity=4 node_type=control version=4.1.0 heartbeat="2021-10-12 17:03:40"
	192.168.111.116 capacity=4 node_type=hybrid version=4.1.0 heartbeat="2021-10-12 17:03:40"
	192.168.111.117 capacity=0 node_type=hybrid version=4.1.0

[default capacity=12 policy=100%]
	104-addr.tatu.home capacity=4 node_type=execution version=ansible-runner-2.1.0 heartbeat="2021-10-12 17:03:40"
	192.168.111.116 capacity=4 node_type=hybrid version=4.1.0 heartbeat="2021-10-12 17:03:40"
	192.168.111.117 capacity=0 node_type=hybrid version=4.1.0
	192.168.111.127 capacity=4 node_type=execution version=ansible-runner-2.1.0 heartbeat="2021-10-12 17:03:40"

[instance_group_test capacity=0]
	192.168.111.117 capacity=0 node_type=hybrid version=4.1.0

[instance_group_test2 capacity=8]
	192.168.111.116 capacity=4 node_type=hybrid version=4.1.0 heartbeat="2021-10-12 17:03:40"
	192.168.111.117 capacity=0 node_type=hybrid version=4.1.0
	192.168.111.127 capacity=4 node_type=execution version=ansible-runner-2.1.0 heartbeat="2021-10-12 17:03:40"

```
