### PR TITLE
Do not overwrite file-based CLUSTER_HOST_ID written by installer

### DIFF
--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -9,7 +9,6 @@ import copy
 import errno
 import sys
 import traceback
-import socket
 
 # Django Split Settings
 from split_settings.tools import optional, include
@@ -88,8 +87,6 @@ except IOError:
         raise
 
 # The below runs AFTER all of the custom settings are imported.
-
-CLUSTER_HOST_ID = socket.gethostname()
 
 DATABASES.setdefault('default', dict()).setdefault('OPTIONS', dict()).setdefault(
     'application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63]


### PR DESCRIPTION
##### SUMMARY
The official installer writes the file `/etc/tower/conf.d/cluster_host_id.py` with a value for `CLUSTER_HOST_ID`, and this value conflicts with what `socket.gethostname()` gives.

Looots of things will not work if this value does not match the value the installer used to do `awx-manage provision_instance --hostname=<cluster host id>`.

This overwrite was introduced in #11341, and granted, this might go break what that was trying to fix, but however that goes, dropping the user's value for this setting is not something we can do.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


