### PR TITLE
Allow for running AWX at non-root path (URL prefixing)

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -180,11 +180,7 @@ class URLModificationMiddleware(MiddlewareMixin):
         return '/'.join(url_units)
 
     def process_request(self, request):
-        if hasattr(request, 'environ') and 'REQUEST_URI' in request.environ:
-            old_path = urllib.parse.urlsplit(request.environ['REQUEST_URI']).path
-            old_path = old_path[request.path.find(request.path_info) :]
-        else:
-            old_path = request.path_info
+        old_path = request.path_info
         new_path = self._convert_named_url(old_path)
         if request.path_info != new_path:
             request.environ['awx.named_url_rewritten'] = request.path

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ui",
+  "homepage": ".",
   "private": true,
   "engines": {
     "node": "14.x"

--- a/awx/ui/src/api/models/ActivityStream.js
+++ b/awx/ui/src/api/models/ActivityStream.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class ActivityStream extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/activity_stream/';
+    this.baseUrl = 'api/v2/activity_stream/';
   }
 }
 

--- a/awx/ui/src/api/models/AdHocCommands.js
+++ b/awx/ui/src/api/models/AdHocCommands.js
@@ -4,7 +4,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class AdHocCommands extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/ad_hoc_commands/';
+    this.baseUrl = 'api/v2/ad_hoc_commands/';
   }
 
   readCredentials(id) {

--- a/awx/ui/src/api/models/Applications.js
+++ b/awx/ui/src/api/models/Applications.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Applications extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/applications/';
+    this.baseUrl = 'api/v2/applications/';
   }
 
   readTokens(appId, params) {

--- a/awx/ui/src/api/models/Auth.js
+++ b/awx/ui/src/api/models/Auth.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Auth extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/auth/';
+    this.baseUrl = 'api/v2/auth/';
   }
 }
 

--- a/awx/ui/src/api/models/Config.js
+++ b/awx/ui/src/api/models/Config.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Config extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/config/';
+    this.baseUrl = 'api/v2/config/';
     this.read = this.read.bind(this);
   }
 

--- a/awx/ui/src/api/models/CredentialInputSources.js
+++ b/awx/ui/src/api/models/CredentialInputSources.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class CredentialInputSources extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/credential_input_sources/';
+    this.baseUrl = 'api/v2/credential_input_sources/';
   }
 }
 

