### PR TITLE
Update auth_plugin Doc Extension File to Fix Malformed Collections Docs

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -13,56 +13,61 @@ class ModuleDocFragment(object):
     # Automation Platform Controller documentation fragment
     DOCUMENTATION = r'''
 options:
-    host:
-        description: The network address of your Automation Platform Controller host.
-        env:
-            - name: CONTROLLER_HOST
-            - name: TOWER_HOST
-              deprecated:
-                removed_from_collection: 'awx.awx.controller'
-                removed_in_version: '4.0.0'
-                alternatives: 'CONTROLLER_HOST'
-    username:
-        description: The user that you plan to use to access inventories on the controller.
-        env:
-            - name: CONTROLLER_USERNAME
-            - name: TOWER_USERNAME
-              deprecated:
-                removed_from_collection: 'awx.awx.controller'
-                removed_in_version: '4.0.0'
-                alternatives: 'CONTROLLER_USERNAME'
-    password:
-        description: The password for your controller user.
-        env:
-            - name: CONTROLLER_PASSWORD
-            - name: TOWER_PASSWORD
-              deprecated:
-                removed_from_collection: 'awx.awx.controller'
-                removed_in_version: '4.0.0'
-                alternatives: 'CONTROLLER_PASSWORD'
-    oauth_token:
-        description:
-            - The OAuth token to use.
-        env:
-            - name: CONTROLLER_OAUTH_TOKEN
-            - name: TOWER_OAUTH_TOKEN
-              deprecated:
-                removed_from_collection: 'awx.awx.controller'
-                removed_in_version: '4.0.0'
-                alternatives: 'CONTROLLER_OAUTH_TOKEN'
-    verify_ssl:
-        description:
-            - Specify whether Ansible should verify the SSL certificate of the controller host.
-            - Defaults to True, but this is handled by the shared module_utils code
-        type: bool
-        env:
-            - name: CONTROLLER_VERIFY_SSL
-            - name: TOWER_VERIFY_SSL
-              deprecated:
-                removed_from_collection: 'awx.awx.controller'
-                removed_in_version: '4.0.0'
-                alternatives: 'CONTROLLER_VERIFY_SSL'
-        aliases: [ validate_certs ]
+  host:
+    description: The network address of your Automation Platform Controller host.
+    env:
+    - name: CONTROLLER_HOST
+    - name: TOWER_HOST
+    deprecated:
+    - removed_from_collection: 'awx.awx.controller'
+    - removed_in: '4.0.0'
+    - why: Collection name change
+    - alternative: 'CONTROLLER_HOST'
+  username:
+    description: The user that you plan to use to access inventories on the controller.
+    env:
+    - name: CONTROLLER_USERNAME
+    - name: TOWER_USERNAME
+    deprecated:
+    - removed_from_collection: 'awx.awx.controller'
+    - removed_in: '4.0.0'
+    - why: Collection name change
+    - alternative: 'CONTROLLER_USERNAME'
+  password:
+    description: The password for your controller user.
+    env:
+    - name: CONTROLLER_PASSWORD
+    - name: TOWER_PASSWORD
+    deprecated:
+    - removed_from_collection: 'awx.awx.controller'
+    - removed_in: '4.0.0'
+    - why: Collection name change
+    - alternative: 'CONTROLLER_PASSWORD'
+  oauth_token:
+    description:
+    - The OAuth token to use.
+    env:
+    - name: CONTROLLER_OAUTH_TOKEN
+    - name: TOWER_OAUTH_TOKEN
+    deprecated:
+    - removed_from_collection: 'awx.awx.controller'
+    - removed_in: '4.0.0'
+    - why: Collection name change
+    - alternative: 'CONTROLLER_OAUTH_TOKEN'
+  verify_ssl:
+    description:
+    - Specify whether Ansible should verify the SSL certificate of the controller host.
+    - Defaults to True, but this is handled by the shared module_utils code
+    type: bool
+    env:
+    - name: CONTROLLER_VERIFY_SSL
+    - name: TOWER_VERIFY_SSL
+    deprecated:
+    - removed_from_collection: 'awx.awx.controller'
+    - removed_in: '4.0.0'
+    - why: Collection name change
+    - alternative: 'CONTROLLER_VERIFY_SSL'
+    aliases: [ validate_certs ]
 
 notes:
 - If no I(config_file) is provided we will attempt to use the tower-cli library

--- a/awx_collection/plugins/inventory/controller.py
+++ b/awx_collection/plugins/inventory/controller.py
@@ -19,7 +19,6 @@ description:
       the path in the command would be /path/to/controller_inventory.(yml|yaml). If some arguments in the config file
       are missing, this plugin will try to fill in missing arguments by reading from environment variables.
     - If reading configurations from environment variables, the path in the command must be @controller_inventory.
-extends_documentation_fragment: awx.awx.auth_plugin
 options:
     inventory_id:
         description:
@@ -35,6 +34,7 @@ options:
         description: Make extra requests to provide all group vars with metadata about the source host.
         type: bool
         default: False
+extends_documentation_fragment: awx.awx.auth_plugin
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/lookup/controller_api.py
+++ b/awx_collection/plugins/lookup/controller_api.py
@@ -15,7 +15,6 @@ description:
     U(https://docs.ansible.com/ansible-tower/latest/html/towerapi/index.html) for API usage.
   - For use that is cross-compatible between the awx.awx and ansible.controller collection
     see the controller_meta module
-extends_documentation_fragment: awx.awx.auth_plugin
 options:
   _terms:
     description:
@@ -63,7 +62,7 @@ options:
       - If a list view returns more an max_objects an exception will be raised
     type: integer
     default: 1000
-
+extends_documentation_fragment: awx.awx.auth_plugin
 notes:
   - If the query is not filtered properly this can cause a performance impact.
 """


### PR DESCRIPTION
This is another attempt to fix the problems reported in the following issues:
- https://github.com/ansible/awx/issues/10776
- https://github.com/ansible/awx/issues/10855

Referenced this documentation page to try to get all of the correct fields included:
https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html#deprecating-modules-and-plugins-in-the-ansible-main-repository

I also updated the format/indentation of the doc extension file to match other ones like tihs: https://github.com/ansible/awx/blob/devel/awx_collection/plugins/doc_fragments/auth.py