### PR TITLE
Add jsconfig to frontend container

### DIFF
--- a/awx/ui/Dockerfile
+++ b/awx/ui/Dockerfile
@@ -5,10 +5,13 @@ ARG TARGET='https://awx:8043'
 ENV TARGET=${TARGET}
 ENV CI=true
 WORKDIR /ui
+ADD .eslintignore .eslintignore
+ADD .eslintrc .eslintrc
+ADD .linguirc .linguirc
+ADD jsconfig.json jsconfig.json
 ADD public public
 ADD package.json package.json
 ADD package-lock.json package-lock.json
-ADD .linguirc .linguirc
 COPY ${NPMRC_FILE} .npmrc
 RUN npm install
 ADD src src


### PR DESCRIPTION
The eslint and jsconfig files are needed to start the dev server.

Without the jsconfig, the ui development server can't resolve src 
modules and will fail to start.

**note:** This is for running the ui dev server in a container, linked to the main awx development environment [as outlined in our readme](https://github.com/ansible/awx/tree/devel/awx/ui#ci-container). I noticed it didn't work anymore, and this commit will fix that.
