### PR TITLE
Reduce duplicate fetches after saving inventory group

### DIFF
--- a/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
@@ -13,14 +13,14 @@ function InventoryGroupEdit({ inventoryGroup }) {
   const handleSubmit = async (values) => {
     try {
       await GroupsAPI.update(groupId, values);
-      history.push(`/inventories/inventory/${id}/groups/${groupId}`);
+      history.push(`/inventories/inventory/${id}/groups/${groupId}/details`);
     } catch (err) {
       setError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/inventories/inventory/${id}/groups/${groupId}`);
+    history.push(`/inventories/inventory/${id}/groups/${groupId}/details`);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
@@ -20,7 +20,7 @@ function InventoryGroupEdit({ inventoryGroup }) {
   };
 
   const handleCancel = () => {
-    history.push(`/inventories/inventory/${id}/groups/${groupId}/details`);
+    history.push(`/inventories/inventory/${id}/groups/${groupId}`);
   };
 
   return (


### PR DESCRIPTION
##### SUMMARY
Reduces the number of duplicate requests when saving inventory group.

Addresses part of #10655

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
