### PR TITLE
Remove the Instance.objects.active_count() method

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -186,10 +186,6 @@ class InstanceManager(models.Manager):
         else:
             return (False, self.me())
 
-    def active_count(self):
-        """Return count of active Tower nodes for licensing."""
-        return self.exclude(node_type='hop').count()
-
 
 class InstanceGroupManager(models.Manager):
     """A custom manager class for the Instance model.

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -77,7 +77,7 @@ def test_instance_dup(org_admin, organization, project, instance_factory, instan
     ig_all = instance_group_factory("all", instances=[i1, i2, i3])
     ig_dup = instance_group_factory("duplicates", instances=[i1])
     project.organization.instance_groups.add(ig_all, ig_dup)
-    actual_num_instances = Instance.objects.active_count()
+    actual_num_instances = Instance.objects.count()
     list_response = get(reverse('api:instance_list'), user=system_auditor)
     api_num_instances_auditor = list(list_response.data.items())[0][1]
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
Literally nothing uses it.  The similar Host.objects.active_count()
method seems to be what is actually important for licensing.

This came up in the initial modeling work to support the mesh visualizer.

related #11431

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
