### PR TITLE
Update dependency slackclient to slack_sdk

### DIFF
--- a/awx/locale/en-us/LC_MESSAGES/django.po
+++ b/awx/locale/en-us/LC_MESSAGES/django.po
@@ -4856,7 +4856,7 @@ msgid "Exception connecting to PagerDuty: {}"
 msgstr ""
 
 #: awx/main/notifications/pagerduty_backend.py:87
-#: awx/main/notifications/slack_backend.py:48
+#: awx/main/notifications/slack_backend.py:49
 #: awx/main/notifications/twilio_backend.py:47
 msgid "Exception sending messages: {}"
 msgstr ""

--- a/awx/main/tests/unit/notifications/test_slack.py
+++ b/awx/main/tests/unit/notifications/test_slack.py
@@ -1,0 +1,73 @@
+import pytest
+
+from unittest import mock
+from django.core.mail.message import EmailMessage
+
+import awx.main.notifications.slack_backend as slack_backend
+
+
+def test_send_messages():
+    with mock.patch('awx.main.notifications.slack_backend.WebClient') as slack_sdk_mock:
+        WebClient_mock = slack_sdk_mock.return_value
+        WebClient_mock.chat_postMessage.return_value = {'ok': True}
+        backend = slack_backend.SlackBackend('slack_access_token')
+        message = EmailMessage(
+            'test subject',
+            'test body',
+            [],
+            [
+                '#random',
+            ],
+        )
+        sent_messages = backend.send_messages(
+            [
+                message,
+            ]
+        )
+        WebClient_mock.chat_postMessage.assert_called_once_with(channel='random', as_user=True, text='test subject')
+        assert sent_messages == 1
+
+
+def test_send_messages_with_color():
+    with mock.patch('awx.main.notifications.slack_backend.WebClient') as slack_sdk_mock:
+        WebClient_mock = slack_sdk_mock.return_value
+        WebClient_mock.chat_postMessage.return_value = {'ok': True}
+        backend = slack_backend.SlackBackend('slack_access_token', hex_color='#006699')
+        message = EmailMessage(
+            'test subject',
+            'test body',
+            [],
+            [
+                '#random',
+            ],
+        )
+        sent_messages = backend.send_messages(
+            [
+                message,
+            ]
+        )
+
+        WebClient_mock.chat_postMessage.assert_called_once_with(channel='random', as_user=True, attachments=[{'color': '#006699', 'text': 'test subject'}])
+        assert sent_messages == 1
+
+
+def test_send_messages_fail():
+    with mock.patch('awx.main.notifications.slack_backend.WebClient') as slack_sdk_mock, pytest.raises(RuntimeError, match=r'.*not_in_channel.*'):
+        WebClient_mock = slack_sdk_mock.return_value
+        WebClient_mock.chat_postMessage.return_value = {'ok': False, 'error': 'not_in_channel'}
+        backend = slack_backend.SlackBackend('slack_access_token')
+        message = EmailMessage(
+            'test subject',
+            'test body',
+            [],
+            [
+                '#not_existing',
+            ],
+        )
+        sent_messages = backend.send_messages(
+            [
+                message,
+            ]
+        )
+        WebClient_mock.chat_postMessage.assert_called_once_with(channel='not_existing', as_user=True, text='test subject')
+        assert sent_messages == 0

--- a/docs/licenses/slack-sdk.txt
+++ b/docs/licenses/slack-sdk.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Slack Technologies, Inc
+Copyright (c) 2015- Slack Technologies, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -108,12 +108,6 @@ Upgrading to 4.0.0 causes error because imports changed.
 ImportError: cannot import name 'KeyVaultClient'
 ```
 
-### slackclient
-
-Imports as used in `awx/main/notifications/slack_backend.py` changed
-in version 2.0. This plugin code will need to change and be re-tested
-as the upgrade takes place.
-
 ### django-jsonfield
 
 Instead of calling a `loads()` operation, the returned value is casted into

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -50,7 +50,7 @@ social-auth-core==3.3.1  # see UPGRADE BLOCKERs
 social-auth-app-django==3.1.0  # see UPGRADE BLOCKERs
 redis
 requests
-slackclient==1.1.2  # see UPGRADE BLOCKERs
+slack-sdk
 tacacs_plus==1.0  # UPGRADE BLOCKER: auth does not work with later versions
 twilio
 twisted[tls]>=20.3.0  # CVE-2020-10108, CVE-2020-10109

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -320,7 +320,6 @@ requests==2.23.0
     #   python-dsv-sdk
     #   python-tss-sdk
     #   requests-oauthlib
-    #   slackclient
     #   social-auth-core
     #   twilio
 requests-oauthlib==1.3.0
@@ -358,13 +357,12 @@ six==1.14.0
     #   pyrad
     #   pyrsistent
     #   python-dateutil
-    #   slackclient
     #   social-auth-app-django
     #   social-auth-core
     #   tacacs-plus
     #   twilio
     #   websocket-client
-slackclient==1.1.2
+slack-sdk==3.11.2
     # via -r /awx_devel/requirements/requirements.in
 smmap==3.0.1
     # via gitdb
@@ -399,9 +397,7 @@ uwsgi==2.0.18
 uwsgitop==0.11
     # via -r /awx_devel/requirements/requirements.in
 websocket-client==0.57.0
-    # via
-    #   kubernetes
-    #   slackclient
+    # via kubernetes
 wheel==0.36.2
     # via -r /awx_devel/requirements/requirements.in
 xmlsec==1.3.3


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Update deprecated dependency from slackclient 1.1.2 to slack-sdk 3.11.2."
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR updates the implementation of the slack backend for notifications to use the slack_sdk instead of the deprecated slackclient. This removes one `UPGRADE BLOCKER` from `requirements/requirements.in`. Unit tests are included.


According to the [official documentation](https://slack.dev/python-slackclient/):
> The [slackclient](https://pypi.org/project/slackclient/) PyPI project is in maintenance mode now and [slack-sdk](https://pypi.org/project/slack-sdk/) project is the successor.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - awx/main/notifications/slack_backend.py

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.4.1.dev93+g87a3638c32
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This needs manual testing before merging.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
