### PR TITLE
more time-out resilient project-update playbook

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -103,6 +103,9 @@
             dest: "{{ project_path|quote }}/.archive"
             state: directory
 
+        # the status_code is only defined if the request was handled
+        # all status_codes >= 400 are marked as failed
+        # 10s timeout 1st attempt + 10s delay * 12 retries == 250s
         - name: Get archive from url
           get_url:
             url: "{{ scm_url|quote }}"
@@ -111,6 +114,11 @@
             url_password: "{{ scm_password|default(omit) }}"
             force_basic_auth: true
           register: get_archive
+          retries: 12
+          delay: 10
+          until: >
+            get_archive is succeeded or
+            get_archive.status_code is defined 
 
         - name: Unpack archive
           project_archive:
@@ -172,6 +180,10 @@
         - install_collections
 
     - block:
+
+        # when a timeout occurs ansible-galaxy will result in:
+        # rc: 1 and "[ERROR]: failed to download the file: The read operation timed out"
+        # approx. 10s timeout first run + 10s delay * 12 retries == 250s
         - name: fetch galaxy roles from requirements.(yml/yaml)
           command: >
             ansible-galaxy role install -r {{ item }}
@@ -187,6 +199,11 @@
           environment:
             ANSIBLE_FORCE_COLOR: false
             GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+          retries: 12
+          delay: 10
+          until: >
+            galaxy_result is succeeded or
+            'The read operation timed out' not in galaxy_result.stderr
 
       when: roles_enabled|bool
       tags:

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -210,6 +210,9 @@
         - install_roles
 
     - block:
+        # when a timeout occurs ansible-galaxy will result in:
+        # rc: 1 and "[ERROR]: failed to download the file: The read operation timed out"
+        # approx. 10s timeout first run + 10s delay * 12 retries == 250s
         - name: fetch galaxy collections from collections/requirements.(yml/yaml)
           command: >
             ansible-galaxy collection install -r {{ item }}
@@ -231,6 +234,11 @@
             # Put the local tmp directory in same volume as collection destination
             # otherwise, files cannot be moved accross volumes and will cause error
             ANSIBLE_LOCAL_TEMP: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/tmp"
+          retries: 12
+          delay: 10
+          until: >
+            galaxy_collection_result is succeeded or
+            'The read operation timed out' not in galaxy_collection_result.stderr
 
       when:
         - "ansible_version.full is version_compare('2.9', '>=')"


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "added retries to the get_url and ansible-galaxy task to make the project-update playbook more resilient in case of  time-outs"
-->

##### SUMMARY
In our environment/ setup we switched from using Git to our own HTTP(S) download service which uses a on-premise S3 as the back-end to store and pull Ansible Projects/ S3 objects. This migration made project updates much faster, and the S3 service is very durable, reliable and always up... but sometimes it coops with some latency (issues) that would exceed the default 10-seconds download time-out for the get_url and ansible-galaxy update roles and collection tasks.

We've added some retry parameters to ensure the download of the project archive and the task which executes Ansible Galaxy to fetch Ansible collections and Ansible roles does not immediately fail when time-outs occur. Any other error like [403] Authentication issues, or [404] File not found or [5xx] errors will make the task fail immediately. 

We have this change already implemented in our production environment, which resulted in proper handling of time-out/ latency issues, and no automatic incidents being created of the very few (<0,001%) project updates that would have been failed. Now these project updates do finish after one or two retries... 

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 14.1.1.dev4206+gddc428532f.d20211218
```

##### ADDITIONAL INFORMATION
Added below parameters to the "Get archive from url" task:
```
          retries: 12
          delay: 10
          until: >
            get_archive is succeeded or
            get_archive.status_code is defined 
```

Added below parameters to the fetch galaxy roles and collections tasks:
```
retries: 12
          delay: 10
          until: >
            galaxy_collection_result is succeeded or
            'The read operation timed out' not in galaxy_collection_result.stderr

```
