### PR TITLE
Add job data to workflow approval notification template data

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -870,6 +870,7 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
     def context(self, approval_status):
         workflow_url = urljoin(settings.TOWER_URL_BASE, '/#/jobs/workflow/{}'.format(self.workflow_job.id))
         return {
+            'job': self.notification_data(),
             'approval_status': approval_status,
             'approval_node_name': self.workflow_approval_template.name,
             'workflow_url': workflow_url,


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Add basic job data to options in workflow approval notification templates"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current workflow approval notifications have the `job_metadata` attached as a JSON string but they do not have the non-strigified data. This takes the same information that is in `job_metadata` and puts it into the `job` key of the context so it can be used in notifications.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.4.1.dev245+g031ddcda90.d20211229
```



