### PR TITLE
Skip additional instance checks on unrecognized hosts

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -514,6 +514,7 @@ def inspect_execution_nodes(instance_list):
                 logger.warn(f"Registered execution node '{hostname}' (marked disabled by default)")
             else:
                 logger.warn(f"Unrecognized node on mesh advertising ansible-runner work type: {hostname}")
+                continue
 
             was_lost = instance.is_lost(ref_time=nowtime)
             last_seen = parse_date(ad['Time'])


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Skip checking the health of mesh instances that are not registered with the application when `MESH_AUTODISCOVERY_ENABLED` is disabled. Not skipping the health checks results in an `UnboundLocalError` when autodiscovery is disabled and an unregistered instance advertising the `ansible-runner` work command is available on the receptor mesh.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API / dispatcher

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.4.1.dev93+g1503e7f992
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

To replicate this issue, launch a new instance of receptor connected to the AWX receptor mesh with an arbitrary (and unregistered) node ID:
```
receptor --node-id=foobarbaz \
  --control-service-filename=/path/to/awx/receptor.sock \
  --work-command-worktype=ansible-runner \
  --work-command-command=ansible-runner \
  --work-command-params=worker \
  --work-command-allowruntimeparams=true \
  --tcp-peer-address=localhost:2222
```
Then restart AWX and the dispatcher service will start failing with this traceback:
```
2021-10-27 16:52:23,629 DEBUG    awx.main.tasks Cluster node heartbeat task.
2021-10-27 16:35:53,867 WARNING  awx.main.tasks Unrecognized node on mesh advertising ansible-runner work type: foobarbaz
Traceback (most recent call last):
  File "/usr/bin/awx-manage", line 8, in <module>
    sys.exit(manage())
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/__init__.py", line 171, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/management/commands/run_dispatcher.py", line 62, in handle
    consumer.run()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/dispatch/worker/base.py", line 149, in run
    self.worker.on_start()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/dispatch/worker/task.py", line 128, in on_start
    dispatch_startup()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 170, in dispatch_startup
    cluster_node_heartbeat()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 536, in cluster_node_heartbeat
    inspect_execution_nodes(instance_list)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 493, in inspect_execution_nodes
    was_lost = instance.is_lost(ref_time=nowtime)
UnboundLocalError: local variable 'instance' referenced before assignment
```
With this patch the unknown node is skipped:
```
2021-10-27 16:52:23,629 DEBUG    awx.main.tasks Cluster node heartbeat task.
2021-10-27 16:52:23,650 WARNING  awx.main.tasks Unrecognized node on mesh advertising ansible-runner work type: foobarbaz
```