--- a/awx/ui/src/api/models/CredentialTypes.js
+++ b/awx/ui/src/api/models/CredentialTypes.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class CredentialTypes extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/credential_types/';
+    this.baseUrl = 'api/v2/credential_types/';
   }
 
   async loadAllTypes(

--- a/awx/ui/src/api/models/CredentialTypes.test.js
+++ b/awx/ui/src/api/models/CredentialTypes.test.js
@@ -20,7 +20,7 @@ describe('CredentialTypesAPI', () => {
 
     expect(mockHttp.get).toHaveBeenCalledTimes(1);
     expect(mockHttp.get.mock.calls[0]).toEqual([
-      `/api/v2/credential_types/`,
+      `api/v2/credential_types/`,
       { params: { page_size: 200 } },
     ]);
     expect(types).toEqual(typesData);
@@ -41,11 +41,11 @@ describe('CredentialTypesAPI', () => {
 
     expect(mockHttp.get).toHaveBeenCalledTimes(2);
     expect(mockHttp.get.mock.calls[0]).toEqual([
-      `/api/v2/credential_types/`,
+      `api/v2/credential_types/`,
       { params: { page_size: 200 } },
     ]);
     expect(mockHttp.get.mock.calls[1]).toEqual([
-      `/api/v2/credential_types/`,
+      `api/v2/credential_types/`,
       { params: { page_size: 200, page: 2 } },
     ]);
     expect(types).toHaveLength(4);

--- a/awx/ui/src/api/models/Credentials.js
+++ b/awx/ui/src/api/models/Credentials.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Credentials extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/credentials/';
+    this.baseUrl = 'api/v2/credentials/';
 
     this.readAccessList = this.readAccessList.bind(this);
     this.readAccessOptions = this.readAccessOptions.bind(this);

--- a/awx/ui/src/api/models/Dashboard.js
+++ b/awx/ui/src/api/models/Dashboard.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Dashboard extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/dashboard/';
+    this.baseUrl = 'api/v2/dashboard/';
   }
 
   readJobGraph(params) {

--- a/awx/ui/src/api/models/ExecutionEnvironments.js
+++ b/awx/ui/src/api/models/ExecutionEnvironments.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class ExecutionEnvironments extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/execution_environments/';
+    this.baseUrl = 'api/v2/execution_environments/';
   }
 
   readUnifiedJobTemplates(id, params) {

--- a/awx/ui/src/api/models/Groups.js
+++ b/awx/ui/src/api/models/Groups.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Groups extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/groups/';
+    this.baseUrl = 'api/v2/groups/';
 
     this.associateHost = this.associateHost.bind(this);
     this.createHost = this.createHost.bind(this);

--- a/awx/ui/src/api/models/Hosts.js
+++ b/awx/ui/src/api/models/Hosts.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Hosts extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/hosts/';
+    this.baseUrl = 'api/v2/hosts/';
 
     this.readFacts = this.readFacts.bind(this);
     this.readAllGroups = this.readAllGroups.bind(this);

--- a/awx/ui/src/api/models/InstanceGroups.js
+++ b/awx/ui/src/api/models/InstanceGroups.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class InstanceGroups extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/instance_groups/';
+    this.baseUrl = 'api/v2/instance_groups/';
 
     this.associateInstance = this.associateInstance.bind(this);
     this.disassociateInstance = this.disassociateInstance.bind(this);

--- a/awx/ui/src/api/models/Instances.js
+++ b/awx/ui/src/api/models/Instances.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Instances extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/instances/';
+    this.baseUrl = 'api/v2/instances/';
 
     this.readHealthCheckDetail = this.readHealthCheckDetail.bind(this);
     this.healthCheck = this.healthCheck.bind(this);

--- a/awx/ui/src/api/models/Inventories.js
+++ b/awx/ui/src/api/models/Inventories.js
@@ -4,7 +4,7 @@ import InstanceGroupsMixin from '../mixins/InstanceGroups.mixin';
 class Inventories extends InstanceGroupsMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/inventories/';
+    this.baseUrl = 'api/v2/inventories/';
 
     this.readAccessList = this.readAccessList.bind(this);
     this.readAccessOptions = this.readAccessOptions.bind(this);

--- a/awx/ui/src/api/models/InventoryScripts.js
+++ b/awx/ui/src/api/models/InventoryScripts.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class InventoryScripts extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/inventory_scripts/';
+    this.baseUrl = 'api/v2/inventory_scripts/';
   }
 }
 

--- a/awx/ui/src/api/models/InventorySources.js
+++ b/awx/ui/src/api/models/InventorySources.js
@@ -8,7 +8,7 @@ class InventorySources extends LaunchUpdateMixin(
 ) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/inventory_sources/';
+    this.baseUrl = 'api/v2/inventory_sources/';
 
     this.createSchedule = this.createSchedule.bind(this);
     this.createSyncStart = this.createSyncStart.bind(this);

--- a/awx/ui/src/api/models/InventoryUpdates.js
+++ b/awx/ui/src/api/models/InventoryUpdates.js
@@ -4,7 +4,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class InventoryUpdates extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/inventory_updates/';
+    this.baseUrl = 'api/v2/inventory_updates/';
     this.createSyncCancel = this.createSyncCancel.bind(this);
   }
 

--- a/awx/ui/src/api/models/JobTemplates.js
+++ b/awx/ui/src/api/models/JobTemplates.js
@@ -8,7 +8,7 @@ class JobTemplates extends SchedulesMixin(
 ) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/job_templates/';
+    this.baseUrl = 'api/v2/job_templates/';
 
     this.createSchedule = this.createSchedule.bind(this);
     this.launch = this.launch.bind(this);

--- a/awx/ui/src/api/models/Jobs.js
+++ b/awx/ui/src/api/models/Jobs.js
@@ -4,7 +4,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class Jobs extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/jobs/';
+    this.baseUrl = 'api/v2/jobs/';
     this.jobEventSlug = '/job_events/';
   }
 

--- a/awx/ui/src/api/models/Labels.js
+++ b/awx/ui/src/api/models/Labels.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Labels extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/labels/';
+    this.baseUrl = 'api/v2/labels/';
   }
 }
 

--- a/awx/ui/src/api/models/Me.js
+++ b/awx/ui/src/api/models/Me.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Me extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/me/';
+    this.baseUrl = 'api/v2/me/';
   }
 }
 

