### PR TITLE
add creation of nginx user for docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ receiver:
 	$(PYTHON) manage.py run_callback_receiver
 
 nginx:
+	useradd -g nginx nginx
 	nginx -g "daemon off;"
 
 jupyter:


### PR DESCRIPTION
as hinted by https://github.com/Achim-Hentschel in https://github.com/ansible/awx/issues/9552#issuecomment-816710547

<!--- changelog-entry
msg: "fix issue #11276 - nginx not starting due to missing user inside tools_awx_1"
-->

##### SUMMARY
add user and group nginx inside the docker container

##### ISSUE TYPE
 - Bugfix Pull Request

##### AWX VERSION
```
19.3.0
```


##### ADDITIONAL INFORMATION
<!---
see https://github.com/ansible/awx/issues/11276
  -->

