### PR TITLE
Make awx-python script available in k8s app images

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -199,6 +199,8 @@ ADD tools/ansible/roles/dockerfile/files/rsyslog.conf /var/lib/awx/rsyslog/rsysl
 ADD tools/ansible/roles/dockerfile/files/wait-for-migrations /usr/local/bin/wait-for-migrations
 
 ## File mappings
+ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
+ADD tools/scripts/awx-python /usr/bin/awx-python
 {% if build_dev|bool %}
 ADD tools/docker-compose/launch_awx.sh /usr/bin/launch_awx.sh
 ADD tools/docker-compose/nginx.conf /etc/nginx/nginx.conf
@@ -216,8 +218,6 @@ ADD tools/scripts/config-watcher /usr/bin/config-watcher
 {% endif %}
 {% if (build_dev|bool) or (kube_dev|bool) %}
 ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
-ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
-ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
 
 # Pre-create things we need to access


### PR DESCRIPTION

##### SUMMARY
Currently, the `awx-python` script is not making it into the AWX k8s container, which means that awx-manage cannot run. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

