### PR TITLE
Update ping endpoint to use last_seen

### DIFF
--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -156,7 +156,7 @@ class ApiV2PingView(APIView):
                     node=instance.hostname,
                     node_type=instance.node_type,
                     uuid=instance.uuid,
-                    heartbeat=instance.modified,
+                    heartbeat=instance.last_seen,
                     capacity=instance.capacity,
                     version=instance.version,
                 )


### PR DESCRIPTION
Update ping endpoint to use last_seen, instead of `modified` on
instances `heartbeat`.

See: https://github.com/ansible/awx/issues/11523
