### PR TITLE
Adding ppc64le support parameters

### DIFF
--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -9,5 +9,5 @@ template_dest: '_build'
 receptor_image: quay.io/ansible/receptor:devel
 
 # Helper vars to construct the proper download URL for the current architecture
-tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
-kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm" }[ansible_facts.architecture] }}'
+tini_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'
+kubectl_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'


### PR DESCRIPTION
##### SUMMARY

Added parameters to build docker image for ppc64le platform

##### ISSUE TYPE

 - Feature Pull Request

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.1.dev47+ga77041ede0
```
