### PR TITLE
related #10961 Render Jinja template before checking for valid JSON

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -14,7 +14,7 @@ from oauthlib import oauth2
 from oauthlib.common import generate_token
 
 # Jinja
-from jinja2 import Environment, sandbox, StrictUndefined
+from jinja2 import sandbox, StrictUndefined
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError, SecurityError
 
 # Django
@@ -4490,7 +4490,9 @@ class NotificationTemplateSerializer(BaseSerializer):
                 body = messages[event].get('body', {})
                 if body:
                     try:
-                        rendered_body = Environment(undefined=DescriptiveUndefined).from_string(body).render(JobNotificationMixin.context_stub())
+                        rendered_body = (
+                            sandbox.ImmutableSandboxedEnvironment(undefined=DescriptiveUndefined).from_string(body).render(JobNotificationMixin.context_stub())
+                        )
                         potential_body = json.loads(rendered_body)
                         if not isinstance(potential_body, dict):
                             error_list.append(

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -14,7 +14,7 @@ from oauthlib import oauth2
 from oauthlib.common import generate_token
 
 # Jinja
-from jinja2 import sandbox, StrictUndefined
+from jinja2 import Environment, sandbox, StrictUndefined
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError, SecurityError
 
 # Django
@@ -4490,7 +4490,9 @@ class NotificationTemplateSerializer(BaseSerializer):
                 body = messages[event].get('body', {})
                 if body:
                     try:
-                        potential_body = json.loads(body)
+                        rendered_body = Environment(undefined=DescriptiveUndefined).from_string(body).render(JobNotificationMixin.context_stub())
+                        logger.error("RENDERED " + rendered_body)
+                        potential_body = json.loads(rendered_body)
                         if not isinstance(potential_body, dict):
                             error_list.append(
                                 _("Webhook body for '{}' should be a json dictionary. Found type '{}'.".format(event, type(potential_body).__name__))

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4491,7 +4491,6 @@ class NotificationTemplateSerializer(BaseSerializer):
                 if body:
                     try:
                         rendered_body = Environment(undefined=DescriptiveUndefined).from_string(body).render(JobNotificationMixin.context_stub())
-                        logger.error("RENDERED " + rendered_body)
                         potential_body = json.loads(rendered_body)
                         if not isinstance(potential_body, dict):
                             error_list.append(


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Webhook validation will now render the template before validating the JSON"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Before this change AWX would try to validate the JSON of a webhook body *without* rendering the template. Now rendering is done first using the `JobNotificationMixin.context_stub()`. This allows for the use of for loops and conditionals in Webhook templates.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
