### PR TITLE
Add setting for optionally disabling ansible-runner process isolation

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -969,6 +969,9 @@ class BaseTask(object):
         if settings.IS_K8S:
             return {}
 
+        if not settings.RUNNER_PROCESS_ISOLATION:
+            return {"process_isolation": False}
+
         image = instance.execution_environment.image
         params = {
             "container_image": image,

--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -21,6 +21,12 @@ def get_default_execution_environment():
     return ExecutionEnvironment.objects.filter(organization=None, managed=False).first()
 
 
+# this is the root of the private data dir as seen from inside
+# of the container running a job. if process isolation is disabled
+# then this should just be host project root directory
+CONTAINER_ROOT = '/runner' if settings.RUNNER_PROCESS_ISOLATION else settings.PROJECTS_ROOT
+
+
 def get_default_pod_spec():
     ee = get_default_execution_environment()
     if ee is None:
@@ -35,16 +41,11 @@ def get_default_pod_spec():
                 {
                     "image": ee.image,
                     "name": 'worker',
-                    "args": ['ansible-runner', 'worker', '--private-data-dir=/runner'],
+                    "args": ['ansible-runner', 'worker', f'--private-data-dir={CONTAINER_ROOT}'],
                 }
             ],
         },
     }
-
-
-# this is the root of the private data dir as seen from inside
-# of the container running a job
-CONTAINER_ROOT = '/runner'
 
 
 def to_container_path(path, private_data_dir):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -536,6 +536,9 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {}
 SOCIAL_AUTH_SAML_ORGANIZATION_ATTR = {}
 SOCIAL_AUTH_SAML_TEAM_ATTR = {}
 
+# Enable ansible-runner's process isolation setting to support using execution environments
+RUNNER_PROCESS_ISOLATION = True
+
 # Any ANSIBLE_* settings will be passed to the task runner subprocess
 # environment
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Add `RUNNER_PROCESS_ISOLATION` setting to configure containerized isolation via ansible-runner"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Currently the `process_isolation` parameter for Ansible Runner is [hardcoded to `True`](https://github.com/ansible/awx/blob/devel/awx/main/tasks.py#L975). This update makes this setting configurable via a Django setting called `RUNNER_PROCESS_ISOLATION` to allow a user to disable containerized process isolation if they want to (the default of `True` remains unchanged). This is intended to support development, testing, and small-scale environments where using containerized execution environments is either not possible or unnecessary.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.1.dev26+g3232b6b005
```


