### PR TITLE
Display host name for Associate Modal

### DIFF
--- a/awx/ui/src/components/AssociateModal/AssociateModal.js
+++ b/awx/ui/src/components/AssociateModal/AssociateModal.js
@@ -18,10 +18,7 @@ const QS_CONFIG = (order_by = 'name') =>
 
 function AssociateModal({
   header = t`Items`,
-  columns = [
-    { key: 'hostname', name: t`Name` },
-    { key: 'node_type', name: t`Node Type` },
-  ],
+  columns = [],
   title = t`Select Items`,
   onClose,
   onAssociate,

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -280,6 +280,10 @@ function InstanceList() {
           title={t`Select Instances`}
           optionsRequest={readInstancesOptions}
           displayKey="hostname"
+          columns={[
+            { key: 'hostname', name: t`Name` },
+            { key: 'node_type', name: t`Node Type` },
+          ]}
         />
       )}
       {error && (


### PR DESCRIPTION
Display host name for Associate Modal

![image](https://user-images.githubusercontent.com/9053044/138747220-fbc83bc2-b790-4ac4-8b8a-3cc658e8179e.png)

See: https://github.com/ansible/awx/issues/11256
