### PR TITLE
Remove unnecessary DEBUG logger level settings

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -881,7 +881,7 @@ LOGGING = {
         'daphne': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'rest_framework.request': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'WARNING', 'propagate': False},
         'py.warnings': {'handlers': ['console']},
-        'awx': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG'},
+        'awx': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger']},
         'awx.conf': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
@@ -897,12 +897,12 @@ LOGGING = {
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
-        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
-        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'level': 'DEBUG', 'propagate': False},
-        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'propagate': False},
+        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
+        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
+        'social': {'handlers': ['console', 'file', 'tower_warnings']},
+        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
+        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
     },
 }
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -901,7 +901,6 @@ LOGGING = {
         'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
         'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
         'social': {'handlers': ['console', 'file', 'tower_warnings']},
-        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
     },
 }

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -901,6 +901,7 @@ LOGGING = {
         'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
         'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
         'social': {'handlers': ['console', 'file', 'tower_warnings']},
+        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
     },
 }


### PR DESCRIPTION
##### SUMMARY
I'm just trying to remove some code that doesn't have any true effect here so that our logging config is easier to read.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This does change a numerical value, before:

```
In [29]: import logging

In [30]: logger = logging.getLogger('awx')

In [31]: logger.level
Out[31]: 10

```

after:

```
In [2]: import logging

In [3]: logger = logging.getLogger('awx')

In [4]: logger.level
Out[4]: 0

```

But as I understand it, the distinction between 0 and 10 only matters if you use custom (lower) log levels. We certainly don't. Even if we did, that should be something that can be handled by the `LOG_AGGREGATOR_LEVEL` setting, and a filter in the logger definition is not where we want it.
