### PR TITLE
[WIP] Let container group jobs stay in Pending, allowing for pods to queue for resources in k8s

### DIFF
--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from django.utils.timezone import now as tz_now
 from django.contrib.contenttypes.models import ContentType
 
-from awx.main.models import Instance, UnifiedJob, WorkflowJob, InstanceGroup
+from awx.main.models import Instance, UnifiedJob, WorkflowJob
 from awx.main.tasks.receptor import receptor_work_status, RECEPTOR_AWX_STATE_MAP
 
 logger = logging.getLogger('awx.main.dispatch')
@@ -15,16 +15,16 @@ def reap_job(j, status):
     if UnifiedJob.objects.get(id=j.id).status not in ('running', 'waiting'):
         # just in case, don't reap jobs that aren't running
         return
-    if j.instance_group.is_container_group:
-        status, detail = receptor_work_status(j.work_unit_id)
-        if RECEPTOR_AWX_STATE_MAP[status] != j.status:
+    if j.instance_group and j.instance_group.is_container_group:
+        receptor_status, detail = receptor_work_status(j.work_unit_id)
+        if RECEPTOR_AWX_STATE_MAP[receptor_status] != j.status:
             # Sometimes the job has exited already, but we had not had chance to update the
             # job status with one of these terminal states.
             # Update the status and return early.
             # Otherwise the job truly is gone but still marked as running, in which case it should
             # rightfully be reaped
-            j.status = RECEPTOR_AWX_STATE_MAP[status]
-            j.save()
+            j.status = RECEPTOR_AWX_STATE_MAP[receptor_status]
+            j.save(update_fields=['status'])
             return
     j.status = status
     j.start_args = ''  # blank field to remove encrypted passwords

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -38,7 +38,7 @@ from awx.main.utils.common import create_partition
 from awx.main.signals import disable_activity_stream
 from awx.main.scheduler.dependency_graph import DependencyGraph
 from awx.main.utils import decrypt_field
-from awx.main.tasks.receptor import RECEPTOR_AWX_STATE_MAP, receptor_work_status
+from awx.main.tasks.receptor import receptor_work_status
 
 logger = logging.getLogger('awx.main.scheduler')
 
@@ -483,10 +483,10 @@ class TaskManager:
         return created_dependencies
 
     def update_receptor_status(self, task):
-        status, detail = receptor_work_status(task.work_unit_id)
-        if RECEPTOR_AWX_STATE_MAP[status] != task.status:
-            logger.warn('Found pending task {} with work unit id {} updating to be in status {}'.format(task.log_format, task.work_unit_id, status.lower()))
-            task.status = RECEPTOR_AWX_STATE_MAP[status]
+        receptor_status, detail = receptor_work_status(task.work_unit_id, translate_to_awx_job_status=True)
+        if receptor_status != task.status:
+            logger.warn('Found pending task {} with work unit id {} updating to be in status {}'.format(task.log_format, task.work_unit_id, receptor_status))
+            task.status = receptor_status
             task.save()
         else:
             logger.warn('Task {} with work unit id {} is still Pending in receptor'.format(task.log_format, task.work_unit_id))

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -38,7 +38,10 @@ from awx.main.utils.common import create_partition
 from awx.main.signals import disable_activity_stream
 from awx.main.scheduler.dependency_graph import DependencyGraph
 from awx.main.utils import decrypt_field
-
+from awx.main.tasks.receptor import (
+    RECEPTOR_RUNNING_STATE,
+    receptor_work_status
+)
 
 logger = logging.getLogger('awx.main.scheduler')
 
@@ -482,12 +485,26 @@ class TaskManager:
         UnifiedJob.objects.filter(pk__in=[task.pk for task in undeped_tasks]).update(dependencies_processed=True)
         return created_dependencies
 
+    def update_receptor_status(self, task):
+        logger.warn('Found pending task with work unit id {}'.format(task.work_unit_id))
+        status, detail = receptor_work_status(task.work_unit_id)
+        if status.lower() != task.status:
+            logger.warn('Found pending task {} with work unit id {} updating to be in status {}'.format(task.log_format, task.work_unit_id, status.lower()))
+            task.status = status.lower()
+            task.save()
+        else:
+            logger.warn('Task {} with work unit id {} is still Pending in receptor'.format(task.log_format, task.work_unit_id))
+
+
     def process_pending_tasks(self, pending_tasks):
         running_workflow_templates = {wf.unified_job_template_id for wf in self.get_running_workflow_jobs()}
         tasks_to_update_job_explanation = []
         for task in pending_tasks:
             if self.start_task_limit <= 0:
                 break
+            if task.work_unit_id:
+                self.update_receptor_status(task)
+                continue
             blocked_by = self.job_blocked_by(task)
             if blocked_by:
                 task.log_lifecycle("blocked", blocked_by=blocked_by)

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -484,6 +484,12 @@ class TaskManager:
 
     def update_receptor_status(self, task):
         receptor_status, detail = receptor_work_status(task.work_unit_id, translate_to_awx_job_status=True)
+        if detail == 'exceeded quota':
+            logger.warn('Task {} being resubmitted because work was rejected by kuberenetes API for exceeding a ResourceQuota'.format(task.log_format))
+            task.work_unit_id = None
+            task.status = 'pending'
+            task.save()
+            return
         if receptor_status != task.status:
             logger.warn('Found pending task {} with work unit id {} updating to be in status {}'.format(task.log_format, task.work_unit_id, receptor_status))
             task.status = receptor_status

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -78,7 +78,7 @@ def get_receptor_ctl():
         return ReceptorControl(receptor_sockfile)
 
 
