### PR TITLE
Add resource requests to default podspec

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -381,7 +381,7 @@ class AWXReceptorJob:
                             self.task.instance.result_traceback = detail
                             self.task.instance.save(update_fields=['result_traceback'])
                         else:
-                            logger.warn(f'No result details or output from {self.task.instance.log_format}, status:\n{unit_status}')
+                            logger.warn(f'No result details or output from {self.task.instance.log_format}, status:\n{state_name}')
                     except Exception:
                         raise RuntimeError(detail)
 

--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -38,6 +38,7 @@ def get_default_pod_spec():
                     "image": ee.image,
                     "name": 'worker',
                     "args": ['ansible-runner', 'worker', '--private-data-dir=/runner'],
+                    "resources": {"requests": {"cpu": "250m", "memory": "100Mi"}},
                 }
             ],
         },

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -71,7 +71,7 @@ IS_K8S = False
 AWX_CONTAINER_GROUP_K8S_API_TIMEOUT = 10
 AWX_CONTAINER_GROUP_DEFAULT_NAMESPACE = os.getenv('MY_POD_NAMESPACE', 'default')
 # Timeout when waiting for pod to enter running state. If the pod is still in pending state , it will be terminated. Valid time units are "s", "m", "h". Example : "5m" , "10s".
-AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT = "5m"
+AWX_CONTAINER_GROUP_POD_PENDING_TIMEOUT = "2h"
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/


### PR DESCRIPTION
Extend the timeout, assuming that we want to let the kubernetes scheduler
start containers when it wants to start them. This allows us to make
resource requests knowing that when some jobs queue up waiting for
resources, they will not get reaped in as short of a
timeout.

this is an alternative to https://github.com/ansible/awx/pull/11551
How is this different:
  * doesn't replicate what is already a bad pattern w/ the ResourceQuota workaround
  * don't get pretty messages in awx UI, it does show "running" the whole time

How does this achieve similar goals:
* DO get expected behavior that jobs queue up in kubernetes and complete eventually

Problem with this approach:
Reveals that image pull errors are not well reflected in receptor https://github.com/ansible/receptor/issues/521, for which I'm working on https://github.com/ansible/receptor/pull/522

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Allow adding resource requests to the default podspec for container group jobs."
-->