### PR TITLE
Only update the job_explanation on error if there wasn't already one

### DIFF
--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1544,7 +1544,8 @@ class BaseTask(object):
             rc = res.rc
 
             if status in ('timeout', 'error'):
-                self.instance.job_explanation = f"Job terminated due to {status}"
+                job_explanation = f"Job terminated due to {status}"
+                self.instance.job_explanation = self.instance.job_explanation or job_explanation
                 if status == 'timeout':
                     status = 'failed'
 


### PR DESCRIPTION
##### SUMMARY
Making sure that we don't clobber any other `job_explanation` that gets set when some sort of immediate non-Ansible error gets raised.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