-def receptor_work_status(unit_id):
+def receptor_work_status(unit_id, translate_to_awx_job_status=False):
     receptor_ctl = get_receptor_ctl()
     try:
         unit_status = receptor_ctl.simple_command(f'work status {unit_id}')
@@ -88,6 +88,12 @@ def receptor_work_status(unit_id):
         detail = ''
         state_name = ''
         logger.exception(f'An error was encountered while getting status for work unit {unit_id}')
+
+    if translate_to_awx_job_status:
+        if not state_name:
+            logger.exception(f'An error was encountered fetching the work unit status {unit_id}, reporting awx job status as "error"')
+        awx_state_name = RECEPTOR_AWX_STATE_MAP.get(state_name, 'error')
+        return awx_state_name, detail
 
     return state_name, detail
 

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -398,7 +398,7 @@ class AWXReceptorJob:
                             self.task.instance.result_traceback = detail
                             self.task.instance.save(update_fields=['result_traceback'])
                         else:
-                            logger.warn(f'No result details or output from {self.task.instance.log_format}, status:\n{unit_status}')
+                            logger.warn(f'No result details or output from {self.task.instance.log_format}, status:\n{state_name}')
                     except Exception:
                         raise RuntimeError(detail)
 

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -357,9 +357,9 @@ class AWXReceptorJob:
 
         if self.task and self.task.instance.is_container_group_task:
             state_name, detail = receptor_work_status(self.unit_id)
+            log_name = self.task.instance.log_format
             if state_name == RECEPTOR_PENDING_STATE:
-                log_name = self.task.instance.log_format
-                logger.warn(f"Pod for task {log_name} has been created but is not yet running.")
+                logger.warn(f"Pod scheduled but container not yet running for task {log_name}.")
                 self.task.update_model(self.task.instance.pk, status='pending')
         # Both "processor" and "cancel_watcher" are spawned in separate threads.
         # We wait for the first one to return. If cancel_watcher returns first,

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -33,6 +33,7 @@ __RECEPTOR_CONF = '/etc/receptor/receptor.conf'
 RECEPTOR_ACTIVE_STATES = ('Pending', 'Running')
 RECEPTOR_RUNNING_STATE = 'Running'
 RECEPTOR_PENDING_STATE = 'Pending'
+RECEPTOR_AWX_STATE_MAP = {'Running': 'running', 'Pending': 'pending', 'Succeeded': 'successful', 'Error': 'error', 'Failed': 'failed'}
 
 
 class ReceptorConnectionType(Enum):
@@ -75,6 +76,7 @@ def get_receptor_ctl():
         return ReceptorControl(receptor_sockfile, config=__RECEPTOR_CONF, tlsclient=get_tls_client(True))
     except RuntimeError:
         return ReceptorControl(receptor_sockfile)
+
 
 def receptor_work_status(unit_id):
     receptor_ctl = get_receptor_ctl()

--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -38,6 +38,7 @@ def get_default_pod_spec():
                     "image": ee.image,
                     "name": 'worker',
                     "args": ['ansible-runner', 'worker', '--private-data-dir=/runner'],
+                    "resources": {"requests": {"cpu": "250m", "memory": "100Mi"}},
                 }
             ],
         },

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -71,7 +71,7 @@ IS_K8S = False
 AWX_CONTAINER_GROUP_K8S_API_TIMEOUT = 10
 AWX_CONTAINER_GROUP_DEFAULT_NAMESPACE = os.getenv('MY_POD_NAMESPACE', 'default')
 # Timeout when waiting for pod to enter running state. If the pod is still in pending state , it will be terminated. Valid time units are "s", "m", "h". Example : "5m" , "10s".
-AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT = "5m"
+AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT = "2h"
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Let container group jobs stay in pending, and make resource requests in default podspec. This allows for pods to queue for resources in k8s."
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Rely on the receptor status that already reflects when pod was successfully created, but the containers in it have not yet started. This allows us to better use resource requests to make sure workloads we schedule don't disrupt the stability of the AWX control plane which also runs in the same namespace on kubernetes.

I'm open to suggestions, ideas and discussion about this implementation, and this needs some good corner case testing regarding failure and job reaping scenarios.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Currently, we don't by default make any resource requests in the pod spec. This has facilitated the generally successful behavior we currently have, which is to immediately put container group jobs into running after doing the work submit to receptor, providing a pretty short 5 min as a timeout to fail the job if the job's worker container doesn't actually get running in less than 5 min. This works whenever the pod can scheduled fast. Given that the podspec we've generally been using has no resource requests, the should get scheduled fast up to any limit on how many pods can be running on a node or in a namespace, which is generally much higher than is actually reasonable to assume we could run jobs and successfully deal with the output.

For example, if an automation job takes just 250m cpu (1/4 a CPU), by the time I have 80 jobs running on my 5 worker node cluster with 4vCPUs, my cluster CPUs are for all intents and purposes fully commited, and that's just with the jobs, not the control plane. To cope, OCP/k8s can take advantage of the fact that CPU is "compressible", e.g. throttle-able , but this is bad news especially for the control plane, because job event processing is very CPU intensive, and if we fall behind on job event processing, that can spin Redis into an OOM state if its queue of unprocessed events grows.
 
All this is a lot to say, that the way things are, using ContainerGroups with no resource requests is a foot gun, where its easy to start enough jobs that can cause the whole deployment to go sideways, or if you DO use resource requests and jobs do go into pending in OCP/k8s as they queue for resources, AWX can cascade fail jobs that are pending too long. So its a lose-lose situation.
