### PR TITLE
Fix relaunch of jobs

### DIFF
--- a/awx/ui/src/components/JobList/JobListItem.js
+++ b/awx/ui/src/components/JobList/JobListItem.js
@@ -135,7 +135,7 @@ function JobListItem({
                   <Button
                     ouiaId={`${job.id}-relaunch-button`}
                     variant="plain"
-                    onClick={handleRelaunch}
+                    onClick={() => handleRelaunch()}
                     aria-label={t`Relaunch`}
                     isDisabled={isLaunching}
                   >

--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { number, shape } from 'prop-types';
 
 import { t } from '@lingui/macro';
@@ -32,7 +32,8 @@ function canLaunchWithoutPrompt(launchData) {
   );
 }
 
-function LaunchButton({ resource, children, history }) {
+function LaunchButton({ resource, children }) {
+  const history = useHistory();
   const [showLaunchPrompt, setShowLaunchPrompt] = useState(false);
   const [launchConfig, setLaunchConfig] = useState(null);
   const [surveyConfig, setSurveyConfig] = useState(null);
@@ -184,4 +185,4 @@ LaunchButton.propTypes = {
   }).isRequired,
 };
 
-export default withRouter(LaunchButton);
+export default LaunchButton;

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -452,7 +452,7 @@ function JobDetail({ job, inventorySourceLabels }) {
                 <Button
                   ouiaId="job-detail-relaunch-button"
                   type="submit"
-                  onClick={handleRelaunch}
+                  onClick={() => handleRelaunch()}
                   isDisabled={isLaunching}
                 >
                   {t`Relaunch`}

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -161,7 +161,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
                 <Button
                   ouiaId="job-output-relaunch-button"
                   variant="plain"
-                  onClick={handleRelaunch}
+                  onClick={() => handleRelaunch()}
                   aria-label={t`Relaunch`}
                   isDisabled={isLaunching}
                 >


### PR DESCRIPTION
Events were passed to `handleRelaunch` and those events structure were
not parseable to JSON - breaking the relaunch of jobs. React 17 changes
made this bug visible.

See: https://github.com/ansible/awx/issues/11452

