### PR TITLE
Adds metrics for cloud deployments

### DIFF
--- a/awx/api/views/cloud_metrics.py
+++ b/awx/api/views/cloud_metrics.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2018 Red Hat, Inc.
+# All Rights Reserved.
+
+# Python
+import logging
+
+# Django
+from django.utils.translation import ugettext_lazy as _
+
+# Django REST Framework
+from rest_framework.response import Response
+
+# AWX
+# from awx.main.analytics import collectors
+import awx.main.analytics.subsystem_metrics as s_metrics
+from awx.main.analytics.metrics import metrics
+from awx.api import renderers
+
+from rest_framework.views import APIView
+
+
+logger = logging.getLogger('awx.analytics')
+
+
+class MetricsView(APIView):
+
+    authentication_classes = []  # disables authentication
+    permission_classes = []  # disables permission
+
+    name = _('Metrics')
+    swagger_topic = 'Metrics'
+
+    renderer_classes = [renderers.PlainTextRenderer, renderers.PrometheusJSONRenderer, renderers.BrowsableAPIRenderer]
+
+    def get(self, request):
+        '''Show Metrics Details'''
+        metrics_to_show = ''
+        if not request.query_params.get('subsystemonly', "0") == "1":
+            metrics_to_show += metrics().decode('UTF-8')
+        if not request.query_params.get('dbonly', "0") == "1":
+            metrics_to_show += s_metrics.metrics(request)
+        return Response(metrics_to_show)

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -4,6 +4,7 @@
 from django.conf.urls import url, include
 from django.conf import settings
 from awx.main.views import handle_400, handle_403, handle_404, handle_500, handle_csp_violation, handle_login_redirect
+from awx.api.views.cloud_metrics import MetricsView
 
 
 urlpatterns = [
@@ -11,6 +12,7 @@ urlpatterns = [
     url(r'^api/', include('awx.api.urls', namespace='api')),
     url(r'^sso/', include('awx.sso.urls', namespace='sso')),
     url(r'^sso/', include('social_django.urls', namespace='social')),
+    url(r'^metrics/$', MetricsView.as_view(), name='cloud_metrics_view'),
     url(r'^(?:api/)?400.html$', handle_400),
     url(r'^(?:api/)?403.html$', handle_403),
     url(r'^(?:api/)?404.html$', handle_404),


### PR DESCRIPTION

msg: "Adds cloud metrics endpoint"


##### SUMMARY

In order to collect metrics for cloud installations we require an unauthenticated endpoint.   This endpoint should not be exposed outside of the pod when running in openshift/k8s and should not be exposed at all for bare metal installations. 

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.1.dev29+g868e0e9af4.d20211209
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
