### PR TITLE
Fix extra requests when creating WorkFlowJobTemplate

### DIFF
--- a/awx/ui/src/components/AppendBody/AppendBody.js
+++ b/awx/ui/src/components/AppendBody/AppendBody.js
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 function AppendBody({ children }) {
-  const el = document.createElement('div');
+  const [el] = useState(document.createElement('div'));
 
   useEffect(() => {
     document.body.appendChild(el);


### PR DESCRIPTION
Fix extra requests when creating WorkFlowJobTemplate.

I used useRef to store the el - div, but it was becoming more complex to do the clean up. The useState solved the issue. 

See: https://github.com/ansible/awx/issues/11442

