### PR TITLE
Don't expose serviceAccount token on default pod spec

### DIFF
--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -31,6 +31,8 @@ def get_default_pod_spec():
         "kind": "Pod",
         "metadata": {"namespace": settings.AWX_CONTAINER_GROUP_DEFAULT_NAMESPACE},
         "spec": {
+            "serviceAccountName": "default",
+            "automountServiceAccountToken": False,
             "containers": [
                 {
                     "image": ee.image,


### PR DESCRIPTION
##### SUMMARY
We don't need to expose the `serviceAccount` token for the `default` SA  in containers group

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION

![image](https://user-images.githubusercontent.com/809840/149267404-99b16ce4-5a9d-4c5a-824e-e0f0d5c62f16.png)


So even in a special case where the `spec` override does not include the `serviceAccount`, we can em `deepmerge()` and get it as well

```yaml
>>> pod_spec_override
{'apiVersion': 'v1',
 'kind': 'Pod',
 'metadata': {'labels': {'testing': 'mmello'}, 'namespace': 'ansible-devel'},
 'spec': {'containers': [''{'args': ['''ansible-runner',
                                   'worker',
                                   '--private-data-dir=/runner'],
                          'image': 'quay.io/ansible/awx-ee:latest',
                          'name': 'worker',
                          'volumeMounts': [''{'mountPath': '/shared_data',
                                            'name': 'awx-devel-test-claim'}]}],
          'volumes': [''{'name': 'awx-devel-test-claim',
                       'persistentVolumeClaim': {'claimName': 'awx-devel-test-claim'}}]}}
>>> pod_spec
{'apiVersion': 'v1',
 'kind': 'Pod',
 'metadata': {'labels': {'testing': 'mmello'}, 'namespace': 'ansible-devel'},
 'spec': {'automountServiceAccountToken': False,
          'containers': [''{'args': ['''ansible-runner',
                                   'worker',
                                   '--private-data-dir=/runner'],
                          'image': 'quay.io/ansible/awx-ee:latest',
                          'name': 'worker',
                          'volumeMounts': [''{'mountPath': '/shared_data',
                                            'name': 'awx-devel-test-claim'}]}],
          'serviceAccountName': 'default',
          'volumes': [''{'name': 'awx-devel-test-claim',
                       'persistentVolumeClaim': {'claimName': 'awx-devel-test-claim'}}]}}

```

```yaml
kubectl get  pod -n ansible-devel automation-job-mmello2-102-54tdr -o yaml                                                                                 23:43:12
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2022-01-13T04:42:50Z"
  generateName: automation-job-mmello2-102-
  labels:
    ansible-awx: 14676f40-a717-4322-bd4c-0874d2157566
    ansible-awx-job-id: "102"
    testing: mmello
  name: automation-job-mmello2-102-54tdr
  namespace: ansible-devel
  resourceVersion: "69985425"
  uid: b11fafb8-18f6-43ff-8b82-52b07d457a51
spec:
  automountServiceAccountToken: false   <=== here
  containers:
  - args:
    - ansible-runner
    - worker
    - --private-data-dir=/runner
    image: quay.io/ansible/awx-ee:latest
    imagePullPolicy: Always
    name: worker
    resources: {}
    stdin: true
    stdinOnce: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /shared_data
      name: awx-devel-test-claim
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: p50
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default  
  serviceAccountName: default   <==== here
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: awx-devel-test-claim
    persistentVolumeClaim:
      claimName: awx-devel-test-claim
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2022-01-13T04:42:50Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2022-01-13T04:42:54Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2022-01-13T04:42:54Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2022-01-13T04:42:50Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: cri-o://45306576c7cb4275a81a559f0c56e0c3233201db07793830a4156e9d01a8a06d
    image: quay.io/ansible/awx-ee:latest
    imageID: quay.io/ansible/awx-ee@sha256:05d2ddbb53a1cbfe12eb655b0c69c0bc72a712ec35458c30651d0d2582078e30
    lastState: {}
    name: worker
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2022-01-13T04:42:53Z"
  hostIP: 192.168.111.50
  phase: Running
  podIP: 10.233.67.184
  podIPs:
  - ip: 10.233.67.184
  qosClass: BestEffort
  startTime: "2022-01-13T04:42:50Z"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
