### PR TITLE
Handle exception for credential input checks in calling function

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -979,7 +979,7 @@ class BaseTask(object):
 
         if instance.execution_environment.credential:
             cred = instance.execution_environment.credential
-            if cred.has_inputs(field_names=('host', 'username', 'password')):
+            if all([cred.has_input(field_name) for field_name in ('host', 'username', 'password')]):
                 host = cred.get_input('host')
                 username = cred.get_input('username')
                 password = cred.get_input('password')


### PR DESCRIPTION
It looks like the expected behavior is to throw a runtime error when a credential is assigned to an EE and that credential doesn't have the required fields ('host', 'username', 'password'). The method we were using for that check can't return a `False`, though (it only [raises an exception](https://github.com/ansible/awx/blob/devel/awx/main/models/credential/__init__.py#L303) or [returns True](https://github.com/ansible/awx/blob/devel/awx/main/models/credential/__init__.py#L304)), so that exception was unreachable. 