### PR TITLE
Added an example for credential_type

### DIFF
--- a/awx_collection/plugins/modules/credential_type.py
+++ b/awx_collection/plugins/modules/credential_type.py
@@ -71,6 +71,26 @@ EXAMPLES = '''
     state: present
     validate_certs: false
 
+- name: Custom Credential type with inputs as a YAML
+  credential_type:
+      name: Nexus
+      description: Credentials type for Nexus
+      kind: cloud
+      inputs:
+        fields:
+          - type: string
+            id: username
+            label: Username
+          - type: string
+            id: password
+            label: Password
+            secret: true
+        required:
+          - username
+          - password
+      state: present
+      validate_certs: false
+
 - credential_type:
     name: Nexus
     state: absent


### PR DESCRIPTION


<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
Added an example of custom credential type using inputs
as YAML spec.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


