### PR TITLE
Removing time.sleep(3)

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -3189,7 +3189,6 @@ class AWXReceptorJob:
                     except Exception:
                         raise RuntimeError(detail)
 
-        time.sleep(3)
         return res
 
     # Spawned in a thread so Receptor can start reading before we finish writing, we


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 16.0.1.dev3082+g21895bd09b.d20211214
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
time.sleep(3) was added to avoid certain race conditions that would cause receptor to not close the file descriptors properly. Since that issue was resolved , there is no need for time.sleep(3) here. hence , removing it. 
```
