### PR TITLE
Disable awx-config-watcher for k8s images

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -208,13 +208,13 @@ ADD tools/docker-compose/nginx.vh.default.conf /etc/nginx/conf.d/nginx.vh.defaul
 ADD tools/docker-compose/start_tests.sh /start_tests.sh
 ADD tools/docker-compose/bootstrap_development.sh /usr/bin/bootstrap_development.sh
 ADD tools/docker-compose/entrypoint.sh /entrypoint.sh
+ADD tools/scripts/config-watcher /usr/bin/config-watcher
 {% else %}
 ADD tools/ansible/roles/dockerfile/files/launch_awx.sh /usr/bin/launch_awx.sh
 ADD tools/ansible/roles/dockerfile/files/launch_awx_task.sh /usr/bin/launch_awx_task.sh
 ADD tools/ansible/roles/dockerfile/files/settings.py /etc/tower/settings.py
 ADD {{ template_dest }}/supervisor.conf /etc/supervisord.conf
 ADD {{ template_dest }}/supervisor_task.conf /etc/supervisord_task.conf
-ADD tools/scripts/config-watcher /usr/bin/config-watcher
 {% endif %}
 {% if (build_dev|bool) or (kube_dev|bool) %}
 ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link

--- a/tools/ansible/roles/dockerfile/templates/supervisor.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor.conf.j2
@@ -98,6 +98,7 @@ priority=5
 
 # TODO: Exit Handler
 
+{% if kube_dev | bool %}
 [eventlistener:awx-config-watcher]
 command=/usr/bin/config-watcher
 stderr_logfile=/dev/stdout
@@ -106,6 +107,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 events=TICK_60
 priority=0
+{% endif %}
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.web.sock

--- a/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
@@ -47,6 +47,7 @@ priority=5
 
 # TODO: Exit Handler
 
+{% if kube_dev | bool %}
 [eventlistener:awx-config-watcher]
 command=/usr/bin/config-watcher
 stderr_logfile=/dev/stdout
@@ -55,6 +56,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 events=TICK_60
 priority=0
+{% endif %}
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.sock


### PR DESCRIPTION

##### SUMMARY
`awx-config-watcher` is not longer necessary for OCP/k8s images as the `Configmap` should be changed directly in the `SPEC` and managed by the operator. 

Related: https://github.com/ansible/tower/issues/5390

This change only affects images intended for the k8s environment. We still can use the `config-watcher` for local devel environments. 


Fixes:
```
2021-10-27 11:01:26,877 INFO spawned: 'awx-config-watcher' with pid 249
2021-10-27 11:01:26,877 INFO spawned: 'awx-config-watcher' with pid 249
env: ‘python’: No such file or directory
2021-10-27 11:01:26,887 INFO exited: awx-config-watcher (exit status 127; not expected)
2021-10-27 11:01:26,887 INFO exited: awx-config-watcher (exit status 127; not expected)
2021-10-27 11:01:29,894 INFO spawned: 'awx-config-watcher' with pid 252
2021-10-27 11:01:29,894 INFO spawned: 'awx-config-watcher' with pid 252
env: ‘python’: No such file or directory
2021-10-27 11:01:29,903 INFO exited: awx-config-watcher (exit status 127; not expected)
2021-10-27 11:01:29,903 INFO exited: awx-config-watcher (exit status 127; not expected)
2021-10-27 11:01:30,904 INFO gave up: awx-config-watcher entered FATAL state, too many start retries too quickly
2021-10-27 11:01:30,904 INFO gave up: awx-config-watcher entered FATAL state, too many start retries too quickly
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
Built the image with the command below:

```
ansible-playbook tools/ansible/build.yml \
    -e registry=registry.tatu.home \
    -e awx_image=ansible/awx \
    -e awx_version=no-watcher -v
```

Inspecting deployment:
```yaml
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  labels:
    app.kubernetes.io/component: awx
    app.kubernetes.io/managed-by: awx-operator
    app.kubernetes.io/name: awx-devel
    app.kubernetes.io/operator-version: ""
    app.kubernetes.io/part-of: awx-devel
  name: awx-devel
  namespace: default
spec:
  admin_password_secret: awx-devel-admin-password
  admin_user: admin
  bundle_cacert_secret: awx-toca-custom-certs
  create_preload_data: true
  development_mode: true
  garbage_collect_secrets: false
  image: registry.tatu.home/ansible/awx
  image_pull_policy: Always
  image_version: no-watcher
  ingress_type: none
  ldap_cacert_secret: awx-toca-custom-certs
  loadbalancer_port: 80
  loadbalancer_protocol: http
  nodeport_port: 30080
  projects_persistence: false
  projects_storage_access_mode: ReadWriteMany
  projects_storage_size: 8Gi
  replicas: 1
  route_tls_termination_mechanism: Edge
  service_type: loadbalancer
  task_privileged: false
```

```
kubectl describe  deployment awx-devel | grep Image:  
    Image:      quay.io/centos/centos:8
    Image:      docker.io/redis:latest
    Image:      registry.tatu.home/ansible/awx:no-watcher
    Image:      registry.tatu.home/ansible/awx:no-watcher
    Image:      quay.io/ansible/awx-ee:latest
```

As expected, `awx-config-watcher` is not longer present:

```bash
(python3.10) mdemello@storm ~/d/P/awx (awx-config-watcher-dies-ocp)> kubectl iexec awx-devel /bin/bash                                      
Container: ✔ awx-devel-task
bash-4.4$ config-watcher
bash: config-watcher: command not found
bash-4.4$ grep watcher /etc/supervisord*
bash-4.4$ grep watcher /etc/supervisord* | wc -l 
0
```
