### PR TITLE
Revert "Remove unnecessary DEBUG logger level settings (#11441)"

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -881,7 +881,7 @@ LOGGING = {
         'daphne': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'rest_framework.request': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'WARNING', 'propagate': False},
         'py.warnings': {'handlers': ['console']},
-        'awx': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger']},
+        'awx': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG'},
         'awx.conf': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
@@ -897,12 +897,12 @@ LOGGING = {
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
-        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'propagate': False},
-        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
-        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
-        'social': {'handlers': ['console', 'file', 'tower_warnings']},
-        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
-        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
+        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
+        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'level': 'DEBUG', 'propagate': False},
+        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
     },
 }
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This reverts commit 8126f734e37f25ed523ad9a36f61d2e98e65fa60.

job_lifecycle.log was not populating with this commit, so I guess specifying the log level is necessary.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.2.3
```