### PR TITLE
Load ansible.cfg from the branch specified on job template

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1708,7 +1708,7 @@ class RunJob(BaseTask):
             ('ANSIBLE_ROLES_PATH', 'roles_path', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles'),
         )
 
-        config_values = read_ansible_config(job.project.get_project_path(), list(map(lambda x: x[1], path_vars)))
+        config_values = read_ansible_config(os.path.join(private_data_dir, 'project'), list(map(lambda x: x[1], path_vars)))
 
         for env_key, config_setting, folder, default in path_vars:
             paths = default.split(':')


### PR DESCRIPTION
Load ansible.cfg from the branch specified on job template (i.e. the same branch that the playbook exists), not from the branch set in the "project".

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, `ansible.cfg` is loaded from the project directory on "Source Control Branch" set in the **"Project"**.
But when overriding project's branch by job template, the branch of ansible.cfg and
the branch of playbook to run does not match.
Users usually assume that the playbook will run with `ansible.cfg` on the same branch, 
so it should be loaded from "Source Control Branch" on the **"Job Template"**.

I'm trying to fix this in the [similar way as `RunInventoryUpdate` loads `ansible.cfg`](https://github.com/ansible/awx/blob/devel/awx/main/tasks.py#L2548).

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.1.dev10+gd6e4582c9c
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
