### PR TITLE
Bump node and npm versions inside container

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -157,7 +157,7 @@ RUN dnf -y install \
     wget \
     diffutils \
     unzip && \
-    npm install -g n && n 14.15.1 && npm install -g npm@7.20.3 && dnf remove -y nodejs
+    npm install -g n && n 14.18.3 && npm install -g npm@7.24.2 && dnf remove -y nodejs
 
 RUN pip3 install black git+https://github.com/coderanger/supervisor-stdout
 


### PR DESCRIPTION
Bump node and npm versions inside container

Preparing to bump react scripts to 5.0.

See: https://github.com/ansible/awx/issues/11543