--- a/awx/ui/src/api/models/Metrics.js
+++ b/awx/ui/src/api/models/Metrics.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Metrics extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/metrics/';
+    this.baseUrl = 'api/v2/metrics/';
   }
 }
 export default Metrics;

--- a/awx/ui/src/api/models/NotificationTemplates.js
+++ b/awx/ui/src/api/models/NotificationTemplates.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class NotificationTemplates extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/notification_templates/';
+    this.baseUrl = 'api/v2/notification_templates/';
   }
 
   test(id) {

--- a/awx/ui/src/api/models/Notifications.js
+++ b/awx/ui/src/api/models/Notifications.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Notifications extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/notifications/';
+    this.baseUrl = 'api/v2/notifications/';
   }
 }
 

--- a/awx/ui/src/api/models/Organizations.js
+++ b/awx/ui/src/api/models/Organizations.js
@@ -5,7 +5,7 @@ import InstanceGroupsMixin from '../mixins/InstanceGroups.mixin';
 class Organizations extends InstanceGroupsMixin(NotificationsMixin(Base)) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/organizations/';
+    this.baseUrl = 'api/v2/organizations/';
   }
 
   readAccessList(id, params) {

--- a/awx/ui/src/api/models/Organizations.test.js
+++ b/awx/ui/src/api/models/Organizations.test.js
@@ -20,7 +20,7 @@ describe('OrganizationsAPI', () => {
     const testParams = { foo: 'bar' };
     const testParamsDuplicates = { foo: ['bar', 'baz'] };
 
-    const mockBaseURL = `/api/v2/organizations/${orgId}/access_list/`;
+    const mockBaseURL = `api/v2/organizations/${orgId}/access_list/`;
 
     await OrganizationsAPI.readAccessList(orgId);
     await OrganizationsAPI.readAccessList(orgId, testParams);
@@ -41,7 +41,7 @@ describe('OrganizationsAPI', () => {
     const testParams = { foo: 'bar' };
     const testParamsDuplicates = { foo: ['bar', 'baz'] };
 
-    const mockBaseURL = `/api/v2/organizations/${orgId}/teams/`;
+    const mockBaseURL = `api/v2/organizations/${orgId}/teams/`;
 
     await OrganizationsAPI.readTeams(orgId);
     await OrganizationsAPI.readTeams(orgId, testParams);

--- a/awx/ui/src/api/models/ProjectUpdates.js
+++ b/awx/ui/src/api/models/ProjectUpdates.js
@@ -4,7 +4,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class ProjectUpdates extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/project_updates/';
+    this.baseUrl = 'api/v2/project_updates/';
   }
 
   readCredentials(id) {

--- a/awx/ui/src/api/models/Projects.js
+++ b/awx/ui/src/api/models/Projects.js
@@ -8,7 +8,7 @@ class Projects extends SchedulesMixin(
 ) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/projects/';
+    this.baseUrl = 'api/v2/projects/';
 
     this.readAccessList = this.readAccessList.bind(this);
     this.readAccessOptions = this.readAccessOptions.bind(this);

--- a/awx/ui/src/api/models/Roles.js
+++ b/awx/ui/src/api/models/Roles.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Roles extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/roles/';
+    this.baseUrl = 'api/v2/roles/';
   }
 
   disassociateUserRole(roleId, userId) {

--- a/awx/ui/src/api/models/Root.js
+++ b/awx/ui/src/api/models/Root.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Root extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/';
+    this.baseUrl = 'api/';
     this.redirectURL = '/api/v2/config/';
   }
 
@@ -31,7 +31,7 @@ class Root extends Base {
     // automation etc. should relocate this variable file to an importable
     // location in src prior to building. That said, a raw http call
     // works for now.
-    return this.http.get('/static/media/default.strings.json');
+    return this.http.get('static/media/default.strings.json');
   }
 }
 

--- a/awx/ui/src/api/models/Schedules.js
+++ b/awx/ui/src/api/models/Schedules.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Schedules extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/schedules/';
+    this.baseUrl = 'api/v2/schedules/';
   }
 
   createPreview(data) {

--- a/awx/ui/src/api/models/Settings.js
+++ b/awx/ui/src/api/models/Settings.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Settings extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/settings/';
+    this.baseUrl = 'api/v2/settings/';
   }
 
   readAllOptions() {

--- a/awx/ui/src/api/models/SystemJobTemplates.js
+++ b/awx/ui/src/api/models/SystemJobTemplates.js
@@ -7,7 +7,7 @@ const Mixins = SchedulesMixin(NotificationsMixin(Base));
 class SystemJobTemplates extends Mixins {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/system_job_templates/';
+    this.baseUrl = 'api/v2/system_job_templates/';
   }
 
   launch(id, data) {

--- a/awx/ui/src/api/models/SystemJobs.js
+++ b/awx/ui/src/api/models/SystemJobs.js
@@ -5,7 +5,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class SystemJobs extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/system_jobs/';
+    this.baseUrl = 'api/v2/system_jobs/';
   }
 
   readCredentials(id) {

--- a/awx/ui/src/api/models/Teams.js
+++ b/awx/ui/src/api/models/Teams.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Teams extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/teams/';
+    this.baseUrl = 'api/v2/teams/';
   }
 
   associateRole(teamId, roleId) {

--- a/awx/ui/src/api/models/Teams.test.js
+++ b/awx/ui/src/api/models/Teams.test.js
@@ -23,7 +23,7 @@ describe('TeamsAPI', () => {
 
     expect(mockHttp.post).toHaveBeenCalledTimes(1);
     expect(mockHttp.post.mock.calls[0]).toContainEqual(
-      `/api/v2/teams/${teamId}/roles/`,
+      `api/v2/teams/${teamId}/roles/`,
       { id: roleId }
     );
   });
@@ -33,7 +33,7 @@ describe('TeamsAPI', () => {
 
     expect(mockHttp.post).toHaveBeenCalledTimes(1);
     expect(mockHttp.post.mock.calls[0]).toContainEqual(
-      `/api/v2/teams/${teamId}/roles/`,
+      `api/v2/teams/${teamId}/roles/`,
       {
         id: roleId,
         disassociate: true,

--- a/awx/ui/src/api/models/Tokens.js
+++ b/awx/ui/src/api/models/Tokens.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Tokens extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/tokens/';
+    this.baseUrl = 'api/v2/tokens/';
   }
 }
 

--- a/awx/ui/src/api/models/UnifiedJobTemplates.js
+++ b/awx/ui/src/api/models/UnifiedJobTemplates.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class UnifiedJobTemplates extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/unified_job_templates/';
+    this.baseUrl = 'api/v2/unified_job_templates/';
   }
 }
 

--- a/awx/ui/src/api/models/UnifiedJobs.js
+++ b/awx/ui/src/api/models/UnifiedJobs.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class UnifiedJobs extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/unified_jobs/';
+    this.baseUrl = 'api/v2/unified_jobs/';
   }
 }
 

--- a/awx/ui/src/api/models/Users.js
+++ b/awx/ui/src/api/models/Users.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class Users extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/users/';
+    this.baseUrl = 'api/v2/users/';
   }
 
   associateRole(userId, roleId) {

--- a/awx/ui/src/api/models/Users.test.js
+++ b/awx/ui/src/api/models/Users.test.js
@@ -20,7 +20,7 @@ describe('UsersAPI', () => {
 
     expect(mockHttp.post).toHaveBeenCalledTimes(1);
     expect(mockHttp.post.mock.calls[0]).toContainEqual(
-      `/api/v2/users/${userId}/roles/`,
+      `api/v2/users/${userId}/roles/`,
       { id: roleId }
     );
   });
@@ -30,7 +30,7 @@ describe('UsersAPI', () => {
 
     expect(mockHttp.post).toHaveBeenCalledTimes(1);
     expect(mockHttp.post.mock.calls[0]).toContainEqual(
-      `/api/v2/users/${userId}/roles/`,
+      `api/v2/users/${userId}/roles/`,
       {
         id: roleId,
         disassociate: true,

--- a/awx/ui/src/api/models/WorkflowApprovalTemplates.js
+++ b/awx/ui/src/api/models/WorkflowApprovalTemplates.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class WorkflowApprovalTemplates extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/workflow_approval_templates/';
+    this.baseUrl = 'api/v2/workflow_approval_templates/';
   }
 }
 

--- a/awx/ui/src/api/models/WorkflowApprovals.js
+++ b/awx/ui/src/api/models/WorkflowApprovals.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class WorkflowApprovals extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/workflow_approvals/';
+    this.baseUrl = 'api/v2/workflow_approvals/';
   }
 
   approve(id) {

--- a/awx/ui/src/api/models/WorkflowJobTemplateNodes.js
+++ b/awx/ui/src/api/models/WorkflowJobTemplateNodes.js
@@ -3,7 +3,7 @@ import Base from '../Base';
 class WorkflowJobTemplateNodes extends Base {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/workflow_job_template_nodes/';
+    this.baseUrl = 'api/v2/workflow_job_template_nodes/';
   }
 
   createApprovalTemplate(id, data) {

--- a/awx/ui/src/api/models/WorkflowJobTemplates.js
+++ b/awx/ui/src/api/models/WorkflowJobTemplates.js
@@ -5,7 +5,7 @@ import NotificationsMixin from '../mixins/Notifications.mixin';
 class WorkflowJobTemplates extends SchedulesMixin(NotificationsMixin(Base)) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/workflow_job_templates/';
+    this.baseUrl = 'api/v2/workflow_job_templates/';
     this.createSchedule = this.createSchedule.bind(this);
   }
 

--- a/awx/ui/src/api/models/WorkflowJobs.js
+++ b/awx/ui/src/api/models/WorkflowJobs.js
@@ -4,7 +4,7 @@ import RunnableMixin from '../mixins/Runnable.mixin';
 class WorkflowJobs extends RunnableMixin(Base) {
   constructor(http) {
     super(http);
-    this.baseUrl = '/api/v2/workflow_jobs/';
+    this.baseUrl = 'api/v2/workflow_jobs/';
   }
 
   readNodes(id, params) {

--- a/awx/ui/src/components/About/About.js
+++ b/awx/ui/src/components/About/About.js
@@ -41,7 +41,7 @@ function About({ version, isOpen, onClose }) {
       onClose={onClose}
       productName={brandName}
       trademark={`${copyright} ${new Date().getFullYear()} ${redHatInc}`}
-      brandImageSrc="/static/media/logo-header.svg"
+      brandImageSrc="static/media/logo-header.svg"
       brandImageAlt={t`Brand Image`}
     >
       <pre>

--- a/awx/ui/src/components/AppContainer/BrandLogo.js
+++ b/awx/ui/src/components/AppContainer/BrandLogo.js
@@ -14,7 +14,7 @@ const BrandImg = styled.img`
 `;
 
 const BrandLogo = ({ alt }) => (
-  <BrandImg src="/static/media/logo-header.svg" alt={alt} />
+  <BrandImg src="static/media/logo-header.svg" alt={alt} />
 );
 
 export default BrandLogo;

--- a/awx/ui/src/hooks/useWebsocket.js
+++ b/awx/ui/src/hooks/useWebsocket.js
@@ -8,7 +8,7 @@ export default function useWebsocket(subscribeGroups) {
     ws.current = new WebSocket(
       `${window.location.protocol === 'http:' ? 'ws:' : 'wss:'}//${
         window.location.host
-      }/websocket/`
+      }${window.location.pathname}websocket/`
     );
 
     const connect = () => {

--- a/awx/ui/src/screens/Job/JobOutput/connectJobSocket.js
+++ b/awx/ui/src/screens/Job/JobOutput/connectJobSocket.js
@@ -4,7 +4,7 @@ export default function connectJobSocket({ type, id }, onMessage) {
   ws = new WebSocket(
     `${window.location.protocol === 'http:' ? 'ws:' : 'wss:'}//${
       window.location.host
-    }/websocket/`
+    }${window.location.pathname}websocket/`
   );
 
   ws.onopen = () => {

--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -32,7 +32,7 @@ import ErrorDetail from 'components/ErrorDetail';
 import { useSession } from 'contexts/Session';
 import { SESSION_REDIRECT_URL } from '../../constants';
 
-const loginLogoSrc = '/static/media/logo-login.svg';
+const loginLogoSrc = 'static/media/logo-login.svg';
 
 const Login = styled(PFLogin)`
   & .pf-c-brand {

--- a/awx/ui/src/screens/Login/Login.test.js
+++ b/awx/ui/src/screens/Login/Login.test.js
@@ -121,7 +121,7 @@ describe('<Login />', () => {
     });
     const { loginHeaderLogo } = await findChildren(wrapper);
     const { alt, src } = loginHeaderLogo.props();
-    expect([alt, src]).toEqual(['AWX', '/static/media/logo-login.svg']);
+    expect([alt, src]).toEqual(['AWX', 'static/media/logo-login.svg']);
   });
 
   test('custom login info handled correctly', async () => {
@@ -152,7 +152,7 @@ describe('<Login />', () => {
     });
     const { loginHeaderLogo } = await findChildren(wrapper);
     const { alt, src } = loginHeaderLogo.props();
-    expect([alt, src]).toEqual([null, '/static/media/logo-login.svg']);
+    expect([alt, src]).toEqual([null, 'static/media/logo-login.svg']);
     expect(wrapper.find('AlertModal').length).toBe(1);
   });
 

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js
@@ -107,7 +107,7 @@ function AnalyticsStep() {
       <Flex alignItems={{ default: 'alignItemsCenter' }}>
         <img
           width="300"
-          src="/static/media/insights-analytics-dashboard.jpeg"
+          src="static/media/insights-analytics-dashboard.jpeg"
           alt={t`Insights for Ansible Automation Platform dashboard`}
         />
         <Button

--- a/tools/ansible/roles/dockerfile/files/uwsgi.ini
+++ b/tools/ansible/roles/dockerfile/files/uwsgi.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+socket = 127.0.0.1:8050
+processes = 5
+master = true
+vacuum = true
+no-orphans = true
+lazy-apps = true
+master-fifo = /var/lib/awx/awxfifo
+max-requests = 1000
+buffer-size = 32768
+module = awx.wsgi:application

--- a/tools/ansible/roles/dockerfile/files/uwsgi.ini
+++ b/tools/ansible/roles/dockerfile/files/uwsgi.ini
@@ -5,7 +5,15 @@ master = true
 vacuum = true
 no-orphans = true
 lazy-apps = true
+manage-script-name = true
 master-fifo = /var/lib/awx/awxfifo
 max-requests = 1000
 buffer-size = 32768
-module = awx.wsgi:application
+
+if-env = UWSGI_MOUNT_PATH
+mount = %(_)=awx.wsgi:application
+endif =
+
+if-not-env = UWSGI_MOUNT_PATH
+mount = /=awx.wsgi:application
+endif =

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -210,6 +210,7 @@ ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanima
 ADD tools/ansible/roles/dockerfile/files/launch_awx.sh /usr/bin/launch_awx.sh
 ADD tools/ansible/roles/dockerfile/files/launch_awx_task.sh /usr/bin/launch_awx_task.sh
 ADD tools/ansible/roles/dockerfile/files/settings.py /etc/tower/settings.py
+ADD tools/ansible/roles/dockerfile/files/uwsgi.ini /etc/tower/uwsgi.ini
 ADD {{ template_dest }}/supervisor.conf /etc/supervisord.conf
 ADD {{ template_dest }}/supervisor_task.conf /etc/supervisord_task.conf
 {% endif %}

--- a/tools/ansible/roles/dockerfile/templates/supervisor.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor.conf.j2
@@ -28,7 +28,7 @@ directory = /awx_devel
 environment =
     UWSGI_DEV_RELOAD_COMMAND='supervisorctl -c /etc/supervisord_task.conf restart all; supervisorctl restart tower-processes:daphne tower-processes:wsbroadcast'
 {% else %}
-command = /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+command = /var/lib/awx/venv/awx/bin/uwsgi /etc/tower/uwsgi.ini
 directory = /var/lib/awx
 {% endif %}
 autostart = true

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -56,7 +56,7 @@ services:
       - "8013:8013"  # http
       - "8043:8043"  # https
       - "2222:2222"  # receptor foo node
-      - "3001:3001"  # used by the UI dev env
+      - "3000:3001"  # used by the UI dev env
 {% endif %}
   redis_{{ container_postfix }}:
     image: redis:latest

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -56,6 +56,7 @@ services:
       - "8013:8013"  # http
       - "8043:8043"  # https
       - "2222:2222"  # receptor foo node
+      - "3001:3001"  # used by the UI dev env
 {% endif %}
   redis_{{ container_postfix }}:
     image: redis:latest


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Added support for running AWX at non-root path (URL prefixing)"
-->

##### SUMMARY
These changes allow for running AWX at a non-root path, like `https://example.com/awx/`:

![Screen Shot 2021-11-14 at 12 38 15 PM](https://user-images.githubusercontent.com/773186/141667765-b1cb3e30-82ed-4795-a0b0-62880cc3cf20.png)

Must be merged along with https://github.com/ansible/awx-operator/pull/652