### PR TITLE
Add unique host target retention

### DIFF
--- a/awx/main/migrations/0156_unique_host.py
+++ b/awx/main/migrations/0156_unique_host.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0155_improved_health_check'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UniqueHost',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(default=None, editable=False)),
+                ('modified', models.DateTimeField(default=None, editable=False)),
+                ('host_name', models.CharField(default='', max_length=1024, editable=False)),
+                (
+                    'host',
+                    models.ForeignKey(
+                        related_name='unique_hosts', on_delete=django.db.models.deletion.SET_NULL, default=None, editable=False, to='main.Host', null=True
+                    ),
+                ),
+                (
+                    'job_host_summary',
+                    models.ForeignKey(
+                        related_name='unique_hosts',
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        default=None,
+                        editable=False,
+                        to='main.JobHostSummary',
+                        null=True,
+                    ),
+                ),
+                ('recorded_date', models.DateTimeField(default=None, editable=False, null=True)),
+            ],
+            options={
+                'ordering': ('-pk',),
+                'verbose_name_plural': 'unique hosts',
+            },
+        ),
+    ]

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -29,6 +29,11 @@ from awx.main.models.jobs import (  # noqa
     SystemJob,
     SystemJobTemplate,
 )
+
+if settings.UNIQUE_HOST_RETENTION_ENABLED:
+    from awx.main.models.jobs import (
+        UniqueHost,
+    )
 from awx.main.models.events import (  # noqa
     AdHocCommandEvent,
     InventoryUpdateEvent,

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -1088,6 +1088,53 @@ class JobHostSummary(CreatedModifiedModel):
         super(JobHostSummary, self).save(*args, **kwargs)
 
 
+class UniqueHost(CreatedModifiedModel):
+    """
+    Retention of unique host targets (optional)
+    """
+
+    class Meta:
+        app_label = 'main'
+        constraints = [models.UniqueConstraint(name='ensure_unique_hosts', fields=['host_name'])]
+        verbose_name_plural = _('unique hosts')
+        ordering = ('-pk',)
+
+    job_host_summary = models.ForeignKey(
+        'JobHostSummary',
+        related_name='unique_hosts',
+        null=True,
+        default=None,
+        on_delete=models.SET_NULL,
+        editable=False,
+    )
+
+    host = models.ForeignKey(
+        'Host',
+        related_name='unique_hosts',
+        null=True,
+        default=None,
+        on_delete=models.SET_NULL,
+        editable=False,
+    )
+
+    host_name = models.CharField(
+        max_length=1024,
+        default='',
+        editable=False,
+    )
+
+    recorded_date = models.DateTimeField(
+        default=None,
+        editable=False,
+        null=True,
+    )
+
+    def save(self, *args, **kwargs):
+        if self.host is not None:
+            self.host_name = self.host.name
+        super(UniqueHost, self).save(*args, **kwargs)
+
+
 class SystemJobOptions(BaseModel):
     """
     Common fields for SystemJobTemplate and SystemJob.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -981,3 +981,6 @@ DJANGO_GUID = {'GUID_HEADER_NAME': 'X-API-Request-Id'}
 DEFAULT_EXECUTION_QUEUE_NAME = 'default'
 # Name of the default controlplane queue
 DEFAULT_CONTROL_PLANE_QUEUE_NAME = 'controlplane'
+
+# Enable unique host retention
+UNIQUE_HOST_RETENTION_ENABLED = False


### PR DESCRIPTION
New main_uniquehosts db table and config flag


##### SUMMARY
Addition of UniqueHost model and db table with optional flag.  Ensures target execution hosts are retained when jobs are deleted.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - DB

##### ADDITIONAL INFORMATION
