### PR TITLE
Make sure to fire off failure notifications on error

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1542,9 +1542,11 @@ class BaseTask(object):
             status = res.status
             rc = res.rc
 
-            if status == 'timeout':
-                self.instance.job_explanation = "Job terminated due to timeout"
-                status = 'failed'
+            if status in ('timeout', 'error'):
+                self.instance.job_explanation = f"Job terminated due to {status}"
+                if status == 'timeout':
+                    status = 'failed'
+
                 extra_update_fields['job_explanation'] = self.instance.job_explanation
                 # ensure failure notification sends even if playbook_on_stats event is not triggered
                 handle_success_and_failure_notifications.apply_async([self.instance.job.id])


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix problem with failure notifications not firing off when an error happens outside of the Ansible job"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

where the error is unrelated to Ansible, thus is not caught by the
usual methods.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
