### PR TITLE
Modify how manual subform is displayed for projects

### DIFF
--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -224,7 +224,7 @@ function ProjectFormFields({
               isDisabled: true,
             },
             ...scmTypeOptions.map(([value, label]) => {
-              if (label === 'Manual') {
+              if (value === '') {
                 value = 'manual';
               }
               return {


### PR DESCRIPTION
Modify how manual subform is displayed for projects - Do not rely on
label that could be translated, rely on the value.

See: https://github.com/ansible/awx/issues/11505
