### PR TITLE
Rework job canceling to avoid polling the database

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -445,8 +445,8 @@ class AutoscalePool(WorkerPool):
         if 'guid' in body:
             GuidMiddleware.set_guid(body['guid'])
         try:
-            if isinstance(body, dict):
-                if body['task'] == 'cancel_unified_job':  # special local cancel triggered by job canceling
+            if isinstance(body, dict) and 'task' in body:
+                if body['task'].endswith('.cancel_unified_job'):  # special local cancel triggered by job canceling
                     self.cancel_job(body['args'][0])
                 if 'cluster_node_heartbeat' in body['task']:  # when the cluster heartbeat occurs, clean up internally
                     self.cleanup()

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1408,7 +1408,7 @@ class UnifiedJob(
                 self.save(update_fields=cancel_fields)
                 self.websocket_emit_status("canceled")
             if self.celery_task_id:
-                from awx.main.tasks import cancel_unified_job
+                from awx.main.tasks.system import cancel_unified_job
 
                 cancel_unified_job.apply_async([self.celery_task_id], queue=self.get_queue_name())
         return self.cancel_flag

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1407,6 +1407,10 @@ class UnifiedJob(
                     cancel_fields.append('job_explanation')
                 self.save(update_fields=cancel_fields)
                 self.websocket_emit_status("canceled")
+            if self.celery_task_id:
+                from awx.main.tasks import cancel_unified_job
+
+                cancel_unified_job.apply_async([self.celery_task_id], queue=self.get_queue_name())
         return self.cancel_flag
 
     @property

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -247,6 +247,12 @@ def handle_setting_changes(setting_keys):
         reconfigure_rsyslog()
 
 
+@task(queue=get_local_queuename)
+def cancel_unified_job(celery_task_id):
+    """Triggers special action in awx.main.dispatch.pool, this is a placeholder"""
+    pass
+
+
 @task(queue='tower_broadcast_all')
 def delete_project_files(project_path):
     # TODO: possibly implement some retry logic

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -75,7 +75,7 @@ class SpecialInventoryHandler(logging.Handler):
     def emit(self, record):
         # check cancel and timeout status regardless of log level
         this_time = now()
-        if (this_time - self.last_check).total_seconds() > 0.5:  # cancel callback is expensive
+        if (this_time - self.last_check).total_seconds() > 0.1:
             self.last_check = this_time
             if self.cancel_callback():
                 raise PostRunError('Inventory update has been canceled', status='canceled')


### PR DESCRIPTION
##### SUMMARY
This changes the way we inform a running dispatcher process that a job was canceled.

 - Before: we switched the job's `canceled_flag` to True, and the process polls this once every second
 - Proposed: a task is submitted and received by the node's parent dispatcher process, which tells it to do a SIGTERM for that process. The process still polls in a separate thread to look if it got the signal (otherwise it would block on the read)

The `cancel_flag` is still kept here, because the job could still be canceled while in the "waiting" status, before it makes it to the node which runs it. Before the job starts, both the DB flag and the sigterm flag are checked. After that, the logic goes, it's safe to just check the sigterm flag.

If a user wishes to, the task can be resubmitted multiple times, but this shouldn't be necessary.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
19.5.0
```


##### ADDITIONAL INFORMATION
I'm marking this as draft because I may still attempt the 1 other major change that was considered.

Instead of running the `receptorctl work cancel <unit-id>` command at the end of the `AWXReceptorJob` class, we could do that in an independent task similar to `cancel_unified_job`. However, I'm worried about when the dispatcher has a full queue. In the current state, issuing the SIGTERM signal jumps the line. It happens before the task lines up in the multiprocessing queue (which is good). Ideally we would first cancel the receptor job and then send the SIGTERM, but if the dispatcher is overloaded it might end up in a deadlock. Maybe we could have a special condition to handle that, but I don't love that idea.
