### PR TITLE
Consume job_explanation we sometimes set in ansible-runner

### DIFF
--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -203,12 +203,12 @@ class RunnerCallback:
                 if os.path.exists(key_data_file) and stat.S_ISFIFO(os.stat(key_data_file).st_mode):
                     os.remove(key_data_file)
         elif status_data['status'] == 'error':
-            result_traceback = status_data.get('result_traceback', None)
-            if result_traceback:
-                from awx.main.signals import disable_activity_stream  # Circular import
-
-                with disable_activity_stream():
-                    self.instance = self.update_model(self.instance.pk, result_traceback=result_traceback)
+            updates = {}
+            for potential_field in ('result_traceback', 'job_explanation'):
+                if status_data.get(potential_field, None):
+                    updates[potential_field] = status_data[potential_field]
+            if updates:
+                self.instance = self.update_model(self.instance.pk, **updates)
 
 
 class RunnerCallbackForProjectUpdate(RunnerCallback):


### PR DESCRIPTION
##### SUMMARY
Verified with tests

https://github.com/ansible/ansible-runner/blob/ef8edc3832a02786d309941b72ed805f90902b7e/ansible_runner/streaming.py#L113

![Screenshot from 2021-11-06 21-20-31](https://user-images.githubusercontent.com/1385596/140629433-41f82e95-966c-4470-b8d4-448084a5013c.png)

This was encountered in https://github.com/ansible/tower/issues/5423, but is an error handling issue


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

