### PR TITLE
Link from sync status icon to prefiltered list of inventory source sync jobs

### DIFF
--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -26,7 +26,11 @@ import JobListItem from './JobListItem';
 import JobListCancelButton from './JobListCancelButton';
 import useWsJobs from './useWsJobs';
 
-function JobList({ defaultParams, showTypeColumn = false }) {
+function JobList({
+  defaultParams,
+  showTypeColumn = false,
+  additionalRelatedSearchableKeys = [],
+}) {
   const qsConfig = getQSConfig(
     'job',
     {
@@ -243,7 +247,10 @@ function JobList({ defaultParams, showTypeColumn = false }) {
           }
           clearSelected={clearSelected}
           toolbarSearchableKeys={searchableKeys}
-          toolbarRelatedSearchableKeys={relatedSearchableKeys}
+          toolbarRelatedSearchableKeys={[
+            ...relatedSearchableKeys,
+            ...additionalRelatedSearchableKeys,
+          ]}
           renderToolbar={(props) => (
             <DatalistToolbar
               {...props}

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -167,6 +167,9 @@ function Inventory({ setBreadcrumb }) {
                     inventory.id,
                   or__workflowjob__inventory: inventory.id,
                 }}
+                additionalRelatedSearchableKeys={[
+                  'inventoryupdate__inventory_source__inventory',
+                ]}
               />
             </Route>,
             <Route path="*" key="not-found">

--- a/awx/ui/src/screens/Inventory/InventoryList/InventoryListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/InventoryListItem.js
@@ -95,9 +95,19 @@ function InventoryListItem({
         )}
       </TdBreakWord>
       <Td dataLabel={t`Status`}>
-        {inventory.kind !== 'smart' && (
-          <StatusLabel status={syncStatus} tooltipContent={tooltipContent} />
-        )}
+        {inventory.kind !== 'smart' &&
+          (inventory.has_inventory_sources ? (
+            <Link
+              to={`/inventories/inventory/${inventory.id}/jobs?job.or__inventoryupdate__inventory_source__inventory__id=${inventory.id}`}
+            >
+              <StatusLabel
+                status={syncStatus}
+                tooltipContent={tooltipContent}
+              />
+            </Link>
+          ) : (
+            <StatusLabel status={syncStatus} tooltipContent={tooltipContent} />
+          ))}
       </Td>
       <Td dataLabel={t`Type`}>
         {inventory.kind === 'smart' ? t`Smart Inventory` : t`Inventory`}


### PR DESCRIPTION
##### SUMMARY
Issue: #7678

The inventory sync status icon should send the user to a pre-filtered list of inventory source sync jobs. If the inventory has no inventory sources, don't provide a link to the jobs list.  
<img width="937" alt="Screen Shot 2022-01-13 at 10 56 42 AM" src="https://user-images.githubusercontent.com/15881645/149366219-5be7cd7e-e426-4a67-9b55-1e45821c7e41.png">

List pre-filtered by `inventoryupdate__inventory_source__inventory__id`. Since the search key was not returned from the API in `relatedSearchableKeys`, I had to pass it as an additional related search key to display the search chip. 
<img width="933" alt="Screen Shot 2022-01-13 at 10 57 13 AM" src="https://user-images.githubusercontent.com/15881645/149366075-788104c2-b88f-4aa4-81c5-2d83366c1ae2.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
