### PR TITLE
Fix: honor update_secrets in awx.awx.user

### DIFF
--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -163,6 +163,10 @@ def main():
     if password is not None:
         new_fields['password'] = password
 
+    # Prevent password reset when the user exists and update_secrets is False
+    if existing_item and existing_item.get('password') is None and not module.update_secrets:
+      del new_fields['password']
+
     # If the state was present and we can let the module build or update the existing item, this will return on its own
     module.create_or_update_if_needed(existing_item, new_fields, endpoint='users', item_type='user')
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "honor update_secrets in awx.awx.user"
-->

##### SUMMARY

Fix awx.awx.user in awx_collection to honor the update_secrets parameter when set


##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - collection

##### AWX VERSION

```
```


##### ADDITIONAL INFORMATION

In the current awx.awx.user module, even if `update_secrets` is false, the secrets will get updated.
This fixes this issue, making the parameter effective.
