### PR TITLE
Users can send slack notification to a thread

### DIFF
--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -36,10 +36,17 @@ class SlackBackend(AWXBaseEmailBackend, CustomNotificationBase):
                 for r in m.recipients():
                     if r.startswith('#'):
                         r = r[1:]
+                    thread = None
+                    channel = r
+                    thread = None
+                    if ',' in r:
+                        channel, thread = r.split(',')
                     if self.color:
-                        response = client.chat_postMessage(channel=r, as_user=True, attachments=[{"color": self.color, "text": m.subject}])
+                        response = client.chat_postMessage(
+                            channel=channel, thread_ts=thread, as_user=True, attachments=[{"color": self.color, "text": m.subject}]
+                        )
                     else:
-                        response = client.chat_postMessage(channel=r, as_user=True, text=m.subject)
+                        response = client.chat_postMessage(channel=channel, thread_ts=thread, as_user=True, text=m.subject)
                     logger.debug(response)
                     if response['ok']:
                         sent_messages += 1

--- a/awx/main/tests/unit/notifications/test_slack.py
+++ b/awx/main/tests/unit/notifications/test_slack.py
@@ -24,7 +24,7 @@ def test_send_messages():
                 message,
             ]
         )
-        WebClient_mock.chat_postMessage.assert_called_once_with(channel='random', as_user=True, text='test subject')
+        WebClient_mock.chat_postMessage.assert_called_once_with(channel='random', thread_ts=None, as_user=True, text='test subject')
         assert sent_messages == 1
 
 
@@ -47,7 +47,9 @@ def test_send_messages_with_color():
             ]
         )
 
-        WebClient_mock.chat_postMessage.assert_called_once_with(channel='random', as_user=True, attachments=[{'color': '#006699', 'text': 'test subject'}])
+        WebClient_mock.chat_postMessage.assert_called_once_with(
+            channel='random', as_user=True, thread_ts=None, attachments=[{'color': '#006699', 'text': 'test subject'}]
+        )
         assert sent_messages == 1
 
 

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
@@ -45,7 +45,7 @@ const mockTemplate = {
       delete: true,
       copy: true,
     },
-    recent_notifications: [],
+    recent_notifications: [{ status: 'success' }],
   },
   created: '2021-06-16T18:52:23.811374Z',
   modified: '2021-06-16T18:53:37.631371Z',

--- a/awx/ui/src/screens/NotificationTemplate/shared/TypeInputsSubForm.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/TypeInputsSubForm.js
@@ -362,8 +362,14 @@ function SlackFields() {
         type="textarea"
         validate={required(null)}
         isRequired
-        tooltip={t`Enter one Slack channel per line. The pound symbol (#)
-          is required for channels.`}
+        tooltip={
+          <>
+            {t`Enter one Slack channel per line. The pound symbol (#)
+          is required for channels. To respond to or start a thread to a specific message add the parent message Id to the channel where the parent message Id is 16 digits. A dot (.) must be manually inserted after the 10th digit.  ie:#destination-channel, 1231257890.006423. See Slack`}{' '}
+            <a href="https://api.slack.com/messaging/retrieving#individual_messages">{t`documentation`}</a>{' '}
+            <span>{t`for more information.`}</span>
+          </>
+        }
       />
       <PasswordField
         id="slack-token"


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Users can now send a slack notification to a specific slack message, starting/continuing a slack thread."
-->

##### SUMMARY
This addresses #1741 and it updates the `Destination channel` in the tooltip in the UI to give the user some guidance.   It also add a test button on the notification details view in the UI since that is where the user is taken immediately after creating/editing the notification.

`This is my first api PR so I definitely want some constructive feedback.`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
![Screen Shot 2021-10-21 at 12 24 29 PM](https://user-images.githubusercontent.com/39280967/138318493-5e1e7b95-ace5-4437-bc14-495dc1d35555.png)
![Screen Shot 2021-11-01 at 1 48 13 PM](https://user-images.githubusercontent.com/39280967/139716671-04172a20-6bd8-4895-8e29-bd77927abdff.png)

