### PR TITLE
Add labels to default template search

### DIFF
--- a/awx/ui/src/components/TemplateList/TemplateList.js
+++ b/awx/ui/src/components/TemplateList/TemplateList.js
@@ -215,6 +215,10 @@ function TemplateList({ defaultParams }) {
               name: t`Modified By (Username)`,
               key: 'modified_by__username__icontains',
             },
+            {
+              name: t`Label`,
+              key: 'labels__name__icontains',
+            },
           ]}
           toolbarSearchableKeys={searchableKeys}
           toolbarRelatedSearchableKeys={relatedSearchableKeys}


### PR DESCRIPTION

##### SUMMARY
Adds labels to default search list for templates. Discussed in a support meeting. This is a common use case / feature parity  for templates.
