### PR TITLE
Creates end point and beginning of serializer for receptor mesh

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -57,6 +57,7 @@ from awx.main.models import (
     Host,
     Instance,
     InstanceGroup,
+    InstanceLink,
     Inventory,
     InventorySource,
     InventoryUpdate,
@@ -4765,6 +4766,28 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
         if self.context['request'].method == 'PATCH' and attrs == {'enabled': False}:
             return attrs
         return super(ScheduleSerializer, self).validate(attrs)
+
+
+class InstanceLinkSerializer(BaseSerializer):
+    class Meta:
+        model = InstanceLink
+        fields = ('source', 'target')
+
+    source = serializers.SlugRelatedField(slug_field="hostname", read_only=True)
+    target = serializers.SlugRelatedField(slug_field="hostname", read_only=True)
+
+
+class InstanceNodeSerializer(BaseSerializer):
+    class Meta:
+        model = Instance
+        fields = ('id', 'hostname', 'node_type', 'node_state')
+
+    node_state = serializers.SerializerMethodField()
+
+    def get_node_state(self, obj):
+        if not obj.enabled:
+            return "disabled"
+        return "unhealthy" if obj.errors else "healthy"
 
 
 class InstanceSerializer(BaseSerializer):

--- a/awx/api/templates/api/mesh_visualizer.md
+++ b/awx/api/templates/api/mesh_visualizer.md
@@ -1,0 +1,1 @@
+Make a GET request to this resource to obtain a list all Receptor Nodes and their links.

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -28,6 +28,7 @@ from awx.api.views import (
     OAuth2TokenList,
     ApplicationOAuth2TokenList,
     OAuth2ApplicationDetail,
+    MeshVisualizer,
 )
 
 from awx.api.views.metrics import MetricsView
@@ -95,6 +96,7 @@ v2_urls = [
     url(r'^me/$', UserMeList.as_view(), name='user_me_list'),
     url(r'^dashboard/$', DashboardView.as_view(), name='dashboard_view'),
     url(r'^dashboard/graphs/jobs/$', DashboardJobsGraphView.as_view(), name='dashboard_jobs_graph_view'),
+    url(r'^mesh_visualizer/', MeshVisualizer.as_view(), name='mesh_visualizer_view'),
     url(r'^settings/', include('awx.conf.urls')),
     url(r'^instances/', include(instance_urls)),
     url(r'^instance_groups/', include(instance_group_urls)),

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -159,6 +159,7 @@ from awx.api.views.inventory import (  # noqa
     InventoryJobTemplateList,
     InventoryCopy,
 )
+from awx.api.views.mesh_visualizer import MeshVisualizer  # noqa
 from awx.api.views.root import (  # noqa
     ApiRootView,
     ApiOAuthAuthorizationRootView,

--- a/awx/api/views/mesh_visualizer.py
+++ b/awx/api/views/mesh_visualizer.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2018 Red Hat, Inc.
+# All Rights Reserved.
+
+from awx.main.models import InstanceLink, Instance
+from django.utils.translation import ugettext_lazy as _
+
+from awx.api.generics import APIView, Response
+
+from awx.api.serializers import InstanceLinkSerializer, InstanceNodeSerializer
+
+
+class MeshVisualizer(APIView):
+
+    name = _("Mesh Visualizer")
+
+    def get(self, request, format=None):
+
+        data = {
+            'nodes': InstanceNodeSerializer(Instance.objects.all(), many=True).data,
+            'links': InstanceLinkSerializer(InstanceLink.objects.all(), many=True).data,
+        }
+
+        return Response(data)

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -123,6 +123,7 @@ class ApiVersionRootView(APIView):
         data['workflow_approvals'] = reverse('api:workflow_approval_list', request=request)
         data['workflow_job_template_nodes'] = reverse('api:workflow_job_template_node_list', request=request)
         data['workflow_job_nodes'] = reverse('api:workflow_job_node_list', request=request)
+        data['mesh_visualizer_view'] = reverse('api:mesh_visualizer_view', request=request)
         return Response(data)
 
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Adds an API end point for mesh visualizer"
-->

##### SUMMARY
This PR adds an end point for Receptor Mesh, and begins to create the visualizer for it. The end goal here is to have the api view compile data from the Instance Model and the newly created Instance Link model into a response such that the UI only has to make 1 api call to get what it needs to build the mesh visualizer.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
