### PR TITLE
Allow customizing the receptor image in the development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ docker-compose-container-group-clean:
 
 # Base development image build
 docker-compose-build:
-	ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True
+	ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True -e receptor_image=$(RECEPTOR_IMAGE)
 	DOCKER_BUILDKIT=1 docker build -t $(DEVEL_IMAGE_NAME) \
 	    --build-arg BUILDKIT_INLINE_CACHE=1 \
 	    --cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) .
@@ -547,13 +547,14 @@ VERSION:
 	@echo "awx: $(VERSION)"
 
 Dockerfile: tools/ansible/roles/dockerfile/templates/Dockerfile.j2
-	ansible-playbook tools/ansible/dockerfile.yml
+	ansible-playbook tools/ansible/dockerfile.yml -e receptor_image=$(RECEPTOR_IMAGE)
 
 Dockerfile.kube-dev: tools/ansible/roles/dockerfile/templates/Dockerfile.j2
 	ansible-playbook tools/ansible/dockerfile.yml \
 	    -e dockerfile_name=Dockerfile.kube-dev \
 	    -e kube_dev=True \
-	    -e template_dest=_build_kube_dev
+	    -e template_dest=_build_kube_dev \
+	    -e receptor_image=$(RECEPTOR_IMAGE)
 
 awx-kube-dev-build: Dockerfile.kube-dev
 	docker build -f Dockerfile.kube-dev \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ VENV_BASE ?= /var/lib/awx/venv
 DEV_DOCKER_TAG_BASE ?= quay.io/awx
 DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
 
+RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
+
 # Python packages to install only from source (not from binary wheels)
 # Comma separated list
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg2,twilio
@@ -463,6 +465,7 @@ docker-compose-sources: .git/hooks/pre-commit
 	ansible-playbook -i tools/docker-compose/inventory tools/docker-compose/ansible/sources.yml \
 	    -e awx_image=$(DEV_DOCKER_TAG_BASE)/awx_devel \
 	    -e awx_image_tag=$(COMPOSE_TAG) \
+	    -e receptor_image=$(RECEPTOR_IMAGE) \
 	    -e control_plane_node_count=$(CONTROL_PLANE_NODE_COUNT) \
 	    -e execution_node_count=$(EXECUTION_NODE_COUNT) \
 	    -e minikube_container_group=$(MINIKUBE_CONTAINER_GROUP)

--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -6,6 +6,8 @@ dockerfile_dest: '../..'
 dockerfile_name: 'Dockerfile'
 template_dest: '_build'
 
+receptor_image: quay.io/ansible/receptor:devel
+
 # Helper vars to construct the proper download URL for the current architecture
 tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
 kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -187,7 +187,7 @@ COPY --from=builder /var/lib/awx /var/lib/awx
 RUN ln -s /var/lib/awx/venv/awx/bin/awx-manage /usr/bin/awx-manage
 
 {%if build_dev|bool %}
-COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
+COPY --from={{ receptor_image }} /usr/bin/receptor /usr/bin/receptor
 RUN openssl req -nodes -newkey rsa:2048 -keyout /etc/nginx/nginx.key -out /etc/nginx/nginx.csr \
         -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/OU=AWX Development/CN=awx.localhost" && \
     openssl x509 -req -days 365 -in /etc/nginx/nginx.csr -signkey /etc/nginx/nginx.key -out /etc/nginx/nginx.crt && \

--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -83,6 +83,29 @@ ansible/awx_devel                            latest              ba9ec3e8df74   
 
 > By default, this image will be tagged with your branch name. You can specify a custom tag by setting an environment variable, for example: `DEVEL_IMAGE_NAME=quay.io/your_user/awx_devel:17.0.1`
 
+#### Customizing the Receptor Image
+
+By default, the development environment will use the `devel` image from receptor.
+This is used directly in `docker-compose.yml` for the hop nodes.
+The receptor binary is also copied over to the main awx_devel image, used in all other AWX nodes.
+
+Because of this, the `RECEPTOR_IMAGE` environment variable must be set when running
+both docker-compose-build and docker-compose in order to use the correct receptor in all containers.
+
+If you need to create a new receptor image, you can check out receptor and build it like this:
+
+```bash
+CONTAINERCMD=docker TAG=quay.io/ansible/receptor:release_1.1 make container
+```
+
+Then that can be used by AWX like this:
+
+```bash
+export RECEPTOR_IMAGE=quay.io/ansible/receptor:release_1.1
+make docker-compose-build
+make docker-compose
+```
+
 ### Run AWX
 
 ##### Start the containers

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -8,6 +8,7 @@ pg_database: 'awx'
 control_plane_node_count: 1
 minikube_container_group: false
 receptor_socket_file: /var/run/awx-receptor/receptor.sock
+receptor_image: quay.io/ansible/receptor:devel
 
 # Keys for signing work
 receptor_rsa_bits: 4096

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -98,7 +98,7 @@ services:
       - "awx_db:/var/lib/postgresql/data"
 {% if execution_node_count|int > 0 %}
   receptor-hop:
-    image: quay.io/ansible/receptor:devel
+    image: {{ receptor_image }}
     user: root
     container_name: tools_receptor_hop
     hostname: receptor-hop


### PR DESCRIPTION
##### SUMMARY
The Dockerfile that the development environment uses is hard-coded to:

```
quay.io/ansible/receptor:devel
```

This is the only image being produced automatically for upstream, but it leaves us running significantly out-of-date receptor while doing development in hardening of the release. Even the `release_4.1` tag for awx_devel has the `devel` receptor version (which is behind `release_1.1`).

How to use:

in receptor checkout run:

```
CONTAINERCMD=docker TAG=quay.io/alancoding/receptor:release_1.1 make container
```

then inside of the tower / awx repo, run

```
RECEPTOR_IMAGE=quay.io/alancoding/receptor:release_1.1 COMPOSE_TAG=release_4.1 make docker-compose-build
RECEPTOR_IMAGE=quay.io/alancoding/receptor:release_1.1 COMPOSE_TAG=release_4.1 make docker-compose
```

I wish this was a little bit cleaner, but this is the only thing I can image that works right now.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
