### PR TITLE
Fix dev build (docker-compose) problems

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -171,6 +171,11 @@ RUN dnf install -y podman
 RUN echo -e '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\nruntime = "crun"' > /etc/containers/containers.conf
 {% endif %}
 
+# Fix overlay filesystem issue
+{% if build_dev|bool %}
+RUN sed -i '/^#mount_program/s/^#//' /etc/containers/storage.conf
+{% endif %}
+
 # Ensure we must use fully qualified image names
 # This prevents podman prompt that hangs when trying to pull unqualified images
 RUN mkdir -p /etc/containers/registries.conf.d/ && echo "unqualified-search-registries = []" >> /etc/containers/registries.conf.d/force-fully-qualified-images.conf && chmod 644 /etc/containers/registries.conf.d/force-fully-qualified-images.conf

--- a/tools/docker-compose/entrypoint.sh
+++ b/tools/docker-compose/entrypoint.sh
@@ -5,6 +5,7 @@ if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
 cat << EOF > /etc/passwd
 root:x:0:0:root:/root:/bin/bash
 awx:x:`id -u`:`id -g`:,,,:/var/lib/awx:/bin/bash
+nginx:x:`id -u nginx`:`id -g nginx`:Nginx web server:/var/lib/nginx:/sbin/nologin
 EOF
 
 cat <<EOF >> /etc/group


### PR DESCRIPTION
##### SUMMARY
Fixing a couple of bugs in the docker-compose based dev build..

Prevent deletion of nginx user by entrypoint.sh (related #9552)
Enable fuse-overlayfs in all images - native overlay not supported until kernel 5.13+ (related #10099)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Dev build

##### AWX VERSION
```
19.4.1.dev92+ge447b667e5.d20211027
```


##### ADDITIONAL INFORMATION

nginx user problem output (looped failures):

```
tools_awx_1     | awx-nginx stdout | nginx -g "daemon off;"
tools_awx_1     | awx-nginx stdout | 
tools_awx_1     | 2021-10-27 19:40:13,261 INFO exited: awx-nginx (exit status 2; not expected)
tools_awx_1     | 2021-10-27 19:40:13,262 INFO spawned: 'awx-nginx' with pid 422
tools_awx_1     | awx-nginx stdout | nginx: [emerg] getpwnam("nginx") failed
tools_awx_1     | awx-nginx stdout | 
tools_awx_1     | awx-nginx stdout | make[1]: *** [Makefile:244: nginx] Error 1
tools_awx_1     | awx-nginx stdout | make[1]: Leaving directory '/awx_devel'
tools_awx_1     | awx-nginx stdout | 
tools_awx_1     | awx-nginx stdout | make[1]: Entering directory '/awx_devel'
tools_awx_1     | awx-nginx stdout | 

```

overlay fs problem (various containers):
```
tools_awx_1     | Error: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver

```

Refs:
https://www.redhat.com/sysadmin/podman-rootless-overlay
https://www.redhat.com/en/blog/working-container-storage-library-and-tools-red-hat-enterprise-linux
