### PR TITLE
awx.awx.token: doc: show how token can be retrieved from facts

### DIFF
--- a/awx_collection/plugins/modules/token.py
+++ b/awx_collection/plugins/modules/token.py
@@ -85,9 +85,9 @@ EXAMPLES = '''
         controller_username: "{{ my_username }}"
         controller_password: "{{ my_password }}"
 
-    - name: Use our new token to make another call
+    - name: Use our new token (via the Ansible facts system) to make another call
       job_list:
-        controller_oauthtoken: "{{ token }}"
+        controller_oauthtoken: "{{ ansible_facts.controller_token.token }}"
 
   always:
     - name: Delete our Token with the token we created


### PR DESCRIPTION
Signed-off-by: Vincent Rubiolo <vincent.libre@cryostase.eu>

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "awx.awx.token: improve doc to show how token can be retrieved from facts"
-->

##### SUMMARY
The documentation is mentioning the fact that the token is put into the fact system + refer to the examples but they do not show that. This PR corrects this.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
None (docs)

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
19.4.0
```
