### PR TITLE
Remove dev-only log filters and downgrade periodic logs

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -248,7 +248,7 @@ class WorkerPool(object):
         except Exception:
             logger.exception('could not fork')
         else:
-            logger.warn('scaling up worker pid:{}'.format(worker.pid))
+            logger.debug('scaling up worker pid:{}'.format(worker.pid))
         return idx, worker
 
     def debug(self, *args, **kwargs):
@@ -387,7 +387,7 @@ class AutoscalePool(WorkerPool):
                 # more processes in the pool than we need (> min)
                 # send this process a message so it will exit gracefully
                 # at the next opportunity
-                logger.warn('scaling down worker pid:{}'.format(w.pid))
+                logger.debug('scaling down worker pid:{}'.format(w.pid))
                 w.quit()
                 self.workers.remove(w)
             if w.alive:

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -60,7 +60,7 @@ class AWXConsumerBase(object):
         return f'listening on {self.queues}'
 
     def control(self, body):
-        logger.warn(body)
+        logger.warn(f'Received control signal:\n{body}')
         control = body.get('control')
         if control in ('status', 'running'):
             reply_queue = body['reply_to']
@@ -137,7 +137,7 @@ class AWXConsumerPG(AWXConsumerBase):
     def run(self, *args, **kwargs):
         super(AWXConsumerPG, self).run(*args, **kwargs)
 
-        logger.warn(f"Running worker {self.name} listening to queues {self.queues}")
+        logger.info(f"Running worker {self.name} listening to queues {self.queues}")
         init = False
 
         while True:

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -188,7 +188,7 @@ class BaseWorker(object):
                 if 'uuid' in body:
                     uuid = body['uuid']
                     finished.put(uuid)
-        logger.warn('worker exiting gracefully pid:{}'.format(os.getpid()))
+        logger.debug('worker exiting gracefully pid:{}'.format(os.getpid()))
 
     def perform_work(self, body):
         raise NotImplementedError()

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -239,7 +239,7 @@ class TaskManager:
                 update_fields = ['status', 'start_args']
                 workflow_job.status = new_status
                 if reason:
-                    logger.info(reason)
+                    logger.info(f'Workflow job {workflow_job.id} failed due to reason: {reason}')
                     workflow_job.job_explanation = gettext_noop("No error handling paths found, marking workflow as failed")
                     update_fields.append('job_explanation')
                 workflow_job.start_args = ''  # blank field to remove encrypted passwords

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -795,7 +795,12 @@ LOGGING = {
         'job_lifecycle': {'()': 'awx.main.utils.formatters.JobLifeCycleFormatter'},
     },
     'handlers': {
-        'console': {'()': 'logging.StreamHandler', 'level': 'DEBUG', 'filters': ['require_debug_true_or_test', 'guid'], 'formatter': 'simple'},
+        'console': {
+            '()': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'filters': ['require_debug_true_or_test', 'dynamic_level_filter', 'guid'],
+            'formatter': 'simple',
+        },
         'null': {'class': 'logging.NullHandler'},
         'file': {'class': 'logging.NullHandler', 'formatter': 'simple'},
         'syslog': {'level': 'WARNING', 'filters': ['require_debug_false'], 'class': 'logging.NullHandler', 'formatter': 'simple'},

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -35,13 +35,6 @@ LOGGING['handlers']['console']['()'] = 'awx.main.utils.handlers.ColorHandler'  #
 LOGGING['handlers']['task_system'] = LOGGING['handlers']['console'].copy()  # noqa
 COLOR_LOGS = True
 
-# celery is annoyingly loud when docker containers start
-LOGGING['loggers'].pop('celery', None)  # noqa
-# avoid awx.main.dispatch WARNING-level scaling worker up/down messages
-LOGGING['loggers']['awx.main.dispatch']['level'] = 'ERROR'  # noqa
-# suppress the spamminess of the awx.main.scheduler and .tasks loggers
-LOGGING['loggers']['awx']['level'] = 'INFO'  # noqa
-
 ALLOWED_HOSTS = ['*']
 
 mimetypes.add_type("image/svg+xml", ".svg", True)
@@ -56,13 +49,6 @@ CSRF_COOKIE_SECURE = False
 # Override django.template.loaders.cached.Loader in defaults.py
 template = next((tpl_backend for tpl_backend in TEMPLATES if tpl_backend['NAME'] == 'default'), None)  # noqa
 template['OPTIONS']['loaders'] = ('django.template.loaders.filesystem.Loader', 'django.template.loaders.app_directories.Loader')
-
-CALLBACK_QUEUE = "callback_tasks"
-
-# Enable dynamically pulling roles from a requirement.yml file
-# when updating SCM projects
-# Note: This setting may be overridden by database settings.
-AWX_ROLES_ENABLED = True
 
 # Disable Pendo on the UI for development/test.
 # Note: This setting may be overridden by database settings.


### PR DESCRIPTION
##### SUMMARY
I strongly prefer to share the logging settings between development and production to whatever extent possible.

With this, the global setting defaults to DEBUG. If we want INFO instead, we can talk about what is needed to make that happen. We do have the CTiT setting for the log level which applies to all logs.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Without this, the dispatcher is effectively silenced. That's troublesome to me because you don't know what tasks are running. Yes, periodic tasks are annoying, but we should ask more general questions like - "will DEBUG or INFO include logs from periodic actions?"
