### PR TITLE
Added support to import manual projects

### DIFF
--- a/awxkit/awxkit/api/mixins/has_status.py
+++ b/awxkit/awxkit/api/mixins/has_status.py
@@ -34,9 +34,9 @@ class HasStatus(object):
             self.assert_status(status)
         return self
 
-    def wait_until_completed(self, interval=5, timeout=60, **kwargs):
+    def wait_until_completed(self, interval=5, timeout=60, *, status=None, **kwargs):
         start_time = datetime.utcnow()
-        HasStatus.wait_until_status(self, self.completed_statuses, interval=interval, timeout=timeout, **kwargs)
+        HasStatus.wait_until_status(self, status or self.completed_statuses, interval=interval, timeout=timeout, **kwargs)
         if not getattr(self, 'event_processing_finished', True):
             elapsed = datetime.utcnow() - start_time
             time_left = timeout - elapsed.total_seconds()

--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -240,7 +240,8 @@ class ApiV2(base.Base):
                         # When creating a project, we need to wait for its
                         # first project update to finish so that associated
                         # JTs have valid options for playbook names
-                        _page.wait_until_completed()
+                        status = _page.completed_statuses + ['ok']
+                        _page.wait_until_completed(status=status)
                 else:
                     _page = _page.put(post_data)
                     changed = True


### PR DESCRIPTION
msg: ""

##### SUMMARY

Import manual project marked as failed even when is completed successfully.
This issue may cause to wait until timeout expired.

Here's an example output:
```
Object import failed: Project-13 has status of ok, which is not in ['successful', 'failed', 'error', 'canceled'].
TIME WHEN STATUS WAS FOUND: 2021-10-21 12:59:21.217321 (UTC)
```
The suggested solution based on the following code from the [awx/main/models/unified_jobs.py](https://github.com/ansible/awx/blob/devel/awx/main/models/unified_jobs.py) module:
```
    PROJECT_STATUS_CHOICES = COMMON_STATUS_CHOICES + [
        ('ok', _('OK')),  # Project is not configured for SCM and path exists.
        ('missing', _('Missing')),  # Project path does not exist.
    ]
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 19.4.1.dev91+g8a7cd911aa.d20211022
```
