### PR TITLE
Use the AWX HTTP client headers for rocketchat notifications

### DIFF
--- a/awx/main/notifications/rocketchat_backend.py
+++ b/awx/main/notifications/rocketchat_backend.py
@@ -9,6 +9,7 @@ from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 
 from awx.main.notifications.base import AWXBaseEmailBackend
+from awx.main.utils import get_awx_http_client_headers
 from awx.main.notifications.custom_notification_base import CustomNotificationBase
 
 logger = logging.getLogger('awx.main.notifications.rocketchat_backend')
@@ -38,7 +39,9 @@ class RocketChatBackend(AWXBaseEmailBackend, CustomNotificationBase):
                 if optvalue is not None:
                     payload[optval] = optvalue.strip()
 
-            r = requests.post("{}".format(m.recipients()[0]), data=json.dumps(payload), verify=(not self.rocketchat_no_verify_ssl))
+            r = requests.post(
+                "{}".format(m.recipients()[0]), data=json.dumps(payload), headers=get_awx_http_client_headers(), verify=(not self.rocketchat_no_verify_ssl)
+            )
 
             if r.status_code >= 400:
                 logger.error(smart_text(_("Error sending notification rocket.chat: {}").format(r.status_code)))

--- a/awx/main/tests/unit/notifications/test_rocketchat.py
+++ b/awx/main/tests/unit/notifications/test_rocketchat.py
@@ -7,8 +7,11 @@ import awx.main.notifications.rocketchat_backend as rocketchat_backend
 
 
 def test_send_messages():
-    with mock.patch('awx.main.notifications.rocketchat_backend.requests') as requests_mock:
+    with mock.patch('awx.main.notifications.rocketchat_backend.requests') as requests_mock, mock.patch(
+        'awx.main.notifications.rocketchat_backend.get_awx_http_client_headers'
+    ) as version_mock:
         requests_mock.post.return_value.status_code = 201
+        version_mock.return_value = {'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'}
         backend = rocketchat_backend.RocketChatBackend()
         message = EmailMessage(
             'test subject',
@@ -23,7 +26,12 @@ def test_send_messages():
                 message,
             ]
         )
-        requests_mock.post.assert_called_once_with('http://example.com', data='{"text": "test subject"}', verify=True)
+        requests_mock.post.assert_called_once_with(
+            'http://example.com',
+            data='{"text": "test subject"}',
+            headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
+            verify=True,
+        )
         assert sent_messages == 1
 
 
@@ -84,8 +92,11 @@ def test_send_messages_with_icon_url():
 
 
 def test_send_messages_with_no_verify_ssl():
-    with mock.patch('awx.main.notifications.rocketchat_backend.requests') as requests_mock:
+    with mock.patch('awx.main.notifications.rocketchat_backend.requests') as requests_mock, mock.patch(
+        'awx.main.notifications.rocketchat_backend.get_awx_http_client_headers'
+    ) as version_mock:
         requests_mock.post.return_value.status_code = 201
+        version_mock.return_value = {'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'}
         backend = rocketchat_backend.RocketChatBackend(rocketchat_no_verify_ssl=True)
         message = EmailMessage(
             'test subject',
@@ -100,5 +111,10 @@ def test_send_messages_with_no_verify_ssl():
                 message,
             ]
         )
-        requests_mock.post.assert_called_once_with('http://example.com', data='{"text": "test subject"}', verify=False)
+        requests_mock.post.assert_called_once_with(
+            'http://example.com',
+            data='{"text": "test subject"}',
+            headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
+            verify=False,
+        )
         assert sent_messages == 1


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Use the AWX HTTP client headers for rocketchat notifications"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Posting notifications from AWX to a Rocket.Chat instance fails, because the HTTP header `Content-Type: application/json` is missing. This change adds the default AWX HTTP client headers [the same way](https://github.com/ansible/awx/blob/d74679a5f9b4eefbc09a6ec1bd910ea17b578640/awx/main/notifications/webhook_backend.py#L75) it's done with the `webhook_backend.py`.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - main/notifications/rocketchat_backend.py
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.4.1.dev71+gc7a7bb6cb6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
