### PR TITLE
Revert "Set SESSION_COOKIE_NAME by default"

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -242,9 +242,6 @@ SUBSYSTEM_METRICS_INTERVAL_SAVE_TO_REDIS = 2
 # The maximum allowed jobs to start on a given task manager cycle
 START_TASK_LIMIT = 100
 
-# Name of our session cookie
-SESSION_COOKIE_NAME = 'awxsessionid'
-
 # Disallow sending session cookies over insecure connections
 SESSION_COOKIE_SECURE = True
 


### PR DESCRIPTION
##### SUMMARY
This reverts commit 59c6f35b0b38b95900832fb6a81485b430364eb5

This caused 403 errors in the way that awxkit was being used in integration tests, and makes them pretty unusable. To change this setting, we need to have those passing, which might involve changes to awxkit, I'm not really sure what it would require. Right now I want to merge this so that other PRs can get test results.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


